### PR TITLE
fix(egress): re-validate the landed host after a web-fetch tab follows redirects

### DIFF
--- a/extension/peerd-runtime/tools/web/primitives.js
+++ b/extension/peerd-runtime/tools/web/primitives.js
@@ -12,6 +12,12 @@
 // fetches go through ctx.webFetch (denylist-gated) NOT ctx.safeFetch
 // (provider-allowlist-locked).
 
+// Deep imports of the PURE host guards (not the /peerd-egress barrel, which
+// pulls in vault/storage + the polyfill and would break the bun test runner —
+// same reason as tools/gates.js). Used to re-validate where a tab LANDED.
+import { findDenylistMatch } from '../../../peerd-egress/denylist/denylist.js';
+import { isPrivateOrLocalHost } from '../../../peerd-egress/fetch/private-network.js';
+
 const PAGE_LOAD_TIMEOUT_MS = 30_000;
 const FETCH_TIMEOUT_MS = 20_000;
 
@@ -25,6 +31,29 @@ const FETCH_TIMEOUT_MS = 20_000;
 const tabsOf = (ctx) => /** @type {typeof chrome.tabs} */ (/** @type {unknown} */ (ctx.tabs));
 /** @param {ToolContext} ctx @returns {typeof chrome.scripting} */
 const scriptingOf = (ctx) => /** @type {typeof chrome.scripting} */ (/** @type {unknown} */ (ctx.scripting));
+
+/**
+ * Re-validate the host a tab ACTUALLY landed on — after it natively followed
+ * any HTTP redirect / meta-refresh / JS navigation the dispatcher's origin
+ * gate never saw — against the denylist + the private-network (SSRF) guard.
+ * A real tab follows redirects client-side, so the landed host can differ from
+ * the requested one and MUST face the same guards before its content is read
+ * back into the agent. Returns a denial, or null when the landing is allowed.
+ *
+ * @param {string} finalUrl
+ * @param {ToolContext} ctx
+ * @returns {{ host: string, reason: string } | null}
+ */
+export const landedHostDenial = (finalUrl, ctx) => {
+  let host;
+  try { host = new URL(finalUrl).hostname; }
+  catch { return null; }  // unparseable landing — nothing readable anyway
+  const patterns = /** @type {readonly string[]} */ (ctx?.denylist ?? []);
+  const match = findDenylistMatch(host, patterns);
+  if (match) return { host, reason: `denylist:${match}` };
+  if (isPrivateOrLocalHost(host)) return { host, reason: 'private_network' };
+  return null;
+};
 
 /**
  * Fetch a URL through the SW's webFetch (denylist-gated + audited)

--- a/extension/peerd-runtime/tools/web/read.js
+++ b/extension/peerd-runtime/tools/web/read.js
@@ -9,7 +9,7 @@
 // background — flashing a tab the user can't even reach would just yank
 // them. Tabs the user should SEE go through open_tab (which takes focus).
 
-import { fetchUrl, openWebTab, readTabContent, closeTab } from './primitives.js';
+import { fetchUrl, openWebTab, readTabContent, closeTab, landedHostDenial } from './primitives.js';
 import { shouldEscalate } from './policy.js';
 import { originOfUrl } from '../defs/dom-helpers.js';
 import { wrapUntrusted } from '../prompt-wrap.js';
@@ -62,8 +62,16 @@ export const readArticleTool = {
     try {
       fetched = await fetchUrl(args.url, { method: 'GET' }, ctx);
     } catch (e) {
-      // safeFetch failure (network, abort, allowlist miss) — fall
-      // through to tab escalation.
+      // why: a webFetch redirect refusal is an egress DECISION, not a
+      // transient failure — escalating it would just have the tab follow the
+      // same redirect natively, past the guard. Treat it as terminal (parity
+      // with call_api); the landed-host re-check in escalate() backstops any
+      // redirect a tab still follows for the genuinely-transient paths below.
+      if (/** @type {{ reason?: string }} */ (e)?.reason === 'redirect_blocked') {
+        return { ok: false, error: `redirected: ${args.url} issued an HTTP redirect to a host that is not permitted; not following it.` };
+      }
+      // Genuine transient failure (network, abort, anti-bot) — fall through
+      // to tab escalation.
       return await escalate(args, ctx, { reason: `fetch_failed:${/** @type {{ message?: string }} */ (e)?.message ?? 'unknown'}` });
     }
 
