### PR TITLE
feat(dweb): user kill switch to shut down all dweb networking

### DIFF
--- a/extension/background/routes/dweb.js
+++ b/extension/background/routes/dweb.js
@@ -201,6 +201,22 @@ export const makeDwebRoutes = (deps) => {
       await ensureOffscreen();
       return browser.runtime.sendMessage({ type: 'dweb/base-host/start' });
     },
+    // The master OFF — the user-facing kill switch, symmetric to start
+    // (docs/specs/FEATURE-FIRST-CLASS-MESSAGING.md §2). Persist the preference
+    // FIRST so it won't auto-restart on the next unlock (maybeStartBaseNetwork
+    // gates on dwebEnabled), then tear down a live host. NOT gated on dwebOn():
+    // we must be able to stop precisely as we flip the setting off. Gated only on
+    // DWEB_ENABLED — the store package prunes this module entirely.
+    'dweb/base/stop': async () => {
+      if (!DWEB_ENABLED) return { ok: false, error: 'dweb-disabled' };
+      await settingsStore.update({ dwebEnabled: false });
+      // Never SPAWN the offscreen just to stop it: if it isn't up, there is no
+      // live network to tear down. The offscreen stop handler closes every room,
+      // drops the mesh + lobby, and clears the re-sub timer (dweb-base.js).
+      const contexts = await browser.runtime.getContexts({ contextTypes: /** @type {any} */ (['OFFSCREEN_DOCUMENT']) });
+      if (contexts.length) await browser.runtime.sendMessage({ type: 'dweb/base-host/stop' });
+      return { ok: true, running: false };
+    },
     'dweb/base/status': async () => {
       if (!dwebOn()) return { ok: false, error: 'dweb-disabled' };
       await ensureOffscreen();

--- a/extension/home/network-section.js
+++ b/extension/home/network-section.js
@@ -381,6 +381,7 @@ export const NetworkSection = () => {
   /** @type {string | null} */
   let error = null;
   let starting = false;
+  let stopping = false;
   /** @type {ReturnType<typeof setInterval> | number} */
   let timer = 0;
   let dead = false;      // set on unmount — an in-flight poll must not redraw
@@ -403,6 +404,17 @@ export const NetworkSection = () => {
     starting = true; if (!dead) m.redraw();
     try { await send({ type: 'dweb/base/start' }); } catch (e) { error = /** @type {{ message?: string }} */ (e)?.message || String(e); }
     starting = false;
+    await refresh(send);
+  };
+
+  /** The kill switch: shut down ALL dweb networking + persist it off. @param {Send} send */
+  const stop = async (send) => {
+    // Destructive — drops every live connection — so confirm before the kill.
+    if (typeof confirm === 'function'
+      && !confirm('Shut down all peer-to-peer networking? This drops every live connection and keeps it off (it won’t come back on unlock) until you start it again.')) return;
+    stopping = true; if (!dead) m.redraw();
+    try { await send({ type: 'dweb/base/stop' }); } catch (e) { error = /** @type {{ message?: string }} */ (e)?.message || String(e); }
+    stopping = false;
     await refresh(send);
   };
 
@@ -460,6 +472,14 @@ export const NetworkSection = () => {
               m('span.peerd-net-path', { class: `peerd-net-path--${pi.kind}` }, pi.label),
             ]);
           })),
+        // Kill switch — symmetric to "Start the network" in the offline view.
+        // Drops every live connection and persists dweb off (won't auto-restart
+        // on unlock) — docs/specs/FEATURE-FIRST-CLASS-MESSAGING.md §2.
+        m('button.peerd-net-btn', {
+          disabled: stopping,
+          style: 'margin-top:10px; font-size:12px; opacity:.75;',
+          onclick: () => stop(send),
+        }, stopping ? 'Stopping…' : 'Stop the network'),
       ]);
     },
   };


### PR DESCRIPTION
Implements the network kill switch from `docs/specs/FEATURE-FIRST-CLASS-MESSAGING.md` §2 — turning the dweb on is a deliberate user action, so shutting it down must be one too.

## What
- **New `dweb/base/stop` SW route** (`background/routes/dweb.js`) — symmetric to `dweb/base/start`:
  - Persists `dwebEnabled = false` first, so it **won't auto-restart on the next unlock** (`maybeStartBaseNetwork` already gates on the setting, `service-worker.js:2639`).
  - Tears down a live host via the existing **complete** offscreen teardown (`dweb/base-host/stop`, `offscreen/dweb-base.js:388-397`: closes every room, drops the mesh + lobby, clears the re-sub timer).
  - Never spawns the offscreen just to stop it (checks `getContexts` first).
  - Gated on `DWEB_ENABLED` only (not `dwebOn()`) so it can stop precisely as it flips the setting off.
- **"Stop the network" control** in the home Network section (`home/network-section.js`), confirm-gated since it drops live connections.

Net effect: one user action turns **all** dweb networking off and keeps it off until they start it again — also the master fail-closed for the §7 unattended messaging surface once that lands.

## Scope
The offscreen-side teardown already existed and is complete; this PR wires it to a user-reachable route + UI. The inbound-monitor teardown referenced in spec §2 is N/A until those monitors exist (workstream B).

## Verification
`bun run lint` and `bun run typecheck` clean. (Extension UI/SW — not dev-server-previewable; reload the unpacked extension to exercise.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)