### PR TITLE
fix(ui): input-bar session safety + composer keydown hardening

### DIFF
--- a/extension/sidepanel/components/input-bar.js
+++ b/extension/sidepanel/components/input-bar.js
@@ -214,6 +214,14 @@ export const InputBar = {
       saveDraft(ui._sid, ui.value);
       ui.value = loadDraft(sid);
       ui.transcriptBaseline = '';
+      // why: staged files belong to the chat they were attached in — InputBar
+      // isn't remounted on an in-place switch, so without this the chips (and
+      // their base64 bytes) ride into the switched-to chat and upload with ITS
+      // next send: a private file into the wrong conversation. Drafts persist
+      // text per-chat; attachment bytes don't, so clear them (the user
+      // re-stages in the new chat if they meant to).
+      ui.attachments = [];
+      ui.attachError = null;
       ui._sid = sid;
     }
     const hasKey = state.providers?.hasKey;
@@ -243,9 +251,12 @@ export const InputBar = {
         const reply = await send({ type: 'agent/send', text, goal: true });
         ui.busy = false;
         // Disarm only on a clean launch; on failure restore the draft and
-        // stay armed so the user can retry without re-toggling.
+        // stay armed so the user can retry without re-toggling. Guard the
+        // restore on sid (same reason as the normal send below): a chat switch
+        // during the await must not dump this goal text into another chat.
         if (reply?.ok) onGoalSent?.();
-        else ui.value = text;
+        else if (ui._sid === sid) ui.value = text;
+        else saveDraft(sid, text);
         m.redraw();
         return;
       }
@@ -267,12 +278,22 @@ export const InputBar = {
       });
       ui.busy = false;
       if (!reply?.ok) {
-        // Put the draft back so the user can retry — files included.
-        ui.value = text;
-        if (attachments) ui.attachments = attachments;
-        // Surface the SW's fail-closed refusal (e.g. an over-cap file)
-        // where the chips are; turn-level errors render in the chat.
-        if (attachments && reply?.error) ui.attachError = reply.error;
+        // why guard on sid: the user may have switched chats during the await.
+        // Restoring into the shared `ui` would dump THIS send's text / files /
+        // error into whatever chat is now in view. Same chat → restore inline
+        // for an immediate retry (files included). Switched away → put the text
+        // back on the ORIGINAL chat's draft (attachment bytes can't ride a
+        // draft, so they drop — re-staging is the cost of a failed send + a
+        // switch).
+        if (ui._sid === sid) {
+          ui.value = text;
+          if (attachments) ui.attachments = attachments;
+          // Surface the SW's fail-closed refusal (e.g. an over-cap file)
+          // where the chips are; turn-level errors render in the chat.
+          if (attachments && reply?.error) ui.attachError = reply.error;
+        } else {
+          saveDraft(sid, text);
+        }
       }
       m.redraw();
     };
