### PR TITLE
fix(sw): hydrate settings before boot auto-resume (hardening for #11)

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -2733,7 +2733,14 @@ vault.attemptResume().then((resumed) => {
     // self-gates on the setting, an interrupted-turn verdict, vault state, the
     // not-busy slot, and a per-marker dedupe, so firing here is safe even if a
     // later session-open fires it too.
-    sessionCache.sessionGet('currentSessionId')
+    // why settingsStore.load() first: loadSettings() runs un-awaited at boot, so
+    // the autoResumeInterruptedTurns gate inside maybeAutoResume could read the
+    // channel default (ON) before the user's stored value hydrates — resuming a
+    // user who explicitly DISABLED it, once, in the cold-start window. load() is
+    // idempotent (re-reads kv, recomputes the merged view), so gating on it here
+    // just guarantees the setting is hydrated before the gate consults it.
+    settingsStore.load()
+      .then(() => sessionCache.sessionGet('currentSessionId'))
       .then((/** @type {any} */ cur) => maybeAutoResume(cur)).catch(() => {});
   }
   // why: resume an in-flight Ralph run AFTER the vault is back — a run


### PR DESCRIPTION
Closes the one disclosed gap in #11.

## What
The boot resume chain fired `maybeAutoResume()` without ensuring `settingsStore.load()` had completed. Because `loadSettings()` runs un-awaited at boot, the `autoResumeInterruptedTurns` gate inside `maybeAutoResume` could read the **channel default (ON)** before the user's stored value hydrated — resuming, once, a user who had explicitly **disabled** auto-resume during the cold-start window.

## Fix
Gate the boot resume chain on `settingsStore.load()` first:

```js
settingsStore.load()
  .then(() => sessionCache.sessionGet('currentSessionId'))
  .then((cur) => maybeAutoResume(cur)).catch(() => {});
```

`settingsStore.load()` is idempotent (re-reads kv, recomputes the merged view), so calling it again here simply guarantees the stored setting is hydrated before the gate consults it.

## Why this lands as a follow-up PR into the #11 branch
The session's git proxy only permits pushes to its own working branch, not directly to `fix/resume-frozen-turn` — so merging this small PR is how the one-liner folds into #11. The diff is the single hardening commit on top of #11.

## Gates (verified locally on #11 + this commit merged onto current `main`)
- `bun test ./tests` — **2081 pass / 0 fail**
- `bun run typecheck` (strict) — clean
- `eslint extension` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHffCSYFCRUBQSAWCshR4K)_