### PR TITLE
fix(firefox): strip Chrome-only COEP/COOP keys + signal headless unavailable

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -1661,20 +1661,28 @@ const ensureOffscreen = async () => {
   }
 };
 
+// why gate on offscreen availability: Firefox has no chrome.offscreen, so the
+// offscreen-hosted job/pdf workers can never run there. Injecting null (not a
+// live client) makes the tools' own `if (!client) return *_unavailable` guard
+// trip — so js_run/read_pdf report a clean "not supported in this build" signal
+// the agent can act on, instead of dispatching a job message no context answers
+// and surfacing an opaque "headless job failed".
+const offscreenAvailable = typeof (/** @type {any} */ (browser)).offscreen?.createDocument === 'function';
+
 // The headless-JS client (the js_run tool). execHeadless ensures the offscreen
 // doc, then dispatches a 'job/run' message to job-runner.js hosted there.
 // Defined after ensureOffscreen; buildToolContext reads it lazily at dispatch.
-const jsOffscreenClient = makeOffscreenJsClient({
+const jsOffscreenClient = offscreenAvailable ? makeOffscreenJsClient({
   ensureOffscreen,
   sendMessage: (m) => browser.runtime.sendMessage(m),
-});
+}) : null;
 
 // The PDF-extraction client (the read_pdf tool). ensureOffscreen, then a
 // 'pdf/extract' message to offscreen/pdf-extract.js (pdf.js in a Worker).
-const pdfOffscreenClient = makeOffscreenPdfClient({
+const pdfOffscreenClient = offscreenAvailable ? makeOffscreenPdfClient({
   ensureOffscreen,
   sendMessage: (m) => browser.runtime.sendMessage(m),
-});
+}) : null;
 
 // ── Local WebGPU runner bridge (FEATURE-LOCAL-WEBGPU B / M1) ────────────────
 // The local-webgpu adapter generates by calling generateLocalForAdapter, which

--- a/packaging/gen-manifest.ts
+++ b/packaging/gen-manifest.ts
@@ -36,7 +36,13 @@ const PREVIEW_PUBKEY_FILE = join(MANIFESTS_DIR, 'preview-chrome-key.pub');
 // Keys Chrome doesn't know (would log warnings on load) get stripped from
 // chromium manifests; keys Chrome owns get stripped from Firefox ones.
 const FIREFOX_ONLY_KEYS = ['browser_specific_settings', 'sidebar_action'];
-const CHROME_ONLY_KEYS = ['update_url', 'key', 'side_panel', 'sandbox'];
+// COEP/COOP are Chromium-only MANIFEST keys (they cross-origin-isolate
+// extension pages so CheerpX gets SharedArrayBuffer). Firefox doesn't honor
+// them as manifest keys — left in, they're dead weight an AMO validator can
+// flag. (The WebVM is already non-functional on Firefox without isolation;
+// stripping the keys just keeps the manifest clean.)
+const CHROME_ONLY_KEYS = ['update_url', 'key', 'side_panel', 'sandbox',
+  'cross_origin_embedder_policy', 'cross_origin_opener_policy'];
 
 // Permissions Firefox doesn't implement. Stripping them keeps AMO
 // validation clean; Firefox runtime parity is its own workstream — the

