### PR TITLE
fix(runtime): re-check abort between stream end and tool dispatch

### DIFF
--- a/extension/peerd-runtime/cost/DEV-NOTES.md
+++ b/extension/peerd-runtime/cost/DEV-NOTES.md
@@ -53,8 +53,15 @@ lifetime spend/usage for the conversation. Absent on pre-feature sessions;
 The halt reuses `activeAbortController` in `runAgentTurn` — the same controller
 the Stop button (`agent/stop`) and steer-live mid-turn send use. On
 `limitExceeded(sessionTally.cost, limitUsd)` the SW calls
-`abortController.abort()`; the agent loop's existing AbortError branch persists
-the partial message and yields `stopReason:'aborted'`. No new cancellation path.
+`abortController.abort()`. The agent loop catches it at TWO points, both
+persisting the partial message as `stopReason:'aborted'`: the mid-stream
+AbortError branch (abort while the stream is still open) AND an explicit
+pre-dispatch check after the stream ends, before the tool-dispatch waves. The
+pre-dispatch check is load-bearing for the SPEND limit specifically: adapters
+emit `usage` (where the limit fires) one event before `message-stop`, so the
+abort lands in the stream-end→dispatch gap — which the AbortError branch alone
+would miss, running the already-emitted `tool_use` blocks before the next
+loop-top check caught it.
 
 The side panel surfaces it via `turn/spend-limit-reached` → `cost.limitReached`
 → the meter's halt banner + a `spend-limit-reached` entry in the error mapper.

--- a/extension/peerd-runtime/loop/agent-loop.js
+++ b/extension/peerd-runtime/loop/agent-loop.js
@@ -669,6 +669,28 @@ export async function* runUserTurn(ctx) {
       return;
     }
 
+    // Re-check abort AFTER the stream ended, BEFORE any side-effecting dispatch.
+    // why: a hard spend-limit halt / Stop / steer can abort() in the GAP between
+    // the stream finishing and dispatch — the limit's abort() rides the `usage`
+    // event, which adapters emit one event BEFORE `message-stop`, so the
+    // for-await ends normally and the mid-stream AbortError branch (:563) never
+    // sees it. Without this guard the loop would run every already-emitted
+    // tool_use this step (writes / call_api / vm / edit / app side effects) and
+    // persist their results before the next loop-top check (:303) finally
+    // catches the abort. Mark the turn aborted — so detectInterruptedTurn treats
+    // it as a deliberate stop, NOT a resumable tools-pending interruption — and
+    // short-circuit before the dispatch waves.
+    if (wasAborted()) {
+      await sessions.updateAssistantMessage(sessionId, assistantStub.id, {
+        stopReason: 'aborted',
+      });
+      yield {
+        type: 'stop', sessionId,
+        messageId: assistantStub.id, stopReason: 'aborted',
+      };
+      return;
+    }
+
     // ---- Dispatch tool calls --------------------------------------------
     // Dispatch ONE call and build its persisted result block. Never throws
     // — a failure (including a thrown dispatcher) becomes an error result,

--- a/extension/tests/unit/peerd-runtime/agent-loop.test.js
+++ b/extension/tests/unit/peerd-runtime/agent-loop.test.js
@@ -329,6 +329,53 @@ describe('agent loop — runUserTurn', () => {
       expect(resultMsg.toolResults[0].content.includes('denylist')).toBe(true);
     });
 
+    it('aborts in the stream-end → dispatch gap WITHOUT running the pending tools', async () => {
+      // The hard spend-limit halt (and Stop / steer) abort() the controller as
+      // the stream ends: adapters emit `usage` — where the limit check rides —
+      // one event BEFORE `message-stop`, so the for-await ends normally and the
+      // mid-stream AbortError branch never fires. The loop must re-check abort
+      // before dispatch, or it runs every already-emitted tool_use anyway.
+      const controller = new AbortController();
+      const callModel = () => (async function* () {
+        yield { type: 'text-delta', text: 'working' };
+        yield { type: 'tool-use-start', id: 't_A', name: 'inspect_storage' };
+        yield { type: 'tool-use-delta', id: 't_A', partialJson: '{}' };
+        yield { type: 'tool-use-stop', id: 't_A' };
+        controller.abort();                 // limit / Stop lands here, pre message-stop
+        yield { type: 'message-stop', stopReason: 'tool_use' };
+      })();
+      const { sessions, ctx } = buildCtx({ callModel, signal: controller.signal });
+      /** @type {any[]} */
+      const dispatched = [];
+      ctx.tools = [{ name: 'inspect_storage', description: '', schema: {} }];
+      ctx.toolDispatch = async (/** @type {any} */ call) => {
+        dispatched.push(call);
+        return { ok: true, content: 'should not run',
+          meta: { toolName: call.name, primitive: 'inspect', gates: [], durationMs: 0 } };
+      };
+      const session = await sessions.create();
+      ctx.sessionId = session.sessionId;
+
+      const events = await drain(runUserTurn(asRunCtx(ctx)));
+
+      // The pending tool_use never ran — no side effect, no tool-result event.
+      expect(dispatched.length).toBe(0);
+      expect(events.some((e) => e.type === 'tool-result')).toBe(false);
+
+      const stored = present(await sessions.get(session.sessionId));
+      // No tool_result message was appended (user -> assistant only).
+      expect(stored.messages.some((m) =>
+        m.role === 'user' && Array.isArray(msg(m).toolResults))).toBe(false);
+      // The turn is marked aborted — so detectInterruptedTurn treats it as a
+      // deliberate stop, NOT a resumable tools-pending interruption.
+      const assistant = msg(stored.messages.find((m) => m.role === 'assistant'));
+      expect(assistant.stopReason).toBe('aborted');
+      expect(Array.isArray(assistant.toolUses)).toBe(true); // the tool_use is still recorded
+      // The final stop reports aborted.
+      const stops = events.filter((e) => e.type === 'stop');
+      expect(asEv(stops[stops.length - 1]).stopReason).toBe('aborted');
+    });
+
     it('runs consecutive READ-class calls concurrently when a classifier is injected', async () => {
       // Two reads in one turn + ctx.classifyToolCall → both dispatches must
       // be in flight together, results persist in EMITTED order even though


### PR DESCRIPTION
## #4 - abort not checked between stream end and tool dispatch
`runUserTurn` only consulted the abort signal at the loop top and inside the mid-stream AbortError branch. An abort firing as the stream finished (the hard spend-limit's `abort()` rides the `usage` event, one before `message-stop`) landed in the gap and was ignored until the next iteration - so the loop dispatched every already-emitted `tool_use` (writes / call_api / vm / edit) and persisted results first. This made the "hard" spend limit soft for the round already requested; a Stop / steer in the same gap behaved likewise.

Re-check `wasAborted()` after the stream ends, before the dispatch waves: mark the turn `stopReason:'aborted'` (so `detectInterruptedTurn` treats it as a deliberate stop, not a resumable tools-pending interruption) and short-circuit before any side effect.

## Tests
- First abort/dispatch test in `agent-loop.test.js` - revert-proven: removing the guard fails it (in-browser 596->595/1, AssertionError on this test). Restored -> 596/0.
- Full bun suite 2050 pass; typecheck; lint.
- Corrected the now-stale `cost/DEV-NOTES.md` claim that the existing AbortError branch already absorbed the halt.
- Follow-ups (non-blocking): a benign double `stop` event (last-write-wins); a mid-wave abort window still unguarded (narrower than the one closed); an aborted-in-gap turn shows a cosmetic stuck "running..." card (the retained `toolUses` are deliberate, for orphan-repair).

Closes #4