### PR TITLE
fix: onboarding is a home-page blocker; silence egress-wrapper boot output

### DIFF
--- a/extension/home/home.js
+++ b/extension/home/home.js
@@ -25,6 +25,7 @@ import { INITIAL_STATE, reduceChat, putSubagentSession } from '../sidepanel/chat
 import { ChatView } from '../sidepanel/components/chat-view.js';
 import { ConfirmModal, NoticeBar } from '../sidepanel/components/app.js';
 import { VaultGate } from '../sidepanel/components/vault-gate.js';
+import { OnboardingView, needsOnboarding } from '../sidepanel/components/onboarding-view.js';
 import { peerNotifications } from '/shared/peer-notifications.js';
 
 /** @typedef {import('./library-section.js').Send} Send */
@@ -523,6 +524,16 @@ const HomeApp = {
     // succeeds. Wrapped in .options-gate so it sits in the upper third (home.css).
     if (!currentState.vault?.initialized || currentState.vault.locked) {
       return m('.options-gate', m(VaultGate, { state: currentState, send }));
+    }
+
+    // Onboarding is a HOME-page blocker (DESIGN-12): once the vault is unlocked,
+    // the first-run "meet your peer" funnel gates the experience right here —
+    // before any navigation — and lifts itself when the SW's onboardingComplete
+    // latch flips on the next state push. It deliberately does NOT live in the
+    // side panel (you reach the panel by popping it from an onboarded home), so
+    // it can never surprise-trigger after you've started using home.
+    if (needsOnboarding(currentState)) {
+      return m('.options-gate', m(OnboardingView, { state: currentState, send }));
     }
 
     const showDweb = DWEB_ENABLED && currentState.settings?.dwebEnabled;

--- a/extension/sidepanel/components/app.js
+++ b/extension/sidepanel/components/app.js
@@ -10,7 +10,6 @@ import m from '/vendor/mithril/mithril.js';
 import { VaultGate } from './vault-gate.js';
 import { ChatView } from './chat-view.js';
 import { SessionsView } from './sessions-view.js';
-import { OnboardingView } from './onboarding-view.js';
 import { openOptions } from '/shared/open-options.js';
 import { openHome } from '/shared/open-home.js';
 import { CHANNEL } from '/shared/channel-config.js';
@@ -30,12 +29,8 @@ export const App = {
   view: ({ attrs }) => {
     const { state, send, voiceManager, uiActions, view, optionsActive, activeTabIsWeb } = attrs;
     const unlocked = state.vault.initialized && !state.vault.locked;
-    // First-run onboarding ('onboarding' is what the sidepanel.js route
-    // gate resolves EVERY route to until the profile's latch flips). It
-    // renders as a hero screen like the vault gate — no TopBar — so the
-    // TopBar wordmark mounts fresh afterwards and plays its typing
-    // intro exactly once, at the real start of use.
-    const onboarding = unlocked && view === 'onboarding';
+    // First-run onboarding is a HOME-page blocker (home.js), not a side-panel
+    // route — the panel is reached by popping it from an onboarded home.
 
     // why: ONE app-shell with a stable `.body` at position 1. The header
     // sits at position 0 and is `null` until unlocked — so the lock /
@@ -58,12 +53,11 @@ export const App = {
       : null;
 
     return m('div', { class: 'app-shell' }, [
-      unlocked && !onboarding ? m(TopBar, { state, send, optionsActive }) : null,
+      unlocked ? m(TopBar, { state, send, optionsActive }) : null,
       notices,
       m('.body', unlocked
         ? [
-            onboarding        ? m(OnboardingView, { state, send })
-            : view === 'chat'   ? m(ChatView, { state, send, voiceManager, uiActions, surface: 'sidepanel', activeTabIsWeb })
+            view === 'chat'   ? m(ChatView, { state, send, voiceManager, uiActions, surface: 'sidepanel', activeTabIsWeb })
             : view === 'chats'  ? m(SessionsView, { state, send })
             : m(PlaceholderView, { label: 'Unknown view' }),
           ]

--- a/extension/sidepanel/sidepanel.js
+++ b/extension/sidepanel/sidepanel.js
@@ -14,7 +14,6 @@
 import m from '/vendor/mithril/mithril.js';
 import browser from '/vendor/browser-polyfill.js';
 import { App } from './components/app.js';
-import { needsOnboarding } from './components/onboarding-view.js';
 import { createVoiceManager } from '/peerd-runtime/index.js';
 import { INITIAL_STATE, reduceChat, putSubagentSession } from './chat-reducer.js';
 
@@ -307,13 +306,10 @@ if (browser.tabs?.onActivated) {
 /** @param {string} view */
 const routeArgs = (view) => ({ state: currentState, send, voiceManager, uiActions, view, optionsActive, activeTabIsWeb });
 
-// First-run route gate: after vault setup and before anything else,
-// EVERY route resolves to the onboarding screen until the default
-// profile's onboardingComplete latch flips (persisted by the SW — it
-// never re-fires). Evaluated per redraw, so the gate lifts the moment
-// the post-onboarding state push lands, with no route change needed.
-/** @param {string} view */
-const gatedView = (view) => (needsOnboarding(currentState) ? 'onboarding' : view);
+// First-run onboarding is NOT gated here — it lives on the HOME page as a
+// blocker (home.js needsOnboarding gate). The side panel is reached by popping
+// it from an already-onboarded home, so routing it through onboarding too only
+// caused a surprise trigger when the panel opened after home use.
 
 // why only two routes: settings + context (memory/activity/denylist/
 // skills/hooks) moved to the full-tab options page — the panel is the
@@ -331,7 +327,7 @@ const gatedView = (view) => (needsOnboarding(currentState) ? 'onboarding' : view
 const Root = {
   view: () => {
     const path = m.route.get();
-    return m(App, routeArgs(gatedView(path.startsWith('/chats') ? 'chats' : 'chat')));
+    return m(App, routeArgs(path.startsWith('/chats') ? 'chats' : 'chat'));
   },
 };
 m.route(root, '/chat', { '/chat': Root, '/chats': Root });

--- a/extension/vm-tab/vm-tab.js
+++ b/extension/vm-tab/vm-tab.js
@@ -1037,9 +1037,10 @@ const installWrappers = async () => {
   const encoder = new TextEncoder();
   const stagingName = `/peerdwrappers${Date.now().toString(36)}`;
   // devMode: prepend `set -x` to the sourced wrappers so the PERSISTENT shell
-  // traces every later step (curl/wget/git, pkg installs), and run the install
-  // VISIBLE (below) so the [diag]/[verify] lines reach the terminal instead of
-  // being swallowed. Off by default — extra noise.
+  // traces every later step (curl/wget/git, pkg installs). The install itself
+  // ALWAYS runs silent (below) — its [diag]/[verify] lines are captured in
+  // stdout for the verify parse, never dumped to the terminal. That boot-time
+  // wall of egress-wrapper output is just noise to the user.
   const wrappersSrc = (vmDevMode ? 'set -x\n' : '') + WRAPPERS_BASH;
   await dataDev.writeFile(stagingName, encoder.encode(wrappersSrc));
   const stagedPath = `/peerd-data${stagingName}`;
@@ -1061,7 +1062,7 @@ const installWrappers = async () => {
     'unset __f __t',
     'echo "[peerd-egress] bash function wrappers installed"',
   ].join('\n');
-  return runViaShell(script, { silent: !vmDevMode });
+  return runViaShell(script, { silent: true });
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Two first-run cleanups (folding into the v0.1.0 re-cut).

**1. Onboarding → home-page blocker, off the side panel.** It was side-panel-only (`sidepanel.js` routed every view to `onboarding`) while home had no gate — so a new user could chat on home, then opening the side panel surprise-triggered the funnel. Now `home.js` gates on `needsOnboarding` right after the vault gate (blocks before any navigation; lifts on the SW `onboardingComplete` push), and the side panel no longer routes through onboarding. Dead handling removed from `app.js`/`sidepanel.js`.

**2. Quiet egress wrappers.** The boot `[diag]/[verify]/wrappers installed` wall hit the WebVM terminal in dev builds (`silent:!vmDevMode`). Now `silent: true` always — the `[verify]` lines are still captured in `stdout` for the verify parse, so nothing downstream changes.

typecheck + eslint clean; 2097 bun tests pass; e2e only RPC-completes onboarding (no side-panel assertion), so unaffected. Home onboarding render is the owner's quick load-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)