### PR TITLE
feat(egress): make IDB/OPFS storage non-evictable (unlimitedStorage)

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -16,6 +16,7 @@
   },
   "permissions": [
     "storage",
+    "unlimitedStorage",
     "sidePanel",
     "scripting",
     "tabs",

--- a/manifests/base.json
+++ b/manifests/base.json
@@ -20,6 +20,7 @@
 
   "permissions": [
     "storage",
+    "unlimitedStorage",
     "sidePanel",
     "scripting",
     "tabs",


### PR DESCRIPTION
## What

Makes peerd's local storage — vault, sessions, audit log, memory (IndexedDB) + the engine filesystems (OPFS) — **non-evictable**, closing a real data-loss gap. By default this storage is "best-effort" durability and the browser can evict it under disk pressure; for a no-backend product whose vault holds the user's only copy of their API key, eviction = silent, unrecoverable loss.

> Re-land of the pre-reset PR (the original was wiped with the history flatten). The e2e harness from that batch already landed; this is the other half.

## The fix (one permission)

`unlimitedStorage` exempts the extension's IDB + OPFS from eviction on **Chrome and Firefox**.

**Finding worth recording:** the intuitive call — `navigator.storage.persist()` — is a **no-op for extensions on Chrome** (returns `false` even from a document context; verified live in Chrome for Testing). The web persistent-durability bit and the extension eviction-exemption are *separate* mechanisms, and only the permission grants the latter. So this ships **just the permission** — no `persist()` call (dead code on Chrome, redundant on Firefox).

- `manifests/base.json`: add `unlimitedStorage` → regenerated into all four channel manifests (store/preview × chrome/firefox; not stripped).

## Permission note
`unlimitedStorage` is a low-friction, no-install-warning permission, justified for a local-first vault/sessions app. Ships on all channels (store users' vaults need durability too).

## Gates
bun test **2050/0**, typecheck + tscheck-floor (475/475) + lint + dweb-boundary clean, regenerated `manifest.json` committed (drift check).
