### PR TITLE
docs: fix drift — stale paths, renamed symbols, shipped-as-future labels

### DIFF
--- a/ARCHITECTURE-CHANGES.md
+++ b/ARCHITECTURE-CHANGES.md
@@ -5,10 +5,14 @@
 ## NEWEST: dweb Phase 1 — rooms, gossip, the dwapp bridge, the commons (2026-06-13, branch `dweb/phase1`)
 
 > Preview-channel only; the store build prunes `peerd-distributed/`
-> entirely (unchanged boundary). On a dedicated branch, **not merged** —
-> awaiting manual testing. Reframed by `docs/distributed/NORTH-STAR.md`
-> (D-5…D-9); sequenced in `docs/distributed/ROADMAP.md` Phase 1; wire
-> formats in `PROTOCOL.md §3.4/§3.6/§6.3/§6.4/§8.1`; new threat sections
+> entirely (unchanged boundary). **LANDED — and since superseded by the
+> always-on base network:** the per-app `room-host.js` was removed in
+> favor of `peerd-distributed/base-network.js`, now hosted in the
+> offscreen doc (`offscreen/dweb-base.js`) so the network outlives any
+> tab — not the app-tab page this entry describes. Reframed by
+> `docs/distributed/NORTH-STAR.md` (D-5…D-9); sequenced in
+> `docs/distributed/ROADMAP.md` Phase 1; wire formats in
+> `PROTOCOL.md §3.4/§3.6/§6.3/§6.4/§8.1`; new threat sections
 > `THREAT-MODEL.md §12/§13`; placement in `ARCHITECTURE.md §8.1`.
 
 - **Rooms replace the 2-peer dance.** `transport/signaling.js` reducer:
@@ -133,7 +137,7 @@
   Anywhere ARCHITECTURE.md still narrates trust modes (personas
   rationale, migration table), read it as historical. New in its
   place: **Plan permits pure URL loads** — `PLAN_NAVIGATION_TOOLS =
-  {navigate, open_tab}` in `permissions/policy.js`, never clicks
+  {navigate, open_tab}` in `peerd-runtime/permissions/policy.js`, never clicks
   (`docs/DECISIONS.md` #16).
 - **`peerd-runtime/loop/undo.js` (listed below as V1.1) will NOT be
   built** — generalized turn rollback failed feasibility
@@ -238,7 +242,12 @@ Move files if you've already created them in old paths. Update imports. Public A
 
 ## peerd-distributed V1 state
 
-Essentially empty:
+> Historical (original migration notice). **Superseded** — see the dweb
+> entry at the top of this file: `peerd-distributed/` is now a ~46-file
+> shipped module (identity, codec, content addressing, the always-on
+> base network), no longer the placeholder this snippet describes.
+
+Essentially empty (as originally reserved):
 
     // peerd-distributed/index.js  (V1)
     export const VERSION = 'unimplemented — dweb surface reserved for V2+';

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -250,8 +250,8 @@ handling, fake-fetch integration tests.
 
 **Purpose.** The security layer. Every defense and storage primitive the
 extension relies on lives here: the vault (encrypted secrets), the
-egress allowlist (`safeFetch`), the denylist matcher, the trust-mode
-policy, the confirmation gate protocol, and the audit log.
+egress allowlist (`safeFetch`), the denylist matcher, the confirmation
+gate protocol, and the audit log.
 
 Named "egress" because the load-bearing security primitive is the egress
 allowlist (`safeFetch`) — for the **credentialed provider path**, that's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,7 +306,7 @@ land with deliberate design work):
   `tools/manifest-command.js`, enforced in `gates.js`), on top of the
   registration/exposure split. What's still ahead is binding a manifest to
   a *profile* (rides the Profiles item above). Note: the do/get/check
-  browser-runner is already trimmed to a 4–9-tool allow-list by
+  browser-runner is already trimmed to a tight allow-list by
   construction (`runner/index.js` READ_TOOLSET / DO_TOOLSET) — it never
   sees the full surface.
 - OpenAI provider adapter — the file doesn't exist yet (OpenRouter

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -305,7 +305,7 @@ denylist is checked before any per-tool authorization. A denylist hit:
 3. Logs to the audit log.
 4. Surfaces in the UI as a security event.
 
-Default denylist (seed data, in `/assets/denylist-default.json`) covers:
+Default denylist (seed data, in `peerd-egress/denylist/default.json`) covers:
 
 - Major US banks: Chase, BofA, Wells Fargo, Citi, Capital One, US Bank, PNC,
   TD, Truist, Schwab, Fidelity, Vanguard, E*TRADE, Robinhood, Coinbase,
@@ -316,8 +316,7 @@ Default denylist (seed data, in `/assets/denylist-default.json`) covers:
   domains (state by state via wildcard pattern).
 - Password managers: 1password.com, bitwarden.com, lastpass.com, dashlane.com,
   keepersecurity.com, nordpass.com, *.proton.me.
-- Identity: accounts.google.com, login.microsoftonline.com, login.live.com,
-  appleid.apple.com, okta.com (wildcard), auth0.com.
+- Identity: appleid.apple.com, okta.com (wildcard), auth0.com.
 
 The denylist is editable by the user — they can add to it or remove defaults.
 Default state on install: all defaults active. Removing a default requires a
@@ -1324,101 +1323,82 @@ Stored in `/background/agent-loop/system-prompt.txt`. Key points:
 ## 10.5. Temporal grounding (clock)
 
 Terminal-hosted agents have only the timestamp the harness chooses to
-inject. Peerd has more: it lives in the browser, which continuously
-observes real things — tab focus, idle state, system sleep, navigation,
-network state. This is the basis for genuine temporal grounding rather
-than just static timestamps.
+inject. Peerd injects a compact temporal block per turn so the model is
+grounded in real wall-clock time and in how much of it passed since the
+user last spoke.
 
 The cost concern is real: anything injected per-turn adds context every
-turn. The design is deliberately spartan. Default cost is ~15 tokens.
-Notable events expand the block conditionally, capped at ~50 tokens.
+turn. The design is deliberately spartan (owner direction, 2026-06-12):
+the block carries the absolute clock plus, at most, one coarse "time
+since the user's previous message" clause — nothing else.
 
 ### 10.5.1 Per-turn temporal block — default
 
-A single line, ~15-20 tokens, injected by `loop/system-prompt.js`
-immediately before the latest user message in each turn:
+A single line, injected by `loop/system-prompt.js` immediately before
+the latest user message in each turn. On the first turn or a fast
+follow-up (gap < 60s) it is just the absolute clock:
 
 ```
