### PR TITLE
Surface-aware starter grid: 3×2 on home, page-aware Browse in the panel

### DIFF
--- a/extension/sidepanel/components/app.js
+++ b/extension/sidepanel/components/app.js
@@ -24,10 +24,11 @@ export const App = {
    * @param {{ attrs: {
    *   state: ChatState, send: Send, voiceManager: any,
    *   uiActions: UiActions, view: string, optionsActive: boolean,
+   *   activeTabIsWeb?: boolean,
    * } }} vnode
    */
   view: ({ attrs }) => {
-    const { state, send, voiceManager, uiActions, view, optionsActive } = attrs;
+    const { state, send, voiceManager, uiActions, view, optionsActive, activeTabIsWeb } = attrs;
     const unlocked = state.vault.initialized && !state.vault.locked;
     // First-run onboarding ('onboarding' is what the sidepanel.js route
     // gate resolves EVERY route to until the profile's latch flips). It
@@ -62,7 +63,7 @@ export const App = {
       m('.body', unlocked
         ? [
             onboarding        ? m(OnboardingView, { state, send })
-            : view === 'chat'   ? m(ChatView, { state, send, voiceManager, uiActions, surface: 'sidepanel' })
+            : view === 'chat'   ? m(ChatView, { state, send, voiceManager, uiActions, surface: 'sidepanel', activeTabIsWeb })
             : view === 'chats'  ? m(SessionsView, { state, send })
             : m(PlaceholderView, { label: 'Unknown view' }),
           ]

--- a/extension/sidepanel/components/chat-view.js
+++ b/extension/sidepanel/components/chat-view.js
@@ -25,9 +25,10 @@ export const ChatView = {
   /**
    * @param {{ attrs: {
    *   state: ChatState, send: Send, voiceManager: any, uiActions?: UiActions,
+   *   surface?: string, activeTabIsWeb?: boolean,
    * } }} vnode
    */
-  view: ({ attrs: { state, send, voiceManager, uiActions } }) => {
+  view: ({ attrs: { state, send, voiceManager, uiActions, surface, activeTabIsWeb } }) => {
     const messages = state.session?.messages ?? [];
     const hasKey = state.providers?.hasKey;
     // Fingerprint of the settings that shape the model-picker options. The
@@ -88,7 +89,7 @@ export const ChatView = {
 
       showVoiceOnboarding ? m(VoiceOnboardingCard, { send }) : null,
 
-      messages.length === 0 ? m(EmptyState, { hasKey, send })
+      messages.length === 0 ? m(EmptyState, { hasKey, send, surface, activeTabIsWeb })
         : m(MessageList, {
             messages,
             vmStreams: state.vmStreams,
@@ -284,6 +285,19 @@ const STARTER_PROMPTS = [
   { type: 'app', label: 'App', text: 'Build me a Mandelbrot set explorer I can zoom and pan.' },
 ];
 
+// The starter set is page-aware in the SIDE PANEL: when the panel sits next to
+// a real web page (an http(s) tab, not peerd's own home/options page), the
+// Browse path offers to summarize THAT page — the thing you're looking at —
+// instead of the generic Hacker News demo. On the home full-tab surface (no
+// "page next to you") it always shows the Hacker News prompt. Kept a pure fn of
+// attrs so armReveal + view agree on the exact text they animate/render.
+/** @param {{ surface?: string, activeTabIsWeb?: boolean }} attrs */
+const promptsFor = (attrs) => (attrs.surface !== 'home' && attrs.activeTabIsWeb
+  ? STARTER_PROMPTS.map((p) => (p.type === 'web'
+      ? { ...p, label: 'Summarize', text: 'Summarize the current page.' }
+      : p))
+  : STARTER_PROMPTS);
+
 // Action-type glyphs for the path cards. Two voices, both monochrome
 // (currentColor): conceptual paths (ask / web) are stroked LINE icons in
 // the same voice as the composer's send/clip glyphs; the three engine
@@ -361,7 +375,7 @@ export const PATH_TYPE = { ms: 18, start: 980, cascade: 90 };
  * @property {boolean[]} started
  */
 
-/** @typedef {{ state: EmptyState_State, attrs: { hasKey?: boolean, send: Send } }} EmptyStateVnode */
+/** @typedef {{ state: EmptyState_State, attrs: { hasKey?: boolean, send: Send, surface?: string, activeTabIsWeb?: boolean } }} EmptyStateVnode */
 
 // Arm the one-shot type-in (step 3) for every card. Idempotent via
 // `ui.armed`, so the redraw-driven onupdate can't re-trigger it; only runs
@@ -371,11 +385,15 @@ const armReveal = (vnode) => {
   const ui = vnode.state;
   if (ui.armed || reducedMotion() || !vnode.attrs.hasKey) return;
   ui.armed = true;
-  STARTER_PROMPTS.forEach((p, i) => {
+  promptsFor(vnode.attrs).forEach((p, i) => {
     const text = p.text;
     const tick = () => {
       ui.shown[i] += 1;
       if (ui.shown[i] < text.length) ui.timers.push(setTimeout(tick, PATH_TYPE.ms));
+      // why Infinity (not text.length): once a card has settled, render its
+      // FULL text even if the prompt later swaps (a side-panel tab switch can
+      // change the Browse prompt) — a shorter `shown` would truncate it.
+      else ui.shown[i] = Infinity;
       m.redraw();
     };
     // why the started flip: the cursor must not show until THIS tile's
@@ -417,13 +435,20 @@ const EmptyState = {
     vnode.state.timers.forEach((t) => clearTimeout(t));
   },
   /** @param {EmptyStateVnode} vnode */
-  view: ({ attrs: { hasKey, send }, state: ui }) => m('.placeholder', m('.empty-state', [
+  view: ({ attrs, state: ui }) => {
+    const { hasKey, send } = attrs;
+    // The home full-tab surface has room for a wider 3-across grid; the side
+    // panel stays 2-across (its column is narrow). One flag drives both the
+    // wider container and the 3-column track (CSS owns the actual widths).
+    const isHome = attrs.surface === 'home';
+    const prompts = promptsFor(attrs);
+    return m('.placeholder', m('.empty-state', { class: isHome ? 'empty-state--home' : '' }, [
     m('p', 'peerd is ready.'),
     m('p.muted', hasKey
       ? 'Ask anything — or pick a path:'
       : 'Add your Anthropic or OpenRouter API key in Settings to start chatting.'),
     hasKey
-      ? m('.path-menu', STARTER_PROMPTS.map((p, i) => {
+      ? m('.path-menu', { class: isHome ? 'path-menu--home' : '' }, prompts.map((p, i) => {
           const shown = ui.shown?.[i] ?? Infinity;
           const done = shown >= p.text.length;
           // cursor shows only once this tile has STARTED typing and isn't done
@@ -452,7 +477,8 @@ const EmptyState = {
           ]);
         }))
       : m('button', { onclick: () => openOptions('providers') }, 'Open settings'),
-  ])),
+    ]));
+  },
 };
 
 // Map an error code OR a raw provider message into a clear, human line.

--- a/extension/sidepanel/sidepanel.js
+++ b/extension/sidepanel/sidepanel.js
@@ -264,14 +264,23 @@ const FULLPAGE_URLS = (() => {
   } catch { return []; }
 })();
 let optionsActive = false;
+// Is the tab next to the panel a real, summarizable web page (an http(s) page,
+// not peerd's own home/options tab, a chrome:// page, or the new-tab page)? The
+// fresh-chat "Browse" starter uses this to offer "summarize the current page"
+// over the generic Hacker News demo — same active-tab read, so it rides the
+// same listeners below.
+let activeTabIsWeb = false;
 const refreshOptionsActive = async () => {
   if (!FULLPAGE_URLS.length || !browser.tabs?.query) return;
   try {
     const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
     const url = tab?.url;
     const next = !!(url && FULLPAGE_URLS.some((u) => url.startsWith(u)));
-    if (next !== optionsActive) { optionsActive = next; m.redraw(); }
-  } catch { /* leave optionsActive as-is — fail-safe keeps the logo present */ }
+    const nextWeb = !!(url && /^https?:\/\//i.test(url));
+    if (next !== optionsActive || nextWeb !== activeTabIsWeb) {
+      optionsActive = next; activeTabIsWeb = nextWeb; m.redraw();
+    }
+  } catch { /* leave state as-is — fail-safe keeps the logo present */ }
 };
 if (browser.tabs?.onActivated) {
   browser.tabs.onActivated.addListener(refreshOptionsActive);
@@ -284,7 +293,7 @@ if (browser.tabs?.onActivated) {
 }
 
 /** @param {string} view */
-const routeArgs = (view) => ({ state: currentState, send, voiceManager, uiActions, view, optionsActive });
+const routeArgs = (view) => ({ state: currentState, send, voiceManager, uiActions, view, optionsActive, activeTabIsWeb });
 
 // First-run route gate: after vault setup and before anything else,
 // EVERY route resolves to the onboarding screen until the default

--- a/extension/sidepanel/styles.css
+++ b/extension/sidepanel/styles.css
@@ -2221,6 +2221,9 @@ button.icon:hover { background: var(--bg); }
  * state. The prompts are the menu items for now; later this surface
  * presents recipes / workflows. */
 .empty-state { width: min(100%, 360px); }
+/* Home full-tab surface: the starter grid goes 3-across (vs the panel's
+   2-across), so widen the container to keep the tiles a comfortable size. */
+.empty-state--home { width: min(100%, 560px); }
 
 .path-menu {
   display: grid;
@@ -2229,6 +2232,9 @@ button.icon:hover { background: var(--bg); }
   margin-top: 16px;
   width: 100%;
 }
+/* Home surface: 3 columns (the six prompts read as 3×2) — the panel keeps the
+   narrow 2-column default above (2×3). */
+.path-menu--home { grid-template-columns: repeat(3, 1fr); }
 .path-card {
   --path-accent: var(--accent);   /* per-type override below */
   display: flex;


### PR DESCRIPTION
## What

The fresh-chat **"pick a path" starter grid** was a fixed 2-column layout in every surface. It now adapts to where it's shown, and the Browse prompt reads the page.

### Home: 3 × 2
On the home full-tab surface the six prompts lay out **3 across** (3×2), with a wider container so the tiles stay a comfortable size. Driven by the `surface` attr `ChatView` already receives; CSS owns the actual widths (`.empty-state--home`, `.path-menu--home`).

### Side panel: 2 × 3
The narrow side-panel column keeps the **2-column** default (2×3) — three across is too cramped there.

### Page-aware Browse (panel only)
When the side panel sits next to a **real web page** — an `http(s)` tab, *not* peerd's own home/options page, a `chrome://` page, or the new-tab page — the **Browse** path offers **"Summarize the current page"** instead of the generic *"Open Hacker News…"* demo. It rides the side panel's existing active-tab read (`refreshOptionsActive`), so it updates live as you switch tabs. On home (or when the active tab is a peerd/extension page), the Hacker News prompt stays.

The type-in reveal now settles finished cards to a full render, so a live prompt swap on a tab switch never truncates the text.

## How it's wired
- `sidepanel.js` — `refreshOptionsActive` also computes `activeTabIsWeb` (same active-tab query + listeners it already had); added to `routeArgs`.
- `app.js` → `ChatView` → `EmptyState` — threads `surface` + `activeTabIsWeb` down.
- `chat-view.js` — `promptsFor(attrs)` (pure) swaps the Browse prompt; `surface` adds the home grid modifier.
- `styles.css` — `.empty-state--home` (wider) + `.path-menu--home` (3 cols).

## Files
- `extension/sidepanel/sidepanel.js`
- `extension/sidepanel/components/app.js`
- `extension/sidepanel/components/chat-view.js`
- `extension/sidepanel/styles.css`

## Testing
- `bun run typecheck` ✅
- `eslint extension` ✅
- `bun run check:tscheck` ✅ (475/475) · `bun run check:boundary` ✅
- Existing `ChatView` test (`tools-chip.test.js`) mounts without `surface`/`activeTabIsWeb` — both are optional and default to the panel 2-col / no-swap behavior, so it's unaffected. Couldn't run the CDP/in-browser harness here (Chrome-for-Testing download blocked by the sandbox network policy) — relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012AEgR63CbdB4PKhSG7oHUD

---
_Generated by [Claude Code](https://claude.ai/code/session_012AEgR63CbdB4PKhSG7oHUD)_