### PR TITLE
Add a mode-row Loop toggle to launch the Ralph loop from chat

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -246,7 +246,7 @@ helpers/stubs/vendored deps.
 - **Denylist editor view** — in-panel denylist add/remove with format helpers (user overlay over seed). `extension/sidepanel/components/denylist-view.js`
 - **Hooks view** — in-panel surface for pre/post tool-use hooks state. `extension/sidepanel/components/hooks-view.js`
 - **Ralph loop panel** — renders persistent fresh-context loop state pushed over `ralph/*` events; halt button. `extension/sidepanel/components/ralph-panel.js`
-- **Loop arming toggle** — mode-row pill (beside Plan/Act) that arms the next send to launch a Ralph loop on the draft as its goal, via the existing `/loop` path; the in-chat entry point the loop previously lacked. `extension/sidepanel/components/mode-badge.js` (`LoopToggle`)
+- **Goal toggle** — mode-row pill (beside Plan/Act) that arms the next send to launch a Ralph autonomous goal run on the draft, via the existing `/loop` path; the in-chat entry point the loop previously lacked. `extension/sidepanel/components/mode-badge.js` (`GoalToggle`)
 - **Async subagent status bar** — self-hiding bar pinning in-flight async `spawn_subagent` tasks (DESIGN-11). `extension/sidepanel/components/async-tasks-bar.js`
 - **Injection-safe Markdown renderer** — hand-rolled MD→HTML (no third-party lib) for assistant replies, hardened against untrusted-web-content influence. `extension/shared/markdown.js`
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -246,6 +246,7 @@ helpers/stubs/vendored deps.
 - **Denylist editor view** — in-panel denylist add/remove with format helpers (user overlay over seed). `extension/sidepanel/components/denylist-view.js`
 - **Hooks view** — in-panel surface for pre/post tool-use hooks state. `extension/sidepanel/components/hooks-view.js`
 - **Ralph loop panel** — renders persistent fresh-context loop state pushed over `ralph/*` events; halt button. `extension/sidepanel/components/ralph-panel.js`
+- **Loop arming toggle** — mode-row pill (beside Plan/Act) that arms the next send to launch a Ralph loop on the draft as its goal, via the existing `/loop` path; the in-chat entry point the loop previously lacked. `extension/sidepanel/components/mode-badge.js` (`LoopToggle`)
 - **Async subagent status bar** — self-hiding bar pinning in-flight async `spawn_subagent` tasks (DESIGN-11). `extension/sidepanel/components/async-tasks-bar.js`
 - **Injection-safe Markdown renderer** — hand-rolled MD→HTML (no third-party lib) for assistant replies, hardened against untrusted-web-content influence. `extension/shared/markdown.js`
 

--- a/extension/sidepanel/components/chat-view.js
+++ b/extension/sidepanel/components/chat-view.js
@@ -14,7 +14,7 @@ import { openOptions } from '/shared/open-options.js';
 import { mapError, errorSettingsTarget } from '../error-display.js';
 import { MessageList } from './message-list.js';
 import { InputBar } from './input-bar.js';
-import { ModeSelector, EffortDial } from './mode-badge.js';
+import { ModeSelector, EffortDial, LoopToggle } from './mode-badge.js';
 import { RalphPanel } from './ralph-panel.js';
 import { AsyncTasksBar } from './async-tasks-bar.js';
 
@@ -22,14 +22,35 @@ import { AsyncTasksBar } from './async-tasks-bar.js';
 /** @typedef {(msg: object) => Promise<any>} Send */
 /** @typedef {Record<string, ((...args: any[]) => any) | undefined>} UiActions */
 
