### PR TITLE
fix(sw): auto-resume an interrupted turn after a service-worker respawn

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -2733,7 +2733,14 @@ vault.attemptResume().then((resumed) => {
     // self-gates on the setting, an interrupted-turn verdict, vault state, the
     // not-busy slot, and a per-marker dedupe, so firing here is safe even if a
     // later session-open fires it too.
-    sessionCache.sessionGet('currentSessionId')
+    // why settingsStore.load() first: loadSettings() runs un-awaited at boot, so
+    // the autoResumeInterruptedTurns gate inside maybeAutoResume could read the
+    // channel default (ON) before the user's stored value hydrates — resuming a
+    // user who explicitly DISABLED it, once, in the cold-start window. load() is
+    // idempotent (re-reads kv, recomputes the merged view), so gating on it here
+    // just guarantees the setting is hydrated before the gate consults it.
+    settingsStore.load()
+      .then(() => sessionCache.sessionGet('currentSessionId'))
       .then((/** @type {any} */ cur) => maybeAutoResume(cur)).catch(() => {});
   }
   // why: resume an in-flight Ralph run AFTER the vault is back — a run

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -2725,6 +2725,16 @@ vault.attemptResume().then((resumed) => {
     auditLog.append({ type: 'vault_unlocked' }).catch(() => {});
     pushState();
     maybeStartBaseNetwork('resume');
+    // why: the SW can die MID-TURN; on respawn the DK is back from session
+    // storage but the interrupted turn stays frozen until the user re-opens
+    // the chat. Drive the SAME auto-resume the unlock + session-open routes
+    // use (routes/vault.js) for the session in view — a wake is precisely when
+    // we most want to resume the turn the eviction killed. maybeAutoResume
+    // self-gates on the setting, an interrupted-turn verdict, vault state, the
+    // not-busy slot, and a per-marker dedupe, so firing here is safe even if a
+    // later session-open fires it too.
+    sessionCache.sessionGet('currentSessionId')
+      .then((/** @type {any} */ cur) => maybeAutoResume(cur)).catch(() => {});
   }
   // why: resume an in-flight Ralph run AFTER the vault is back — a run
   // needs unlocked secrets to call the model. If the SW died mid-run, the


### PR DESCRIPTION
## #5 - interrupted turn frozen after SW respawn
On a mid-turn SW eviction the vault DK is restored from session storage on respawn, but the boot `attemptResume` block never re-drove the interrupted turn - it stayed frozen (a half-written answer / a tool card stuck "pending") until the user re-opened the chat. Drive `maybeAutoResume` for the in-view session from the boot resume block, mirroring `routes/vault.js`.

`maybeAutoResume` self-gates on the `autoResumeInterruptedTurns` setting, the `detectInterruptedTurn` verdict, an unlocked vault, a not-busy slot, and a per-marker dedupe - so firing here is safe even when a later session-open fires it too.

## Tests / coverage (disclosed honestly)
- Full bun suite 2050 pass; typecheck; lint.
- The classifier this relies on (`detectInterruptedTurn`) is covered by `resume-detect.test.ts`. **Gap:** the boot -> `maybeAutoResume` *wiring itself* has no automated coverage (an in-browser SW-respawn test is its proper home).
- Minor: `loadSettings()` and `attemptResume()` both run un-awaited at boot, so a user who explicitly *disabled* auto-resume could be resumed once in the cold-start window before the setting hydrates (default is on; the op is idempotent). Optional hardening.

Closes #5