### PR TITLE
fix(ocr): MV3-valid CSP — drop worker-src blob: (broke extension load)

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -31,7 +31,7 @@
     "<all_urls>"
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; worker-src 'self' blob:; connect-src 'self' blob: https: wss: http://localhost:11434",
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' blob: https: wss: http://localhost:11434",
     "sandbox": "sandbox allow-scripts allow-forms allow-popups allow-modals allow-popups-to-escape-sandbox allow-pointer-lock allow-downloads; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; worker-src 'self' blob:; child-src 'self' blob:;"
   },
   "sandbox": {

--- a/extension/offscreen/pdf-extract.js
+++ b/extension/offscreen/pdf-extract.js
@@ -150,8 +150,14 @@ const extractViaOcr = async (bytes, { dev = false } = {}) => {
     // createWorker spins up vendor/tesseract/worker.min.js, which loads the core
     // WASM (corePath) and the language model (langPath). cacheMethod:'none' — we
     // already cache the bytes in IDB (ocr-store), no second cache layer.
+    // workerBlobURL:false — load the worker DIRECTLY from the same-origin
+    // workerPath, not via a blob: Worker. MV3's extension_pages CSP only allows
+    // 'self' in worker-src (blob: is rejected and would invalidate the whole
+    // manifest), so the worker must be a 'self' URL. The core/lang it then loads
+    // are blob: URLs, which ride connect-src 'self' blob: (a network directive,
+    // unrestricted in MV3) — see manifests/*.json.
     worker = await Tesseract.createWorker('eng', 1, {
-      corePath, langPath, workerPath, gzip: true, cacheMethod: 'none',
+      corePath, langPath, workerPath, gzip: true, cacheMethod: 'none', workerBlobURL: false,
     });
 
     const pageCount = pdf.numPages;

--- a/manifests/base.json
+++ b/manifests/base.json
@@ -37,7 +37,7 @@
   ],
 
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; worker-src 'self' blob:; connect-src 'self' blob: https: wss://disks.webvm.io http://localhost:11434",
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' blob: https: wss://disks.webvm.io http://localhost:11434",
     "sandbox": "sandbox allow-scripts allow-forms allow-popups allow-modals allow-popups-to-escape-sandbox allow-pointer-lock allow-downloads; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; worker-src 'self' blob:; child-src 'self' blob:;"
   },
 

--- a/manifests/dev.patch.json
+++ b/manifests/dev.patch.json
@@ -10,7 +10,7 @@
     "default_title": "peerd (dev)"
   },
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; worker-src 'self' blob:; connect-src 'self' blob: https: wss: http://localhost:11434"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' blob: https: wss: http://localhost:11434"
   },
   "web_accessible_resources": [
     {

--- a/manifests/preview.patch.json
+++ b/manifests/preview.patch.json
@@ -13,6 +13,6 @@
     "default_title": "peerd preview"
   },
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; worker-src 'self' blob:; connect-src 'self' blob: https: wss://disks.webvm.io wss://bootstrap.peerd.ai http://localhost:11434"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' blob: https: wss://disks.webvm.io wss://bootstrap.peerd.ai http://localhost:11434"
   }
 }


### PR DESCRIPTION
**Hotfix for main** — #43 turned main red. The OCR CSP added `worker-src 'self' blob:` to the offscreen `extension_pages` policy, but Chrome MV3 restricts `worker-src` to `'self'`/`'none'`/`'wasm-unsafe-eval'`/localhost — `blob:` there **invalidates the whole manifest**, so the extension fails to load. The side-panel **e2e** caught it (3/3 "service-worker target never appeared"); the package matrix passed because it builds artifacts without loading the extension.

**Fix**
- Drop `worker-src 'self' blob:` from base/dev/preview CSP (regenerated manifest). Keep `blob:` in `connect-src` — a network directive (unrestricted in MV3, like the existing `https:`/`wss:`) — which is what the worker's core-WASM/lang `blob:` fetches actually need.
- `createWorker(..., { workerBlobURL: false })` so the tesseract worker loads directly from the same-origin `vendor/tesseract/worker.min.js` (a `'self'` URL) instead of a `blob:` Worker, matching `worker-src 'self'`.

Local `preflight` green (drift, lint, types, boundary, 2088 tests). The e2e can't be reproduced locally (needs CI's headless Chrome-for-Testing — local everyday Chrome fails to load the unpacked extension regardless of CSP), so **this PR's CI e2e is the real gate** before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)