-<time>2026-06-05T14:34:21Z · t+47s</time>
+<time>now 2026-06-05T14:34:21Z</time>
 ```
 
-`now` is the absolute timestamp (compact ISO, no fractional seconds).
-`t+` is the delta since the previous turn boundary. That's it. This is
-what's injected every turn when nothing notable has happened.
+`now` is the absolute timestamp (compact ISO, seconds precision, no
+fractional seconds). That's it when the user is in the same sitting.
 
-### 10.5.2 Conditional expansion — only when notable
+### 10.5.2 The elapsed clause — only on a real gap
 
-If the user was idle > 30s during the gap, an `idle` field appears:
-
-```
-<time>2026-06-05T14:34:21Z · t+22m · idle 18m</time>
-```
-
-If notable events occurred between turns (tab navigation in the focused
-window, system sleep/wake, network state transition), they appear as
-arrow-style markers in compact form:
+When more than 60s passed since the user's previous message, one coarse,
+self-describing clause is appended:
 
 ```
-<time>2026-06-05T14:34:21Z · t+5m · tab→github.com, sleep 3m</time>
+<time>now 2026-06-05T14:34:21Z · 2h 1m since the user's previous message</time>
 ```
 
-**Expansion rules:**
+The elapsed value is deliberately lossy — "minutes vs hours vs days",
+not precision (`90s → 1m`, `47m → 47m`, `2h 1m → 2h 1m`, `3d 7h → 3
+days`). It is plain words, not notation, so the model never has to infer
+what a marker means. The block carries exactly this one thing beyond the
+clock; the old `t+`/idle/event-marker forms and the background event
+recorder that fed them were removed (owner direction, 2026-06-12) as
+bloat that confused models in the field.
 
-- Idle line: only if user idle > 30s during inter-turn gap
-- Events line: only if events recorded AND classified notable
-- Notable events: active-tab navigation, system sleep/wake (>1min),
-  network online/offline transition, session pause/resume,
-  extension reload (SW restart)
-- Non-notable events (filtered out): pointer movement, scroll, key
-  presses, inactive-tab loads, ordinary network requests, idle <30s
+### 10.5.3 Cost
 
-### 10.5.3 Token budget
-
-| Scenario | Approx tokens |
-|---|---|
-| Default (nothing notable) | ~15 |
-| With idle marker | ~22 |
-| With 1-2 events | ~25-30 |
-| Long pause with multiple events | ~40 |
-
-Hard cap: 50 tokens. If the block would exceed 50 tokens, the event
-list is truncated and replaced with `… +N more`. Defaults are designed
-to be cheap; the cap prevents pathological cases.
+The block is a single short line — the clock plus, at most, the one
+elapsed clause. There is no conditional event expansion and no token
+cap to manage. When the model needs exact arithmetic it calls `now()`.
 
 ### 10.5.4 Clock tools (on-demand precision)
 
-For when the agent needs more than the block provides, three on-demand
+For when the agent needs more than the block provides, two on-demand
 tools — registered like any other tool, called only when the agent
 asks:
 
-- `now()` → returns full ISO timestamp + timezone + day-of-week
-- `time_since(checkpoint_id)` → returns delta since a saved checkpoint
-  (the agent saves checkpoints by passing a label into `now()`)
-- `wait_until(when_or_duration)` → blocks the agent for N seconds or
-  until an absolute time; subject to trust mode (Paranoid requires
-  confirmation for waits >1min)
+- `now()` → returns full ISO timestamp + timezone + day-of-week. To
+  measure an interval, the model calls `now()` twice and subtracts.
+- `wait_until(when_or_duration)` → blocks the agent for a duration or
+  until an absolute ISO time; hard-capped at 10 minutes.
 
-V1.1+ adds event-aware variants:
-
-- `wait_for_event(type, timeout)` → blocks until a notable event of
-  the named type fires (tab-navigation, idle-end, network-online, …)
+(A `now()`-checkpoint + `time_since` pair used to live here; it was
+removed 2026-06-12 — the checkpoint store was an in-memory Map in an
+MV3 service worker that restarts constantly, so checkpoints silently
+evaporated.)
 
 ### 10.5.5 Module layout
 
 ```
 peerd-runtime/clock/
