### PR TITLE
test: property/fuzz the denylist matcher + the SSE stream parser

### DIFF
--- a/tests/peerd-egress/denylist-fuzz.test.ts
+++ b/tests/peerd-egress/denylist-fuzz.test.ts
@@ -1,0 +1,91 @@
+// Property fuzz for the denylist host matcher — the security-critical gate that
+// keeps peerd off "sites it will never touch". The class of bug here is a
+// BYPASS: a host that should match a pattern slipping through because of a
+// host-form variation a browser treats as equivalent (case, a port, a trailing
+// FQDN dot). A real bypass was already fixed for port + trailing dot; this pins
+// the whole class with thousands of generated cases.
+//
+// Inputs are kept to the shapes the matcher actually receives — a URL.host
+// ("hostname:port", port last) or a URL.hostname ("hostname", trailing dot
+// possible). The PRNG is seeded so any failure reproduces from the fixed seed.
+
+import { describe, test, expect } from 'bun:test';
+import { findDenylistMatch } from '../../extension/peerd-egress/denylist/denylist.js';
+
+const rng = (seed: number) => () => {
+  seed = (seed + 0x6D2B79F5) | 0;
+  let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+};
+const randLabel = (r: () => number) => {
+  const alpha = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  const n = 1 + Math.floor(r() * 8);
+  let s = '';
+  for (let i = 0; i < n; i++) s += alpha[Math.floor(r() * alpha.length)];
+  return s;
+};
+const randHost = (r: () => number) =>
+  Array.from({ length: 2 + Math.floor(r() * 3) }, () => randLabel(r)).join('.');
+
+// Equivalence-preserving mutations a browser/URL would treat as the SAME host.
+// Case can always apply; a port (URL.host) and a trailing dot (URL.hostname) do
+// NOT co-occur in a single URL field, so pick at most one.
+const mutate = (r: () => number, host: string) => {
+  let h = host;
+  if (r() < 0.6) h = [...h].map((c) => (r() < 0.5 ? c.toUpperCase() : c)).join('');
+  const form = r();
+  if (form < 0.35) h = `${h}:${1 + Math.floor(r() * 65535)}`;   // URL.host (port last)
+  else if (form < 0.7) h = h + '.'.repeat(1 + Math.floor(r() * 3)); // URL.hostname (trailing dot)
+  return h;
+};
+
+describe('denylist matcher — property fuzz', () => {
+  test('never throws on arbitrary host / pattern input', () => {
+    const r = rng(0x1234);
+    for (let i = 0; i < 2000; i++) {
+      const host = r() < 0.5
+        ? randHost(r)
+        : Array.from({ length: Math.floor(r() * 24) }, () => Math.floor(r() * 128)).map((c) => String.fromCharCode(c)).join('');
+      const patterns = Array.from({ length: Math.floor(r() * 4) },
+        () => (r() < 0.5 ? randHost(r) : `*.${randHost(r)}`));
+      expect(() => findDenylistMatch(host, patterns)).not.toThrow();
+    }
+  });
+
+  test('a denylisted host stays matched under case / port / trailing-dot variation (no bypass)', () => {
+    const r = rng(0xBEEF);
+    for (let i = 0; i < 4000; i++) {
+      const base = randHost(r);
+      const wildcard = r() < 0.5;
+      const pattern = wildcard ? `*.${base}` : base;
+      const host = wildcard ? `${randLabel(r)}.${base}` : base;
+      expect(findDenylistMatch(host, [pattern])).toBe(pattern); // the plain form matches
+      const m = mutate(r, host);
+      const got = findDenylistMatch(m, [pattern]);
+      if (got !== pattern) throw new Error(`BYPASS: host="${m}" pattern="${pattern}" → ${String(got)}`);
+    }
+  });
+
+  test('wildcard *.base matches a subdomain but NOT the apex or a glued host', () => {
+    const r = rng(0x2468);
+    for (let i = 0; i < 2000; i++) {
+      const base = randHost(r);
+      expect(findDenylistMatch(`${randLabel(r)}.${base}`, [`*.${base}`])).toBe(`*.${base}`); // subdomain → match
+      expect(findDenylistMatch(base, [`*.${base}`])).toBe(null);        // apex → NOT a subdomain
+      expect(findDenylistMatch(`x${base}`, [`*.${base}`])).toBe(null);  // glued (no dot) → no match
+    }
+  });
+
+  test('known canonicalization edge cases (regression of the fixed bypasses)', () => {
+    const P = ['chase.com'];
+    expect(findDenylistMatch('chase.com', P)).toBe('chase.com');
+    expect(findDenylistMatch('CHASE.COM', P)).toBe('chase.com');      // case
+    expect(findDenylistMatch('Chase.Com.', P)).toBe('chase.com');     // case + trailing dot
+    expect(findDenylistMatch('chase.com:8443', P)).toBe('chase.com'); // port
+    expect(findDenylistMatch('chase.com..', P)).toBe('chase.com');    // multiple trailing dots
+    // and the boundary non-matches the gate relies on
+    expect(findDenylistMatch('evilchase.com', P)).toBe(null);
+    expect(findDenylistMatch('chase.com.attacker.com', P)).toBe(null);
+  });
+});

