### PR TITLE
fix(ui): transient-state honesty — rate-limit bleed + aborted tool cards

### DIFF
--- a/extension/sidepanel/chat-reducer.js
+++ b/extension/sidepanel/chat-reducer.js
@@ -348,8 +348,13 @@ export const reduceChat = (state, msg) => {
       // job — see the module header.) why preserve pendingConfirm: confirm
       // state is owned by the confirm/request|resolved channel, NOT the
       // snapshot (it carries null) — folding ...msg.state must never wipe a
-      // live prompt a 'state' push races with (DESIGN-12).
-      return { ...state, ...msg.state, pendingConfirm: state.pendingConfirm, lastError: null, cost: { ...state.cost,
+      // live prompt a 'state' push races with (DESIGN-12). why rateLimit:null:
+      // the snapshot carries no rateLimit field, so without an explicit reset
+      // the previous chat's retry banner survives the fold and paints on the
+      // switched-to (idle) chat — a stale "⏳ Rate limited" control in the wrong
+      // conversation. A switched-to chat is never mid-retry from the previous
+      // one; an active retry in THIS chat re-asserts via the next pause/delta.
+      return { ...state, ...msg.state, pendingConfirm: state.pendingConfirm, lastError: null, rateLimit: null, cost: { ...state.cost,
         session: msg.state?.session?.cost ?? state.cost.session,
         limitUsd: msg.state?.settings?.spendLimitUsd ?? state.cost.limitUsd,
         limitReached: false } };

--- a/extension/sidepanel/components/message-list.js
+++ b/extension/sidepanel/components/message-list.js
@@ -323,7 +323,9 @@ const AssistantMessage = {
             : '⚠ output limit reached — response may be cut short')
         : message.stopReason === 'max_steps'
           ? m('.stop-chip', '⚠ step cap reached — send a message to continue')
-          : null,
+          : message.stopReason === 'aborted'
+            ? m('.stop-chip', '⏹ stopped')
+            : null,
       // Tool calls render below the text bubble (or alone if there's
       // no text).
       hasToolUses
@@ -332,6 +334,9 @@ const AssistantMessage = {
               key: toolUse.id,
               toolUse,
               toolResult,
+              // an aborted turn never produced this tool's result — render it
+              // 'cancelled', not a perpetual 'running…' (see ToolCall).
+              interrupted: message.stopReason === 'aborted',
               liveStream: vmStreams?.[toolUse.id] ?? null,
               subagents,
               loadSubagent,
@@ -435,6 +440,7 @@ const ToolCall = {
    * @param {{
    *   attrs: {
    *     toolUse: ToolUse, toolResult: ToolResult|null,
+   *     interrupted?: boolean,
    *     liveStream?: { stdout: string, stderr: string }|null,
    *     subagents?: TranscriptArgs['subagents'],
    *     loadSubagent?: (sessionId: string) => void,
@@ -443,16 +449,20 @@ const ToolCall = {
    *   state: ToolCallState,
    * }} vnode
    */
-  view: ({ attrs: { toolUse, toolResult, liveStream, subagents, loadSubagent, peerName, depth }, state: ui }) => {
+  view: ({ attrs: { toolUse, toolResult, interrupted, liveStream, subagents, loadSubagent, peerName, depth }, state: ui }) => {
     // spawn_subagent gets its own card: the expanded body is the child's
     // full transcript rendered inline (recursively), not a result blob.
     if (toolUse.name === 'spawn_subagent') {
-      return renderSubagentCard({ toolUse, toolResult, subagents, loadSubagent, peerName, depth: depth ?? 0, ui });
+      return renderSubagentCard({ toolUse, toolResult, interrupted, subagents, loadSubagent, peerName, depth: depth ?? 0, ui });
     }
     const meta = toolResult?.meta ?? null;
+    // why 'cancelled': a tool_use with no result on an ABORTED turn (Stop /
+    // spend-limit / steer) is NOT still running — without this it shows
+    // "running…" with a pulsing dot forever, and persists that way across a
+    // reload. 'cancelled' gives the card a terminal, honest resting state.
     const status = toolResult
       ? (toolResult.is_error ? 'failed' : 'ok')
-      : 'pending';
+      : (interrupted ? 'cancelled' : 'pending');
     const showLiveStream = toolUse.name === 'vm_boot' && !toolResult
       && liveStream && (liveStream.stdout || liveStream.stderr);
     // why: a single compact line is the resting state — a status dot,
@@ -466,11 +476,12 @@ const ToolCall = {
       }, [
         m('span.disclosure', ui.expanded ? '▼' : '▶'),
         m(`span.tool-status-dot.dot-${status}`,
-          { title: status === 'failed' ? 'failed' : status === 'pending' ? 'running' : 'ok' }),
+          { title: status === 'failed' ? 'failed' : status === 'pending' ? 'running' : status === 'cancelled' ? 'cancelled' : 'ok' }),
         m('span.tool-name', toolUse.name),
         m('span.tool-args', argsSummary(toolUse.input)),
         m('.spacer'),
         status === 'pending' ? m('span.tool-pending', 'running…')
+          : status === 'cancelled' ? m('span.tool-cancelled', 'cancelled')
           : meta ? m('span.tool-duration', `${meta.durationMs}ms`) : null,
       ]),
       // why: a vm_boot can take many seconds to finish (pip install,
@@ -522,7 +533,7 @@ const ToolCall = {
         m('.tool-result', [
           toolResult
             ? m('pre.tool-result-content', formatResultContent(toolResult))
-            : m('p.muted', 'Result pending…'),
+            : m('p.muted', interrupted ? 'Cancelled — the turn was stopped before this tool ran.' : 'Result pending…'),
         ]),
       ]) : null,
     ]);
@@ -538,15 +549,15 @@ const ToolCall = {
 // MAX_NESTED_DEPTH visually; deeper runs are still inspectable.
 /**
  * @param {{
- *   toolUse: ToolUse, toolResult: ToolResult|null,
+ *   toolUse: ToolUse, toolResult: ToolResult|null, interrupted?: boolean,
  *   subagents?: TranscriptArgs['subagents'],
  *   loadSubagent?: (sessionId: string) => void,
  *   peerName?: string, depth: number, ui: ToolCallState,
  * }} args
  */
-const renderSubagentCard = ({ toolUse, toolResult, subagents, loadSubagent, peerName, depth, ui }) => {
+const renderSubagentCard = ({ toolUse, toolResult, interrupted, subagents, loadSubagent, peerName, depth, ui }) => {
   const meta = toolResult?.meta ?? null;
-  const status = toolResult ? (toolResult.is_error ? 'failed' : 'ok') : 'pending';
+  const status = toolResult ? (toolResult.is_error ? 'failed' : 'ok') : (interrupted ? 'cancelled' : 'pending');
   const childId = resolveChildSessionId(toolUse, toolResult, subagents);
   const childSession = childId ? subagents?.sessions?.[childId] : null;
   const task = childSession?.task ?? toolUse.input?.task ?? '';
@@ -563,11 +574,12 @@ const renderSubagentCard = ({ toolUse, toolResult, subagents, loadSubagent, peer
     m('.tool-call-header', { onclick: onToggle }, [
       m('span.disclosure', ui.expanded ? '▼' : '▶'),
       m(`span.tool-status-dot.dot-${status}`,
-        { title: status === 'failed' ? 'failed' : status === 'pending' ? 'running' : 'ok' }),
+        { title: status === 'failed' ? 'failed' : status === 'pending' ? 'running' : status === 'cancelled' ? 'cancelled' : 'ok' }),
       m('span.tool-name', 'spawn_subagent'),
       m('span.tool-args', `"${truncate(String(task), 48)}"`),
       m('.spacer'),
       status === 'pending' ? m('span.tool-pending', 'running…')
+        : status === 'cancelled' ? m('span.tool-cancelled', 'cancelled')
         : meta ? m('span.tool-duration', `${meta.durationMs}ms`) : null,
     ]),
     ui.expanded ? m('.subagent-body', [
@@ -580,7 +592,7 @@ const renderSubagentCard = ({ toolUse, toolResult, subagents, loadSubagent, peer
           ? m('.subagent-transcript',
               renderTranscript({ messages: childSession.messages, subagents, loadSubagent, peerName, depth: depth + 1 }))
           : childId
-            ? m('p.muted', status === 'pending' ? 'subagent running…' : 'loading transcript…')
+            ? m('p.muted', status === 'pending' ? 'subagent running…' : status === 'cancelled' ? 'subagent cancelled' : 'loading transcript…')
             : m('p.muted', 'no child transcript recorded'),
     ]) : null,
   ]);

--- a/extension/sidepanel/styles.css
+++ b/extension/sidepanel/styles.css
@@ -1061,6 +1061,10 @@ button.icon:hover { background: var(--bg); }
   background: var(--ok);
   animation: peerd-dot-pulse 1.2s ease-in-out infinite;
 }
+/* aborted-turn tool: a static, muted dot — no pulse, a terminal resting state. */
+.tool-call.tool-cancelled { opacity: 0.6; }
+.tool-status-dot.dot-cancelled { background: var(--fg-muted); }
+.tool-cancelled { color: var(--fg-muted); font-size: 11px; font-style: italic; flex-shrink: 0; }
 @keyframes peerd-dot-pulse {
   0%, 100% { opacity: 0.35; }
   50%      { opacity: 1; }

--- a/extension/tests/index.js
+++ b/extension/tests/index.js
@@ -88,6 +88,7 @@ import './unit/sidepanel/goal-bar.test.js';
 import './unit/sidepanel/memory-suggestions.test.js';
 import './unit/sidepanel/tools-chip.test.js';
 import './unit/sidepanel/attachments.test.js';
+import './unit/sidepanel/message-list.test.js';
 
 // --- home (chassis): the full-tab Library page ---
 import './unit/home/library-section.test.js';

--- a/extension/tests/unit/sidepanel/message-list.test.js
+++ b/extension/tests/unit/sidepanel/message-list.test.js
@@ -1,0 +1,59 @@
+// @ts-check
+// MessageList — aborted-turn tool cards must show a terminal "cancelled"
+// state, not a perpetual "running…". An aborted turn (Stop / spend-limit /
+// steer) persists its toolUses with no tool_result; without threading the
+// parent message's stopReason the card derives status='pending' forever (and
+// across a reload).
+
+import m from '/vendor/mithril/mithril.js';
+import { describe, it, expect } from '../../framework.js';
+import { MessageList } from '/sidepanel/components/message-list.js';
+
+const flush = async () => {
+  await new Promise((r) => setTimeout(r, 0));
+  m.redraw.sync();
+};
+
+/** @param {any[]} messages */
+const mount = (messages) => {
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  m.mount(root, { view: () => m(MessageList, { messages }) });
+  return { root, unmount: () => { m.mount(root, null); root.remove(); } };
+};
+
+describe('sidepanel.message-list aborted cards', () => {
+  it('an aborted turn shows "cancelled" tool cards, not a perpetual "running…"', async () => {
+    const { root, unmount } = mount([{
+      role: 'assistant', id: 'a1', content: '', stopReason: 'aborted',
+      toolUses: [{ id: 't1', name: 'click', input: {} }],
+    }]);
+    try {
+      await flush();
+      const card = /** @type {Element} */ (root.querySelector('.tool-call'));
+      expect(card).toBeTruthy();
+      // terminal cancelled state — no live "running…" label, no pulsing dot
+      expect(card.classList.contains('tool-cancelled')).toBe(true);
+      expect(card.querySelector('.dot-cancelled')).toBeTruthy();
+      expect(card.querySelector('.tool-pending')).toBeFalsy();
+      // the turn itself shows a "stopped" chip
+      const chip = /** @type {Element} */ (root.querySelector('.stop-chip'));
+      expect(chip).toBeTruthy();
+      expect((chip.textContent || '').includes('stopped')).toBe(true);
+    } finally { unmount(); }
+  });
+
+  it('a live turn (no abort) keeps the "running…" pending state', async () => {
+    const { root, unmount } = mount([{
+      role: 'assistant', id: 'a1', content: '', // no stopReason → turn in flight
+      toolUses: [{ id: 't1', name: 'click', input: {} }],
+    }]);
+    try {
+      await flush();
+      const card = /** @type {Element} */ (root.querySelector('.tool-call'));
+      expect(card.classList.contains('tool-pending')).toBe(true);
+      expect(card.classList.contains('tool-cancelled')).toBe(false);
+      expect(card.querySelector('.tool-pending')).toBeTruthy();
+    } finally { unmount(); }
+  });
+});

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -33,7 +33,7 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // sessions/store.js, vm-tab.js). The dev-only peerd-distributed/demo/
 // harness (pruned from every package, wired into nothing) was removed
 // rather than typed.
-const COVERED_FLOOR = 472;
+const COVERED_FLOOR = 473;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/tests/sidepanel/chat-reducer.test.ts
+++ b/tests/sidepanel/chat-reducer.test.ts
@@ -67,6 +67,20 @@ describe('reduceChat', () => {
     expect(after.session.sessionId).toBe('s1');                       // snapshot still applied
   });
 
+  // A 'state' snapshot (session switch / settings push) must clear the previous
+  // chat's transient rate-limit banner — the snapshot carries no rateLimit
+  // field, so an omitted reset bleeds the "⏳ Rate limited" banner into the
+  // switched-to (idle) chat.
+  test('a state snapshot clears a stale rate-limit banner (no cross-session bleed)', () => {
+    const paused = reduceChat(withSession('A'), {
+      type: 'turn/rate-limit-pause', sessionId: 'A', attempt: 2, retryAfterMs: 5000,
+    });
+    expect(paused.rateLimit).toEqual({ attempt: 2, retryAfterMs: 5000 });
+    const switched = reduceChat(paused, { type: 'state', state: { session: { sessionId: 'B', messages: [] } } });
+    expect(switched.session.sessionId).toBe('B');
+    expect(switched.rateLimit).toBe(null);
+  });
+
   test('async-tasks/update keys the snapshot by parent session', () => {
     const s1 = reduceChat(INITIAL_STATE, { type: 'async-tasks/update', parentSessionId: 'p1', tasks: [{ taskId: 'as-1' }] });
     expect(s1.asyncTasks.p1).toEqual([{ taskId: 'as-1' }]);


### PR DESCRIPTION
Two side-panel UI-state bugs from a verified hunt, both about a stale transient control shown after a chat switch or a Stop.

## #4 - Rate-limit banner bled across a chat switch
The reducer's `'state'` snapshot fold rebuilt `pendingConfirm`/`lastError`/`cost` but **omitted `rateLimit`**, and the SW snapshot carries no `rateLimit` field - so the previous chat's "⏳ Rate limited — retrying" banner survived the fold and painted on the switched-to (idle) chat. Reset `rateLimit` in the `'state'` case.
- **Bun test, revert-proven: 10→9/1** without the fix.

## #3 - Aborted-turn tool cards stuck "running…" forever
Card status was derived purely from `tool_result` presence; an aborted turn (Stop / spend-limit / steer) persists its `toolUses` with no result, so the card showed a pulsing "running…" dot **indefinitely, even across a reload**. Threaded the parent message's `stopReason === 'aborted'` into `ToolCall` + the subagent card: a result-less tool on an aborted turn now renders a terminal **`cancelled`** state (static muted dot), and the turn shows a "⏹ stopped" chip.
- New in-browser regression test (cancelled-on-abort + still-pending-when-live). *(This also closes the cosmetic follow-up noted on the abort fix #13.)*

## Tests / gates
- Full bun suite 2077 pass; in-browser 599/0; typecheck + lint clean; tscheck floor bumped 472→473 for the new `// @ts-check` test.

## Filed separately (needs a design decision)
**#5** - the same `'state'` fold *over-clears* the spend-limit halt (`lastError`/`cost.limitReached` forced false on every push), so toggling Plan/Act erases the "raise your limit" banner while still halted. The clean fix surfaces `limitReached` in the SW snapshot (re-derive) rather than blanket-clear - filed as an issue.

Found via a verified side-panel bug-hunt (find → 3 refute-by-default verifiers → fix).