+/**
+ * Component-local state for ChatView.
+ * @typedef {Object} ChatViewState
+ * @property {boolean} loopArmed             the loop toggle's arm state (UI-only)
+ * @property {string|null|undefined} _sid    which chat the arm state belongs to
+ */
+
+/**
+ * @typedef {{ state: ChatViewState, attrs: {
+ *   state: ChatState, send: Send, voiceManager: any, uiActions?: UiActions,
+ *   surface?: string, activeTabIsWeb?: boolean,
+ * } }} ChatViewVnode
+ */
+
 export const ChatView = {
-  /**
-   * @param {{ attrs: {
-   *   state: ChatState, send: Send, voiceManager: any, uiActions?: UiActions,
-   *   surface?: string, activeTabIsWeb?: boolean,
-   * } }} vnode
-   */
-  view: ({ attrs: { state, send, voiceManager, uiActions, surface, activeTabIsWeb } }) => {
+  /** @param {ChatViewVnode} vnode */
+  oninit(vnode) {
+    // Loop arming is pure composer intent (it just rewrites the next send
+    // into the existing /loop path), so it lives here as UI-only state —
+    // no SW round-trip. Reset when the chat changes (each chat owns its
+    // own loop), mirroring the InputBar's per-session draft swap.
+    vnode.state.loopArmed = false;
+    vnode.state._sid = vnode.attrs.state?.session?.sessionId;
+  },
+
+  /** @param {ChatViewVnode} vnode */
+  view: ({ attrs: { state, send, voiceManager, uiActions, surface, activeTabIsWeb }, state: ui }) => {
+    const sid = state.session?.sessionId;
+    if (sid !== ui._sid) { ui._sid = sid; ui.loopArmed = false; }
     const messages = state.session?.messages ?? [];
     const hasKey = state.providers?.hasKey;
     // Fingerprint of the settings that shape the model-picker options. The
@@ -135,6 +156,15 @@ export const ChatView = {
             && (state.session?.provider ?? state.providers?.current) === 'anthropic'
           ? m(EffortDial, { settings: state.settings, send })
           : null,
+        // Loop arming — the first in-chat entry point for the Ralph loop
+        // (it was previously reachable only via the hidden `/loop` command).
+        // Arms the NEXT send to launch a loop; the InputBar consumes the arm
+        // and disarms. Greyed until there's a key (the send it arms needs one).
+        m(LoopToggle, {
+          armed: ui.loopArmed,
+          disabled: !hasKey,
+          onToggle: (/** @type {boolean} */ next) => { ui.loopArmed = next; },
+        }),
         m('.spacer'),
         // /system presence chip — the session's custom instructions
         // silently change every turn's system prompt, so their existence
@@ -153,7 +183,11 @@ export const ChatView = {
 
       // (The per-chat usage chip lives inside the InputBar action row,
       // next to the mic/Send buttons — feature 06.)
-      m(InputBar, { state, send, voiceManager }),
+      m(InputBar, {
+        state, send, voiceManager,
+        loopArmed: ui.loopArmed,
+        onLoopSent: () => { ui.loopArmed = false; },
+      }),
     ]);
   },
 };

--- a/extension/sidepanel/components/chat-view.js
+++ b/extension/sidepanel/components/chat-view.js
@@ -14,7 +14,7 @@ import { openOptions } from '/shared/open-options.js';
 import { mapError, errorSettingsTarget } from '../error-display.js';
 import { MessageList } from './message-list.js';
 import { InputBar } from './input-bar.js';
-import { ModeSelector, EffortDial, LoopToggle } from './mode-badge.js';
+import { ModeSelector, EffortDial, GoalToggle } from './mode-badge.js';
 import { RalphPanel } from './ralph-panel.js';
 import { AsyncTasksBar } from './async-tasks-bar.js';
 
@@ -25,7 +25,7 @@ import { AsyncTasksBar } from './async-tasks-bar.js';
 /**
  * Component-local state for ChatView.
  * @typedef {Object} ChatViewState
- * @property {boolean} loopArmed             the loop toggle's arm state (UI-only)
+ * @property {boolean} goalArmed             the Goal toggle's arm state (UI-only)
  * @property {string|null|undefined} _sid    which chat the arm state belongs to
  */
 
@@ -39,18 +39,18 @@ import { AsyncTasksBar } from './async-tasks-bar.js';
 export const ChatView = {
   /** @param {ChatViewVnode} vnode */
   oninit(vnode) {
-    // Loop arming is pure composer intent (it just rewrites the next send
+    // Goal arming is pure composer intent (it just rewrites the next send
     // into the existing /loop path), so it lives here as UI-only state —
     // no SW round-trip. Reset when the chat changes (each chat owns its
     // own loop), mirroring the InputBar's per-session draft swap.
-    vnode.state.loopArmed = false;
+    vnode.state.goalArmed = false;
     vnode.state._sid = vnode.attrs.state?.session?.sessionId;
   },
 
   /** @param {ChatViewVnode} vnode */
   view: ({ attrs: { state, send, voiceManager, uiActions, surface, activeTabIsWeb }, state: ui }) => {
     const sid = state.session?.sessionId;
-    if (sid !== ui._sid) { ui._sid = sid; ui.loopArmed = false; }
+    if (sid !== ui._sid) { ui._sid = sid; ui.goalArmed = false; }
     const messages = state.session?.messages ?? [];
     const hasKey = state.providers?.hasKey;
     // Fingerprint of the settings that shape the model-picker options. The
@@ -156,14 +156,15 @@ export const ChatView = {
             && (state.session?.provider ?? state.providers?.current) === 'anthropic'
           ? m(EffortDial, { settings: state.settings, send })
           : null,
-        // Loop arming — the first in-chat entry point for the Ralph loop
+        // Goal arming — the first in-chat entry point for the Ralph loop
         // (it was previously reachable only via the hidden `/loop` command).
-        // Arms the NEXT send to launch a loop; the InputBar consumes the arm
-        // and disarms. Greyed until there's a key (the send it arms needs one).
-        m(LoopToggle, {
-          armed: ui.loopArmed,
+        // Arms the NEXT send to launch an autonomous goal run; the InputBar
+        // consumes the arm and disarms. Greyed until there's a key (the send
+        // it arms needs one).
+        m(GoalToggle, {
+          armed: ui.goalArmed,
           disabled: !hasKey,
-          onToggle: (/** @type {boolean} */ next) => { ui.loopArmed = next; },
+          onToggle: (/** @type {boolean} */ next) => { ui.goalArmed = next; },
         }),
         m('.spacer'),
         // /system presence chip — the session's custom instructions
@@ -185,8 +186,8 @@ export const ChatView = {
       // next to the mic/Send buttons — feature 06.)
       m(InputBar, {
         state, send, voiceManager,
-        loopArmed: ui.loopArmed,
-        onLoopSent: () => { ui.loopArmed = false; },
+        goalArmed: ui.goalArmed,
+        onGoalSent: () => { ui.goalArmed = false; },
       }),
     ]);
   },

--- a/extension/sidepanel/components/input-bar.js
+++ b/extension/sidepanel/components/input-bar.js
@@ -168,7 +168,7 @@ const saveDraft = (sid, text) => {
  *   state: InputBarState,
  *   attrs: {
  *     state: ChatState, send: Send, voiceManager?: any,
- *     loopArmed?: boolean, onLoopSent?: () => void,
+ *     goalArmed?: boolean, onGoalSent?: () => void,
  *   },
  * }} InputBarVnode
  */
@@ -206,7 +206,7 @@ export const InputBar = {
   },
 
   /** @param {InputBarVnode} vnode */
-  view: ({ attrs: { state, send, voiceManager, loopArmed, onLoopSent }, state: ui }) => {
+  view: ({ attrs: { state, send, voiceManager, goalArmed, onGoalSent }, state: ui }) => {
     const streaming = !!state.streaming;
     const sid = state.session?.sessionId;
     // Switched chats → save the draft we were holding and load the new chat's.
@@ -229,12 +229,12 @@ export const InputBar = {
       const text = ui.value.trim();
       if (!text || ui.busy) return;
 
-      // Loop-armed (mode-row toggle): this send launches a Ralph loop with
-      // the draft as its goal instead of a normal turn. Reuses the SW's
-      // `/loop` path — byte-identical to typing "/loop <goal>" — then
-      // disarms via onLoopSent. Attachments don't apply to a loop goal, so
-      // they stay staged for a later normal send.
-      if (loopArmed) {
+      // Goal-armed (mode-row toggle): this send launches a Ralph goal run
+      // with the draft as its goal instead of a normal turn. Reuses the
+      // SW's `/loop` path — byte-identical to typing "/loop <goal>" — then
+      // disarms via onGoalSent. Attachments don't apply to a goal, so they
+      // stay staged for a later normal send.
+      if (goalArmed) {
         ui.busy = true;
         ui.value = '';
         saveDraft(sid, '');
@@ -244,7 +244,7 @@ export const InputBar = {
         ui.busy = false;
         // Disarm only on a clean launch; on failure restore the draft and
         // stay armed so the user can retry without re-toggling.
-        if (reply?.ok) onLoopSent?.();
+        if (reply?.ok) onGoalSent?.();
         else ui.value = text;
         m.redraw();
         return;
@@ -422,8 +422,8 @@ export const InputBar = {
 
     const placeholder = !hasKey
       ? 'Add an API key in Settings to start.'
-      : loopArmed
-        ? 'Describe a goal to loop on…'
+      : goalArmed
+        ? 'Describe a goal to run autonomously…'
         : streaming
           ? 'Type to steer the current turn…'
           : 'Message peerd…';
@@ -552,10 +552,10 @@ export const InputBar = {
               m('button.send-btn', {
                 type: 'submit',
                 disabled: !hasKey || ui.busy || !ui.value.trim(),
-                'aria-label': loopArmed ? 'Start a loop on this goal'
+                'aria-label': goalArmed ? 'Start an autonomous run on this goal'
                   : streaming ? 'Send and steer the current turn' : 'Send',
-                title: loopArmed
-                  ? 'Start an autonomous loop on this goal (plan → build → repeat)'
+                title: goalArmed
+                  ? 'Start an autonomous run on this goal (plan → build → repeat)'
                   : streaming
                     ? 'Sending will abort the current turn and continue with your new message'
                     : 'Send (⌘/Ctrl + Enter)',

--- a/extension/sidepanel/components/input-bar.js
+++ b/extension/sidepanel/components/input-bar.js
@@ -166,7 +166,10 @@ const saveDraft = (sid, text) => {
 /**
  * @typedef {{
  *   state: InputBarState,
- *   attrs: { state: ChatState, send: Send, voiceManager?: any },
+ *   attrs: {
+ *     state: ChatState, send: Send, voiceManager?: any,
+ *     loopArmed?: boolean, onLoopSent?: () => void,
+ *   },
  * }} InputBarVnode
  */
 
@@ -203,7 +206,7 @@ export const InputBar = {
   },
 
   /** @param {InputBarVnode} vnode */
-  view: ({ attrs: { state, send, voiceManager }, state: ui }) => {
+  view: ({ attrs: { state, send, voiceManager, loopArmed, onLoopSent }, state: ui }) => {
     const streaming = !!state.streaming;
     const sid = state.session?.sessionId;
     // Switched chats → save the draft we were holding and load the new chat's.
@@ -225,6 +228,27 @@ export const InputBar = {
       e?.preventDefault?.();
       const text = ui.value.trim();
       if (!text || ui.busy) return;
+
+      // Loop-armed (mode-row toggle): this send launches a Ralph loop with
+      // the draft as its goal instead of a normal turn. Reuses the SW's
+      // `/loop` path — byte-identical to typing "/loop <goal>" — then
+      // disarms via onLoopSent. Attachments don't apply to a loop goal, so
+      // they stay staged for a later normal send.
+      if (loopArmed) {
+        ui.busy = true;
+        ui.value = '';
+        saveDraft(sid, '');
+        ui.transcriptBaseline = '';
+        closePalette(ui);
+        const reply = await send({ type: 'agent/send', text: `/loop ${text}` });
+        ui.busy = false;
+        // Disarm only on a clean launch; on failure restore the draft and
+        // stay armed so the user can retry without re-toggling.
+        if (reply?.ok) onLoopSent?.();
+        else ui.value = text;
+        m.redraw();
+        return;
+      }
 
       // why gate at send too (not just the button): staged files must
       // never ride a send the provider can't honor — e.g. the user
@@ -398,9 +422,11 @@ export const InputBar = {
 
     const placeholder = !hasKey
       ? 'Add an API key in Settings to start.'
-      : streaming
-        ? 'Type to steer the current turn…'
-        : 'Message peerd…';
+      : loopArmed
+        ? 'Describe a goal to loop on…'
+        : streaming
+          ? 'Type to steer the current turn…'
+          : 'Message peerd…';
 
     // aria-activedescendant points at the active option when the palette
     // is open, so screen readers announce the highlighted candidate.
@@ -526,10 +552,13 @@ export const InputBar = {
               m('button.send-btn', {
                 type: 'submit',
                 disabled: !hasKey || ui.busy || !ui.value.trim(),
-                'aria-label': streaming ? 'Send and steer the current turn' : 'Send',
-                title: streaming
-                  ? 'Sending will abort the current turn and continue with your new message'
-                  : 'Send (⌘/Ctrl + Enter)',
+                'aria-label': loopArmed ? 'Start a loop on this goal'
+                  : streaming ? 'Send and steer the current turn' : 'Send',
+                title: loopArmed
+                  ? 'Start an autonomous loop on this goal (plan → build → repeat)'
+                  : streaming
+                    ? 'Sending will abort the current turn and continue with your new message'
+                    : 'Send (⌘/Ctrl + Enter)',
               }, ARROW_ICON()),
             ]),
           ]),

--- a/extension/sidepanel/components/mode-badge.js
+++ b/extension/sidepanel/components/mode-badge.js
@@ -96,23 +96,24 @@ export const ModeSelector = {
 };
 
 /**
- * Loop arming toggle. The mode-row entry point for the Ralph persistent
- * loop (peerd-runtime/ralph). Until now a loop could only be launched by
- * typing the undiscoverable `/loop [goal]` slash command; this surfaces it
- * beside Plan/Act. It is NOT a synchronous state flip like Plan/Act — a
- * loop is "launch a background run WITH a goal" — so the toggle ARMS the
- * next send: while ON, sending sends the draft as the loop's goal (the
- * InputBar routes it through the same /loop path) and the toggle disarms.
- * The running loop then surfaces in its own RalphPanel, which owns the
- * stop/status half. Same pill family + accent-when-active as the planact
- * controls (owner call for this row).
+ * Goal toggle. The mode-row entry point for the Ralph persistent loop
+ * (peerd-runtime/ralph). Labeled "Goal" — it arms the NEXT message to be
+ * the goal of an autonomous run (plan → build → repeat) rather than a
+ * single turn; the InputBar routes that send through the engine's `/loop`
+ * path and the toggle disarms (one launch per arm). Before this, the loop
+ * could only be launched via the undiscoverable `/loop [goal]` command.
+ * The running run then surfaces in its own RalphPanel, which owns the
+ * stop/status half. why "Goal" not "Loop": the control is a one-shot
+ * launch-with-a-goal, not a sticky mode — the word matches the behavior.
+ * Same pill family + accent-when-armed as the planact controls (owner
+ * call for this row).
  *
  * attrs:
- *   armed     — whether the next send is armed to launch a loop
+ *   armed     — whether the next send is armed to launch a goal run
  *   disabled  — no API key yet (the send it arms can't fire)
  *   onToggle  — flip handler; receives the next armed boolean
  */
-export const LoopToggle = {
+export const GoalToggle = {
   /**
    * @param {{ attrs: {
    *   armed?: boolean,
@@ -122,17 +123,17 @@ export const LoopToggle = {
    */
   view: ({ attrs: { armed, disabled, onToggle } }) => {
     const on = !!armed;
-    return m('button.loop-toggle', {
+    return m('button.goal-toggle', {
       class: on ? 'is-on' : '',
       disabled: !!disabled,
       'aria-pressed': String(on),
       title: on
-        ? 'Loop is armed — your next message starts an autonomous loop on that goal '
+        ? 'Goal is armed — your next message starts an autonomous run on that goal '
           + '(plan → build → repeat). Click to disarm.'
-        : 'Loop — arm the next message to run as an autonomous loop '
+        : 'Goal — arm the next message to run as an autonomous goal '
           + '(plan → build → repeat) instead of a single turn.',
       onclick: () => onToggle(!on),
-    }, on ? 'Loop: on' : 'Loop');
+    }, on ? 'Goal: on' : 'Goal');
   },
 };
 

--- a/extension/sidepanel/components/mode-badge.js
+++ b/extension/sidepanel/components/mode-badge.js
@@ -95,6 +95,47 @@ export const ModeSelector = {
   },
 };
 
+/**
+ * Loop arming toggle. The mode-row entry point for the Ralph persistent
+ * loop (peerd-runtime/ralph). Until now a loop could only be launched by
+ * typing the undiscoverable `/loop [goal]` slash command; this surfaces it
+ * beside Plan/Act. It is NOT a synchronous state flip like Plan/Act — a
+ * loop is "launch a background run WITH a goal" — so the toggle ARMS the
+ * next send: while ON, sending sends the draft as the loop's goal (the
+ * InputBar routes it through the same /loop path) and the toggle disarms.
+ * The running loop then surfaces in its own RalphPanel, which owns the
+ * stop/status half. Same pill family + accent-when-active as the planact
+ * controls (owner call for this row).
+ *
+ * attrs:
+ *   armed     — whether the next send is armed to launch a loop
+ *   disabled  — no API key yet (the send it arms can't fire)
+ *   onToggle  — flip handler; receives the next armed boolean
+ */
+export const LoopToggle = {
+  /**
+   * @param {{ attrs: {
+   *   armed?: boolean,
+   *   disabled?: boolean,
+   *   onToggle: (next: boolean) => void,
+   * } }} vnode
+   */
+  view: ({ attrs: { armed, disabled, onToggle } }) => {
+    const on = !!armed;
+    return m('button.loop-toggle', {
+      class: on ? 'is-on' : '',
+      disabled: !!disabled,
+      'aria-pressed': String(on),
+      title: on
+        ? 'Loop is armed — your next message starts an autonomous loop on that goal '
+          + '(plan → build → repeat). Click to disarm.'
+        : 'Loop — arm the next message to run as an autonomous loop '
+          + '(plan → build → repeat) instead of a single turn.',
+      onclick: () => onToggle(!on),
+    }, on ? 'Loop: on' : 'Loop');
+  },
+};
+
 const EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'];
 
 /**

--- a/extension/sidepanel/styles.css
+++ b/extension/sidepanel/styles.css
@@ -258,6 +258,7 @@ html, body, #app {
   .channel-badge { transition: none; }
   /* Feature 03: kill the Plan/Act pill transition for reduced-motion. */
   .planact-mode { transition: none; }
+  .loop-toggle { transition: none; }
 }
 
 /* Hero size — the big "manifest" wordmark on the lock / sign-up screen.
@@ -597,6 +598,32 @@ html, body, #app {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }
+
+/* Loop arming toggle (mode row) — arms the next send to launch a Ralph
+   persistent loop instead of a single turn. Same pill family as the planact
+   controls; the ARMED state wears the shared accent (consistency with the
+   active Act / Confirm pills — owner call for this row). */
+.loop-toggle {
+  font-size: 12px;
+  line-height: 1;
+  padding: 3px 9px;
+  margin-left: 6px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+.loop-toggle.is-on {
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+.loop-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.loop-toggle:disabled { opacity: 0.5; cursor: not-allowed; }
 
 .body { flex: 1; padding: 14px; overflow-y: auto; }
 

--- a/extension/sidepanel/styles.css
+++ b/extension/sidepanel/styles.css
@@ -258,7 +258,7 @@ html, body, #app {
   .channel-badge { transition: none; }
   /* Feature 03: kill the Plan/Act pill transition for reduced-motion. */
   .planact-mode { transition: none; }
-  .loop-toggle { transition: none; }
+  .goal-toggle { transition: none; }
 }
 
 /* Hero size — the big "manifest" wordmark on the lock / sign-up screen.
@@ -599,11 +599,11 @@ html, body, #app {
   outline-offset: -2px;
 }
 
-/* Loop arming toggle (mode row) — arms the next send to launch a Ralph
-   persistent loop instead of a single turn. Same pill family as the planact
+/* Goal toggle (mode row) — arms the next send to launch a Ralph autonomous
+   goal run instead of a single turn. Same pill family as the planact
    controls; the ARMED state wears the shared accent (consistency with the
    active Act / Confirm pills — owner call for this row). */
-.loop-toggle {
+.goal-toggle {
   font-size: 12px;
   line-height: 1;
   padding: 3px 9px;
@@ -615,15 +615,15 @@ html, body, #app {
   cursor: pointer;
   transition: background 120ms ease, color 120ms ease;
 }
-.loop-toggle.is-on {
+.goal-toggle.is-on {
   background: var(--accent);
   color: var(--accent-fg);
 }
-.loop-toggle:focus-visible {
+.goal-toggle:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }
-.loop-toggle:disabled { opacity: 0.5; cursor: not-allowed; }
+.goal-toggle:disabled { opacity: 0.5; cursor: not-allowed; }
 
 .body { flex: 1; padding: 14px; overflow-y: auto; }
 

--- a/extension/tests/index.js
+++ b/extension/tests/index.js
@@ -84,6 +84,7 @@ import './unit/sidepanel/denylist-view.test.js';
 import './unit/sidepanel/ralph-panel.test.js';
 import './unit/sidepanel/onboarding-view.test.js';
 import './unit/sidepanel/mode-selector.test.js';
+import './unit/sidepanel/loop-toggle.test.js';
 import './unit/sidepanel/memory-suggestions.test.js';
 import './unit/sidepanel/tools-chip.test.js';
 import './unit/sidepanel/attachments.test.js';

--- a/extension/tests/index.js
+++ b/extension/tests/index.js
@@ -84,7 +84,7 @@ import './unit/sidepanel/denylist-view.test.js';
 import './unit/sidepanel/ralph-panel.test.js';
 import './unit/sidepanel/onboarding-view.test.js';
 import './unit/sidepanel/mode-selector.test.js';
-import './unit/sidepanel/loop-toggle.test.js';
+import './unit/sidepanel/goal-toggle.test.js';
 import './unit/sidepanel/memory-suggestions.test.js';
 import './unit/sidepanel/tools-chip.test.js';
 import './unit/sidepanel/attachments.test.js';

--- a/extension/tests/unit/sidepanel/goal-toggle.test.js
+++ b/extension/tests/unit/sidepanel/goal-toggle.test.js
@@ -1,14 +1,14 @@
 // @ts-check
-// LoopToggle — the mode-row entry point for the Ralph persistent loop. Until
-// this control, a loop could only be launched via the undiscoverable `/loop`
-// command; the toggle ARMS the next send to run as a loop (the InputBar then
-// rewrites it onto the same /loop path and disarms). These tests pin the arm
-// contract: an off pill, a click that reports the next armed boolean, the
-// armed look (accent + aria-pressed), and the no-key disabled state.
+// GoalToggle — the mode-row entry point for the Ralph persistent loop. Until
+// this control, a goal run could only be launched via the undiscoverable
+// `/loop` command; the toggle ARMS the next send to run as an autonomous goal
+// (the InputBar then rewrites it onto the same /loop path and disarms). These
+// tests pin the arm contract: an off pill, a click that reports the next armed
+// boolean, the armed look (accent + aria-pressed), and the no-key disabled state.
 
 import m from '/vendor/mithril/mithril.js';
 import { describe, it, expect } from '../../framework.js';
-import { LoopToggle } from '/sidepanel/components/mode-badge.js';
+import { GoalToggle } from '/sidepanel/components/mode-badge.js';
 
 /**
  * Fake onToggle(): records the next-armed booleans the component reports.
@@ -26,7 +26,7 @@ const makeToggle = () => {
 const mount = (attrs) => {
   const root = document.createElement('div');
   document.body.appendChild(root);
-  m.mount(root, { view: () => m(LoopToggle, attrs) });
+  m.mount(root, { view: () => m(GoalToggle, attrs) });
   m.redraw.sync();
   return { root, unmount: () => { m.mount(root, null); root.remove(); } };
 };
@@ -36,17 +36,17 @@ const mount = (attrs) => {
  * @returns {HTMLButtonElement}
  */
 const needToggle = (root) => {
-  const el = root.querySelector('.loop-toggle');
-  if (!el) throw new Error('missing element: .loop-toggle');
+  const el = root.querySelector('.goal-toggle');
+  if (!el) throw new Error('missing element: .goal-toggle');
   return /** @type {HTMLButtonElement} */ (el);
 };
 
-describe('LoopToggle (mode-row loop arming)', () => {
+describe('GoalToggle (mode-row goal arming)', () => {
   it('renders an unarmed pill', () => {
     const { root, unmount } = mount({ onToggle: makeToggle() });
     try {
       const btn = needToggle(root);
-      expect(btn.textContent).toBe('Loop');
+      expect(btn.textContent).toBe('Goal');
       expect(btn.getAttribute('aria-pressed')).toBe('false');
       expect(btn.className.includes('is-on')).toBe(false);
       expect(btn.disabled).toBe(false);
@@ -67,7 +67,7 @@ describe('LoopToggle (mode-row loop arming)', () => {
     const { root, unmount } = mount({ armed: true, onToggle });
     try {
       const btn = needToggle(root);
-      expect(btn.textContent).toBe('Loop: on');
+      expect(btn.textContent).toBe('Goal: on');
       expect(btn.getAttribute('aria-pressed')).toBe('true');
       expect(btn.className.includes('is-on')).toBe(true);
       btn.click();

--- a/extension/tests/unit/sidepanel/loop-toggle.test.js
+++ b/extension/tests/unit/sidepanel/loop-toggle.test.js
@@ -1,0 +1,88 @@
+// @ts-check
+// LoopToggle — the mode-row entry point for the Ralph persistent loop. Until
+// this control, a loop could only be launched via the undiscoverable `/loop`
+// command; the toggle ARMS the next send to run as a loop (the InputBar then
+// rewrites it onto the same /loop path and disarms). These tests pin the arm
+// contract: an off pill, a click that reports the next armed boolean, the
+// armed look (accent + aria-pressed), and the no-key disabled state.
+
+import m from '/vendor/mithril/mithril.js';
+import { describe, it, expect } from '../../framework.js';
+import { LoopToggle } from '/sidepanel/components/mode-badge.js';
+
+/**
+ * Fake onToggle(): records the next-armed booleans the component reports.
+ * @returns {((next: boolean) => void) & { calls: boolean[] }}
+ */
+const makeToggle = () => {
+  /** @type {boolean[]} */
+  const calls = [];
+  return Object.assign(/** @param {boolean} next */ (next) => { calls.push(next); }, { calls });
+};
+
+/**
+ * @param {{ armed?: boolean, disabled?: boolean, onToggle: (next: boolean) => void }} attrs
+ */
+const mount = (attrs) => {
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  m.mount(root, { view: () => m(LoopToggle, attrs) });
+  m.redraw.sync();
+  return { root, unmount: () => { m.mount(root, null); root.remove(); } };
+};
+
+/**
+ * @param {ParentNode} root
+ * @returns {HTMLButtonElement}
+ */
+const needToggle = (root) => {
+  const el = root.querySelector('.loop-toggle');
+  if (!el) throw new Error('missing element: .loop-toggle');
+  return /** @type {HTMLButtonElement} */ (el);
+};
+
+describe('LoopToggle (mode-row loop arming)', () => {
+  it('renders an unarmed pill', () => {
+    const { root, unmount } = mount({ onToggle: makeToggle() });
+    try {
+      const btn = needToggle(root);
+      expect(btn.textContent).toBe('Loop');
+      expect(btn.getAttribute('aria-pressed')).toBe('false');
+      expect(btn.className.includes('is-on')).toBe(false);
+      expect(btn.disabled).toBe(false);
+    } finally { unmount(); }
+  });
+
+  it('clicking the unarmed pill reports onToggle(true)', () => {
+    const onToggle = makeToggle();
+    const { root, unmount } = mount({ onToggle });
+    try {
+      needToggle(root).click();
+      expect(onToggle.calls).toEqual([true]);
+    } finally { unmount(); }
+  });
+
+  it('armed pill shows the accent + aria-pressed and disarms on click', () => {
+    const onToggle = makeToggle();
+    const { root, unmount } = mount({ armed: true, onToggle });
+    try {
+      const btn = needToggle(root);
+      expect(btn.textContent).toBe('Loop: on');
+      expect(btn.getAttribute('aria-pressed')).toBe('true');
+      expect(btn.className.includes('is-on')).toBe(true);
+      btn.click();
+      expect(onToggle.calls).toEqual([false]);
+    } finally { unmount(); }
+  });
+
+  it('is disabled (and inert) with no API key', () => {
+    const onToggle = makeToggle();
+    const { root, unmount } = mount({ disabled: true, onToggle });
+    try {
+      const btn = needToggle(root);
+      expect(btn.disabled).toBe(true);
+      btn.click();  // disabled buttons don't fire
+      expect(onToggle.calls.length).toBe(0);
+    } finally { unmount(); }
+  });
+});

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -33,7 +33,7 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // sessions/store.js, vm-tab.js). The dev-only peerd-distributed/demo/
 // harness (pruned from every package, wired into nothing) was removed
 // rather than typed.
-const COVERED_FLOOR = 475;
+const COVERED_FLOOR = 477;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.


### PR DESCRIPTION
## Why

The Ralph persistent loop is fully built (`peerd-runtime/ralph/`), but its only entry point was the `/loop [goal]` command — and that command isn't even registered in the composer palette (`composer/command-sources.js` only surfaces user `.peerd/commands/` + skills). It's a hardcoded interception in `background/routes/sessions.js`, so it never surfaced in the UI and you had to already know the magic word. Only the *running/stopping* half had UI: the `RalphPanel` and its Stop button.

This adds the **launch** half as a mode-row toggle, the way the loop was missing from the main chat.

## What

A loop isn't a synchronous state flip like Plan/Act — it's "launch a background run **with a goal**" — so the toggle **arms the next send**: while on, sending routes the draft through the existing `/loop` path as the loop's goal, then the toggle disarms. The running loop then shows up in the `RalphPanel`, which keeps owning status/stop. Reusing the `/loop` path means the toggle inherits exactly the behavior of typing `/loop <goal>` — no new loop semantics introduced.

- **`LoopToggle`** — new pill in `mode-badge.js`, same family/accent as the Plan/Act + effort controls; armed state wears the shared accent.
- **`ChatView`** holds the arm state (pure composer intent — no SW round-trip), resets it per chat, and threads it to the `InputBar`.
- **`InputBar`** branches an armed send onto `/loop <goal>`, disarms on a clean launch (restores the draft + stays armed on failure), and reflects the armed state in the placeholder + send affordance.
- Styles, `FEATURES.md` catalog entry, and the typecheck-coverage floor updated.

## Tests / checks

- New `tests/unit/sidepanel/loop-toggle.test.js` mirrors the proven `mode-selector.test.js` harness (off pill, click reports next-armed bool, armed look, no-key disabled).
- `bun run typecheck` clean · `bun run lint` clean · `bun run check:tscheck` 477/477 (floor bumped to 477) · Bun suite `2081 pass / 0 fail`.
- ⚠️ The in-browser DOM suite (which actually executes `loop-toggle.test.js`) couldn't run here — the Chrome-for-Testing download is blocked by this environment's egress policy. The test follows the same mount/click/assert pattern as the passing `mode-selector` test, but it should be confirmed via the CDP harness / CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iKhDySM1DFLxu8to9FMDG

---
_Generated by [Claude Code](https://claude.ai/code/session_017iKhDySM1DFLxu8to9FMDG)_