### PR TITLE
fix(ui): reset SW-owned ephemeral state on disconnect + cancel onboarding slide timer

### DIFF
--- a/extension/sidepanel/components/onboarding-view.js
+++ b/extension/sidepanel/components/onboarding-view.js
@@ -71,6 +71,7 @@ import { PEER_NAME_MAX } from '/peerd-runtime/index.js';
  * @property {number} step
  * @property {''|'out'|'in'} anim
  * @property {PromptState|null} prompt
+ * @property {ReturnType<typeof setTimeout>|null} stepTimer
  */
 
 // Same five custom props the composer's send disc draws from (sidepanel
@@ -195,6 +196,7 @@ const goToStep = (ui, next) => {
   stopTease(ui);
   stopPromptType(ui);
   const swap = () => {
+    ui.stepTimer = null;
     ui.step = next;
     ui.anim = 'in';
     startPromptType(ui);
@@ -203,7 +205,11 @@ const goToStep = (ui, next) => {
   if (reducedMotion()) { ui.anim = ''; swap(); return; }
   ui.anim = 'out';
   m.redraw();
-  setTimeout(swap, 170);
+  // Track the slide-transition timer so onremove can cancel it — otherwise an
+  // unmount within the 170ms window (e.g. a vault auto-lock) fires swap()
+  // against detached component state. Clear any prior one first.
+  if (ui.stepTimer) clearTimeout(ui.stepTimer);
+  ui.stepTimer = setTimeout(swap, 170);
 };
 
 /** @typedef {{ state: OnbState, attrs: { send: Send, state?: ChatState } }} OnbVnode */
@@ -220,6 +226,7 @@ export const OnboardingView = {
     vnode.state.step = 0;       // 0 name · 1 call-me · 2 notes
     vnode.state.anim = '';      // ''|'out'|'in' — step transition class
     vnode.state.prompt = null;  // typed question state for steps 1/2
+    vnode.state.stepTimer = null;
     if (!reducedMotion()) {
       startTease(vnode.state);
     }
@@ -229,6 +236,7 @@ export const OnboardingView = {
   onremove(vnode) {
     stopTease(vnode.state);
     stopPromptType(vnode.state);
+    if (vnode.state.stepTimer) clearTimeout(vnode.state.stepTimer);
   },
 
   /** @param {OnbVnode} vnode */

--- a/extension/sidepanel/sidepanel.js
+++ b/extension/sidepanel/sidepanel.js
@@ -76,6 +76,18 @@ const handlePortDisconnect = () => {
     vault: { ...currentState.vault, locked: true, unlockedAt: 0 },
     providers: { ...currentState.providers, hasKey: false },
     lastError: null,
+    // why reset these: they are SW-OWNED ephemeral projections. The SW just
+    // died with its confirm coordinator, turn slots, ralph/goal drivers and
+    // notice queue — so a stale confirm modal (now UNANSWERABLE: the coordinator
+    // that owned the prompt is gone), rate-limit banner, Stop spinner, notice,
+    // or goal-run pill would linger with nothing behind it. Reset to the
+    // INITIAL_STATE defaults; a revived SW replays anything genuinely still live
+    // via getPending() + the fresh state push.
+    pendingConfirm: null,
+    rateLimit: null,
+    streaming: false,
+    notices: INITIAL_STATE.notices,
+    goalRuns: INITIAL_STATE.goalRuns,
   };
   m.redraw();
   port = null;


### PR DESCRIPTION
Two side-panel hygiene fixes from the UI hunt.

## #33 - stale confirm modal / banners survive a service-worker death
`handlePortDisconnect` reset only `vault`/`providers`/`lastError`, leaving the **SW-owned ephemeral projections** (`pendingConfirm`, `rateLimit`, `streaming`, `notices`, `goalRuns`) intact. When the SW dies it takes its confirm coordinator / turn slots / ralph+goal drivers / notice queue with it - so a stale confirm modal (now **unanswerable**, since the coordinator that owned the prompt is gone) plus a stale rate-limit banner / Stop spinner / notice / goal pill linger with nothing behind them. Reset them to `INITIAL_STATE` defaults; a revived SW replays anything genuinely live via `getPending()` + the fresh state push. (Fails safe today - the dropped click runs no side-effect - so this is hygiene, not a hole.)

## #34 - onboarding slide-transition timer not cancelled on unmount
`OnboardingView`'s 170ms `setTimeout(swap, …)` was untracked, so an unmount within that window (e.g. a vault auto-lock) fired `swap()` against detached component state. Track it on `ui.stepTimer` and `clearTimeout` in `onremove` (and clear a prior one in `goToStep`).

Both are simple, low-severity hygiene fixes; testing the SW-disconnect path / timer race directly is fiddly, so verification is by inspection + the in-browser suite (598/0, onboarding + sidepanel coverage). typecheck + lint clean.

Closes #33, closes #34