### PR TITLE
fix(egress): normalize host (port + trailing dot) before denylist match

### DIFF
--- a/extension/peerd-egress/denylist/denylist.js
+++ b/extension/peerd-egress/denylist/denylist.js
@@ -20,14 +20,32 @@
 // having to decide policy.
 
 /**
- * Find which pattern (if any) a hostname matches.
+ * Reduce a host to the matcher's canonical form: lowercase, no `:port`, no
+ * trailing dot. why DEFENSIVELY here (not just "callers must pass a clean
+ * hostname"): callers pass `URL.host` (carries `:port`) and `URL.hostname`
+ * (an absolute FQDN keeps its trailing dot — `new URL('https://chase.com./')`
+ * → `'chase.com.'`). Either form silently misses the exact-match / `*.`-suffix
+ * checks below, which is a denylist BYPASS (`chase.com.` and `chase.com:8443`
+ * both slip past `chase.com`). Normalizing at the single matcher entry point
+ * closes it for every caller (webFetch, the dispatcher origin gate, and the
+ * WebVM HTTP bridge, which reaches webFetch with no other gate).
  *
- * @param {string} hostname        a fully-qualified hostname (no scheme, no port)
+ * @param {string} host
+ * @returns {string}
+ */
+const canonicalHost = (host) =>
+  String(host).toLowerCase().replace(/:\d+$/, '').replace(/\.+$/, '');
+
+/**
+ * Find which pattern (if any) a host matches. Accepts a `URL.host` /
+ * `URL.hostname` value (port and trailing dot are normalized away).
+ *
+ * @param {string} hostname        a hostname (scheme already stripped)
  * @param {readonly string[]} patterns
  * @returns {string | null}        the matched pattern, or null
  */
 export const findDenylistMatch = (hostname, patterns) => {
-  const h = hostname.toLowerCase();
+  const h = canonicalHost(hostname);
   for (const p of patterns) {
     if (matchPattern(h, p.toLowerCase())) return p;
   }

--- a/extension/peerd-egress/fetch/web-fetch.js
+++ b/extension/peerd-egress/fetch/web-fetch.js
@@ -81,7 +81,9 @@ export const makeWebFetch = ({ getDenylist, matchDenylist, audit, fetchFn }) => 
       _audit({ type: 'egress_denied', details: { origin: u.origin, reason: 'private_network' } }).catch(() => {});
       throw new EgressDeniedError(u.origin);
     }
-    const denylisted = matchDenylist(u.host, getDenylist());
+    // u.hostname (not u.host): the denylist matches bare hostnames; u.host
+    // carries :port. (The matcher also normalizes defensively — see denylist.js.)
+    const denylisted = matchDenylist(u.hostname, getDenylist());
     if (denylisted) {
       _audit({ type: 'egress_denied', details: { origin: u.origin, reason: 'denylist', method } }).catch(() => {});
       throw new EgressDeniedError(u.origin);

--- a/tests/peerd-egress/denylist-match.test.ts
+++ b/tests/peerd-egress/denylist-match.test.ts
@@ -1,0 +1,54 @@
+// findDenylistMatch — host normalization (denylist-bypass guard) + boundary
+// correctness. The matcher receives URL.host / URL.hostname values from
+// webFetch, the dispatcher origin gate, and the WebVM bridge; a :port or a
+// trailing-dot FQDN must NOT slip a denylisted origin past the exact /
+// `*.`-suffix checks.
+
+import { describe, test, expect } from 'bun:test';
+import { findDenylistMatch, matchesDenylist } from '../../extension/peerd-egress/denylist/denylist.js';
+
+const PATTERNS = ['chase.com', '*.chase.com', '*.proton.me'];
+
+describe('findDenylistMatch — host normalization (bypass guard)', () => {
+  test('exact apex still matches', () => {
+    expect(findDenylistMatch('chase.com', PATTERNS)).toBe('chase.com');
+    expect(findDenylistMatch('mail.chase.com', PATTERNS)).toBe('*.chase.com');
+  });
+
+  test('trailing-dot FQDN does NOT bypass', () => {
+    expect(findDenylistMatch('chase.com.', PATTERNS)).toBe('chase.com');
+    expect(findDenylistMatch('mail.chase.com.', PATTERNS)).toBe('*.chase.com');
+  });
+
+  test('non-default port (URL.host form) does NOT bypass', () => {
+    expect(findDenylistMatch('chase.com:8443', PATTERNS)).toBe('chase.com');
+    expect(findDenylistMatch('mail.chase.com:8443', PATTERNS)).toBe('*.chase.com');
+  });
+
+  test('port + trailing dot together do NOT bypass', () => {
+    expect(findDenylistMatch('chase.com.:8443', PATTERNS)).toBe('chase.com');
+  });
+
+  test('uppercase host is matched', () => {
+    expect(findDenylistMatch('CHASE.COM.', PATTERNS)).toBe('chase.com');
+    expect(matchesDenylist('Mail.Chase.Com:443', PATTERNS)).toBe(true);
+  });
+});
+
+describe('findDenylistMatch — boundary correctness (no over-match)', () => {
+  test('subdomain wildcard matches a real subdomain, not a substring', () => {
+    expect(findDenylistMatch('mail.proton.me', PATTERNS)).toBe('*.proton.me');
+    expect(findDenylistMatch('protonmail.com', PATTERNS)).toBe(null);
+  });
+
+  test('does not match a lookalike apex or a deeper foreign domain', () => {
+    expect(findDenylistMatch('evilchase.com', PATTERNS)).toBe(null);
+    expect(findDenylistMatch('chase.com.evil.com', PATTERNS)).toBe(null);
+  });
+
+  test('normalization cannot be abused to over-match', () => {
+    // stripping a trailing dot must not turn a foreign host into a match
+    expect(findDenylistMatch('notchase.com.', PATTERNS)).toBe(null);
+    expect(findDenylistMatch('chase.com.attacker.com', PATTERNS)).toBe(null);
+  });
+});


### PR DESCRIPTION
## What

Hardens the sensitive-site denylist matcher against two host-normalization gaps: a **trailing-dot FQDN** (`chase.com.`) and a **non-default port** (`chase.com:8443`) both slipped past the exact / `*.`-suffix match — because callers pass `URL.host` (carries `:port`) / `URL.hostname` (an absolute FQDN keeps its trailing dot) into a matcher that assumed an already-clean hostname. The **WebVM HTTP bridge** is the most exposed path (it reaches `webFetch` with no other gate).

## Fix
- `denylist.js`: normalize the host (lowercase, strip `:port`, strip trailing dot) at the **single matcher entry point** → covers every caller (webFetch, the dispatcher origin gate, the WebVM bridge).
- `web-fetch.js`: pass `u.hostname` not `u.host`.
- Tests: bypass cases (trailing-dot / port / uppercase) **plus boundary correctness locked** so the normalization can't be abused to over-match (`protonmail.com`, `evilchase.com`, `chase.com.attacker.com` all stay non-matches).

## Gates
bun test **2058/0**, typecheck + tscheck-floor (475/475) + lint + dweb-boundary clean.

Touches `peerd-egress` (the egress chokepoint) — kept minimal and fully tested.
