### PR TITLE
fix(provider): complete the OpenAI-formatter mirror (image attachments + content_filter)

### DIFF
--- a/extension/peerd-provider/format/from-openai.js
+++ b/extension/peerd-provider/format/from-openai.js
@@ -65,7 +65,14 @@ const mapStopReason = (finish) => {
   if (finish === 'tool_calls') return 'tool_use';
   if (finish === 'stop') return 'end_turn';
   if (finish === 'length') return 'max_tokens';
-  return finish ?? undefined;
+  if (finish === 'content_filter') return 'end_turn';
+  // why never leak the raw value: the agent loop branches on a FIXED internal
+  // vocabulary and treats anything it doesn't recognize as a clean final turn.
+  // A foreign finish_reason (the legacy 'function_call' — which we never
+  // trigger since we request via `tools` — or any future value) is mapped to a
+  // clean end_turn rather than passed through. null/undefined (not finished
+  // yet) stays undefined.
+  return finish ? 'end_turn' : undefined;
 };
 
 /**
@@ -155,6 +162,13 @@ export async function* fromOpenAiStream(body, { provider = 'openrouter' } = {}) 
     }
 
     if (choice.finish_reason) {
+      // why surface content_filter: the provider BLOCKED the model's output, so
+      // the delta usually carries no text — without this the turn finalizes as a
+      // silent empty assistant bubble with no explanation. Emit a visible note
+      // (the response was filtered, not a transport error) before the stop.
+      if (choice.finish_reason === 'content_filter') {
+        yield { type: 'text-delta', text: '[The provider blocked this response under its content policy.]' };
+      }
       stopReason = mapStopReason(choice.finish_reason);
       // Close out any started tool calls before the message stop. The
       // message-stop itself is deferred (see pendingUsage) so the usage

--- a/extension/peerd-provider/format/to-openai.js
+++ b/extension/peerd-provider/format/to-openai.js
@@ -19,7 +19,9 @@
 // the API 400s — same orphan hazard as Anthropic, repaired below.
 
 /** @typedef {import('../types.js').InternalMessage} InternalMessage */
+/** @typedef {import('../types.js').UserMessage} UserMessage */
 /** @typedef {import('../types.js').ToolUseBlock} ToolUseBlock */
+/** @typedef {import('../types.js').Attachment} Attachment */
 
 /**
  * @typedef {Object} OpenAiToolCall
@@ -29,11 +31,20 @@
  */
 
 /**
+ * One content part of a multimodal user message. OpenAI carries vision input
+ * as an array of parts: text + image_url (a data: URL or https URL). There is
+ * no document part — PDFs are Anthropic-only.
+ * @typedef {{ type: 'text', text: string }
+ *        | { type: 'image_url', image_url: { url: string } }} OpenAiContentPart
+ */
+
+/**
  * One OpenAI /chat/completions wire message. The shape varies by role —
- * `tool_calls` rides assistant turns, `tool_call_id` rides tool results.
+ * `tool_calls` rides assistant turns, `tool_call_id` rides tool results,
+ * and a user message with image attachments carries a content-part ARRAY.
  * @typedef {Object} OpenAiMessage
  * @property {'system'|'user'|'assistant'|'tool'} role
- * @property {string | null} [content]
+ * @property {string | null | OpenAiContentPart[]} [content]
  * @property {OpenAiToolCall[]} [tool_calls]
  * @property {string} [tool_call_id]
  */
@@ -51,6 +62,52 @@ const toToolCalls = (toolUses) =>
       arguments: JSON.stringify(tu.input ?? {}),
     },
   }));
