### PR TITLE
release: v0.1.1 — accurate VM wrapper instructions + silence egress trace flood

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -785,8 +785,12 @@ Revisit if/when we ship a paid tier.
   handles this natively — pages are pulled on demand.
 - Pre-bake a handful of packages users will reach for immediately: `python3`,
   `pip`, `pandas`, `requests`, `jq`, `curl`, `git`, `ripgrep`. This is a
-  V1.1 polish — V1 ships with the stock CheerpX base and lets the agent
-  `apt install` what it needs.
+  later polish — today ships the stock CheerpX Debian image (python3 + pip +
+  git + jq + coreutils, 32-bit i686). There are no live apt repos: `apt
+  install` is shimmed to error (return 100). Packages come from the
+  host-side-resolving wrappers — pip (pure-python wheels), npm/yarn/pnpm
+  (named packages), gem (pure-ruby) — or `dpkg -i` on a curl-fetched .deb;
+  bake a custom image for native/compiled deps.
 - Persistence: CheerpX persistent block device backed by IndexedDB. State
   in `/root` and `/home/agent` survives between sessions. "Reset VM" wipes it.
 
@@ -851,10 +855,12 @@ export const run = async (cmd, opts = {}) => {
 
 The VM is hard-sandboxed by WASM. Even if the agent runs malicious code
 inside it, that code cannot escape to the browser, cannot read cookies,
-cannot make network requests outside what CheerpX's emulated network layer
-permits (which goes through the same `safeFetch` egress layer — we plumb
-its emulated socket through our allowlist). Network access from inside the
-VM is OFF by default in V1; user can enable per-session with a confirm.
+cannot make network requests except HTTP/HTTPS routed through bash-function
+wrappers (curl / wget / git clone / peerd-fetch and the pip/npm/gem shims)
+that call peerd-egress host-side, behind the denylist + SSRF/private-network
+guard. There are no raw sockets — ssh/nc/ping/etc. are stubbed to error.
+This HTTP egress path is always active (no per-session enable); it is gated
+by the denylist (allowlist-free `webFetch`) rather than an on/off switch.
 
 ---
 
@@ -2298,12 +2304,12 @@ implementation, not ones I'd make unilaterally:
    vs. a sticky banner at the top of the side panel. Inline reads
    naturally but can be scrolled past; sticky is harder to miss but
    intrusive.
-6. **VM network access default.** Off in V1 (as written above) means the
-   agent can't `pip install` without explicit per-session enable. That's
-   safer but annoying. Alternative: enabled by default with the same
-   egress allowlist applied (`pypi.org`, `github.com`, npm registry, etc.).
-   I lean toward off-by-default with a one-click enable + a curated common
-   allowlist when enabled.
+6. **VM network access default.** RESOLVED: VM HTTP egress is always-on,
+   gated by the denylist + SSRF/private-network guard (not an on/off
+   per-session toggle). `pip install` (pure-python), npm/gem install, and
+   git clone all work out of the box via the host-side-resolving wrappers;
+   no per-session enable and no curated allowlist — any non-denylisted
+   public host is reachable.
 
 ---
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -55,16 +55,18 @@ small "pending confirm" banner appears at the top of the panel with a
 
 ## 6. VM network access default
 
-**Off by default.** Per-session enable via a one-click confirm; when
-enabled, an egress allowlist for common dev origins applies
-(`pypi.org`, `pythonhosted.org`, `github.com`, `raw.githubusercontent.com`,
-`registry.npmjs.org`, `repo.maven.apache.org`, `crates.io`).
-The agent can request additions; user confirms each.
+**Always-on, denylist-gated.** The VM's curl/wget/git/pip/npm/gem ride
+the same audited egress as the web tools: allowlist-free `webFetch`
+guarded by the always-on denylist, an SSRF/private-network block (no
+LAN/localhost/loopback), redirect fail-close, and the audit log. Any
+non-denylisted public HTTP(S) host works; there is no curated per-origin
+allowlist to add to, and no per-session enable gate.
 
-This is the conservative-by-default version. If we get user feedback
-that the `pip install` friction is constant, revisit with a "trusted
-sources only" mode that auto-enables the curated allowlist without a
-prompt per session.
+This supersedes the original conservative off-by-default + curated-
+allowlist proposal: in practice the denylist + SSRF guard carry the
+safety weight, and gating every `pip install` behind a per-session
+confirm was pure friction. See `docs/engine/VM-NETWORKING.md` and
+`extension/peerd-egress/README.md` for the egress model.
 
 ---
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "peerd (dev)",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "An AI assistant that automates tasks in your browser. Local-first: your own API key, no account, no servers, no tracking.",
   "side_panel": {
     "default_path": "sidepanel/sidepanel.html"

--- a/extension/peerd-provider/system-prompt.txt
+++ b/extension/peerd-provider/system-prompt.txt
@@ -221,25 +221,47 @@ work, parallel included, goes through spawn_subagent above.
 
 ──── webvm specifics ──────────────────────────────────────────────────
 
-Image: stock Debian + python3, pip, git, jq, POSIX toolchain, Python
-stdlib. Network is HTTP/HTTPS only (no TCP/UDP in the kernel — pip
-install, apt, raw sockets all fail with "no route to host").
+Image: stock Debian (32-bit i686) + python3, pip, git, jq, POSIX
+toolchain, Python stdlib. The kernel has NO raw sockets: raw Python
+sockets, ssh, scp, nc, ping, rsync, dig fail at the kernel (shimmed to a
+peerd error, exit 1). apt/apt-get is shimmed too — install/update/etc.
+print a peerd error and return 100 (no live Debian repos; use the
+package wrappers below, or `dpkg -i` a curl-fetched .deb). But HTTP/HTTPS
+DOES work, and so does package install, through bash function wrappers.
 
-HTTP/HTTPS works via four bash function wrappers installed at VM boot
-that route through peerd-egress (same denylist + audit as web tools):
+The wrappers install at VM boot and route through peerd-egress — the same
+denylist + SSRF guard + audit as the web tools. It is allowlist-free: any
+non-denylisted public host works, no per-host confirm.
 
-  curl <url>      # GET; supports -o, -O, -s
-  wget <url>      # GET; supports -O
-  git clone <url> # github.com archive download + unpack
-  peerd-fetch <url> [outfile]
+  curl <url>            # full HTTP: -X, -H, -d/--data(@file), --json, -I, -f, -A, -e, -o/-O, -w '%{http_code}'
+  wget <url>            # GET or POST: -O, --header, --post-data/--post-file, --method, --body-data
+  git clone <url> [dir] # GitHub + GitLab (+ best-effort others); -b <branch|tag|sha>; private via vault git:<host>
+  peerd-fetch <url> [outfile]   # plain GET, cached host-side
+  pip install <pkg…>    # pure-Python wheels; also -r requirements.txt
+  npm install <pkg…>    # also yarn add / pnpm add; NAMED packages only
+  gem install <name…>   # pure-Ruby gems
+
+pip/npm/gem resolve the package + its deps host-side, stage them, then
+install offline in the VM — so `pip install requests` just works.
+Gotchas: pip prefers pure py3-none-any wheels (an i686 wheel may match,
+but C-extension / native builds fail loudly naming the package); npm/
+yarn/pnpm take NAMED packages only (a bare `npm install` from package.json
+FAILS — runtime deps only, no dev/peer/optional, no install scripts, no
+native addons); gem is pure-Ruby only and needs a gem binary in the image
+(no Bundler/Gemfile). git clone is a SNAPSHOT — no .git, no history, and
+only `clone` works (pull/push/fetch/commit do not). Staging fetches over
+the network, so big installs can be slow: raise vm_boot's timeoutMs
+(default 60s, max 300s) instead of giving up.
 
 Bash checks functions before PATH, so they shadow /usr/bin/{curl,wget,
-git}. Use them directly: vm_boot("curl https://api.github.com/repos/X
-| jq ."). `bash -c '...'` inherits via `export -f`; `sh -c` (dash)
-does NOT — use bash for subshells.
+git,pip,npm,gem}. Commands run in a persistent /bin/bash --login -i
+session — use the wrappers directly: vm_boot("curl https://api.github.com/repos/X
+| jq ."). `bash -c '...'` inherits them via `export -f`; `sh -c` (dash)
+does NOT — always use bash for subshells.
 
 vm_import is the bulk alternative (runs in peerd, writes bytes to a VM
-path). Use for >1MB responses or binaries.
+path). Use it for >1MB responses, binaries, or anything the wrappers
+can't fetch — apt packages, native/C-extension wheels or sdists.
 
 If a wrapper returns "Could not resolve host" / shell-not-found, the
 wrappers FAILED to install — check the in-tab boot log; don't tell the
@@ -259,9 +281,14 @@ for binaries or >200KB use vm_import.
 
 Canonical "run a GitHub project" flow:
   vm_boot("git clone https://github.com/<user>/<repo>")
+  vm_boot("pip install -r <repo>/requirements.txt")   # Python: if pure
   vm_boot("cd <repo> && python3 -m <pkg>")
+For a JS repo there's no package.json install — name the deps explicitly
+(`npm install <pkg> <pkg>`); a bare `npm install` errors. pip's -r
+requirements.txt is the only manifest-file install supported.
 
-Look for small pure-Python projects — anything needing `pip install` won't work.
+Pure-Python projects run cleanly; projects pulling compiled/native deps
+won't (those builds need a toolchain the VM lacks).
 
 ──── trust + security ────────────────────────────────────────────────
 

--- a/extension/peerd-runtime/tools/defs/vm-boot.js
+++ b/extension/peerd-runtime/tools/defs/vm-boot.js
@@ -47,22 +47,26 @@ export const vmBootTool = {
     'bash, POSIX). Persistent bash — cd, exported vars, and history persist',
     'across calls; pipes/redirects/&&/|| work. No `vm` arg → the chat\'s',
     'current VM (auto-created if none); pass `vm` to target another.',
-    'NO NETWORK in the kernel: curl / wget / git clone / peerd-fetch are bash',
-    'wrappers routed through peerd-egress — use THEM for fetching. apt and',
-    'ONLINE pip do NOT work — and even `pip install local.whl` HANGS, because',
-    'pip reaches PyPI for dependency resolution. To install a Python package:',
-    'vm_import its wheel, then `pip install --no-index --no-deps <whl>` (fully',
-    'offline), or just unzip the wheel (it is a zip) onto PYTHONPATH. Raw Python',
-    'sockets do not work. Use `bash -c` (not `sh -c`) for subshells. Slow',
-    'commands (builds, large installs) — raise timeoutMs. Returns stdout,',
-    'stderr, exit code, duration. Default 60s (timeoutMs, max 300s).',
+    'No raw sockets in the kernel, but HTTP(S) AND package install work via',
+    'bash wrappers routed through peerd-egress: curl / wget / git clone /',
+    'peerd-fetch for fetching, and `pip install <pkg>` (also -r',
+    'requirements.txt), `npm install`, `gem install` for packages — peerd',
+    'stages the package + its deps offline, then installs in the VM, so',
+    '`pip install requests` just works. NOT supported: compiled/native',
+    'packages (C extensions, no toolchain), apt, raw Python sockets. Staging',
+    'fetches over the network, so big installs are slow — raise timeoutMs',
+    'rather than giving up. Use `bash -c` (not `sh -c`) for subshells.',
+    'Returns stdout, stderr, exit code, duration. Default 60s (timeoutMs,',
+    'max 300s).',
   ].join(' '),
   schema: {
     type: 'object',
     properties: {
       cmd: {
         type: 'string',
-        description: 'Shell command to run (interpreted by /bin/sh -c).',
+        description: 'Shell command to run in a persistent /bin/bash --login -i '
+          + 'session (bash semantics; the curl/wget/git/pip/npm/gem wrappers are '
+          + 'bash functions). Use `bash -c`, never `sh -c`, for subshells.',
       },
       vm: {
         type: 'string',

--- a/extension/peerd-runtime/tools/defs/vm-import.js
+++ b/extension/peerd-runtime/tools/defs/vm-import.js
@@ -25,10 +25,12 @@ export const vmImportTool = {
   description: [
     'Download a URL and write the bytes into a VM at `path`. The fetch',
     'runs IN PEERD (through peerd-egress: denylist + audit), NOT inside',
-    'the VM. Use it to stage large or binary data, or anything apt / pip',
-    'install / raw Python sockets would need (those have no network inside',
-    'the VM). An error here is peerd-side (denylist, unreachable host, VM',
-    'not booted) — read it verbatim; the VM never tried. Max 50MB.',
+    'the VM. Use it to stage large or binary data, or anything the in-VM',
+    'wrappers cannot fetch — apt packages, native/C-extension pip wheels',
+    'or sdists, raw-socket downloads. (Pure-Python `pip install` and',
+    'npm/gem installs DO work in-VM via vm_boot; only reach for vm_import',
+    'when those cannot.) An error here is peerd-side (denylist, unreachable',
+    'host, VM not booted) — read it verbatim; the VM never tried. Max 50MB.',
     'Returns the written path and byte count.',
   ].join(' '),
   schema: {

--- a/extension/vm-tab/vm-tab.js
+++ b/extension/vm-tab/vm-tab.js
@@ -178,14 +178,20 @@ peerd-fetch() {
   local id="\${RANDOM}\${RANDOM}\${RANDOM}$$"
   printf '___PEERD_HTTP___:%s:%s\\n' "$id" "$url"
   local n=0
+  # why: under devMode set -x this 20Hz poll loop would echo ~4 trace lines
+  # every 50ms and flood the terminal during any slow fetch. Suspend xtrace for
+  # the wait (portable to any bash version, unlike local dash), restore it after.
+  local __peerd_x=""; case $- in *x*) __peerd_x=1; set +x;; esac
   while [ ! -f "/peerd-data/peerddone\${id}" ]; do
     sleep 0.05
     n=$((n + 1))
     if [ "$n" -gt "$PEERD_HTTP_TIMEOUT_TICKS" ]; then
+      [ -n "$__peerd_x" ] && set -x
       echo "peerd-fetch: timed out after \${PEERD_HTTP_TIMEOUT}s waiting for response (id=\${id})" >&2
       return 124
     fi
   done
+  [ -n "$__peerd_x" ] && set -x
   if [ -f "/peerd-data/peerderr\${id}" ]; then
     cat "/peerd-data/peerderr\${id}" >&2
     return 1
@@ -214,14 +220,20 @@ __peerd_emit_req() {
   id="\${RANDOM}\${RANDOM}\${RANDOM}$$"
   printf '___PEERD_REQ___:%s:%s\\n' "$id" "$payload"
   n=0
+  # why: silence this 20Hz poll loop so devMode set -x does not flood the
+  # terminal during slow requests (curl/wget + every pip/npm/gem install route
+  # through here). Suspend xtrace for the wait, restore after (portable bash).
+  local __peerd_x=""; case $- in *x*) __peerd_x=1; set +x;; esac
   while [ ! -f "/peerd-data/peerddone\${id}" ]; do
     sleep 0.05
     n=$((n + 1))
     if [ "$n" -gt "$PEERD_HTTP_TIMEOUT_TICKS" ]; then
+      [ -n "$__peerd_x" ] && set -x
       echo "peerd-http: timed out after \${PEERD_HTTP_TIMEOUT}s (id=\${id})" >&2
       return 124
     fi
   done
+  [ -n "$__peerd_x" ] && set -x
   PEERD_LAST_STATUS=""
   if [ -f "/peerd-data/peerdmeta\${id}" ]; then
     PEERD_LAST_STATUS="$(grep -Eo '"status":[0-9]+' "/peerd-data/peerdmeta\${id}" | grep -Eo '[0-9]+')"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "peerd",
   "private": true,
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Browser-native AI agent harness. Solo dev — Bun is for tests + one-shot vendor scripts only; the extension itself runs no build step.",
   "license": "Apache-2.0",
   "homepage": "https://peerd.ai",


### PR DESCRIPTION
## Why

Two things the user hit live, plus the version bump to ship them:

1. **The agent gives up on `pip install`** — `system-prompt.txt` (and the `vm_boot`/`vm_import` tool descriptions) told the agent *"pip install won't work / no route to host"*, despite a working `pip()` wrapper that stages pure-Python wheels offline via `peerd://pip-install`. So the agent burned a 60s timeout and pivoted to `vm_import`.
2. **Terminal flood** — in dev/preview the wrappers source under `set -x`, and the response-poll loops echoed ~4 trace lines every 50ms, flooding the VM terminal during any slow fetch/install.

## What

**VM instruction accuracy** (from a full audit of every instruction surface — prompt, tool defs, docs — against the actual bash wrappers in `vm-tab.js`):
- `system-prompt.txt` webvm section rewritten: `pip`/`npm`/`yarn`/`pnpm`/`gem` install all work via host-side-resolving wrappers; `curl`/`wget` do full HTTP incl POST/headers; `git clone` is GitHub+GitLab **snapshot-only** (no `.git`, clone-only); `npm`/`gem` are **named-packages-only** (bare `npm install` fails); `apt` is shimmed (return 100), raw sockets stubbed to error.
- `vm_boot` schema: `cmd` runs in a persistent `/bin/bash --login -i` session (was wrongly `/bin/sh -c`, which would lose the bash-function wrappers entirely).
- `vm_import`: `pip` removed from the "no network" grouping.
- `DESIGN.md` / `docs/DECISIONS.md`: VM egress is **always-on, denylist-gated** (allowlist-free `webFetch` + SSRF guard), not off-by-default-with-allowlist; no `apt install`.

**Flood fix** (`vm-tab.js`): suspend xtrace around just the poll loops in `peerd-fetch` + `__peerd_emit_req` (portable `case $- in *x*`), restore after. The meaningful command trace is unaffected. Verified with `bash -n` + an isolated behavioral test on bash 3.2 (loop body produces zero trace lines, xtrace restores cleanly).

**Version** `0.1.0 → 0.1.1` (regenerated manifest). v0.1.0 is already on AMO and cannot be re-signed, so this folds the inflight VM fixes into a new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)