### PR TITLE
ci: tighten two-peer connect budget 60s → 30s (fail fast, retry handles it)

### DIFF
--- a/scripts/cdp/run-dweb-twopeer.mjs
+++ b/scripts/cdp/run-dweb-twopeer.mjs
@@ -33,9 +33,11 @@ const CHROME = process.env.CHROME_PATH || process.env.CHROME
       '/Applications/Chromium.app/Contents/MacOS/Chromium'].find(existsSync)
   || ['chrome', 'google-chrome', 'google-chrome-stable', 'chromium', 'chromium-browser'].map(onPath).find(Boolean);
 
-// ICE on the loopback is near-instant, but two contexts spinning up + the
-// rendezvous + a couple gossip rounds want headroom on a slow CI runner.
-const RESULT_BUDGET_MS = 60_000;
+// A healthy loopback connect is ~1-2s; two contexts spinning up + the rendezvous
+// + a couple gossip rounds still finish well inside 30s. If the peers haven't
+// paired by then it's a hard transient, not slowness — so fail fast and let the
+// CI retry re-run it (a longer budget only burns wall-clock before the retry).
+const RESULT_BUDGET_MS = 30_000;
 const POLL_INTERVAL_MS = 500;
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 


### PR DESCRIPTION
Follow-up to the retry work. The two-peer harness already uses the optimal WebRTC config (no-STUN loopback + mDNS disabled), so a healthy connect is ~1–2s. The flake we saw was **never-connected** (`linked:0`), not slow — so waiting the full 60s before failing just burns wall-clock before the per-job retry re-runs it.

**Change:** `RESULT_BUDGET_MS` 60s → 30s. Still ample headroom for context spin-up + rendezvous + a couple gossip rounds on a healthy run; on a hard transient it fails fast and the retry (up to 3×) kicks in sooner.

This PR's own `dweb two-peer` run is the proof — if it greens, 30s is plenty for a healthy connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)