### PR TITLE
fix(release): non-fatal update-feeds commit + sync feeds to v0.1.1

### DIFF
--- a/.github/workflows/package-and-release.yml
+++ b/.github/workflows/package-and-release.yml
@@ -6,8 +6,10 @@
 #                     contain zero dweb traces as part of packaging).
 #   tag push v*     → additionally: signed preview artifacts, a GitHub
 #                     Release titled peerd-preview-v<X.Y.Z> with the
-#                     preview artifacts + update feeds attached, and the
-#                     regenerated update-feeds/ committed back to main.
+#                     preview artifacts + update feeds attached, and a
+#                     best-effort mirror commit of update-feeds/ back to main
+#                     (non-fatal if branch protection rejects the push — the
+#                     feeds are authoritative as release assets either way).
 #
 # Store uploads (Chrome Web Store / AMO) stay MANUAL — download the
 # verified store artifacts from the release run and submit them after QA.
@@ -342,7 +344,18 @@ jobs:
           if ! git diff --quiet -- update-feeds/; then
             git add update-feeds/
             git commit -m "chore(release): update feeds for $GITHUB_REF_NAME"
-            git push origin main
+            # Best-effort mirror. Branch protection may reject a direct push to
+            # main (PR required) — but the feeds are ALREADY attached to the
+            # release as assets, so this commit must NEVER fail an
+            # otherwise-published release. On rejection, surface the actionable
+            # next step instead of failing the job. (To restore auto-commit,
+            # add github-actions[bot] to the branch-protection bypass list.)
+            if git push origin main 2>push.err; then
+              echo "update-feeds pushed to main"
+            else
+              echo "::warning::could not push update-feeds to main (branch protection?). Feeds ARE attached to release $GITHUB_REF_NAME — deploy peerd-site from the release assets, or merge update-feeds/ to main via PR."
+              cat push.err || true
+            fi
           else
             echo "feeds unchanged"
           fi

--- a/update-feeds/chrome-preview.xml
+++ b/update-feeds/chrome-preview.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gupdate xmlns="http://www.google.com/update2/response" protocol="2.0">
   <app appid="lpdkhfeldihoejbbfonnbekpjclkknoc">
-    <updatecheck codebase="https://github.com/NotASithLord/peerd/releases/download/v0.1.0/peerd-preview-chrome.crx" version="0.1.0"/>
+    <updatecheck codebase="https://github.com/NotASithLord/peerd/releases/download/v0.1.1/peerd-preview-chrome.crx" version="0.1.1"/>
   </app>
 </gupdate>

--- a/update-feeds/firefox-preview.json
+++ b/update-feeds/firefox-preview.json
@@ -3,8 +3,8 @@
     "peerd-preview@peerd.ai": {
       "updates": [
         {
-          "version": "0.1.0",
-          "update_link": "https://github.com/NotASithLord/peerd/releases/download/v0.1.0/peerd-preview-firefox.xpi",
+          "version": "0.1.1",
+          "update_link": "https://github.com/NotASithLord/peerd/releases/download/v0.1.1/peerd-preview-firefox.xpi",
           "applications": {
             "gecko": {
               "strict_min_version": "121.0"


### PR DESCRIPTION
## Why

The v0.1.1 release ([peerd-preview-v0.1.1](https://github.com/NotASithLord/peerd/releases/tag/v0.1.1)) published cleanly — signed `.crx` + `.xpi`, AMO accepted 0.1.1, feeds attached. But the final **"Commit regenerated update feeds to main"** step failed:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

Branch protection now requires PRs, so the `github-actions[bot]` can't push directly to `main`. A post-publish **mirror** commit must never fail an already-published release.

## What

- **Workflow**: the feeds → main push is now **best-effort**. On rejection it emits an actionable `::warning::` (the feeds are authoritative as release assets; deploy peerd-site from them or merge via PR) instead of failing the job. The push line stays, so if `github-actions[bot]` is later added to the branch-protection bypass list, auto-commit resumes with no further change.
- **`update-feeds/`**: brought current to **v0.1.1** (the exact content the failed step would have committed, taken from the published release assets).

YAML validated (`js-yaml`).

## Note for the owner
For installed preview extensions to actually auto-update to v0.1.1, the feeds at `peerd.ai/updates/` still need to be deployed via **peerd-site** (unchanged from before — that deploy was always manual). The `feeds:check` monitor will flag the live feeds as stale until then; that's expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)