### PR TITLE
fix(settings): honest local-provider status, merged WebGPU card, real total download %

### DIFF
--- a/extension/background/routes/providers.js
+++ b/extension/background/routes/providers.js
@@ -38,6 +38,11 @@ export const makeProviderRoutes = (deps) => {
           return { ok: false, error: /** @type {{ message?: string }} */ (e)?.message ?? 'unreachable' };
         }
       }
+      // A keyless provider with NO live inventory (local-webgpu) has no daemon to
+      // ping — its readiness is "is the model downloaded?", surfaced by its own
+      // card (local-model/status), not this 1-token probe. Bail cleanly instead
+      // of falling through to the key path and lying with a "no-key" error.
+      if (adapter?.keyless) return { ok: false, error: 'no-live-test' };
       let key;
       try { key = await vault.getSecret(secretNameForProvider(provider)); }
       catch { return { ok: false, error: 'locked' }; }
@@ -80,6 +85,10 @@ export const makeProviderRoutes = (deps) => {
           providers.push({
             name: p.name, label: p.label, defaultModel: p.defaultModel,
             hasKey: true, keyless: true, keyPreview: null,
+            // liveModels marks a daemon the card can probe (Ollama /api/tags) —
+            // so the badge can read "connected" only when it actually answers,
+            // never default-green.
+            liveModels: !!p.liveModels,
           });
           continue;
         }
