### PR TITLE
fix(ui): error-banner "Open settings" only when Settings can fix it

### DIFF
--- a/extension/sidepanel/components/chat-view.js
+++ b/extension/sidepanel/components/chat-view.js
@@ -11,6 +11,7 @@ import m from '/vendor/mithril/mithril.js';
 import { LINUX_PATH, HTML5_PATH } from '/vendor/simple-icons/brand-paths.js';
 import { manifestLabel } from '/peerd-runtime/index.js';
 import { openOptions } from '/shared/open-options.js';
+import { mapError, errorSettingsTarget } from '../error-display.js';
 import { MessageList } from './message-list.js';
 import { InputBar } from './input-bar.js';
 import { ModeSelector, EffortDial } from './mode-badge.js';
@@ -57,11 +58,17 @@ export const ChatView = {
       // state push).
       state.lastError ? m('.error-banner', [
         m('span', mapError(state.lastError)),
-        m('button.secondary', {
-          // why 'providers': chat errors are overwhelmingly key/model
-          // problems — land the user on the page that fixes them.
-          onclick: () => openOptions('providers'),
-        }, 'Open settings'),
+        // why conditional: only offer "Open settings" when Settings can
+        // actually fix it (key/auth → providers, spend limit → costs). A
+        // 429/529 throttle, a network blip, or an external billing cap aren't
+        // fixable here, so the banner shows the guidance copy alone instead of
+        // misdirecting the user into a page that can't help (errorSettingsTarget).
+        (() => {
+          const target = errorSettingsTarget(state.lastError);
+          return target
+            ? m('button.secondary', { onclick: () => openOptions(target.section) }, 'Open settings')
+            : null;
+        })(),
       ]) : null,
 
       // Rate-limit retry indicator. Without this the retry is a blank
@@ -455,48 +462,7 @@ const EmptyState = {
   ])),
 };
 
-// Map an error code OR a raw provider message into a clear, human line.
-// why: errors reach here two ways — the SW's typed mapping ("provider-
-// http-429") AND the loop's raw throw message ("Provider 'anthropic' HTTP
-// 429: {…}"). The old version only matched the codes, so a real
-// rate-limit / account-limit surfaced as a raw JSON dump (or, mid-retry,
-// nothing). Match both, and name the likely cause + the fix.
-/** @param {unknown} e */
-const mapError = (e) => {
-  if (typeof e !== 'string' || e.length === 0) return 'Something went wrong.';
-  if (e === 'provider-key-missing') return 'No API key yet — add one in Settings.';
-  if (e === 'unknown-provider') return 'No provider registered yet.';
-  if (e === 'session-not-found') return 'Session was reset mid-turn.';
-  if (e === 'spend-limit-reached') return 'Spend limit reached — the agent was halted. Raise the limit in Settings to continue.';
-
-  // Hard account limit (out of credit / over a spend or usage cap). The SW's
-  // typed mapping emits `provider-usage-limit[:detail]`; the loop's raw throw
-  // is the self-explanatory ProviderUsageLimitError message — both land here.
-  if (e.startsWith('provider-usage-limit')) {
-    const detail = e.slice('provider-usage-limit'.length).replace(/^[:\s]+/, '').trim();
-    const suffix = detail ? ` (${detail})` : '';
-    return `Usage/credit limit reached — your provider account is out of credit or over a spend/usage cap. Check your Anthropic / OpenRouter billing & limits, then retry.${suffix}`;
-  }
-
-  const s = e.toLowerCase();
-  /** @param {...string} needles */
-  const has = (...needles) => needles.some((n) => s.includes(n));
-
-  if (e.startsWith('provider-http-401') || has('http 401', 'authentication_error', 'invalid x-api-key')) {
-    return 'API key rejected (401). Check or update it in Settings.';
-  }
-  // Account/credit/quota limits often arrive as 400/403 with a message,
-  // not 429 — catch them by content before the generic HTTP fallback.
-  if (has('credit balance', 'billing', 'quota', 'insufficient_quota', 'usage limit', 'plan limit')) {
-    return 'Provider account limit — out of credit or over a usage cap. Check your Anthropic / OpenRouter billing, then retry.';
-  }
-  if (e.startsWith('provider-http-429') || has('http 429', 'rate_limit', 'rate limit')) {
-    return 'Rate limited (429) — your provider is throttling, or your account hit a usage/credit limit. Wait a moment and retry; if it persists, check your provider account.';
-  }
-  if (e.startsWith('provider-http-529') || has('http 529', 'overloaded')) {
-    return 'Provider overloaded — try again in a moment.';
-  }
-  if (e.startsWith('provider-http-')) return `Provider returned an error (${e.slice('provider-http-'.length)}).`;
-  if (has('http 4', 'http 5')) return `Provider error — ${e}`;
-  return e;
-};
+// mapError + errorSettingsTarget moved to ../error-display.js (pure, Bun-tested)
+// — a component should hold no business logic, and that mapping is worth a
+// test of its own (it matches both the SW's typed codes and the loop's raw
+// throw text).

