### PR TITLE
fix(provider): flush captured usage on a mid-stream Anthropic error

### DIFF
--- a/extension/peerd-provider/format/from-anthropic.js
+++ b/extension/peerd-provider/format/from-anthropic.js
@@ -200,6 +200,14 @@ export async function* fromAnthropicStream(body) {
       }
       case 'error': {
         const message = payload.error?.message ?? 'unknown server error';
+        // why: flush captured usage before the error. Anthropic billed the
+        // prompt the moment message_start arrived (input + cache tokens, with
+        // usageSeen=true), so a mid-stream `error` event must still report it —
+        // exactly the rationale the message_stop case and the truncated-stream
+        // fallback below act on. Without this, a turn that errors after a large
+        // (cached) prompt silently undercounts in the cost meter.
+        const ue = emitUsage();
+        if (ue) yield ue;
         yield { type: 'error', error: message };
         return;
       }

--- a/tests/peerd-provider/usage-stream.test.ts
+++ b/tests/peerd-provider/usage-stream.test.ts
@@ -85,6 +85,32 @@ describe('from-anthropic usage extraction', () => {
     const stop = events.find((e) => e.type === 'message-stop');
     expect(stop.stopReason).toBe('incomplete');
   });
+
+  test('mid-stream error after message_start still reports the usage already billed', async () => {
+    // Anthropic billed the prompt at message_start; a mid-stream `error` event
+    // must flush that captured usage before the error so the cost meter records
+    // it (mirrors the message_stop + truncated-stream paths). Without the flush,
+    // a turn that errors after a large cached prompt silently undercounts.
+    const events = await drain(fromAnthropicStream(streamOf([
+      sse('message_start', {
+        type: 'message_start',
+        message: { usage: { input_tokens: 12, output_tokens: 1, cache_read_input_tokens: 40000 } },
+      }),
+      sse('error', { type: 'error', error: { type: 'overloaded_error', message: 'overloaded' } }),
+    ])));
+
+    const usage = events.find((e) => e.type === 'usage');
+    expect(usage).toBeTruthy();
+    expect(usage.usage.inputTokens).toBe(12);
+    expect(usage.usage.cacheReadTokens).toBe(40000);
+
+    // usage MUST precede the error so it is attributed before the turn ends.
+    const usageIdx = events.findIndex((e) => e.type === 'usage');
+    const errIdx = events.findIndex((e) => e.type === 'error');
+    expect(usageIdx).toBeGreaterThan(-1);
+    expect(errIdx).toBeGreaterThan(usageIdx);
+    expect(events[errIdx].error).toBe('overloaded');
+  });
 });
 
 describe('from-openai/openrouter usage extraction', () => {


### PR DESCRIPTION
`from-anthropic.js`'s `error` case yielded the error and returned **without** calling `emitUsage()`. Anthropic bills the prompt the moment `message_start` arrives (input + cache_read + cache_creation tokens, `usageSeen=true`), so a mid-stream `error` event (overloaded_error / api_error after generation began) silently dropped the already-billed input - the `usage` event is the sole feed for the cost meter, so a turn that errored after a large cached prompt under-reported real spend.

Emit captured usage before the error, mirroring the `message_stop` case and the truncated-stream fallback in the same file (which already flush for exactly this reason).

## Tests
- New case in `usage-stream.test.ts` asserts the usage event leads the error. **Revert-proven:** removing the flush fails it (9 -> 8/1).
- The existing mid-stream-error test (in-browser) is unaffected - its `message_start` carries no usage, so nothing is flushed.
- typecheck + lint clean.

Found via a verified provider-layer bug-hunt (low severity: a cost-meter undercount on an uncommon path, no correctness/crash impact).