-├── now.js         # primitives: now, since, formatDelta
-├── events.js      # background event recorder + classification
+├── now.js         # primitives: isoSecondsZ, formatDelta, parseDuration
 ├── context.js     # temporal block formatter (the prompt injection)
-└── tools.js       # registered clock tool definitions
+├── tools.js       # registered clock tool definitions (now, wait_until)
+└── index.js       # module barrel
 ```
 
-The block is built by `context.js` (pure function from the event
-buffer + current time + previous turn boundary → string), and inserted
-by `loop/system-prompt.js`. `events.js` runs in the service worker and
-maintains a rolling buffer of recent events, classifying notable vs
-filtered as they arrive. The buffer is bounded (last 24h, capped at
-1000 entries) and persists across SW restarts via `chrome.storage`.
+The block is built by `buildTemporalBlock` in `context.js` (a pure
+function from `{ lastTurnAt, nowMs }` → string), and inserted by
+`loop/system-prompt.js`. There is no background event recorder — the
+block needs only the current time and the timestamp of the user's
+previous message.
 
 ---
 
@@ -1802,7 +1782,7 @@ export const MessageList = {
 
 ## 15. Default denylist seed
 
-`/assets/denylist-default.json` ships with the following. Patterns use
+`peerd-egress/denylist/default.json` ships with the following. Patterns use
 glob with `*` only at subdomain position.
 
 ```json
@@ -1825,8 +1805,7 @@ glob with `*` only at subdomain position.
       "amex.com", "*.amex.com",
       "regions.com", "*.regions.com",
       "fifththird.com", "*.fifththird.com", "53.com", "*.53.com",
