### PR TITLE
fix(webvm): pip install actually works — unzip wheels instead of invoking pip

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "peerd (dev)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "An AI assistant that automates tasks in your browser. Local-first: your own API key, no account, no servers, no tracking.",
   "side_panel": {
     "default_path": "sidepanel/sidepanel.html"

--- a/extension/vm-tab/vm-tab.js
+++ b/extension/vm-tab/vm-tab.js
@@ -548,17 +548,40 @@ pip() {
   fi
   local name version file wheels=""
   while IFS=$'\\t' read -r name version file; do [ -n "$name" ] && wheels="$wheels $file"; done < "$manifest"
-  local pipbin="" c
-  for c in /usr/bin/pip3 /usr/local/bin/pip3 /usr/bin/pip /usr/local/bin/pip; do
-    [ -x "$c" ] && { pipbin="$c"; break; }
-  done
-  if [ -z "$pipbin" ]; then
-    echo "peerd-pip: no pip binary in the VM to install the staged wheels ($wheels)" >&2
-    rm -f "$manifest" $wheels; return 1
-  fi
-  "$pipbin" install --no-index --no-deps $wheels 2>>"$errf"
+  if [ -z "$wheels" ]; then echo "peerd-pip: nothing staged to install" >&2; rm -f "$manifest" "$errf"; return 1; fi
+  # Install each pure-Python wheel by UNZIPPING it into a writable
+  # site-packages -- deliberately NOT via pip. On CheerpX pip install fails
+  # two ways: (1) its distro detection opens /dev/null for WRITE, which
+  # CheerpX denies (PermissionError); and (2) the host stages wheels as
+  # pkgstage_<id>_<name>.whl and pip derives the package name/version from the
+  # FILENAME, so the staging prefix breaks its .dist-info lookup. A
+  # py3-none-any wheel is just a zip already laid out for site-packages, so
+  # unzip == install (host-side resolution already staged every dependency,
+  # and the extracted .dist-info keeps pip list / importlib.metadata working).
+  python3 -c '
+import site, os, sys, zipfile
+cands = list(getattr(site, "getsitepackages", lambda: [])()) + [site.getusersitepackages()]
+dest = None
+for d in cands:
+    try:
+        os.makedirs(d, exist_ok=True)
+        t = os.path.join(d, ".peerd_w"); open(t, "w").close(); os.remove(t); dest = d; break
+    except Exception: pass
+if not dest:
+    print("peerd-pip: no writable site-packages dir", file=sys.stderr); sys.exit(1)
+rc = 0
+for whl in sys.argv[1:]:
+    try:
+        zipfile.ZipFile(whl).extractall(dest)
+        b = os.path.basename(whl)
+        if b.startswith("pkgstage_") and b.count("_") >= 2: b = b.split("_", 2)[2]
+        print("installed " + (b[:-4] if b.endswith(".whl") else b))
+    except Exception as e:
+        print("peerd-pip: failed to unpack", os.path.basename(whl), e, file=sys.stderr); rc = 1
+sys.exit(rc)
+' $wheels 2>>"$errf"
   local rc=$?
-  [ -f "$errf" ] && cat "$errf" >&2
+  [ -f "$errf" ] && [ "$rc" != 0 ] && cat "$errf" >&2
   rm -f "$manifest" "$errf" $wheels
   return $rc
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "peerd",
   "private": true,
   "type": "module",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Browser-native AI agent harness. Solo dev — Bun is for tests + one-shot vendor scripts only; the extension itself runs no build step.",
   "license": "Apache-2.0",
   "homepage": "https://peerd.ai",


### PR DESCRIPTION
## Why

Caught live trying `pip install cowpy` in a WebVM: the `pip()` wrapper claims to install pure-Python wheels but **fails on every install**. Two CheerpX bugs in the `pip install --no-index --no-deps <whl>` path:

1. **`/dev/null` write denied** — pip's distro detection does `open('/dev/null', 'w')` for the user-agent string; CheerpX denies `/dev/null` writes → `PermissionError`, install aborts before it starts.
2. **Staging prefix breaks pip** — the host stages each wheel as `pkgstage_<id>_<name>.whl`, and pip derives the package name/version from the *filename*, so it looks for `pkgstage_..._<name>.dist-info` inside the zip → `AssertionError: .dist-info directory not found`.

(This is the structural half of the earlier VM-pip work — v0.1.1 fixed the *prompt* lying about pip; this fixes the wrapper actually working.)

## Fix

Install pure-Python wheels by **unzipping them into a writable site-packages** via `python3`'s `zipfile`, never invoking pip. A `py3-none-any` wheel is already laid out for site-packages, so unzip == install — host-side resolution already staged every dependency wheel, and the extracted `.dist-info` keeps `pip list` / `importlib.metadata` working. This sidesteps both bugs (no pip process → no `/dev/null`; extraction is filename-agnostic → the staging prefix is harmless).

## Verification
- **Standalone**: real cowpy wheel renamed with the `pkgstage_<id>_` prefix → unzips → `import cowpy` renders, `importlib.metadata.version('cowpy') == 1.1.5`, message reads `installed cowpy-1.1.5-...`.
- **End-to-end (venv)**: sourced the *actual* extracted wrapper, overrode only the host-fetch → `pip install cowpy` exits 0, import works.
- `bash -n` on the extracted `WRAPPERS_BASH` + `eslint` clean.

Known limitation (acceptable): console-script entry points (`.data/scripts`) aren't created — library imports are the VM use case. Bump `0.1.1 → 0.1.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)