--- a/tests/peerd-provider/sse-parser-fuzz.test.ts
+++ b/tests/peerd-provider/sse-parser-fuzz.test.ts
@@ -1,0 +1,98 @@
+// Property fuzz for the SSE stream parser — every provider response flows
+// through it, and the classic bug is a record split across network chunk
+// boundaries (a `data:` line, or the blank line that ends a record, arriving in
+// two reads). The gold property: the SAME bytes, split at ANY boundaries, must
+// yield the SAME events. Plus round-trip + never-throws-on-garbage.
+//
+// PRNG is seeded so any failure reproduces from the fixed seed.
+
+import { describe, test, expect } from 'bun:test';
+import { parseSSE } from '../../extension/peerd-provider/format/sse-parser.js';
+
+const rng = (seed: number) => () => {
+  seed = (seed + 0x6D2B79F5) | 0;
+  let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+};
+const enc = new TextEncoder();
+
+const streamOf = (chunks: Uint8Array[]): ReadableStream<Uint8Array> => {
+  let i = 0;
+  return new ReadableStream({ pull(c) { if (i < chunks.length) c.enqueue(chunks[i++]); else c.close(); } });
+};
+const drain = async (s: ReadableStream<Uint8Array>) => {
+  const out: any[] = [];
+  for await (const e of parseSSE(s)) out.push(e);
+  return out;
+};
+const splitBytes = (r: () => number, bytes: Uint8Array, n: number): Uint8Array[] => {
+  if (bytes.length <= 1 || n <= 0) return [bytes];
+  const cuts = [...new Set(Array.from({ length: n }, () => 1 + Math.floor(r() * (bytes.length - 1))))].sort((a, b) => a - b);
+  const chunks: Uint8Array[] = [];
+  let prev = 0;
+  for (const c of cuts) { chunks.push(bytes.slice(prev, c)); prev = c; }
+  chunks.push(bytes.slice(prev));
+  return chunks.filter((c) => c.length > 0);
+};
+
+// A random SSE event. Data chars are drawn from a colon/space-free alphabet so
+// the (spec-mandated) single-leading-space strip never alters the round-trip.
+const DATA_ALPHA = 'abcXYZ0._{}"-';
+const randEvent = (r: () => number) => {
+  const name = r() < 0.3 ? 'message' : `evt${Math.floor(r() * 1000)}`; // 'message' = the default name
+  const lines = Array.from({ length: 1 + Math.floor(r() * 3) }, () => {
+    const len = Math.floor(r() * 12);
+    let s = '';
+    for (let i = 0; i < len; i++) s += DATA_ALPHA[Math.floor(r() * DATA_ALPHA.length)];
+    return s;
+  });
+  return { name, lines };
+};
+type Ev = { name: string, lines: string[] };
+const serialize = (evs: Ev[]) => evs.map((e) =>
+  (e.name === 'message' ? '' : `event: ${e.name}\n`) + e.lines.map((l) => `data: ${l}\n`).join('') + '\n').join('');
+const expected = (evs: Ev[]) => evs.map((e) => ({ event: e.name, data: e.lines.join('\n') }));
+
+describe('SSE parser — property fuzz', () => {
+  test('chunk-boundary invariance: the same bytes split at ANY boundaries yield the same events', async () => {
+    const r = rng(0xC0FFEE);
+    for (let i = 0; i < 400; i++) {
+      const evs = Array.from({ length: 1 + Math.floor(r() * 5) }, () => randEvent(r));
+      const bytes = enc.encode(serialize(evs));
+      const whole = await drain(streamOf([bytes]));
+      const split = await drain(streamOf(splitBytes(r, bytes, 1 + Math.floor(r() * 7))));
+      if (JSON.stringify(whole) !== JSON.stringify(split)) {
+        throw new Error(`boundary mismatch on ${JSON.stringify(serialize(evs))}\n whole=${JSON.stringify(whole)}\n split=${JSON.stringify(split)}`);
+      }
+    }
+  });
+
+  test('round-trips well-formed events', async () => {
+    const r = rng(0xD00D);
+    for (let i = 0; i < 400; i++) {
+      const evs = Array.from({ length: 1 + Math.floor(r() * 5) }, () => randEvent(r));
+      const got = await drain(streamOf([enc.encode(serialize(evs))]));
+      expect(got).toEqual(expected(evs));
+    }
+  });
+
+  test('CRLF line endings parse identically to LF', async () => {
+    const r = rng(0x0D0A);
+    for (let i = 0; i < 300; i++) {
+      const evs = Array.from({ length: 1 + Math.floor(r() * 4) }, () => randEvent(r));
+      const lf = serialize(evs);
+      const crlf = lf.replace(/\n/g, '\r\n');
+      expect(await drain(streamOf([enc.encode(crlf)]))).toEqual(await drain(streamOf([enc.encode(lf)])));
+    }
+  });
+
+  test('never throws on arbitrary bytes (random chunks)', async () => {
+    const r = rng(0xFACE);
+    for (let i = 0; i < 400; i++) {
+      const bytes = new Uint8Array(Array.from({ length: Math.floor(r() * 220) }, () => Math.floor(r() * 256)));
+      const chunks = splitBytes(r, bytes, Math.floor(r() * 4));
+      await expect(drain(streamOf(chunks))).resolves.toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
A robustness force-multiplier: property/fuzz tests for two load-bearing parsers, locking whole **classes** of edge-case bugs instead of the one-at-a-time instances a hunt surfaces. Seeded PRNG, so any failure reproduces from the fixed seed.

## Denylist matcher (security-critical)
~8k generated cases assert **bypass-resistance**: a denylisted host stays matched under every equivalence-preserving variation a browser actually produces (case, a port, a trailing FQDN dot), across exact **and** wildcard patterns - plus no-throw on arbitrary input, and the apex / glued-host wildcard boundaries. This locks the class of the port + trailing-dot bypass already fixed. (Inputs stay realistic to what the matcher receives - a `URL.host` or `URL.hostname`.)

## SSE stream parser
The gold property - **chunk-boundary invariance**: the same bytes split at *any* boundaries yield the same events (the classic "record split across network reads" bug). Plus round-trip, CRLF/LF parity, and no-throw on arbitrary bytes.

**Both green - no new defect surfaced.** The value is the regression lock: these invariants can't silently regress now. Full bun suite green; typecheck + lint + boundary clean. Test-only (no source change).