@@ -374,6 +395,11 @@ export const InputBar = {
 
     /** @param {KeyboardEvent} e */
     const onKeydown = (e) => {
+      // During IME (CJK/kana/pinyin) composition, Enter confirms the IME
+      // candidate — never hijack it to send or to commit a palette pick, or the
+      // user loses their half-composed text. isComposing + the legacy keyCode
+      // 229 both mark an in-progress composition.
+      const composing = e.isComposing || e.keyCode === 229;
       // Palette is open: intercept navigation keys so they drive the
       // popup, not the textarea.
       if (ui.trigger) {
@@ -389,12 +415,17 @@ export const InputBar = {
             ui.paletteIndex = (ui.paletteIndex - 1 + cands.length) % cands.length;
             return;
           }
-          if (e.key === 'Enter' || e.key === 'Tab') {
+          if ((e.key === 'Enter' || e.key === 'Tab') && !composing) {
             // Plain Enter/Tab commits the candidate; Shift+Enter (newline) and
-            // Cmd/Ctrl+Enter (send) fall through. Skip disabled options.
+            // Cmd/Ctrl+Enter (send) fall through. ALWAYS consume a plain
+            // Enter/Tab here — even when the active candidate is disabled (it
+            // commits nothing) — so it never falls through to submit() and
+            // sends the literal trigger text (e.g. "@tab:").
             if (!(e.metaKey || e.ctrlKey) && !e.shiftKey) {
+              e.preventDefault();
               const pick = cands[Math.min(ui.paletteIndex, cands.length - 1)];
-              if (pick && !pick.disabled) { e.preventDefault(); commit(pick); return; }
+              if (pick && !pick.disabled) commit(pick);
+              return;
             }
           }
           if (e.key === 'Escape') {
@@ -405,8 +436,8 @@ export const InputBar = {
         }
       }
       // Enter sends; Shift+Enter inserts a newline (textarea default).
-      // Cmd/Ctrl+Enter also sends, for muscle memory.
-      if (e.key === 'Enter' && !e.shiftKey) {
+      // Cmd/Ctrl+Enter also sends, for muscle memory. Never while composing.
+      if (e.key === 'Enter' && !e.shiftKey && !composing) {
         e.preventDefault();
         submit();
       }

--- a/extension/tests/unit/sidepanel/attachments.test.js
+++ b/extension/tests/unit/sidepanel/attachments.test.js
@@ -36,7 +36,7 @@ const need = (root, sel, _ctor) => {
 /** @param {string} [provider] */
 const baseState = (provider = 'anthropic') => ({
   streaming: false,
-  session: null,
+  session: /** @type {{ sessionId: string } | null} */ (null),
   providers: { hasKey: true, current: provider },
   cost: null,
 });
@@ -144,6 +144,40 @@ describe('sidepanel.attachments', () => {
       expect(msg.attachments[0].data).toBe(btoa('imgbytes'));
       // staging cleared on the successful send
       expect(root.querySelector('.attach-chip')).toBeFalsy();
+    } finally { unmount(); }
+  });
+
+  it('staged attachments do NOT bleed into another chat on switch', async () => {
+    // Cross-session leak: a file staged in chat A must not ride chat B's send.
+    /** @type {Msg[]} */
+    const sent = [];
+    /** @param {Msg} msg */
+    const send = async (msg) => { sent.push(msg); return { ok: true }; };
+    const state = baseState();
+    state.session = { sessionId: 'A' };
+    const { root, unmount } = await mountInputBar(state, send);
+    try {
+      pasteImage(need(root, 'textarea'));
+      await until(() => root.querySelector('.attach-chip'));
+      expect(root.querySelector('.attach-chip')).toBeTruthy();
+
+      // Switch to chat B (InputBar is not remounted — same component instance).
+      state.session = { sessionId: 'B' };
+      m.redraw.sync();
+      await flush();
+      // The chip — and its bytes — must be gone in chat B.
+      expect(root.querySelector('.attach-chip')).toBeFalsy();
+
+      // And B's send carries no attachments inherited from A.
+      const ta = need(root, 'textarea', HTMLTextAreaElement);
+      ta.value = 'hi from B';
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+      m.redraw.sync();
+      need(root, 'form.input-bar')
+        .dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+      await until(() => sent.length > 0);
+      expect(sent[0].text).toBe('hi from B');
+      expect(sent[0].attachments).toBe(undefined);
     } finally { unmount(); }
   });
 


### PR DESCRIPTION
## What

Recreates **#29** (jonybur's verified side-panel bug-hunt) on top of current `main`, with the one fix that was reddening its CI.

## Why a recreation

#29's `lint + boundary + drift` job failed — **typecheck**, not lint:

```
attachments.test.js(157,5): error TS2322: Type '{ sessionId: string }' is not assignable to type 'null'.
attachments.test.js(165,7): error TS2322: ...
```

The new regression test assigns `state.session = { sessionId: 'A' }`, but `baseState()` declared `session: null`, so strict `tsc` inferred the field as `null` and rejected the assignment. Fixed by annotating the field:

```js
session: /** @type {{ sessionId: string } | null} */ (null),
```

No runtime change. #29's branch couldn't be pushed to from this session, so the fix rides a recreation (same pattern as #28).

## The four composer fixes (unchanged from #29)

- **#1 (HIGH)** — staged attachments cleared on an in-place chat switch: they no longer bleed (chips **and** base64 bytes) into the switched-to chat and upload with its next send (a private file into the wrong conversation). Revert-proven in-browser test (`598 → 597/1` when reverted).
- **#7** — failed-send restore guarded on `ui._sid === sid`: a chat switch mid-await no longer dumps text/files into the now-viewed chat (same guard on the goal-armed path).
- **#2** — Enter during IME composition (`isComposing` / `keyCode 229`) no longer sends or commits a palette pick (CJK/kana/pinyin).
- **#6** — an open palette always consumes a plain Enter/Tab, so a disabled candidate never falls through to submit the literal trigger text.

## Verified locally against current `main`

`bun run lint` · `bun run typecheck` · `check:tscheck` (472/472 floor) · `check:boundary` · generated-file drift — **all clean**. In-browser suite passed on #29's branch and this change is type-only.

Full credit to **@jonybur** — this is his hunt + fix; the recreation just adds the test type annotation and reconciles onto current `main`. Supersedes #29.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHffCSYFCRUBQSAWCshR4K)_