### PR TITLE
fix(runtime): decline a session's pending confirm when its turn is aborted

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -2136,7 +2136,10 @@ vault.subscribe(() => { pushState(); });
 // slots also back auto-memory's isBusy gate and pushState's streaming
 // flag. (Replaced the global single-slot AbortController, 2026-06-12 —
 // it killed chat A's stream the moment the user sent in chat B.)
-const turnSlots = makeTurnSlots();
+// onAbort: when a session's turn is aborted (steer-live or Stop), decline any
+// confirm it's parked on — otherwise the parked turn would run the cancelled
+// side-effect after its 120s confirm timeout and double-write the session.
+const turnSlots = makeTurnSlots({ onAbort: (sid) => confirmCoordinator.declineSession(sid) });
 
 // The agent turn driver (runAgentTurn + maybeAutoResume) lives in
 // peerd-runtime/loop/turn-driver.js now — ~530 lines of turn orchestration

--- a/extension/peerd-egress/confirm/protocol.js
+++ b/extension/peerd-egress/confirm/protocol.js
@@ -120,6 +120,27 @@ export const makeConfirmCoordinator = ({
     for (const id of ids) { try { onSettled(id); } catch { /* best-effort */ } }
   };
 
+  /**
+   * Decline (settle to 'no') every pending prompt for ONE session — called when
+   * that session's turn is aborted (Stop / steer-live). why: a turn parked on
+   * ctx.confirm() when the user aborts must NOT later run the side-effecting tool
+   * the user just cancelled, and must not stay parked for the full timeout while
+   * a steered turn writes the same session. Settling to 'no' unblocks the old
+   * turn straight into its abort exit, performing nothing. First-settle-wins (the
+   * settle guard): a user 'yes' that already landed is honored and this no-ops;
+   * otherwise 'no' wins and a late 'yes' for that id is dropped. Session-scoped —
+   * a Stop in one chat never touches a pending confirm in another.
+   *
+   * @param {string | null | undefined} sessionId
+   */
+  const declineSession = (sessionId) => {
+    if (sessionId == null) return;
+    // snapshot: settle() mutates `pending` as it resolves each promise.
+    for (const { settle, prompt } of [...pending.values()]) {
+      if (prompt.sessionId === sessionId) settle('no');
+    }
+  };
+
   // The most-recently-raised un-settled prompt — replayed to a surface that
   // connects AFTER it was broadcast (DESIGN-12 late-joiner; the state snapshot
   // does NOT carry confirm state, which flows on the confirm/* channel).
@@ -130,5 +151,5 @@ export const makeConfirmCoordinator = ({
     return last;
   };
 
-  return { confirm, resolve, reset, getPending };
+  return { confirm, resolve, reset, declineSession, getPending };
 };

--- a/extension/peerd-runtime/loop/turn-slots.js
+++ b/extension/peerd-runtime/loop/turn-slots.js
@@ -35,8 +35,14 @@
  *   isBusy: (sessionId: string) => boolean,
  *   runWhenIdle: (sessionId: string, fn: () => void) => void,
  * }}