--- a/tests/background/offscreen-gate.test.ts
+++ b/tests/background/offscreen-gate.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// The Firefox js_run/read_pdf fix (#6) lives in service-worker.js, which can't
+// be imported under bun (no chrome/browser globals) — so, like pricing.test.ts,
+// we assert against the SOURCE TEXT. This pins the ACTUAL changed line (the
+// `offscreenAvailable ? … : null` gate), which the tool-contract test
+// js-run-unavailable.test.ts does NOT cover: that one exercises the tool's
+// pre-existing `if (!client)` guard (byte-identical on main), so it would pass
+// even with this SW gate reverted. Reverting the gate fails the assertions here.
+const src = readFileSync(
+  join(import.meta.dir, '../../extension/background/service-worker.js'),
+  'utf8',
+);
+
+describe('service worker — offscreen client gating (Firefox parity, #6)', () => {
+  test('offscreenAvailable is derived from the chrome.offscreen probe', () => {
+    // same predicate ensureOffscreen uses for its Firefox early-return, so the
+    // gate and the runtime host degrade together.
+    expect(src).toMatch(/const offscreenAvailable\s*=\s*typeof[\s\S]{0,80}offscreen\?\.createDocument\s*===\s*'function'/);
+  });
+
+  test('jsOffscreenClient is gated to null when offscreen is absent', () => {
+    expect(src).toMatch(/const jsOffscreenClient\s*=\s*offscreenAvailable\s*\?\s*makeOffscreenJsClient\(/);
+    expect(src).toMatch(/makeOffscreenJsClient\([\s\S]{0,200}?\)\s*:\s*null;/);
+  });
+
+  test('pdfOffscreenClient is gated to null when offscreen is absent', () => {
+    expect(src).toMatch(/const pdfOffscreenClient\s*=\s*offscreenAvailable\s*\?\s*makeOffscreenPdfClient\(/);
+    expect(src).toMatch(/makeOffscreenPdfClient\([\s\S]{0,200}?\)\s*:\s*null;/);
+  });
+});

--- a/tests/peerd-runtime/js-run-unavailable.test.ts
+++ b/tests/peerd-runtime/js-run-unavailable.test.ts
@@ -1,0 +1,54 @@
+// js_run — clean "unavailable" signal when the offscreen host is absent.
+//
+// On Firefox there is no chrome.offscreen, so the SW injects a NULL
+// jsOffscreenClient into the tool context (service-worker.js: gated on
+// `offscreenAvailable`). This test pins the TOOL CONTRACT that gating relies
+// on: a missing/!execHeadless client yields the actionable
+// `headless_js_unavailable` error the agent can read — NOT an opaque "headless
+// job failed" from a job message that no offscreen context is alive to answer.
+//
+// Scope note: this exercises the tool's guard (which is unchanged by the fix);
+// the SW-level `offscreenAvailable ? … : null` gate that actually injects the
+// null on Firefox is pinned separately by tests/background/offscreen-gate.test.ts.
+
+import { describe, test, expect } from 'bun:test';
+import { jsRunTool } from '../../extension/peerd-runtime/tools/defs/js-run.js';
+
+const ctx = (over: any = {}) => ({ session: { sessionId: 's1' }, ...over });
+
+describe('js_run — offscreen host availability', () => {
+  test('no jsOffscreenClient (Firefox) → headless_js_unavailable', async () => {
+    const r = await jsRunTool.execute({ code: 'return 1' }, ctx() as any);
+    expect(r).toEqual({ ok: false, error: 'headless_js_unavailable' });
+  });
+
+  test('client present but missing execHeadless → headless_js_unavailable', async () => {
+    const r = await jsRunTool.execute(
+      { code: 'return 1' },
+      ctx({ jsOffscreenClient: {} }) as any,
+    );
+    expect(r).toEqual({ ok: false, error: 'headless_js_unavailable' });
+  });
+
+  test('empty code is rejected before the availability check', async () => {
+    const r = await jsRunTool.execute({ code: '' }, ctx() as any);
+    expect(r).toEqual({ ok: false, error: 'code_required' });
+  });
+
+  test('a live client still dispatches (the tool contract holds with a real client)', async () => {
+    let dispatched = false;
+    const r = await jsRunTool.execute(
+      { code: 'return 1' },
+      ctx({
+        jsOffscreenClient: {
+          execHeadless: async () => {
+            dispatched = true;
+            return { durationMs: 1, value: 1 };
+          },
+        },
+      }) as any,
+    );
+    expect(dispatched).toBe(true);
+    expect(r.ok).toBe(true);
+  });
+});

--- a/tests/store/store-posture.test.ts
+++ b/tests/store/store-posture.test.ts
@@ -93,6 +93,16 @@ describe('store manifest posture', () => {
     expect(firefox.permissions ?? []).not.toContain('debugger');
     expect(firefox.optional_permissions ?? []).not.toContain('debugger');
   });
+
+  test('firefox manifest strips Chromium-only COEP/COOP keys (AMO-clean)', () => {
+    // Firefox doesn't honor these as manifest keys; left in, they're dead
+    // weight an AMO validator can flag. Chrome keeps them (cross-origin
+    // isolation for CheerpX) — assert that's still true.
+    expect(firefox.cross_origin_embedder_policy).toBeUndefined();
+    expect(firefox.cross_origin_opener_policy).toBeUndefined();
+    expect(manifest.cross_origin_embedder_policy).toBeDefined();
+    expect(manifest.cross_origin_opener_policy).toBeDefined();
+  });
 });
 
 describe('store feature flags', () => {


### PR DESCRIPTION
Two Firefox-parity fixes from the issue-hunt.

## #7 - COEP/COOP keys not stripped for Firefox
Added `cross_origin_embedder_policy` / `cross_origin_opener_policy` to `CHROME_ONLY_KEYS` so `applyBrowserTransform` strips them on the **Firefox branch only**. Chrome keeps them (CheerpX needs cross-origin isolation); on Firefox they're dead weight an AMO validator can flag, and the WebVM can't boot there without isolation anyway.

## #6 - js_run fails opaquely on Firefox
Firefox has no `chrome.offscreen`, but `jsOffscreenClient` / `pdfOffscreenClient` were injected unconditionally, so `js_run` / `read_pdf` dispatched a job no offscreen context answers -> opaque "headless job failed". Now gated on `offscreenAvailable` -> `null` on Firefox, tripping each tool's existing `*_unavailable` guard for a clean, actionable signal.

## Tests
- `store-posture`: Firefox strips both keys, Chrome keeps both (revert-proven: reverting the strip fails it, 14->13).
- `offscreen-gate` (new, source-text assertion): both clients are gated `offscreenAvailable ? ... : null` (revert-proven: 3->0 without the gate). The tool-contract test `js-run-unavailable` covers the tool guard, not the SW gate - hence the separate source assertion.
- Full bun suite 2058 pass; typecheck; lint; in-browser 596/0.

Closes #6, closes #7