@@ -100,6 +108,16 @@ const escalate = async (args, ctx, { reason }) => {
   try {
     const opened = await openWebTab(args.url, ctx);
     tabId = opened.tabId;
+    // A real tab natively follows redirects (HTTP 3xx, meta-refresh, JS) the
+    // origin gate never saw — so the host it LANDED on can differ from the one
+    // that was gate-checked. Re-validate it against the denylist + private-
+    // network guard BEFORE reading any content back into the agent; a denied
+    // landing is refused (and audited for visibility), not read.
+    const denial = landedHostDenial(opened.finalUrl, ctx);
+    if (denial) {
+      ctx.audit?.({ type: 'egress_denied', details: { origin: denial.host, reason: `landed:${denial.reason}` } })?.catch?.(() => {});
+      return { ok: false, error: `egress_denied: the page redirected to ${denial.host}, which is not permitted.` };
+    }
     const page = await readTabContent(tabId, ctx);
     return ok({
       via: 'background_tab',

--- a/extension/peerd-runtime/tools/web/search.js
+++ b/extension/peerd-runtime/tools/web/search.js
@@ -10,7 +10,7 @@
 // V1 ships with Google as the default. The engine is configurable
 // later via settings; the engine URL is just a template with `{q}`.
 
-import { openWebTab, readTabContent, closeTab } from './primitives.js';
+import { openWebTab, readTabContent, closeTab, landedHostDenial } from './primitives.js';
 import { originOfUrl } from '../defs/dom-helpers.js';
 import { wrapUntrusted } from '../prompt-wrap.js';
 
@@ -53,6 +53,15 @@ export const webSearchTool = {
     try {
       const opened = await openWebTab(url, ctx);
       tabId = opened.tabId;
+      // Defense-in-depth: a results page can meta-refresh / JS-redirect into a
+      // denylisted or private host. Re-validate the landed host before reading
+      // (the query is agent-controlled, the destination is not — but the same
+      // one-line guard read_article uses applies here too).
+      const denial = landedHostDenial(opened.finalUrl, ctx);
+      if (denial) {
+        ctx.audit?.({ type: 'egress_denied', details: { origin: denial.host, reason: `landed:${denial.reason}` } })?.catch?.(() => {});
+        return { ok: false, error: `egress_denied: the results page redirected to ${denial.host}, which is not permitted.` };
+      }
       const page = await readTabContent(tabId, ctx);
       // why: results-page text is untrusted web content — fence it as
       // data, not instructions, like read_page. web_search is a main-agent

--- a/tests/peerd-runtime/web/landed-host-guard.test.ts
+++ b/tests/peerd-runtime/web/landed-host-guard.test.ts
@@ -1,0 +1,119 @@
+// Web-fetch escalation must re-validate the host a tab LANDED on. A real
+// background tab natively follows redirects (HTTP 3xx / meta-refresh / JS) that
+// the dispatcher's origin gate never saw — so the host the tab ends up on can
+// differ from the gate-checked one, and must face the denylist + private-
+// network guards before any of its content is read back into the agent.
+//
+// Fixtures are deliberately abstract (a generic denylisted.example), not a
+// recognizable real site.
+
+import { describe, it, expect } from 'bun:test';
+import { landedHostDenial } from '/peerd-runtime/tools/web/primitives.js';
+import { readArticleTool } from '/peerd-runtime/tools/web/read.js';
+import { webSearchTool } from '/peerd-runtime/tools/web/search.js';
+
+const baseCtx = (over: Record<string, any> = {}) => ({
+  session: { sessionId: 't' },
+  activeTab: { id: 1, url: 'https://example.com/', origin: 'https://example.com' },
+  audit: async () => {},
+  confirm: async () => 'yes_once' as const,
+  webFetch: async () => { throw new Error('webFetch not mocked'); },
+  tabs: {}, scripting: {}, settings: {}, dom: {}, vm: {},
+  getSecret: async () => null, kv: {}, idb: {},
+  denylist: [] as string[],
+  provider: { name: 'm', model: 'm', hasKey: false },
+  vault: { isLocked: false },
+  ...over,
+});
+
+// A tabs mock that lands on `finalUrl`, recording create / remove and firing
+// the load-complete event so waitForLoad resolves immediately.
+const tabsThatLandOn = (finalUrl: string, calls: any) => ({
+  create: async ({ url }: any) => { calls.createdUrl = url; return { id: 42 }; },
+  get: async (id: number) => ({ id, url: finalUrl }),
+  remove: async (id: number) => { calls.removed = id; },
+  onUpdated: {
+    addListener: (l: any) => { setTimeout(() => l(42, { status: 'complete' }), 0); },
+    removeListener: () => {},
+  },
+});
+const scriptingThatReads = (calls: any) => ({
+  executeScript: async () => { calls.executed = true; return [{ result: { url: 'x', title: 't', text: 'PAGE TEXT' } }]; },
+});
+
+describe('landedHostDenial (pure)', () => {
+  it('denies an exact denylisted landed host', () => {
+    expect(landedHostDenial('https://denylisted.example/x', { denylist: ['denylisted.example'] } as any))
+      .toMatchObject({ host: 'denylisted.example', reason: 'denylist:denylisted.example' });
+  });
+  it('denies a denylisted subdomain landing via a wildcard pattern', () => {
+    expect(landedHostDenial('https://sub.denylisted.example/x', { denylist: ['*.denylisted.example'] } as any)?.reason)
+      .toBe('denylist:*.denylisted.example');
+  });
+  it('denies a private / loopback landed host', () => {
+    expect(landedHostDenial('http://127.0.0.1/x', { denylist: [] } as any)?.reason).toBe('private_network');
+    expect(landedHostDenial('http://192.168.1.1/', { denylist: [] } as any)?.reason).toBe('private_network');
+  });
+  it('allows an ordinary public host', () => {
+    expect(landedHostDenial('https://example.com/x', { denylist: ['denylisted.example'] } as any)).toBe(null);
+  });
+});
+
+describe('read_article re-validates the landed host', () => {
+  it('does NOT escalate a webFetch redirect refusal (terminal — no tab opened)', async () => {
+    const calls: any = {};
+    const ctx = baseCtx({
+      webFetch: async () => { const e: any = new Error('blocked'); e.reason = 'redirect_blocked'; throw e; },
+      tabs: tabsThatLandOn('https://denylisted.example/', calls),
+      scripting: scriptingThatReads(calls),
+      denylist: ['denylisted.example'],
+    });
+    const r: any = await readArticleTool.execute({ url: 'https://redirector.example/x' }, ctx);
+    expect(r.ok).toBe(false);
+    expect(calls.createdUrl).toBeUndefined(); // no tab opened
+    expect(calls.executed).toBeUndefined();   // no content read
+  });
+
+  it('opens a tab on a transient failure but REFUSES a denylisted landing (no read)', async () => {
+    const calls: any = {};
+    const ctx = baseCtx({
+      webFetch: async () => { throw new Error('network down'); }, // transient → escalate
+      tabs: tabsThatLandOn('https://denylisted.example/account', calls),
+      scripting: scriptingThatReads(calls),
+      denylist: ['denylisted.example'],
+    });
+    const r: any = await readArticleTool.execute({ url: 'https://redirector.example/x' }, ctx);
+    expect(r.ok).toBe(false);
+    expect(String(r.error)).toContain('egress_denied');
+    expect(calls.createdUrl).toBe('https://redirector.example/x'); // tab WAS opened
+    expect(calls.executed).toBeUndefined();                        // but content NEVER read
+    expect(calls.removed).toBe(42);                                // tab closed
+  });
+
+  it('reads normally when the landing is an allowed public host', async () => {
+    const calls: any = {};
+    const ctx = baseCtx({
+      webFetch: async () => { throw new Error('network down'); },
+      tabs: tabsThatLandOn('https://example.com/article', calls),
+      scripting: scriptingThatReads(calls),
+      denylist: ['denylisted.example'],
+    });
+    const r: any = await readArticleTool.execute({ url: 'https://example.com/x' }, ctx);
+    expect(r.ok).toBe(true);
+    expect(calls.executed).toBe(true); // content read
+  });
+});
+
+describe('web_search re-validates the landed host (defense-in-depth)', () => {
+  it('refuses a denylisted landing without reading it', async () => {
+    const calls: any = {};
+    const ctx = baseCtx({
+      tabs: tabsThatLandOn('https://denylisted.example/', calls),
+      scripting: scriptingThatReads(calls),
+      denylist: ['denylisted.example'],
+    });
+    const r: any = await webSearchTool.execute({ query: 'hi' }, ctx);
+    expect(r.ok).toBe(false);
+    expect(calls.executed).toBeUndefined();
+  });
+});


### PR DESCRIPTION
The web-fetch tools (`read_article`, `web_search`) escalate to a real background tab when `safeFetch` can't serve a page. A tab natively follows redirects (HTTP 3xx, meta-refresh, JS navigation) that the dispatcher's origin gate never saw - so the host the tab **lands on** can differ from the gate-checked requested host, and its content was read back into the agent without re-checking it.

## Changes
- **`primitives.js`**: new `landedHostDenial(finalUrl, ctx)` - re-validates the landed host against the denylist + the private-network / SSRF guard (the same checks the origin gate applies to the requested URL).
- **`read_article`**: re-check `opened.finalUrl` in `escalate()` before reading; a denied landing is refused (and audited), not read. Also treat a `webFetch` redirect refusal as terminal rather than escalating it (parity with `call_api`).
- **`web_search`**: the same landed-host re-check (defense-in-depth).

## Tests
New bun test (`landed-host-guard.test.ts`), **revert-proven** (reverting `read.js` fails 2/8): a redirect refusal does not escalate, and an escalation that lands on a denylisted / private host is refused without reading its content. Full bun suite 2084 pass; in-browser 598/0; typecheck + lint + boundary clean.

Found via a defensive security audit of the egress surface.