+ * @param {{ onAbort?: (sessionId: string) => void }} [deps]
+ *   onAbort fires whenever a session's turn is aborted (a steer-live supersede
+ *   or Stop). The SW wires it to confirmCoordinator.declineSession, so a turn
+ *   parked on ctx.confirm() is unblocked (declined) instead of left stranded
+ *   for the full timeout while a steered turn writes the same session. Default
+ *   no-op (tests / orchestrators that don't need it).
  */
-export const makeTurnSlots = () => {
+export const makeTurnSlots = ({ onAbort } = {}) => {
   /** @type {Map<string, AbortController>} */
   const slots = new Map();
   /** @type {Map<string, Array<() => void>>} idle-wake queue per session */
@@ -63,8 +69,10 @@ export const makeTurnSlots = () => {
   return {
     claim(sessionId) {
       // Steer-live: a second send into the SAME chat supersedes the
-      // turn already streaming there.
-      slots.get(sessionId)?.abort();
+      // turn already streaming there. onAbort decline-settles the superseded
+      // turn's pending confirm (if any) so it doesn't run the cancelled action.
+      const superseded = slots.get(sessionId);
+      if (superseded) { superseded.abort(); onAbort?.(sessionId); }
       const controller = new AbortController();
       slots.set(sessionId, controller);
       return {
@@ -84,6 +92,7 @@ export const makeTurnSlots = () => {
       const controller = slots.get(sessionId);
       if (!controller) return false;
       controller.abort();
+      onAbort?.(sessionId); // decline any confirm this turn is parked on
       return true;
     },
 

--- a/extension/shared/tool-types.js
+++ b/extension/shared/tool-types.js
@@ -176,6 +176,9 @@
  * @property {SideEffect} sideEffect
  * @property {string} [actionClass]   Plan/Act action class driving the prompt
  *                                    (workspace_write | shell | external)
+ * @property {string | null} [sessionId]   chat the prompt belongs to — lets the
+ *                                    coordinator decline a session's pending
+ *                                    confirms when its turn is aborted
  */
 
 /**

--- a/tests/peerd-egress/confirm-protocol.test.ts
+++ b/tests/peerd-egress/confirm-protocol.test.ts
@@ -101,3 +101,43 @@ describe('confirm coordinator — hang protection', () => {
     expect(c.getPending()).toBe(null);
   });
 });
+
+describe('confirm coordinator — declineSession (turn aborted: Stop / steer)', () => {
+  test('declines pending prompts for that session → the await resolves to "no"', async () => {
+    const c = makeConfirmCoordinator({ notifySidePanel: () => {} });
+    const p = c.confirm({ tool: 'click', description: 'x', origins: [], sideEffect: 'write', sessionId: 's1' } as any);
+    c.declineSession('s1');
+    expect(await p).toBe('no'); // unblocked into a decline — the cancelled side-effect won't run
+  });
+
+  test('only the matching session is declined; another chat is untouched', async () => {
+    let s2Pushed: any = null;
+    const c = makeConfirmCoordinator({ notifySidePanel: (p: any) => { if (p.sessionId === 's2') s2Pushed = p; } });
+    const p1 = c.confirm({ tool: 'click', description: 'x', origins: [], sideEffect: 'write', sessionId: 's1' } as any);
+    const p2 = c.confirm({ tool: 'click', description: 'y', origins: [], sideEffect: 'write', sessionId: 's2' } as any);
+    c.declineSession('s1');
+    expect(await p1).toBe('no');
+    c.resolve(s2Pushed.id, 'yes_once' as any); // s2 still live — a real answer flows
+    expect(await p2).toBe('yes_once');
+  });
+
+  test('first-settle-wins: a user "yes" that already landed is honored; a later decline no-ops', async () => {
+    let pushed: any = null;
+    const c = makeConfirmCoordinator({ notifySidePanel: (p: any) => { pushed = p; } });
+    const p = c.confirm({ tool: 'click', description: 'x', origins: [], sideEffect: 'write', sessionId: 's1' } as any);
+    c.resolve(pushed.id, 'yes_session' as any); // approved first
+    c.declineSession('s1');                      // abort lands after — must not override
+    expect(await p).toBe('yes_session');
+  });
+
+  test('declineSession(null/undefined) is a no-op (prompt stays pending)', async () => {
+    let pushed: any = null;
+    const c = makeConfirmCoordinator({ notifySidePanel: (p: any) => { pushed = p; } });
+    const p = c.confirm({ tool: 'click', description: 'x', origins: [], sideEffect: 'write', sessionId: 's1' } as any);
+    c.declineSession(null as any);
+    c.declineSession(undefined as any);
+    expect(c.getPending()?.id).toBe(pushed.id); // still pending — not declined
+    c.resolve(pushed.id, 'yes_once' as any);
+    expect(await p).toBe('yes_once');
+  });
+});

--- a/tests/peerd-runtime/loop/turn-slots.test.ts
+++ b/tests/peerd-runtime/loop/turn-slots.test.ts
@@ -120,3 +120,45 @@ describe('makeTurnSlots', () => {
     expect(slots.isBusy('a')).toBe(false);
   });
 });
+
+describe('makeTurnSlots — onAbort (decline parked confirms on abort)', () => {
+  test('steer-live supersede fires onAbort for that session', () => {
+    const aborted: string[] = [];
+    const slots = makeTurnSlots({ onAbort: (s) => aborted.push(s) });
+    slots.claim('a');                 // first turn — nothing superseded
+    expect(aborted).toEqual([]);
+    slots.claim('a');                 // steer-live supersede → onAbort('a')
+    expect(aborted).toEqual(['a']);
+  });
+
+  test('stop fires onAbort for that session', () => {
+    const aborted: string[] = [];
+    const slots = makeTurnSlots({ onAbort: (s) => aborted.push(s) });
+    slots.claim('a');
+    expect(slots.stop('a')).toBe(true);
+    expect(aborted).toEqual(['a']);
+  });
+
+  test('claiming a DIFFERENT, fresh session does not fire onAbort', () => {
+    const aborted: string[] = [];
+    const slots = makeTurnSlots({ onAbort: (s) => aborted.push(s) });
+    slots.claim('a');
+    slots.claim('b');                 // no prior controller for b → nothing to decline
+    expect(aborted).toEqual([]);
+  });
+
+  test('stopping an idle session is a no-op (no onAbort)', () => {
+    const aborted: string[] = [];
+    const slots = makeTurnSlots({ onAbort: (s) => aborted.push(s) });
+    expect(slots.stop('a')).toBe(false);
+    expect(aborted).toEqual([]);
+  });
+
+  test('default (no onAbort) still supersedes without throwing', () => {
+    const slots = makeTurnSlots();
+    const first = slots.claim('a');
+    slots.claim('a');
+    expect(first.controller.signal.aborted).toBe(true);
+    expect(slots.isBusy('a')).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Fixes a cancellation gap: when a turn is parked awaiting a confirmation prompt (`ctx.confirm()`) and the user **steers** (sends again in the same chat) or presses **Stop**, the turn slot only aborted the `AbortController` — the confirm promise wasn't abort-aware and nothing settled it. Consequences:

- the old turn stayed blocked for up to the 120 s confirm timeout while the steered turn ran — **two turns writing the same session**, and
- when the parked confirm later resolved "yes", the old turn **ran the side-effecting tool the user thought they had cancelled.**

## Fix
Settle that session's pending confirm(s) to a **decline** on abort:

- `confirm/protocol.js`: `declineSession(sessionId)` — settles matching-session pending prompts to `'no'`. **First-settle-wins** (a user "yes" that already landed is honored); **session-scoped** (Stop in one chat never touches another's confirm).
- `turn-slots.js`: fire an injected `onAbort(sessionId)` on steer-supersede + Stop.
- `service-worker.js`: wire `onAbort → confirmCoordinator.declineSession`.
- `shared/tool-types.js`: declare `ConfirmPrompt.sessionId` (already set by the dispatcher).

## Tests
`declineSession` (session match / cross-session isolation / first-settle-wins / null no-op) + `turn-slots` `onAbort` (fires on steer + Stop; **not** on a fresh claim or an idle Stop).

## Gates
bun test **2059/0**, typecheck + tscheck-floor (475/475) + lint + dweb-boundary clean.

Touches the agent loop + the egress confirm protocol (danger zones) — kept minimal and fully unit-tested.
