### PR TITLE
fix(provider): any configured provider makes the app ready + themed provider select

### DIFF
--- a/extension/background/routes/providers.js
+++ b/extension/background/routes/providers.js
@@ -13,7 +13,7 @@
  */
 export const makeProviderRoutes = (deps) => {
   const {
-    vault, auditLog, pushState,
+    vault, auditLog, pushState, settingsStore,
     listProviders, listProviderModels, listOpenRouterModels, OPENROUTER_POPULAR,
     callModel, getSecret, safeFetch, secretNameForProvider, maskKey, buildModelOptions,
     ProviderHttpError, ProviderKeyMissingError, VaultLockedError,
@@ -143,6 +143,23 @@ export const makeProviderRoutes = (deps) => {
         if (key.length < 8) return { ok: false, error: 'key-too-short' };
         await vault.setSecret(adapter.vaultSecretName, key);
         auditLog.append({ type: 'provider_added', details: { provider } }).catch(() => {});
+        // Auto-activate the provider you just configured if the current
+        // selection isn't usable yet — so a fresh install (default providerName
+        // 'anthropic', no key) becomes ready the moment ANY provider is keyed,
+        // with no separate "select provider" step. Never override an
+        // already-usable selection (an explicit keyless pick, or a provider that
+        // already has a key). Clear providerModel so the new provider's default
+        // model applies (mirrors the Settings provider <select>).
+        const activeName = settingsStore.get().providerName;
+        if (provider !== activeName) {
+          const active = listProviders().find((/** @type {any} */ p) => p.name === activeName);
+          let activeUsable = !!active?.keyless;
+          if (!activeUsable && active?.vaultSecretName) {
+            try { activeUsable = !!(await vault.getSecret(active.vaultSecretName)); }
+            catch { activeUsable = false; }
+          }
+          if (!activeUsable) await settingsStore.update({ providerName: provider, providerModel: '' });
+        }
         // Push fresh state so UI flips its "no key" affordance.
         pushState();
         return { ok: true };

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -2486,7 +2486,7 @@ browser.runtime.onMessage.addListener(/** @type {any} */ (makeDispatcher({
     VaultLockedError,
   }),
   ...makeProviderRoutes({
-    vault, auditLog, pushState, listProviders, listProviderModels, listOpenRouterModels,
+    vault, auditLog, pushState, settingsStore, listProviders, listProviderModels, listOpenRouterModels,
     OPENROUTER_POPULAR, callModel, getSecret, safeFetch, secretNameForProvider, maskKey,
     buildModelOptions, ProviderHttpError, ProviderKeyMissingError, VaultLockedError,
   }),

--- a/extension/sidepanel/components/chat-view.js
+++ b/extension/sidepanel/components/chat-view.js
@@ -487,7 +487,7 @@ const EmptyState = {
     m('p', 'peerd is ready.'),
     m('p.muted', hasKey
       ? 'Ask anything — or pick a path:'
-      : 'Add your Anthropic or OpenRouter API key in Settings to start chatting.'),
+      : 'Connect a provider in Settings to start chatting.'),
     hasKey
       ? m('.path-menu', { class: isHome ? 'path-menu--home' : '' }, prompts.map((p, i) => {
           const shown = ui.shown?.[i] ?? Infinity;

--- a/extension/sidepanel/styles.css
+++ b/extension/sidepanel/styles.css
@@ -703,6 +703,29 @@ textarea {
   outline: none;
 }
 
+/* A bare <select> in a labeled field (e.g. Settings → Provider) otherwise
+   renders the platform's native chrome — a white box in dark mode. Match the
+   text-input surface above and swap the native arrow for a themed chevron so
+   it reads like the rest of the form. (Same appearance-strip approach as
+   type=search below.) The open option list stays OS-native, as selects do. */
+.input-row select {
+  font: inherit;
+  padding: 8px 32px 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background-color: var(--bg);
+  color: var(--fg);
+  outline: none;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%238a8a8a' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  background-size: 14px;
+}
+.input-row select:focus { border-color: var(--accent); }
+
 /* type=search renders the platform's native chrome by default — an OS pill
    that ignores our tokens (most visibly a white box in dark mode) plus a
    magnifier/clear glyph. Strip the native appearance so every filter bar

--- a/tests/background/routes-providers.test.ts
+++ b/tests/background/routes-providers.test.ts
@@ -12,6 +12,7 @@ const baseDeps = (over: Record<string, any> = {}) => ({
   },
   auditLog: { append: async () => {} },
   pushState: () => {},
+  settingsStore: { get: () => ({ providerName: 'anthropic', providerModel: '' }), update: async (_p: any) => {} },
   listProviders: () => [
     { name: 'anthropic', label: 'Anthropic', defaultModel: 'claude', vaultSecretName: 'anthropic.key' },
     { name: 'ollama', label: 'Ollama', defaultModel: 'llama', keyless: true, liveModels: true },
@@ -107,6 +108,43 @@ describe('provider/setKey', () => {
   test('vault locked → locked', async () => {
     const r = makeProviderRoutes(baseDeps({ vault: { setSecret: async () => { throw new VaultLockedError(); } } }));
     expect(await r['provider/setKey']({ provider: 'anthropic', plaintext: 'sk-abcdefgh' })).toEqual({ ok: false, error: 'locked' });
+  });
+
+  // Auto-activate: configuring a provider when the current selection isn't
+  // usable yet promotes the one you just keyed (fresh-install readiness),
+  // but never overrides an already-usable selection.
+  const twoCloud = () => [
+    { name: 'anthropic', label: 'Anthropic', defaultModel: 'claude', vaultSecretName: 'anthropic.key' },
+    { name: 'openrouter', label: 'OpenRouter', defaultModel: 'auto', vaultSecretName: 'openrouter.key' },
+  ];
+  test('auto-activates the keyed provider when the active one is unconfigured', async () => {
+    let updated: any = null;
+    const r = makeProviderRoutes(baseDeps({
+      listProviders: twoCloud,
+      vault: { setSecret: async () => {}, getSecret: async () => null }, // active anthropic has NO key
+      settingsStore: { get: () => ({ providerName: 'anthropic', providerModel: 'claude' }), update: async (p: any) => { updated = p; } },
+    }));
+    expect(await r['provider/setKey']({ provider: 'openrouter', plaintext: 'sk-or-abcdefgh' })).toEqual({ ok: true });
+    expect(updated).toEqual({ providerName: 'openrouter', providerModel: '' });
+  });
+  test('does NOT override an already-usable active provider', async () => {
+    let updated: any = null;
+    const r = makeProviderRoutes(baseDeps({
+      listProviders: twoCloud,
+      vault: { setSecret: async () => {}, getSecret: async () => 'sk-abc' }, // active anthropic HAS a key
+      settingsStore: { get: () => ({ providerName: 'anthropic', providerModel: 'claude' }), update: async (p: any) => { updated = p; } },
+    }));
+    expect(await r['provider/setKey']({ provider: 'openrouter', plaintext: 'sk-or-abcdefgh' })).toEqual({ ok: true });
+    expect(updated).toBe(null);
+  });
+  test('respects an explicit keyless (Ollama) active selection', async () => {
+    let updated: any = null;
+    const r = makeProviderRoutes(baseDeps({
+      vault: { setSecret: async () => {}, getSecret: async () => null },
+      settingsStore: { get: () => ({ providerName: 'ollama', providerModel: '' }), update: async (p: any) => { updated = p; } },
+    }));
+    expect(await r['provider/setKey']({ provider: 'anthropic', plaintext: 'sk-abcdefgh' })).toEqual({ ok: true });
+    expect(updated).toBe(null);
   });
 });
 


### PR DESCRIPTION
**Regression:** on a fresh install, entering an **OpenRouter** key (no Anthropic) and returning to chat still showed the *"Add a key in Settings"* empty-state.

**Root cause:** readiness (`providers.hasKey`) keys off `resolveActiveProvider()`, which is settings-only and defaults `providerName` to `anthropic`. Pasting an OpenRouter key never changed the active provider, so the app kept checking Anthropic's (missing) key. As the owner put it: it assumed Anthropic is the default unless told otherwise.

**Fix (1) — readiness follows configuration.** `provider/setKey` now auto-activates the provider you just configured **when the current selection isn't usable yet** (no key, and not an explicit keyless pick), clearing `providerModel` so the new provider's default model applies. It **never overrides an already-usable selection** (a keyed provider, or a deliberate Ollama pick). `setKey` is the single chokepoint every save path hits, so `providerName` stays correct at the source and all downstream resolution (snapshot readiness, model picker, turns) "just works." Net behavior the owner asked for: everything stays hidden until *any* provider is configured; once one is, the model selector reveals and the active provider is a usable one; as more providers connect, more options appear. Empty-state copy is now provider-agnostic.

**Fix (2) — themed provider select.** Settings → Provider `<select>` rendered native white chrome in dark mode. Added a `.input-row select` rule matching the text inputs + a themed chevron (same `appearance:none` approach as `type=search`).

**Tests:** 3 new `provider/setKey` cases (auto-activate when active is unconfigured; don't override a keyed selection; respect an explicit keyless selection). Full background+meta suite green (292 pass); typecheck + eslint clean.

Note: this corrects new key-adds going forward. A pre-existing install that already stranded a key under a non-active provider would self-correct on the next key save or a manual provider switch — happy to add a one-time reconciliation if you want existing stranded states to heal automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)