-      "huntington.com", "*.huntington.com",
-      "kindred.com", "*.kindred.com"
+      "huntington.com", "*.huntington.com"
     ],
     "brokers": [
       "schwab.com", "*.schwab.com",
@@ -1900,10 +1879,6 @@ glob with `*` only at subdomain position.
       "tutanota.com", "*.tutanota.com"
     ],
     "identity": [
-      "accounts.google.com",
-      "myaccount.google.com",
-      "login.microsoftonline.com",
-      "login.live.com",
       "appleid.apple.com",
       "*.okta.com",
       "*.auth0.com",

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -151,7 +151,7 @@ transfer, ralph, profiles — pure-core/injected-IO so the SW stays thin.
 - **PDF reading (`read_pdf`)** — pdf.js text-layer extraction with opt-in SRI-pinned OCR engine + page assembly. `pdf/`, `tools/defs/read-pdf.js`
 - **Contacts (per-peer overlay)** — did-keyed contacts store (name/notes/tags) + read-time known-peers + activity aggregation from App catalog + audit log. `contacts/`
 - **Sandbox tools (VM / Notebook / App / `js_run`)** — `vm_*`, `js_*` (Notebook sealed worker + headless `js_run`), `app_*` (opaque-iframe dwapps) families dispatched through gates. `tools/defs/`
-- **dweb tools** *(preview-channel only)* — `dweb_share`/`discover`/`install`/`peers`/`block` + guide; exposure-gated to `DWEB_ENABLED` channels, invisible to the agent on a store build. `tools/defs/`, `tools/exposure.js`
+- **dweb tools** *(preview-channel only)* — `dweb_share`/`discover`/`discovery`/`install`/`peers`/`block` + guide; exposure-gated to `DWEB_ENABLED` channels, invisible to the agent on a store build. `tools/defs/`, `tools/exposure.js`
 
 **Not yet**
 

--- a/docs/COMMANDS-DESIGN.md
+++ b/docs/COMMANDS-DESIGN.md
@@ -162,12 +162,11 @@ Deterministic + stable for ties.
 ## 5. Command sources + the feature-07 (skills) adapter
 
 `commandSources` is a `{ list() → [{name, body, description?}] }` contract
-(`command-sources.js`). V1 wires one source: `localStoreSource(store)`
-over the `.peerd/commands/` KV store. The slash-parser, @-resolver, and
+(`command-sources.js`). It wires two sources over the `.peerd/commands/`
+KV store and the skill registry. The slash-parser, @-resolver, and
 palette depend on the **contract**, not on 07.
 
-Feature 07 (skills, built in parallel) can EXPOSE commands. The integrator
-adds a second source and merges:
+Feature 07 (skills) EXPOSES commands. The SW merges both sources:
 
 ```js
 import { mergeSources, localStoreSource, skillRegistrySource } from '/peerd-runtime/index.js';
@@ -181,8 +180,8 @@ const commandSources = mergeSources([
 `{ name, body, description? }` — if 07 names it differently, change the
 single call site, nothing else moves. `mergeSources` dedupes by name
 (earlier source wins, so a user can always shadow a skill command),
-sorts, and **tolerates a throwing source** (07 not yet wired → that
-source degrades to `[]`, the palette still works).
+sorts, and **tolerates a throwing source** (a failing source degrades to
+`[]`, the palette still works).
 
 ## 6. Cross-cutting checklist
 

--- a/docs/COMMANDS-DEV-NOTES.md
+++ b/docs/COMMANDS-DEV-NOTES.md
@@ -25,8 +25,6 @@ Integrator-facing notes. Pairs with `docs/COMMANDS-DESIGN.md`.
 | type               | returns                                              |
 | ------------------ | --------------------------------------------------- |
 | `commands/list`    | `{ commands: [{name, description}] }` (all sources) |
-| `commands/put`     | author/overwrite a LOCAL command                    |
-| `commands/delete`  | remove a local command (idempotent)                 |
 | `composer/tabs`    | `{ tabs: [{id,title,origin,active,blocked}] }` — `blocked` = denylisted/unsupported |
 | `composer/files`   | `{ files: [path] }` — current chat's App files      |
 
@@ -61,17 +59,10 @@ inline raw page text without the `<untrusted_web_content>` fence.
 ## The feature-07 (skills) adapter — wiring
 
 The composer depends on a thin `commandSources` contract, not on 07.
-Today the SW wires only the local store:
+The SW now merges the local store with the skill registry:
 
 ```js
 // background/service-worker.js
-const commandStore = createCommandStore({ kv });
-const commandSources = localStoreSource(commandStore);
-```
-
-When 07's skill registry exists, change those two lines to:
-
-```js
 import { mergeSources, localStoreSource, skillRegistrySource } from '/peerd-runtime/index.js';
 const commandStore = createCommandStore({ kv });
 const commandSources = mergeSources([
@@ -116,5 +107,6 @@ collision (user shadows skill), dedup + sort, throwing source → `[]`.
   refresh. Cheap to make reactive later.
 - **No fuzzy match on command DESCRIPTIONS** — filtering matches the
   name/label only; description is display-only.
-- **Skill commands are read-only here** — `commands/put`/`delete` only
-  touch the local store. 07 owns skill-command lifecycle.
+- **Skill commands are read-only here** — the local `commandStore`
+  (`put`/`remove`) is not exposed over an SW route; only `commands/list`
+  is. 07 owns skill-command lifecycle.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -139,8 +139,9 @@ and tool definitions are stable across all turns of a conversation;
 re-billing them on every turn was the biggest contributor to hitting
 the 30k-input-tokens-per-minute tier limit during real agentic work.
 
-Two of four allowed cache breakpoints used. The other two are reserved
-for message-history pinning when we add it.
+Three of four allowed cache breakpoints used (system prompt, tool
+definitions, and the message-history pin). The fourth is reserved for a
+deeper sliding-window anchor if we add it.
 
 ## 11. `anthropic-dangerous-direct-browser-access: true` header
 

--- a/docs/RALPH-DEV-NOTES.md
+++ b/docs/RALPH-DEV-NOTES.md
@@ -10,8 +10,10 @@ Integrator-facing notes. Design rationale lives in `docs/RALPH.md`.
 | `extension/peerd-runtime/ralph/plan-store.js` | plan-file format (pure `parsePlan`/`serializePlan` + reducers) and `createPlanStore({ kv })`. |
 | `extension/peerd-runtime/ralph/gates.js` | gate factories + `createGateRunner(gates)` (`gates.run() → {pass,results}`). |
 | `extension/peerd-runtime/ralph/index.js` | module surface; re-exported from `peerd-runtime/index.js`. |
-| `extension/background/service-worker.js` §2b | SW wiring: `ralph` instance, adapters, `driveRalph`, routes, boot resume. |
-| `extension/sidepanel/components/ralph-view.js` | start/stop/status UI (route `/ralph`, `∞` nav button). |
+| `extension/peerd-runtime/ralph/driver.js` | `makeRalphDriver(deps)` — driver, adapters, and `driveRalph` (the guarded drive loop + boot resume). |
+| `extension/background/routes/ralph.js` | `makeRalphRoutes(deps)` — the SW message routes. |
+| `extension/background/service-worker.js` | SW wiring only: binds the IO singletons into `makeRalphDriver`/`makeRalphRoutes`. |
+| `extension/sidepanel/components/ralph-panel.js` (+ `ralph-format.js`) | start/stop/status UI — `RalphPanel`, rendered inline within `chat-view.js`. |
 
 ## Storage keys
 
@@ -54,7 +56,7 @@ createRalphLoop({
   gateRunner,                // 10: pluggable gates
   gateContext,               //     () => { vmExec, inspect } per iteration
   checkpoint,                // 02: (msg) => { ok, ref }  — git commit in WebVM
-  isFullAuto,                // 03: () => bool — refuse start unless full-auto
+  canRunUnattended,          // 03: () => bool — refuse start unless Act + confirmActions OFF
   onEvent, shouldHalt, now, maxAttempts,
 });
 ```
@@ -64,8 +66,8 @@ createRalphLoop({
 - **02** — `checkpoint` is best-effort `git add -A && git commit` in the
   session's WebVM (`vmClient.run`). Swap for feature-02's checkpoint
   store by returning `{ ok, ref }`. Called ONLY after gates pass.
-- **03** — `ralphIsFullAuto` currently proxies the session trust mode
-  (`full-auto`/`open`). Replace with the real permissions tier query.
+- **03** — `resolveCanRunUnattended` is the SW adapter: it returns true
+  only when the session is in Act mode with confirmActions OFF.
 - **10** — `ralphGateRunner` is a fixed default list. A hook system can
   build the list per-plan; just pass a different `createGateRunner([...])`.
 
@@ -73,7 +75,7 @@ createRalphLoop({
 
 | Route | Effect |
 |-------|--------|
-| `ralph/start {maxIterations?, mode?}` | refuse unless full-auto; `start()` then `driveRalph()` |
+| `ralph/start {maxIterations?, mode?}` | refuse unless `canRunUnattended`; `start()` then `driveRalph()` |
 | `ralph/halt` | set halt flag + persist `halted` |
 | `ralph/status` | `{ state, plan, summary }` |
 | `ralph/getPlan` / `ralph/setPlan {text}` | read/write the plan file (planning surface) |
@@ -106,7 +108,7 @@ Loop events are pushed to the side panel on the port with
 - **Planning quality**: the planning pass trusts the subagent's returned
   markdown verbatim. A schema-validation gate on the produced plan would
   harden it.
-- **Concurrency**: single-writer is enforced by `[~]` + `ralphDriving`.
+- **Concurrency**: single-writer is enforced by `[~]` + `driving`.
   Multi-plan / parallel-lane runs are explicitly out of scope (would
   break the single-threaded-writes constraint).
 

--- a/docs/RALPH.md
+++ b/docs/RALPH.md
@@ -190,7 +190,7 @@ mockable interfaces:
 |---------|-----------------------------------|----------------------|
 | 01 plan/persistence | `planStore` over `kv` (`load/save/loadText/saveText`) | `createPlanStore({ kv })` |
 | 02 checkpoint/commit | `checkpoint(msg) → { ok, ref }` | git commit in the session's WebVM |
-| 03 permissions tier  | `isFullAuto() → bool` (refuse start otherwise) | session mode = full-auto/open |
+| 03 permissions tier  | `canRunUnattended() → bool` (refuse start otherwise) | `resolveCanRunUnattended`: Act mode + confirmActions OFF |
 | 10 hooks for gates   | `gateRunner.run(ctx) → { pass, results }` | `createGateRunner([...gates])` |
 
 Each is a one-liner to mock, which is exactly why the loop runs
@@ -203,7 +203,7 @@ standalone in the Bun test.
   commits. The panel's event log is a bounded ring (50 lines). The SW
   holds only a tiny `LoopState`, never conversation history.
 - **Single-threaded writes** — at most one `[~]` task; `pickNextTask` is
-  the lock; `driveRalph` is re-entrancy-guarded (`ralphDriving`) so two
+  the lock; `driveRalph` is re-entrancy-guarded (`driving`) so two
   drives can't run concurrently.
 - **Browser-native** — at least one browser gate (console-clean) ships in
   the default set, run via peerd's own tools, NO MCP.

--- a/docs/hooks/DESIGN.md
+++ b/docs/hooks/DESIGN.md
@@ -35,7 +35,6 @@ peerd-runtime/tools/hooks/
   compile.js             UserHookRecord → runnable Hook. declarative + js body kinds. markdown parser.
   defaults/
     egress-allowlist.js  The flagship: the egress allowlist AS a pre-tool-use hook.
-    active-tab-guard.js   The browser-native example: inspects ctx.activeTab.
     index.js             DEFAULT_HOOKS (trusted, code, always-on).
   index.js               module barrel → re-exported from peerd-runtime/index.js
 ```
@@ -146,23 +145,7 @@ is a real policy chokepoint — if the allowlist can be a hook, hooks are
 load-bearing. The egress hook is **code, not config**: it can't be
 exported away or disabled through the user-hook surface.
 
-## 6. Browser-native angle (the mandate)
-
-`defaults/active-tab-guard.js` is the browser-native example. Where the
-egress hook reasons about a declared network origin, this one reaches
-into **the live browser context** — `ctx.activeTab` (the tab the agent is
-driving) — and, for DOM-write tools (`type`, `click`, `page_exec`,
-`page_keys`, `navigate`), stamps a `_browserContext` provenance field
-onto the call (origin, path, a credential-sensitive heuristic, a
-timestamp). This is the `modify` decision path firing on a
-browser-native signal: a pre-hook is the only layer that can see "the
-model wants to TYPE, and the page it will type into is a login form."
-
-V1 annotates rather than blocks (the denylist + origin gate own hard
-origin blocks); a user can ship a lower-`order` pre-hook to hard-block
-instead — hooks compose.
-
-## 7. Storage model — `.peerd/hooks/` without a filesystem
+## 6. Storage model — `.peerd/hooks/` without a filesystem
 
 peerd's workspace is logical: there is no real FS. A user authors hooks
 as markdown-with-frontmatter at the logical path `.peerd/hooks/<id>.md`,
@@ -187,7 +170,7 @@ into a runnable Hook. Two body kinds:
 V1.x reserves a **shell/WebVM body kind** (run a hook as a shell script
 in the sandboxed Linux VM) — the compile seam is where it lands.
 
-## 8. Reversibility (hard constraint)
+## 7. Reversibility (hard constraint)
 
 User hooks are plain serializable records — nothing hidden in opaque
 state:
@@ -196,10 +179,10 @@ state:
 - `saveUserHook` / `removeHook` / `clearUserHooks` — full CRUD; the SW is
   the single writer (single-threaded writes).
 - SW message handlers: `hooks/list`, `hooks/save`, `hooks/remove`,
-  `hooks/export`, `hooks/clear`. Default hooks appear in `hooks/list`
+  `hooks/toggle`. Default hooks appear in `hooks/list`
   with `isDefault: true` and are refused by `hooks/remove`.
 
-## 9. MV3 / persistence
+## 8. MV3 / persistence
 
 Default hooks register synchronously at SW boot (idempotent — safe across
 the 30s idle restart). User hooks load async from storage on each boot;
@@ -207,17 +190,17 @@ the dispatcher reads the live registry per call, so a load completing
 after the SW wakes is picked up immediately. A load failure leaves only
 the defaults installed — the safe degraded state.
 
-## 10. Public API (`peerd-runtime/index.js`)
+## 9. Public API (`peerd-runtime/index.js`)
 
 ```
 registerHook, unregisterHook, listHooks, exportHooks,
 loadUserHooks, saveUserHook, removeHook, clearUserHooks, HOOKS_STORAGE_KEY,
 runPreToolUse, runPostToolUse, selectHooks, hookMatches,
 compileUserHook, parseHookMarkdown,
-DEFAULT_HOOKS, egressAllowlistHook, activeTabGuardHook
+DEFAULT_HOOKS, egressAllowlistHook
 ```
 
-## 11. Cross-cutting checklist
+## 10. Cross-cutting checklist
 
 - [x] **Lethal-trifecta**: pre-hook is the last veto; this feature is central to it.
 - [x] **Fail-closed**: throw/garbage/timeout/malformed-modify → block. Post-hooks intentionally observe-only.
@@ -228,7 +211,6 @@ DEFAULT_HOOKS, egressAllowlistHook, activeTabGuardHook
 - [x] **No telemetry.** Hook outcomes stay in `meta` + the local audit log.
 - [x] **Reversibility.** export / remove / clear; records are plain JSON.
 - [x] **Bare fetch forbidden.** Egress hook reuses egress `originOf`; no fetch here.
-- [x] **a11y / reduced-motion.** No UI shipped in this slice (settings UI is V1.x — see DEV-NOTES); the SW handlers it will call are in place.
-- [x] **Browser-native.** active-tab-guard inspects `ctx.activeTab`.
+- [x] **a11y / reduced-motion.** The Hooks settings UI (`hooks-view.js`, the `'hooks'` section of the options page) is shipped, calling the `hooks/*` SW handlers.
 - [x] **index.js public API.** Module barrel re-exported from runtime index.
 - [x] **Comments say WHY.**

--- a/docs/hooks/DEV-NOTES.md
+++ b/docs/hooks/DEV-NOTES.md
@@ -10,7 +10,7 @@ Integrator-facing notes. Read DESIGN.md first for the model.
 | Registry (register/list/load/save/remove/export) | `extension/peerd-runtime/tools/hooks/registry.js` |
 | Compiler (record → Hook; markdown parser) | `extension/peerd-runtime/tools/hooks/compile.js` |
 | Default egress-allowlist hook | `extension/peerd-runtime/tools/hooks/defaults/egress-allowlist.js` |
-| Browser-native active-tab-guard hook | `extension/peerd-runtime/tools/hooks/defaults/active-tab-guard.js` |
+| Hooks settings UI | `extension/sidepanel/components/hooks-view.js`, mounted as the `'hooks'` section of `extension/options/components/options-app.js` |
 | Module barrel | `extension/peerd-runtime/tools/hooks/index.js` |
 | Public re-export | `extension/peerd-runtime/index.js` |
 | Dispatcher wiring | `extension/peerd-runtime/tools/dispatcher.js` |
@@ -51,7 +51,7 @@ In `dispatcher.js`:
   ...userEndpoints]` (egress hook input) and `now: Date.now`
   (provenance).
 - Message handlers added: `hooks/list`, `hooks/save`, `hooks/remove`,
-  `hooks/export`, `hooks/clear`.
+  `hooks/toggle`.
 
 ## How a feature registers a hook (03 plan/act, 05 Ralph, …)
 
@@ -134,16 +134,17 @@ raw markdown to the `hooks/save` SW handler (`{ markdown }`).
   default wins a tie (you can't out-prioritize the egress floor with an
   equal order — use a lower number deliberately if you mean to).
 
+## Shipped UI
+
+- **Settings UI.** The Hooks section (`hooks-view.js`, mounted as the
+  `'hooks'` section of the options page) lists/edits hooks over the SW
+  `hooks/*` handlers, with per-hook enable/disable via the `hooks/toggle`
+  route (the `enabled` field is honored by `selectHooks`).
+
 ## V1.x gaps (deliberately not built)
 
-- **No settings UI.** The SW `hooks/*` handlers exist; the Mithril panel
-  to list/edit/toggle/export hooks (with a11y + reduced-motion) is V1.x.
-  Wiring point: add a Hooks section that round-trips through those
-  handlers.
 - **Shell / WebVM body kind.** `compile.js` reserves the seam; a hook
   body could run as a shell script in the sandboxed Linux VM. Not in V1.
-- **Per-hook enable/disable toggle from UI.** The `enabled` field is
-  honored by `selectHooks`; no UI surface yet.
 - **More events.** Only `pre-tool-use` / `post-tool-use` ship. Adding
   `session-start` etc. is a new event string + a runner call at the new
   site; the registry/compile layers don't change.
@@ -157,8 +158,7 @@ raw markdown to the `hooks/save` SW handler (`{ markdown }`).
 The Bun suite covers the pure core. Add an in-browser case at
 `extension/tests/runner.html` that dispatches a `mutate_external` tool
 with an off-allowlist origin through the REAL `dispatchToolCall` and
-asserts `hook_blocked:pre-tool-use:egress-allowlist`, plus one that
-asserts `meta.hooks` carries the active-tab-guard `_browserContext`
-annotation. These need the browser (chrome.*, the egress absolute
-import), which is exactly the in-browser suite's job.
+asserts `hook_blocked:pre-tool-use:egress-allowlist`. This needs the
+browser (chrome.*, the egress absolute import), which is exactly the
+in-browser suite's job.
 ```

--- a/docs/skills/DEV-NOTES.md
+++ b/docs/skills/DEV-NOTES.md
@@ -15,7 +15,7 @@ Quick map for the integrator. Everything ships behind
 | Public surface | `extension/peerd-runtime/skills/index.js` → `peerd-runtime/index.js` |
 | SW wiring | `extension/background/service-worker.js` |
 | System-prompt placeholder | `extension/peerd-provider/system-prompt.txt` (`{{SKILLS_BLOCK}}`) + `extension/peerd-runtime/loop/system-prompt.js` |
-| UI | `extension/sidepanel/components/skills-view.js` (route `/skills`, app.js + sidepanel.js) |
+| UI | `extension/sidepanel/components/skills-view.js`, mounted as the `'skills'` section of `extension/options/components/options-app.js` (the full-tab options page) |
 | Tests | `tests/peerd-runtime/skills/{parse,registry,install}.test.ts` |
 
 ## Storage keys

--- a/docs/specs/TOOL-INVENTORY-COMPARISON.md
+++ b/docs/specs/TOOL-INVENTORY-COMPARISON.md
@@ -71,7 +71,7 @@ Coverage key: **✅ covered** · **🟡 partial** · **❌ not covered** ·
 | **Personality** (SOUL.md, soul_read/update) | 🟡 | peerd has per-session `/system` (`<session_instructions>`) + a frugally-expanded USER memory doc + strong built-in voice rules. **peerd deliberately rejects a self-rewriting identity file** — see `SYSTEM-PROMPT-LESSONS.md` §personality. |
 | **MCP app integrations** (47 apps via Klavis Strata cloud) | ❌ (thesis divergence) | peerd reaches the **same apps by driving their real web UIs** with `do`/`get`/`check`, plus `call_api` for public/JSON APIs. No MCP, no cloud gateway. Real trade-off discussed in §2/§3. |
 | **Scheduling** | 🟡 planned | `FEATURE-SCHEDULED-TASKS.md` sketches the hardened version: durable IDB truth, single pinned waker, Firefox boot-scan, budgets, unattended clamps, dry-run. |
-| **Proactive suggestions** | ✅ (landing) | `FEATURE-SMART-NUDGES.md` (reactive, opt-in, no surveillance). |
+| **Proactive suggestions** | 🟡 planned | `FEATURE-SMART-NUDGES.md` (reactive, opt-in, no surveillance). |
 | **Network / console observation** | ⭐ / N/A | BrowserOS lists these "coming soon" (not shipped). peerd has `read_state` + `page_exec` (CDP preview). Not a gap. |
 | **Sub-agents / multi-agent** | ⭐ | `spawn_subagent` (real parallel dispatch, depth-bounded, tool-narrowed, audit lineage) + `request_review`. Ahead of BrowserOS's "Agent Per Tab." |
 | **Code execution** | ⭐ | **WebVM (real Linux), JS Sandbox, Apps** — sandboxed by construction. BrowserOS's "code execution" is host `bash` via Cowork (unsafe). peerd is both safer and more capable here. |


### PR DESCRIPTION
A verified drift audit (24 findings across the doc surface, **0 false positives** - each confirmed against current `main` by a majority of 3 adversarial verifiers) found the docs are **accurate in substance** (architecture, module roles, security posture all hold) but drifted on the **surface detail that points readers at code**. This corrects all of it, grouped by the 5 root causes so it reviews as themes rather than 24 scattered edits.

## Corrections by root cause
- **SW decomposition** (`background/routes/*` + the turn-driver extraction): RALPH-DEV-NOTES driver/UI/route locations (`peerd-runtime/ralph/driver.js`, `background/routes/ralph.js`, `RalphPanel` inline in `chat-view.js`); dropped the nonexistent `service-worker.js §2b` + `ralph-view.js` refs; skills UI is the options-page `'skills'` section, not a `/skills` side-panel route.
- **Renamed symbols:** `isFullAuto` → `canRunUnattended`; `ralphDriving` → `driving`.
- **Shipped features still labelled future:** the hooks settings UI (options page + `hooks/toggle`) and the commands→skills source merge (`mergeSources`) both landed - moved out of "V1.x gaps".
- **Wrong route/symbol inventories:** hook routes are `list/save/remove/toggle` (not `export`/`clear`); only `commands/list` is routed (no `commands/put|delete`).
- **Clock/temporal simplification (2026-06-12):** DESIGN §10.5 rewritten to the real spartan block (`now <ISO>` + optional coarse "N since the user's previous message"), the `now`+`wait_until` toolset (no `time_since`), and the clock dir (`context/index/now/tools` - no `events.js` recorder). Verified verbatim against `clock/context.js` + `clock/tools.js`.
- **Denylist seed:** corrected the path (`peerd-egress/denylist/default.json`), removed the Google/MS identity redirects (removed 2026-06-05, DECISIONS #13 - the seed's own `_notes` confirms) and the nonexistent `kindred.com`.
- **Stale counts/labels:** cache breakpoints 2→3 of 4; runner allow-list "4-9" dropped (defers to `READ_TOOLSET`/`DO_TOOLSET`); FEATURES dweb list + `dweb_discovery`; ARCHITECTURE §2.2 dropped "trust-mode policy"; `PLAN_NAVIGATION_TOOLS` path fully-qualified; dweb Phase 1 marked landed; nudges ✅→🟡 planned.

Every correction was re-verified against current code (path/symbol/count/route).

## ⚠️ One owner judgment call (not a blocker)
The hooks docs described a second default hook **`defaults/active-tab-guard.js`** (across the §2 tree, an entire §6 section, the export list, the checklist, and a DEV-NOTES test ref). **That file does not exist** - `DEFAULT_HOOKS = [egressAllowlistHook]` only, and `_browserContext` appears nowhere. I **removed it from the docs** (a doc describing non-existent code is drift). **If it was meant to ship, that's a separate build task** - say the word and I'll spec/build it instead; this PR just stops the docs from describing a hook that isn't there.

## Deferred (noted, not changed)
`docs/RALPH-DEV-NOTES.md:101` has a forward-looking "V1.x gaps" bullet that still says `isFullAuto` - left as-is because it's an aspirational "harden later" note whose intent may have partially landed; rewriting it is a roadmap judgment, not a drift fix.

Found + verified via a multi-agent drift audit. Docs-only - no code, no gates affected.