### PR TITLE
Raise the wait_until hard cap from 10 minutes to 1 hour

### DIFF
--- a/extension/peerd-runtime/clock/tools.js
+++ b/extension/peerd-runtime/clock/tools.js
@@ -17,10 +17,13 @@ import { formatDelta, isoSecondsZ, parseDuration } from './now.js';
 
 /**
  * Hard cap on wait duration. We don't let the agent freeze a turn for
- * longer than this — the user may want to step in. 10 minutes is
- * generous but bounded.
+ * longer than this — the user may want to step in, and the SW must stay
+ * alive (offscreen keepalive) for the whole blocking sleep, with no
+ * persist/resume if it's evicted mid-wait. 1 hour is the ceiling; for
+ * "wait then check" patterns the agent can still chain shorter waits
+ * across turns (more resilient than one long block).
  */
-const WAIT_MAX_MS = 10 * 60 * 1000;
+const WAIT_MAX_MS = 60 * 60 * 1000;
 
 /** @type {import('/shared/tool-types.js').Tool} */
 export const nowTool = {
@@ -55,7 +58,7 @@ export const waitUntilTool = {
   primitive: 'time',
   description: [
     'Block the agent for a duration ("47s", "5m", "1h30m") or until an',
-    'absolute ISO timestamp ("2026-06-05T14:34:21Z"). Hard cap: 10 minutes.',
+    'absolute ISO timestamp ("2026-06-05T14:34:21Z"). Hard cap: 1 hour.',
     'Use for "wait then check again" patterns (rate-limit cool-down, ',
     'monitoring an external state that updates on its own).',
   ].join(' '),


### PR DESCRIPTION
## What

Raises the `wait_until` hard cap from **10 minutes → 1 hour** (`extension/peerd-runtime/clock/tools.js`, `WAIT_MAX_MS`), and updates the tool description + the rationale comment.

## Why

The cap bounds how long a single agent turn can block on `wait_until`. At 10 minutes, a long "wait then check" had to be chunked across many turns (e.g. a 90-min wait sampled at 10-min intervals). 1 hour lets the agent hold a longer single wait.

## Trade-off (noted in the comment)

A blocking `wait_until` keeps the turn — and the service worker, via the offscreen keepalive — alive for the **whole** duration, with **no persist/resume if it's evicted mid-wait**. So for very long waits, chaining shorter waits across turns is still the more resilient pattern. 1 hour is the new ceiling, not a recommendation to always use it. (A persisted/scheduled wait via `chrome.alarms` is the robust long-wait answer — that's the separate `docs/specs/FEATURE-SCHEDULED-TASKS.md` proposal.)

## Checks

`typecheck` ✅ · `lint` ✅. The existing cap test asks for `999d` (over any cap) and asserts the refusal, so it passes unchanged; it runs in CI's in-browser harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iKhDySM1DFLxu8to9FMDG

---
_Generated by [Claude Code](https://claude.ai/code/session_017iKhDySM1DFLxu8to9FMDG)_