### PR TITLE
fix(provider): retry HTTP 500 in the OpenRouter adapter

### DIFF
--- a/extension/peerd-provider/adapters/openrouter.js
+++ b/extension/peerd-provider/adapters/openrouter.js
@@ -135,7 +135,14 @@ export async function* callOpenRouter(args) {
         detail: apiErrorMessage(bodyText),
       });
     }
-    const retryable = res.status === 429 || res.status === 503 || res.status === 529;
+    // why include 500: OpenRouter is a gateway proxying upstream providers, so
+    // a transient upstream blip commonly surfaces as a one-off 500 (api_error).
+    // The Anthropic adapter already retries 500 for the same reason (anthropic.js)
+    // — without it here, a single transient 500 killed the whole turn even though
+    // an immediate retry almost always succeeds. The hard-limit fast-fail above
+    // (isUsageLimitResponse) already caught a 500 carrying a billing needle.
+    const retryable = res.status === 429 || res.status === 500
+      || res.status === 503 || res.status === 529;
     if (retryable && attempt <= MAX_RATE_LIMIT_RETRIES) {
       const waitMs = computeBackoffMs(res.headers, attempt);
       yield { type: 'rate-limit-pause', retryAfterMs: waitMs, attempt };

--- a/tests/peerd-provider/openrouter-retry.test.ts
+++ b/tests/peerd-provider/openrouter-retry.test.ts
@@ -1,0 +1,74 @@
+// callOpenRouter retry-set coverage, terminal-runnable.
+//
+// Mirrors anthropic-retry.test.ts. OpenRouter is a gateway proxying upstream
+// providers, so a transient upstream blip commonly surfaces as a one-off 500
+// (api_error) — it must retry like the Anthropic adapter, not kill the turn.
+// 500 is the regression target here.
+
+import { describe, test, expect } from 'bun:test';
+import { callOpenRouter } from '../../extension/peerd-provider/adapters/openrouter.js';
+import { ProviderHttpError } from '../../extension/peerd-provider/errors.js';
+
+const stubResponse = (status: number, headers: Record<string, string> = {}, bodyText = '') => ({
+  ok: status >= 200 && status < 300,
+  status,
+  headers: new Headers(headers),
+  body: undefined,
+  text: async () => bodyText,
+});
+
+const okStreamingResponse = () => {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(
+        'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n'));
+      controller.close();
+    },
+  });
+  return { ok: true, status: 200, headers: new Headers(), body, text: async () => '' };
+};
+
+const baseArgs = (overrides: Record<string, unknown> = {}) => ({
+  messages: [{ role: 'user', content: 'hi', id: 'u', when: 0 }],
+  system: 'sys',
+  getSecret: async () => 'sk-or-test',
+  safeFetch: async () => { throw new Error('safeFetch not set'); },
+  _sleep: async () => {},
+  ...overrides,
+});
+
+const drain = async (gen: AsyncGenerator<any>) => {
+  const out: any[] = [];
+  for await (const ev of gen) out.push(ev);
+  return out;
+};
+
+describe('callOpenRouter — retryable status set', () => {
+  // 500 joins 429/503/529 — the regression target (a transient upstream
+  // api_error must retry, matching the Anthropic adapter).
+  test.each([429, 500, 503, 529])('retries %i and recovers on the next attempt', async (status) => {
+    let calls = 0;
+    const safeFetch = async () => {
+      calls++;
+      if (calls === 1) return stubResponse(status, {}, '{"error":{"message":"transient upstream error"}}');
+      return okStreamingResponse();
+    };
+    const events = await drain(callOpenRouter(baseArgs({ safeFetch }) as any));
+    expect(calls).toBe(2);
+    expect(events[0].type).toBe('rate-limit-pause');
+  });
+
+  test.each([400, 401, 403, 404])('throws immediately on non-retryable %i', async (status) => {
+    let calls = 0;
+    const safeFetch = async () => {
+      calls++;
+      return stubResponse(status, {}, 'bad');
+    };
+    let thrown: any;
+    try { await drain(callOpenRouter(baseArgs({ safeFetch }) as any)); }
+    catch (e) { thrown = e; }
+    expect(calls).toBe(1);
+    expect(thrown).toBeInstanceOf(ProviderHttpError);
+    expect(thrown.status).toBe(status);
+  });
+});


### PR DESCRIPTION
OpenRouter is an OpenAI-compatible gateway proxying upstream providers (Anthropic/OpenAI/Google/...), so a transient upstream blip commonly surfaces as a one-off HTTP 500 (api_error). The Anthropic adapter deliberately retries 500 (*"a one-off api_error used to kill the whole turn even though an immediate-ish retry almost always succeeds"*), but the OpenRouter retryable set was `429/503/529` only - so the identical blip killed the whole turn on OpenRouter where it recovers on Anthropic.

Add 500 to the OpenRouter retryable set, matching the sibling adapter's documented intent and shared backoff machinery. The hard-limit fast-fail (`isUsageLimitResponse`) runs before this check, so a 500 carrying a billing needle still fails fast.

## Tests
- New `openrouter-retry.test.ts` mirrors `anthropic-retry.test.ts`, parametrized over `[429, 500, 503, 529]`. **Revert-proven:** dropping 500 from the set fails the 500 case (8 -> 7/1).
- typecheck + lint clean.

Found via a verified provider-layer bug-hunt (low severity: a clean ProviderHttpError, no corruption - but an intent-violating cross-provider parity gap).