@@ -90,6 +99,7 @@ export const makeProviderRoutes = (deps) => {
           name: p.name, label: p.label, defaultModel: p.defaultModel,
           hasKey: !!key,
           keyless: false,
+          liveModels: !!p.liveModels,
           // Masked preview so the user can verify the RIGHT key is stored and
           // isn't whitespace-padded (a frequent cause of provider 401s),
           // without exposing the secret.

--- a/extension/home/home.js
+++ b/extension/home/home.js
@@ -47,14 +47,34 @@ let booted = false;          // first state push arrived — until then, show "L
 const VIEW_KEY = 'peerd.home.activeView';
 const DWEB_VIEWS = new Set(['discover', 'contacts', 'network']);
 const ALL_VIEWS = new Set(['chat', 'chats', 'library', 'eval', 'discover', 'contacts', 'network']);
+/** @param {string | null | undefined} v */
+const isValidView = (v) => !!v && ALL_VIEWS.has(v) && (!DWEB_VIEWS.has(v) || DWEB_ENABLED);
+// A `#view` fragment is an explicit deep-link (openHome('library') → "Open
+// Library"). It wins over the stored view; we consume it (clear the hash) so a
+// later rail click + refresh isn't dragged back to the deep-linked view.
+const viewFromHash = () => {
+  try {
+    const v = (location.hash || '').replace(/^#/, '');
+    return isValidView(v) ? v : null;
+  } catch { return null; }
+};
+// replaceState (not assigning location.hash) — strips the fragment WITHOUT
+// firing another hashchange, so consuming a deep-link doesn't loop.
+const clearHash = () => {
+  try { if (location.hash) history.replaceState(null, '', location.pathname + location.search); }
+  catch { /* history API unavailable */ }
+};
 const readView = () => {
+  const fromHash = viewFromHash();
+  if (fromHash) return fromHash;
   try {
     const v = localStorage.getItem(VIEW_KEY);
-    if (v && ALL_VIEWS.has(v) && (!DWEB_VIEWS.has(v) || DWEB_ENABLED)) return v;
+    if (isValidView(v)) return v;
   } catch { /* storage disabled / private mode */ }
   return 'chat';
 };
 let activeView = readView();  // chat | chats | library | eval | discover | contacts | network
+clearHash();                  // deep-link consumed at boot — see viewFromHash
 /** @param {string} v */
 const setView = (v) => { activeView = v; try { localStorage.setItem(VIEW_KEY, v); } catch { /* ignore */ } };
 // Single-homed chat (DESIGN-12, owner 2026-06-18): when a side panel is open it
@@ -570,6 +590,14 @@ const HomeApp = {
 
 connectPort();
 document.addEventListener('visibilitychange', onVisibility);
+// A deep-link to an ALREADY-open home tab (openHome('library') focusing this
+// tab) changes only the fragment — no reload — so honor it via hashchange too,
+// then clear the fragment so it stays a one-shot jump.
+window.addEventListener('hashchange', () => {
+  const v = viewFromHash();
+  clearHash();
+  if (v && v !== activeView) { setView(v); m.redraw(); }
+});
 const root = document.getElementById('app');
 if (!root) throw new Error('home: #app missing from HTML');
 m.mount(root, HomeApp);

--- a/extension/offscreen/local-model.js
+++ b/extension/offscreen/local-model.js
@@ -121,8 +121,33 @@ export const initLocalModel = async (onProgress = () => {}) => {
     console.log(`[local-model] ${phase}`, extra);
     try { onProgress({ status: 'phase', phase, ...extra }); } catch { /* no listener */ }
   };
+  // why aggregate: Transformers.js reports progress PER FILE, and its `progress`
+  // field resets to 0 each time a new weight file starts — so surfacing a single
+  // file's % (the old behavior) makes the bar lurch backwards. Sum the latest
+  // bytes across every file and attach ONE honest total % the UI can show.
+  /** @type {Map<string, { loaded: number, total: number }>} */
+  const fileBytes = new Map();
+  /** @param {any} p @returns {any} */
+  const withOverall = (p) => {
+    if (p && p.file) {
+      if (p.status === 'done') {
+        // A 'done' event may omit total — fall back to the file's last-known size.
+        const prev = fileBytes.get(p.file);
+        const total = typeof p.total === 'number' ? p.total : prev?.total;
+        if (typeof total === 'number' && total > 0) fileBytes.set(p.file, { loaded: total, total });
+      } else if (typeof p.total === 'number' && p.total > 0) {
+        fileBytes.set(p.file, { loaded: typeof p.loaded === 'number' ? p.loaded : 0, total: p.total });
+      }
+    }
+    if (fileBytes.size === 0) return p;
+    let overallLoaded = 0;
+    let overallTotal = 0;
+    for (const { loaded, total } of fileBytes.values()) { overallLoaded += loaded; overallTotal += total; }
+    const overall = overallTotal > 0 ? Math.min(100, (overallLoaded / overallTotal) * 100) : undefined;
+    return { ...p, overall, overallLoaded, overallTotal };
+  };
   /** @param {string} label @returns {(p: object) => void} */
-  const tap = (label) => (p) => { console.log(`[local-model] ${label}`, p); onProgress(p); };
+  const tap = (label) => (p) => { console.log(`[local-model] ${label}`, p); onProgress(withOverall(p)); };
   loadingPromise = (async () => {
     report('probing WebGPU');
     const cap = await probeWebgpu();

--- a/extension/options/options.css
+++ b/extension/options/options.css
@@ -346,10 +346,11 @@
   .library-refresh.is-spinning, .disc-refresh.is-spinning { animation: none; }
 }
 
-/* --- Local models (WebGPU) — rendered inside the Providers & models page -- */
-.providers-subhead { font-size: 14px; margin: 6px 0 10px; color: var(--fg); }
-.local-models > .muted { max-width: 64ch; margin: 0 0 16px; }
-.lm-card { border: 1px solid var(--border); border-radius: 8px; background: var(--bg-elev); padding: 14px 16px; max-width: 620px; }
+/* --- Local models (WebGPU) — the on-device provider card body ------------- */
+/* The local model now renders INSIDE its provider card: the test/download body
+   sits under the card header (logo + name + badge), separated by a hairline. */
+.provider-card-local .local-models { margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--border); }
+.local-models > .muted { max-width: 64ch; margin: 0 0 12px; }
 .lm-head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
 .lm-name-group { display: inline-flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
 .lm-name { font-weight: 600; font-size: 15px; color: var(--fg); }

--- a/extension/options/sections/dweb.js
+++ b/extension/options/sections/dweb.js
@@ -84,7 +84,7 @@ export const DwebSection = {
           + 'peer-to-peer one-to-one chats. It ships pre-loaded in your '
           + 'Library, tagged “dweb” — open it there. To try it, open it in '
           + 'two profiles (or two machines) and join the same room code.'),
-        m('button.secondary', { type: 'button', onclick: () => openHome() }, 'Open Library'),
+        m('button.secondary', { type: 'button', onclick: () => openHome('library') }, 'Open Library'),
       ]) : null,
 
       resetRow(send, ['dwebEnabled']),

--- a/extension/options/sections/local-models.js
+++ b/extension/options/sections/local-models.js
@@ -20,12 +20,23 @@ import { MODEL_SPECS, probeLocalModelCapability, judgeModelCapability } from '/p
 // The shipped WebGPU models (one for now; the list grows as more are vendored).
 const MODELS = [MODEL_SPECS['gemma-4-e2b']].filter(Boolean);
 
+const GB = 2 ** 30;
+
 /** @param {any} status local-model/status reply */
 const dlText = (status) => {
   const p = status?.progress;
   if (!p) return 'Downloading… (one-time, ~3 GB — this takes a few minutes)';
   if (p.status === 'error') return `Error: ${p.message || 'download failed'}`;
   if (p.status === 'phase') return p.phase || 'Working…';
+  // Prefer the AGGREGATE across all weight files — a single, monotonic total %.
+  // The per-file `progress` (the fallback below) resets to 0 each new file, so it
+  // misreads as a stall/regression mid-download.
+  if (typeof p.overall === 'number') {
+    const gb = (typeof p.overallLoaded === 'number' && typeof p.overallTotal === 'number' && p.overallTotal > 0)
+      ? ` (${(p.overallLoaded / GB).toFixed(1)} / ${(p.overallTotal / GB).toFixed(1)} GB)`
+      : '';
+    return `Downloading model — ${p.overall.toFixed(0)}%${gb}`;
+  }
   if (typeof p.progress === 'number' && p.file) return `Downloading ${String(p.file).split('/').pop()} — ${p.progress.toFixed(0)}%`;
   if (p.file) return `Downloading ${String(p.file).split('/').pop()}…`;
   return 'Downloading…';
@@ -73,11 +84,11 @@ export const LocalModelsSection = {
     poll();
   },
 
-  /** @param {{ state: any, attrs: { send: Send } }} vnode */
+  /** @param {{ state: any, attrs: { send: Send, logo?: any, label?: string } }} vnode */
   view(vnode) {
     const ui = vnode.state;
+    const { logo = null, label = 'Local (WebGPU)' } = vnode.attrs;
     const spec = MODELS[0];
-    if (!spec) return m('p.muted', 'No WebGPU models are bundled in this build.');
     const status = ui.status;
     const available = !!status?.available;
     const downloaded = !!status?.downloaded; // weights cached (survives reloads)
@@ -85,6 +96,28 @@ export const LocalModelsSection = {
     const loading = !!status?.loading || ui.downloading;
     const verdict = ui.verdict;
     const canDownload = !!verdict?.capable && !ready && !loading;
+
+    // Header badge mirrors the cloud provider cards — but green (.key-set) is
+    // reserved for "actually ready", i.e. the model is installed. Until then a
+    // NEUTRAL chip: keyless, yes, but not yet usable, so it must NOT read as the
+    // verified-green the API providers earn by having a working key.
+    const badge = ready
+      ? m('span.key-badge.key-set', '✓ Installed')
+      : loading
+        ? m('span.key-badge.key-local', 'Downloading…')
+        : m('span.key-badge.key-local', 'On-device — not installed');
+
+    const header = m('.provider-card-main', [
+      logo,
+      m('.provider-card-text', [
+        m('span.provider-card-name', label),
+        badge,
+      ]),
+    ]);
+
+    if (!spec) {
+      return m('.provider-card', [header, m('p.muted', { style: 'margin:10px 0 0;' }, 'No WebGPU models are bundled in this build.')]);
+    }
 
     const stateLine = ready
       ? m('.lm-state.ok', available
@@ -94,10 +127,11 @@ export const LocalModelsSection = {
         : verdict ? m('.lm-state', { class: verdict.capable ? 'ok' : 'bad' }, `${verdict.capable ? '✓' : '✕'} ${verdict.reason}`)
           : m('.lm-state.muted', '🔒 Locked — run a hardware test to check this model can run on this machine.');
 
-    return m('.local-models', [
-      m('p.muted', 'Run a model fully on-device via WebGPU — free, private (page content never leaves your machine for the read step), and offline. '
-        + 'Test your hardware first; if it passes, download once (then it’s browser-cached).'),
-      m('.lm-card', [
+    return m('.provider-card.provider-card-local', [
+      header,
+      m('.local-models', [
+        m('p.muted', 'Run a model fully on-device via WebGPU — free, private (page content never leaves your machine for the read step), and offline. '
+          + 'Test your hardware first; if it passes, download once (then it’s browser-cached).'),
         m('.lm-head', [
           m('span.lm-name-group', [
             m('span.lm-name', spec.label),

--- a/extension/options/sections/providers.js
+++ b/extension/options/sections/providers.js
@@ -23,7 +23,7 @@ import { resetRow } from './reset-row.js';
 import { LocalModelsSection } from './local-models.js';
 
 /** @typedef {import('./reset-row.js').Send} Send */
-/** @typedef {{ name: string, label: string, hasKey?: boolean, keyless?: boolean, keyPreview?: string }} ProviderRow */
+/** @typedef {{ name: string, label: string, hasKey?: boolean, keyless?: boolean, liveModels?: boolean, keyPreview?: string }} ProviderRow */
 
 // ── Provider logos ──────────────────────────────────────────────────────
 // Inline SVG marks (no network, no external asset — same privacy posture
@@ -75,6 +75,10 @@ export const ProvidersSection = {
     vnode.state.keyMsg = {};        // name -> { ok, text }
     vnode.state.keyEditing = {};    // name -> bool (Replace revealed the field)
     vnode.state.providerStatus = null;  // [{ name, label, defaultModel, hasKey }]
+    // name -> 'checking' | 'connected' | 'down' — the LIVE reachability of a
+    // keyless daemon (Ollama). Drives the badge so green means "actually
+    // connected", never just "no key needed".
+    vnode.state.connStatus = {};
     ProvidersSection.loadProviderStatus(vnode);
   },
 
@@ -83,8 +87,31 @@ export const ProvidersSection = {
   /** @param {{ state: any, attrs: { send: Send } }} vnode */
   loadProviderStatus(vnode) {
     vnode.attrs.send({ type: 'provider/status' }).then((/** @type {any} */ r) => {
-      if (r?.ok) { vnode.state.providerStatus = r.providers; m.redraw(); }
+      if (r?.ok) {
+        vnode.state.providerStatus = r.providers;
+        m.redraw();
+        // Auto-probe keyless providers that expose a live daemon (Ollama): the
+        // badge should reflect REAL reachability, not a default-green. Quiet
+        // (no card message) so an unused provider doesn't shout a red error on
+        // mount — clicking Test still gives the full message.
+        for (const p of r.providers) {
+          if (p.keyless && p.liveModels) ProvidersSection.probeConnection(vnode, p.name);
+        }
+      }
     }).catch(() => {});
+  },
+
+  // Quietly ping a keyless daemon (provider/test) and record reachability for
+  // the badge. The explicit Test button reuses provider/test too, but also
+  // surfaces the full message; this path only moves the badge.
+  /** @param {{ state: any, attrs: { send: Send } }} vnode @param {string} name */
+  probeConnection(vnode, name) {
+    vnode.state.connStatus[name] = 'checking';
+    m.redraw();
+    vnode.attrs.send({ type: 'provider/test', provider: name }).then((/** @type {any} */ r) => {
+      vnode.state.connStatus[name] = r?.ok ? 'connected' : 'down';
+      m.redraw();
+    }).catch(() => { vnode.state.connStatus[name] = 'down'; m.redraw(); });
   },
 
   /** @param {{ attrs: { state: any, send: Send }, state: any }} vnode */
@@ -160,6 +187,9 @@ export const ProvidersSection = {
       ui.keyBusy[name] = true; ui.keyMsg[name] = null; m.redraw();
       const reply = await send({ type: 'provider/test', provider: name });
       ui.keyBusy[name] = false;
+      // Keep the badge in sync with an explicit Test (keyless daemons only — the
+      // badge for keyed providers tracks hasKey, not live reachability).
+      ui.connStatus[name] = reply?.ok ? 'connected' : 'down';
       ui.keyMsg[name] = reply?.ok
         ? {
             ok: true,
@@ -207,7 +237,13 @@ export const ProvidersSection = {
           m('.provider-card-text', [
             m('span.provider-card-name', p.label),
             p.keyless
-              ? m('span.key-badge.key-set', '✓ Local — no key needed')
+              // Keyless local daemon (Ollama): green is EARNED by a live probe,
+              // not given for free. Neutral until we've confirmed it answers.
+              ? (ui.connStatus[p.name] === 'connected'
+                  ? m('span.key-badge.key-set', '✓ Connected')
+                  : ui.connStatus[p.name] === 'checking'
+                    ? m('span.key-badge.key-local', 'Checking…')
+                    : m('span.key-badge.key-local', 'Local — no key needed'))
               : p.hasKey
                 ? m('span.key-badge.key-set', p.keyPreview ? `✓ ${p.keyPreview}` : '✓ Key saved')
                 : m('span.key-badge.key-unset', 'No key set'),
@@ -268,7 +304,14 @@ export const ProvidersSection = {
         + 'independently and encrypted in the vault. OpenRouter is an '
         + 'OpenAI-compatible gateway to many vendors’ models. Ollama '
         + 'runs models on THIS machine — keyless, $0, fully local.'),
-      m('.provider-cards', providerRows.map(renderProviderCard)),
+      // The on-device WebGPU model is a full provider now — its card hosts the
+      // hardware-test → download → ready flow inline (the old split-out
+      // "On-device models" section is folded in here), with a status-driven
+      // badge instead of a meaningless key form.
+      m('.provider-cards', providerRows.map((p) =>
+        p.name === 'local-webgpu'
+          ? m(LocalModelsSection, { state, send, logo: providerLogo('local-webgpu'), label: p.label })
+          : renderProviderCard(p))),
 
       // OpenRouter model curation — only once a key is saved (the gateway has
       // hundreds of models, so the user checks which ones the chat picker
@@ -356,12 +399,6 @@ export const ProvidersSection = {
         '. All traffic goes through ', m('code', 'safeFetch'),
         ' against the hardcoded provider allowlist.',
       ]),
-
-      // On-device WebGPU models live on the SAME page as the cloud providers —
-      // one place to configure every model the agent can use, local or remote.
-      m('.settings-divider'),
-      m('h3.providers-subhead', 'On-device models (WebGPU)'),
-      m(LocalModelsSection, { state, send }),
     ]);
   },
 };

--- a/extension/shared/open-home.js
+++ b/extension/shared/open-home.js
@@ -1,5 +1,5 @@
 // @ts-check
-// Open the peerd home page (the full-tab Library surface).
+// Open the peerd home page (the full-tab SPA: Chat / Library / …).
 //
 // why focus-or-create (not a bare tabs.create like the options deep-link):
 // home is a primary surface a user returns to often, so a second click
@@ -8,19 +8,35 @@
 // for an existing home tab and activate it, else create one. Best-effort:
 // any tabs-API gap falls back to a plain create.
 //
+// why the optional `view`: a caller like the "Open Library" button means a
+// SPECIFIC section, but home otherwise restores the last-used view from
+// localStorage (often Chat) — landing you somewhere other than asked. The
+// view rides as a URL fragment (`#library`); home reads it on boot AND on
+// hashchange (the focus-existing-tab path, where no reload fires), then
+// clears it so it doesn't override later rail navigation on refresh.
+//
 // Lives in shared/ so the side panel and any other surface can call it.
 
 import browser from '/vendor/browser-polyfill.js';
 
 const HOME_PATH = 'home/home.html';
 
-export const openHome = async () => {
+/**
+ * @param {string} [view] target home view (e.g. 'library', 'chat'); omitted
+ *   restores the last-used view.
+ */
+export const openHome = async (view) => {
   try {
-    const url = browser.runtime.getURL(HOME_PATH);
+    const base = browser.runtime.getURL(HOME_PATH);
+    const url = view ? `${base}#${view}` : base;
     const tabs = (await browser.tabs?.query?.({})) ?? [];
-    const existing = tabs.find((t) => typeof t.url === 'string' && t.url.startsWith(url));
+    // Match on the hashless base — an already-open home tab carries no (or a
+    // different) fragment, so startsWith(url) would miss it.
+    const existing = tabs.find((t) => typeof t.url === 'string' && t.url.startsWith(base));
     if (existing?.id != null) {
-      await browser.tabs.update(existing.id, { active: true });
+      // Pass the fragment-bearing url only when a view was requested: changing
+      // just the hash navigates the live tab (fires hashchange) without a reload.
+      await browser.tabs.update(existing.id, { active: true, ...(view ? { url } : {}) });
       if (existing.windowId != null) await browser.windows?.update?.(existing.windowId, { focused: true });
       return;
     }

--- a/extension/sidepanel/styles.css
+++ b/extension/sidepanel/styles.css
@@ -2197,6 +2197,9 @@ button.icon:hover { background: var(--bg); }
 }
 .key-badge.key-set   { color: var(--ok); border-color: var(--ok); }
 .key-badge.key-unset { color: var(--fg-muted); }
+/* Keyless local providers (Ollama, on-device WebGPU): neutral until proven
+   ready/connected — green (.key-set) is reserved for that, never default. */
+.key-badge.key-local { color: var(--fg-muted); }
 .provider-card-form { margin-top: 10px; }
 /* why: flex-direction:row is REQUIRED — the generic `.input-row` sets
    column, so without this the input + Save stack vertically (and centered


### PR DESCRIPTION
## What & why

Owner feedback on the **Providers & models** settings page (plus two adjacent papercuts):

> The UX for this is all wrong. These two providers shouldn't be default green, since green correlates to "connected and verified" in the two API providers. Ollama should only be green if it is in fact successfully connected. Local WebGPU should prob have the Gemma stuff lower on the page actually come up into there instead of being split out.
>
> [Open Library] does not take you to library.
>
> idk when this regressed but it should tell me the total loading %

### Changes

**1. Keyless providers are no longer default-green.**
Green (`.key-set`) meant "connected and verified" for the API cards, but the keyless cards wore it for free. Added a neutral `.key-local` chip; green is now earned, never given.

**2. Ollama goes green only when actually connected.**
A quiet auto-probe runs on mount (`provider/test` → `/api/tags`); the explicit **Test** button feeds the same signal. The badge shows `Checking…` → `✓ Connected` (green) or falls back to the neutral chip. No red error on mount for users who don't run Ollama.

**3. Local (WebGPU) is now a real provider card.**
The hardware-test → download → ready flow (the "Gemma stuff") renders **inline** in the card under a status-driven badge (`On-device — not installed` → `Downloading…` → `✓ Installed`). The split-out "On-device models (WebGPU)" section at the bottom is folded in and removed. This also fixes the **broken Test** that returned a nonsensical "No key saved for this provider yet." — a keyless provider with no live inventory now bails cleanly instead of falling through to the key path.

**4. "Open Library" deep-links to the Library.**
`openHome()` opened `home.html`, which restored the last-used view (usually Chat). It now accepts an optional view; `openHome('library')` rides a `#library` fragment that home honors on boot **and** on `hashchange` (the focus-existing-tab path, where no reload fires), then clears it so later rail navigation isn't dragged back on refresh.

**5. Download progress shows one honest total %.**
The offscreen engine reported the **current file's** %, which resets to 0 each new weight file — reading as a stall/regression. It now aggregates bytes across all files and surfaces a single monotonic `Downloading model — NN% (x.x / y.y GB)`.

## Testing
- `bun test ./tests` — 2085 pass, 0 fail (incl. updated `routes-providers` shape via `toMatchObject`).
- `bun run typecheck` (strict), `bun run lint`, `bun run check:tscheck` (floor 473/473) — all clean.
- UI changes (mithril views) are not covered by the bun suite; verified by reasoning + the surrounding gates. Owner load-test still owns the live WebGPU download path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8Tdxvq1o3daUv9HDpJmiS

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Tdxvq1o3daUv9HDpJmiS)_