+
+// A one-line trace for an attachment that can't ride the OpenAI wire on THIS
+// turn — a stripped record (its bytes already shipped on the turn it was sent,
+// the send-once contract) or a PDF (OpenAI chat completions has no document
+// part; PDFs are Anthropic-only). Keeps the model aware the file existed
+// without the bytes, mirroring to-anthropic.js's stripped sentinel.
+/** @param {Attachment} a */
+const attachmentNote = (a) => {
+  const name = String(a.name ?? 'file').replace(/[<>"]/g, '');
+  return a.stripped
+    ? `<attachment "${name}" (${a.mediaType}) ${a.size}B — sent on its original turn>`
+    : `<attachment "${name}" (${a.mediaType}) — PDFs are only sent on the Anthropic provider; omitted here>`;
+};
+
+/** @param {Attachment} a */
+const isLiveImage = (a) =>
+  !a?.stripped && a.kind === 'image' && typeof a.data === 'string' && a.data.length > 0;
+
+/**
+ * Build the OpenAI `content` for a user message. Live image attachments become
+ * `image_url` parts (OpenAI vision); the text — plus a one-line note for any
+ * stripped or PDF attachment — leads as a text part. Falls back to a plain
+ * string when there are no live images, keeping the common case compact.
+ *
+ * @param {UserMessage} m
+ * @returns {string | OpenAiContentPart[]}
+ */
+const userContent = (m) => {
+  const text = typeof m.content === 'string' ? m.content : '';
+  /** @type {Attachment[]} */
+  const atts = Array.isArray(m.attachments) ? m.attachments : [];
+  const liveImages = atts.filter(isLiveImage);
+  const notes = atts
+    .filter((a) => (a?.stripped && (a.kind === 'image' || a.kind === 'pdf'))
+      || (!a?.stripped && a.kind === 'pdf' && typeof a.data === 'string' && a.data.length > 0))
+    .map(attachmentNote);
+  const fullText = [...notes, ...(text.length > 0 ? [text] : [])].join('\n');
+  if (liveImages.length === 0) return fullText;
+  /** @type {OpenAiContentPart[]} */
+  const parts = [];
+  if (fullText.length > 0) parts.push({ type: 'text', text: fullText });
+  for (const a of liveImages) {
+    parts.push({ type: 'image_url', image_url: { url: `data:${a.mediaType};base64,${a.data}` } });
+  }
+  return parts;
+};
 
 /**
  * Map internal messages to the OpenAI messages array. The `system`
@@ -85,8 +142,13 @@ const toOpenAiMessages = (system, messages) => {
             content: typeof tr.content === 'string' ? tr.content : JSON.stringify(tr.content),
           });
         }
-      } else if (typeof m.content === 'string') {
-        out.push({ role: 'user', content: m.content });
+      } else {
+        const content = userContent(m);
+        // Skip a truly empty user message (no text, no live image, no note).
+        if ((typeof content === 'string' && content.length > 0)
+            || (Array.isArray(content) && content.length > 0)) {
+          out.push({ role: 'user', content });
+        }
       }
     }
   }

--- a/tests/peerd-provider/openai-formatter-parity.test.ts
+++ b/tests/peerd-provider/openai-formatter-parity.test.ts
@@ -1,0 +1,91 @@
+// OpenAI-formatter parity with the Anthropic path.
+//   #1 to-openai.js: user image attachments must ride as image_url content
+//      parts (they were silently dropped, so vision input never reached the
+//      model); PDFs and stripped records leave a visible note instead of
+//      silent loss.
+//   #2 from-openai.js: a content_filter finish_reason must surface a visible
+//      note + a clean terminal stop, not leak raw and finalize an empty bubble.
+
+import { describe, test, expect } from 'bun:test';
+import { _toOpenAiMessagesForTests as toOpenAiMessages } from '../../extension/peerd-provider/format/to-openai.js';
+import { fromOpenAiStream } from '../../extension/peerd-provider/format/from-openai.js';
+
+const streamOf = (chunks: string[]): ReadableStream<Uint8Array> => {
+  const enc = new TextEncoder();
+  let i = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (i < chunks.length) controller.enqueue(enc.encode(chunks[i++]));
+      else controller.close();
+    },
+  });
+};
+const drain = async (gen: AsyncGenerator<any>) => {
+  const out: any[] = [];
+  for await (const ev of gen) out.push(ev);
+  return out;
+};
+const userMsg = (over: Record<string, unknown>) => ({ role: 'user', id: 'u1', when: 0, ...over });
+
+describe('to-openai — user image attachments (#1 parity)', () => {
+  test('a live image becomes an image_url content part alongside the text', () => {
+    const msgs = toOpenAiMessages('', [userMsg({
+      content: 'what is in this image?',
+      attachments: [{ kind: 'image', mediaType: 'image/png', data: 'AAAA', size: 3 }],
+    })] as any);
+    const user: any = msgs.find((m: any) => m.role === 'user');
+    expect(Array.isArray(user.content)).toBe(true);
+    expect(user.content.some((p: any) => p.type === 'text' && p.text.includes('what is in this image?'))).toBe(true);
+    const img = user.content.find((p: any) => p.type === 'image_url');
+    expect(img).toBeTruthy();
+    expect(img.image_url.url).toBe('data:image/png;base64,AAAA');
+  });
+
+  test('a stripped image leaves a text note, no image_url (bytes already sent on its turn)', () => {
+    const msgs = toOpenAiMessages('', [userMsg({
+      content: 'follow-up',
+      attachments: [{ kind: 'image', mediaType: 'image/png', size: 1234, stripped: true }],
+    })] as any);
+    const user: any = msgs.find((m: any) => m.role === 'user');
+    expect(typeof user.content).toBe('string');
+    expect(user.content).toContain('sent on its original turn');
+    expect(user.content).toContain('follow-up');
+  });
+
+  test('a live PDF leaves a note (OpenAI wire has no document part), not silent loss', () => {
+    const msgs = toOpenAiMessages('', [userMsg({
+      content: 'read this',
+      attachments: [{ kind: 'pdf', mediaType: 'application/pdf', data: 'JVBER', size: 4 }],
+    })] as any);
+    const user: any = msgs.find((m: any) => m.role === 'user');
+    expect(typeof user.content).toBe('string');
+    expect(user.content).toContain('Anthropic');
+    expect(user.content).toContain('read this');
+  });
+
+  test('a plain text message stays a compact string (no regression)', () => {
+    const msgs = toOpenAiMessages('', [userMsg({ content: 'hi' })] as any);
+    const user: any = msgs.find((m: any) => m.role === 'user');
+    expect(user.content).toBe('hi');
+  });
+});
+
+describe('from-openai — content_filter + unknown finish_reason (#2)', () => {
+  const finalChunk = (finish: string) =>
+    `data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: finish }] })}\n\ndata: [DONE]\n\n`;
+
+  test('content_filter surfaces a visible note and a clean end_turn (not a silent empty bubble)', async () => {
+    const events = await drain(fromOpenAiStream(streamOf([finalChunk('content_filter')])));
+    const note = events.find((e) => e.type === 'text-delta');
+    expect(note).toBeTruthy();
+    expect(note.text).toMatch(/content policy|blocked/i);
+    const stop = events.find((e) => e.type === 'message-stop');
+    expect(stop.stopReason).toBe('end_turn');
+  });
+
+  test('an unknown finish_reason is mapped to end_turn, never leaked raw', async () => {
+    const events = await drain(fromOpenAiStream(streamOf([finalChunk('some_future_reason')])));
+    const stop = events.find((e) => e.type === 'message-stop');
+    expect(stop.stopReason).toBe('end_turn');
+  });
+});


### PR DESCRIPTION
The OpenAI-shaped formatter (used by the OpenRouter + Ollama adapters) was an incomplete mirror of the Anthropic path, silently dropping two things.

## #1 - `to-openai.js` dropped user image/PDF attachments
A user message was converted to a plain text string, ignoring `m.attachments` - so on an OpenRouter/Ollama vision model the image **never reached the model** and it answered blind, with no error. Now a live image rides as an OpenAI `image_url` content part (the standard vision wire form); the text leads as a text part. OpenAI chat completions has no document part, so a PDF - and a stripped record whose bytes already shipped on its original turn - leaves a one-line note instead of vanishing silently (mirrors `to-anthropic`'s stripped sentinel).

## #2 - `from-openai.js` leaked an unmapped finish_reason
`mapStopReason` only knew `tool_calls`/`stop`/`length`, so a `content_filter` finish (the provider **blocked** the model's output) passed through raw; the agent loop only special-cases `incomplete`, so it finalized a silent empty assistant bubble with no explanation. Now `content_filter` maps to a clean `end_turn` **and** emits a visible note; any other/unknown finish_reason (incl. legacy `function_call`, which we never trigger since we request via `tools`) maps to `end_turn` instead of leaking a foreign value into the loop's vocabulary.

## Tests
- New `openai-formatter-parity.test.ts` covers both directions (image_url part, stripped/PDF notes, content_filter note + end_turn, unknown -> end_turn). **Revert-proven:** restoring both files fails 5/6.
- Full bun suite 2087 pass; typecheck + lint clean; no in-browser provider test affected.

Found via a verified provider-layer bug-hunt. Same root cause as the two sibling PRs: the OpenAI path drifted from the canonical Anthropic path. (#1 had one verifier argue medium - silent wrong-answer on a shipped provider whose model picker lists gpt-4o/gemini.)