--- a/extension/sidepanel/error-display.js
+++ b/extension/sidepanel/error-display.js
@@ -1,0 +1,84 @@
+// @ts-check
+// Error display — the PURE mapping of an error code / raw provider message
+// to (a) a human-readable line and (b) which Settings section, if any, can
+// actually remedy it.
+//
+// why a standalone module (not inline in chat-view): a component must hold
+// no business logic, and this mapping is load-bearing + worth testing on its
+// own. Errors reach the UI two ways — the SW's typed codes ("provider-http-
+// 429") AND the loop's raw throw text ("Provider 'anthropic' HTTP 429: {…}")
+// — so the matcher has to handle both, which is exactly the kind of thing
+// that rots silently without a test.
+
+/**
+ * Map an error code OR a raw provider message into a clear, human line.
+ *
+ * @param {unknown} e
+ * @returns {string}
+ */
+export const mapError = (e) => {
+  if (typeof e !== 'string' || e.length === 0) return 'Something went wrong.';
+  if (e === 'provider-key-missing') return 'No API key yet — add one in Settings.';
+  if (e === 'unknown-provider') return 'No provider registered yet.';
+  if (e === 'session-not-found') return 'Session was reset mid-turn.';
+  if (e === 'spend-limit-reached') return 'Spend limit reached — the agent was halted. Raise the limit in Settings to continue.';
+
+  // Hard account limit (out of credit / over a spend or usage cap). The SW's
+  // typed mapping emits `provider-usage-limit[:detail]`; the loop's raw throw
+  // is the self-explanatory ProviderUsageLimitError message — both land here.
+  if (e.startsWith('provider-usage-limit')) {
+    const detail = e.slice('provider-usage-limit'.length).replace(/^[:\s]+/, '').trim();
+    const suffix = detail ? ` (${detail})` : '';
+    return `Usage/credit limit reached — your provider account is out of credit or over a spend/usage cap. Check your Anthropic / OpenRouter billing & limits, then retry.${suffix}`;
+  }
+
+  const s = e.toLowerCase();
+  /** @param {...string} needles */
+  const has = (...needles) => needles.some((n) => s.includes(n));
+
+  if (e.startsWith('provider-http-401') || has('http 401', 'authentication_error', 'invalid x-api-key')) {
+    return 'API key rejected (401). Check or update it in Settings.';
+  }
+  // Account/credit/quota limits often arrive as 400/403 with a message,
+  // not 429 — catch them by content before the generic HTTP fallback.
+  if (has('credit balance', 'billing', 'quota', 'insufficient_quota', 'usage limit', 'plan limit')) {
+    return 'Provider account limit — out of credit or over a usage cap. Check your Anthropic / OpenRouter billing, then retry.';
+  }
+  if (e.startsWith('provider-http-429') || has('http 429', 'rate_limit', 'rate limit')) {
+    return 'Rate limited (429) — your provider is throttling, or your account hit a usage/credit limit. Wait a moment and retry; if it persists, check your provider account.';
+  }
+  if (e.startsWith('provider-http-529') || has('http 529', 'overloaded')) {
+    return 'Provider overloaded — try again in a moment.';
+  }
+  if (e.startsWith('provider-http-')) return `Provider returned an error (${e.slice('provider-http-'.length)}).`;
+  if (has('http 4', 'http 5')) return `Provider error — ${e}`;
+  return e;
+};
+
+/**
+ * Which Settings section, if any, can actually fix this error.
+ *
+ * why this gate: the banner used to offer "Open settings" for EVERY error,
+ * which misdirects on the most common ones — a 429/529 throttle, a network
+ * blip, or an external billing cap aren't fixable in peerd's Settings, so
+ * sending the user there is a dead end. Only key/auth/config (→ providers)
+ * and the spend limit (→ costs) live in Settings; for everything else the
+ * banner shows the guidance copy alone (mapError already says "wait and
+ * retry" / "check your provider billing").
+ *
+ * @param {unknown} e
+ * @returns {{ section: string } | null}  null = no in-app remedy
+ */
+export const errorSettingsTarget = (e) => {
+  if (typeof e !== 'string' || e.length === 0) return null;
+  if (e === 'provider-key-missing' || e === 'unknown-provider') return { section: 'providers' };
+  if (e === 'spend-limit-reached') return { section: 'costs' };
+  const s = e.toLowerCase();
+  if (e.startsWith('provider-http-401')
+      || s.includes('http 401') || s.includes('authentication_error') || s.includes('invalid x-api-key')) {
+    return { section: 'providers' };
+  }
+  // Transient (429/529/overloaded/network), external billing/usage caps, and
+  // generic provider errors: no Settings page fixes them.
+  return null;
+};

--- a/tests/sidepanel/error-display.test.ts
+++ b/tests/sidepanel/error-display.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect } from 'bun:test';
+import { mapError, errorSettingsTarget } from '../../extension/sidepanel/error-display.js';
+
+// The error banner reads BOTH the SW's typed codes ("provider-http-429") and
+// the loop's raw throw text ("Provider 'anthropic' HTTP 429: {…}"). mapError
+// turns either into human copy; errorSettingsTarget decides whether the
+// "Open settings" button is even useful (the bug: it used to show for every
+// error, misdirecting on transient/billing faults Settings can't fix).
+
+describe('mapError', () => {
+  test('non-string / empty → generic', () => {
+    expect(mapError(null)).toBe('Something went wrong.');
+    expect(mapError('')).toBe('Something went wrong.');
+  });
+
+  test('typed codes', () => {
+    expect(mapError('provider-key-missing')).toMatch(/add one in Settings/i);
+    expect(mapError('spend-limit-reached')).toMatch(/Spend limit reached/i);
+    expect(mapError('provider-usage-limit')).toMatch(/Usage\/credit limit/i);
+    expect(mapError('provider-usage-limit:over cap')).toMatch(/\(over cap\)/);
+  });
+
+  test('raw provider throw text is matched, not dumped', () => {
+    expect(mapError("Provider 'anthropic' HTTP 429: {...}")).toMatch(/Rate limited/i);
+    expect(mapError('Provider HTTP 529: overloaded')).toMatch(/overloaded/i);
+    expect(mapError('authentication_error: invalid x-api-key')).toMatch(/key rejected/i);
+    expect(mapError('Your credit balance is too low')).toMatch(/account limit/i);
+  });
+});
+
+describe('errorSettingsTarget — only when Settings can fix it', () => {
+  test('key/auth/config → providers', () => {
+    expect(errorSettingsTarget('provider-key-missing')).toEqual({ section: 'providers' });
+    expect(errorSettingsTarget('unknown-provider')).toEqual({ section: 'providers' });
+    expect(errorSettingsTarget('provider-http-401')).toEqual({ section: 'providers' });
+    expect(errorSettingsTarget("Provider 'anthropic' HTTP 401: authentication_error")).toEqual({ section: 'providers' });
+  });
+
+  test('spend limit → costs (where the setting lives)', () => {
+    expect(errorSettingsTarget('spend-limit-reached')).toEqual({ section: 'costs' });
+  });
+
+  test('transient / external faults → null (no in-app remedy, no misdirection)', () => {
+    expect(errorSettingsTarget('provider-http-429')).toBeNull();
+    expect(errorSettingsTarget('provider-http-529')).toBeNull();
+    expect(errorSettingsTarget("Provider 'anthropic' HTTP 429: rate_limit")).toBeNull();
+    expect(errorSettingsTarget('provider-usage-limit')).toBeNull();
+    expect(errorSettingsTarget('Your credit balance is too low')).toBeNull();
+    expect(errorSettingsTarget('session-not-found')).toBeNull();
+    expect(errorSettingsTarget('')).toBeNull();
+    expect(errorSettingsTarget(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
## #8 - error banner always offers "Open settings"
The chat error banner offered "Open settings" for **every** error, but the common ones aren't fixable there: a 429/529 throttle, a network blip, or an external billing cap sent the user to a providers page that can't help. The action now routes by category: key/auth -> providers, spend-limit -> costs (where the setting actually lives), transient/billing/generic -> no button (the copy already says "wait and retry" / "check your provider billing").

Extracted `mapError` + the new `errorSettingsTarget` into a pure `sidepanel/error-display.js` (a component should hold no business logic).

## Tests / coverage (disclosed honestly)
- `error-display.test.ts` (new): pins the providers/costs/null routing - revert-proven (re-introducing "always providers" fails the transient->null cases, 6->5).
- Full bun suite 2056 pass; typecheck; lint.
- **Gap:** the chat-view banner IIFE that *consumes* the decision is untested (the decision logic itself is). A thin in-browser ChatView test is the follow-up.

Closes #8