### PR TITLE
WebVM terminal: stop tracing the persistent shell; devMode off by default

### DIFF
--- a/extension/background/routes/engine.js
+++ b/extension/background/routes/engine.js
@@ -78,8 +78,8 @@ export const makeEngineRoutes = (deps) => {
         if (!record) return { ok: false, error: 'vm-not-found' };
         // why devMode rides along: vm-tab has no settings of its own; it reads
         // it here (once, at boot) to honour the "verbose VM diagnostics" toggle
-        // (Settings → Behavior) — `set -x` in the sourced wrappers + visible
-        // install/verify output.
+        // (Settings → Behavior) — surfaces the install/verify output in the
+        // terminal at boot (the persistent shell is never traced with `set -x`).
         return { ok: true, record, devMode: !!settingsStore.get().devMode };
       } catch (e) {
         return { ok: false, error: /** @type {{ message?: string }} */ (e)?.message ?? String(e) };

--- a/extension/options/sections/behavior.js
+++ b/extension/options/sections/behavior.js
@@ -179,8 +179,8 @@ export const BehaviorSection = {
       m('.settings-divider'),
       m('h3', 'Developer mode'),
       m('p', devMode
-        ? 'Verbose VM diagnostics ON: install + verify scripts are visible in the WebVM terminal, `set -x` traces every install step, marker round-trips are timed in the boot log, and the boot card auto-expands. Takes effect on the next WebVM reset.'
-        : 'Show verbose WebVM internals: install + verify scripts in the terminal, per-command bash tracing, marker timing in the boot log. Useful when curl/wget wrappers aren’t working and you need to see why. Off by default — extra noise.'),
+        ? 'Verbose VM diagnostics ON: the wrapper install + verify output is shown in the WebVM terminal at boot, and marker round-trips are timed in the boot log. Your own commands are never traced. Takes effect on the next WebVM reset.'
+        : 'Show the WebVM wrapper install + verify output in the terminal at boot, plus marker timing in the boot log. Useful when curl/wget wrappers aren’t working and you need to see why. Off by default — extra noise.'),
       m('div', { style: 'display:flex; gap:8px; align-items:center;' }, [
         m('button.secondary', {
           type: 'button',

--- a/extension/shared/channel-config.js
+++ b/extension/shared/channel-config.js
@@ -22,7 +22,7 @@ export const CHANNEL_DEFAULTS = Object.freeze({
   voiceSilenceMs: 1500,
   voiceOnboardingDismissed: false,
   ocrEnabled: false,
-  devMode: true,
+  devMode: false,
   reasoningEnabled: true,
   reasoningEffort: "medium",
   providerName: "anthropic",

--- a/extension/vm-tab/vm-tab.js
+++ b/extension/vm-tab/vm-tab.js
@@ -75,6 +75,8 @@ const DOM = {
 let vmName = '';
 let diskOverlayKey = '';
 // Verbose VM diagnostics (Settings → Behavior `devMode`); set from vm/get-meta.
+// Surfaces the one-time wrapper install/verify output at boot — it does NOT
+// trace the shell (no `set -x`), so your own commands stay clean either way.
 let vmDevMode = false;
 /** @type {string[]} */
 const bootLogLines = [];
@@ -131,7 +133,8 @@ const loadVmRecord = async () => {
   const reply = /** @type {any} */ (await browser.runtime.sendMessage({ type: 'vm/get-meta', vmId: hash }));
   if (!reply?.ok) throw new Error(reply?.error ?? `vm not found in registry: ${hash}`);
   // Developer mode (Settings → Behavior): verbose VM diagnostics. Read once at
-  // boot; gates `set -x` in the wrappers + visible install/verify output below.
+  // boot; gates the VISIBLE install/verify output below (no `set -x` — the
+  // persistent shell is never traced; the boot LOG carries the diagnostics).
   vmDevMode = !!reply.devMode;
   return reply.record;
 };
@@ -178,20 +181,14 @@ peerd-fetch() {
   local id="\${RANDOM}\${RANDOM}\${RANDOM}$$"
   printf '___PEERD_HTTP___:%s:%s\\n' "$id" "$url"
   local n=0
-  # why: under devMode set -x this 20Hz poll loop would echo ~4 trace lines
-  # every 50ms and flood the terminal during any slow fetch. Suspend xtrace for
-  # the wait (portable to any bash version, unlike local dash), restore it after.
-  local __peerd_x=""; case $- in *x*) __peerd_x=1; set +x;; esac
   while [ ! -f "/peerd-data/peerddone\${id}" ]; do
     sleep 0.05
     n=$((n + 1))
     if [ "$n" -gt "$PEERD_HTTP_TIMEOUT_TICKS" ]; then
-      [ -n "$__peerd_x" ] && set -x
       echo "peerd-fetch: timed out after \${PEERD_HTTP_TIMEOUT}s waiting for response (id=\${id})" >&2
       return 124
     fi
   done
-  [ -n "$__peerd_x" ] && set -x
   if [ -f "/peerd-data/peerderr\${id}" ]; then
     cat "/peerd-data/peerderr\${id}" >&2
     return 1
@@ -220,20 +217,14 @@ __peerd_emit_req() {
   id="\${RANDOM}\${RANDOM}\${RANDOM}$$"
   printf '___PEERD_REQ___:%s:%s\\n' "$id" "$payload"
   n=0
-  # why: silence this 20Hz poll loop so devMode set -x does not flood the
-  # terminal during slow requests (curl/wget + every pip/npm/gem install route
-  # through here). Suspend xtrace for the wait, restore after (portable bash).
-  local __peerd_x=""; case $- in *x*) __peerd_x=1; set +x;; esac
   while [ ! -f "/peerd-data/peerddone\${id}" ]; do
     sleep 0.05
     n=$((n + 1))
     if [ "$n" -gt "$PEERD_HTTP_TIMEOUT_TICKS" ]; then
-      [ -n "$__peerd_x" ] && set -x
       echo "peerd-http: timed out after \${PEERD_HTTP_TIMEOUT}s (id=\${id})" >&2
       return 124
     fi
   done
-  [ -n "$__peerd_x" ] && set -x
   PEERD_LAST_STATUS=""
   if [ -f "/peerd-data/peerdmeta\${id}" ]; then
     PEERD_LAST_STATUS="$(grep -Eo '"status":[0-9]+' "/peerd-data/peerdmeta\${id}" | grep -Eo '[0-9]+')"
@@ -1065,18 +1056,21 @@ const runViaShell = async (/** @type {string} */ cmd, /** @type {any} */ opts = 
 };
 
 // ---------------------------------------------------------------------------
-// Wrapper install (silent, via DataDevice staging + source).
+// Wrapper install (via DataDevice staging + source). Silent by default;
+// devMode surfaces the [diag]/[verify] output. Never traces the shell.
 // ---------------------------------------------------------------------------
 
 const installWrappers = async () => {
   const encoder = new TextEncoder();
   const stagingName = `/peerdwrappers${Date.now().toString(36)}`;
-  // devMode: prepend `set -x` to the sourced wrappers so the PERSISTENT shell
-  // traces every later step (curl/wget/git, pkg installs). The install itself
-  // ALWAYS runs silent (below) — its [diag]/[verify] lines are captured in
-  // stdout for the verify parse, never dumped to the terminal. That boot-time
-  // wall of egress-wrapper output is just noise to the user.
-  const wrappersSrc = (vmDevMode ? 'set -x\n' : '') + WRAPPERS_BASH;
+  // why NO `set -x` prepend: it stays ON in the PERSISTENT shell and then traces
+  // EVERY later interactive command — including peerd's own ___PEERD_*___
+  // completion markers and the http/pkg-fetch bridge plumbing — so one `pip
+  // install` reads as 40 lines of `+ __peerd_emit_req …`. devMode instead just
+  // makes the one-time install/verify output VISIBLE at boot (the `silent` flag
+  // below); off by default it stays captured-but-hidden (parsed for [verify],
+  // never dumped). Your own commands are never traced either way.
+  const wrappersSrc = WRAPPERS_BASH;
   await dataDev.writeFile(stagingName, encoder.encode(wrappersSrc));
   const stagedPath = `/peerd-data${stagingName}`;
   const script = [
@@ -1097,7 +1091,7 @@ const installWrappers = async () => {
     'unset __f __t',
     'echo "[peerd-egress] bash function wrappers installed"',
   ].join('\n');
-  return runViaShell(script, { silent: true });
+  return runViaShell(script, { silent: !vmDevMode });
 };
 
 // ---------------------------------------------------------------------------

--- a/packaging/default-settings.mjs
+++ b/packaging/default-settings.mjs
@@ -60,10 +60,13 @@ export const defaults = {
   // this flag only governs the on-device OCR engine for image-only PDFs.
   ocrEnabled: { store: false, preview: false },
 
-  // The one real friction divergence today: preview users get the
-  // advanced/diagnostic surfaces (verbose WebVM boot, debug panels) on
-  // by default; store users opt in.
-  devMode: { store: false, preview: true },
+  // Verbose VM diagnostics (Settings → Behavior). OFF by default on BOTH
+  // channels — its own UI copy already calls it "extra noise". On, it surfaces
+  // the one-time wrapper install/verify output in the WebVM terminal at boot;
+  // it does NOT trace the shell (no `set -x` — that used to leak peerd's
+  // internal markers + bridge plumbing into every interactive command). The
+  // verify results reach the boot LOG regardless, so debugging keeps its signal.
+  devMode: { store: false, preview: false },
 
   // why: extended thinking renders a collapsible "Reasoning" section —
   // the premium feel. On for everyone.
@@ -180,7 +183,7 @@ export const defaults = {
   // spec §12). Preview ships to contributors and early testers; making
   // them toggle dweb on before the demo is pure friction, and the channel
   // boundary IS friction tolerance, not a safety floor (see the file
-  // header) — same posture as `devMode: { preview: true }`. NOT a safety
+  // header) — same posture as `advancedAutomationEnabled: { preview: true }`. NOT a safety
   // relaxation: the dweb module is preview-channel-only (the store package
   // prunes it and sets DWEB_ENABLED=false, so this key is absent there
   // entirely from CHANNEL_DEFAULTS), identity needs an unlocked vault, and


### PR DESCRIPTION
Rebased onto current `main`, which already shipped the **onboarding home-page gate** (#48) and a **partial terminal fix** (#49, released v0.1.1). This PR keeps only the terminal piece — made complete.

## The remaining problem

#49 kept the persistent `set -x` (prepended to the sourced wrappers under devMode) and added `set +x` guards around the 20Hz poll loops to tame the flood. But xtrace stays **on for the whole session**, so every later *interactive* command is still traced — a plain `pip install cowpy` renders as ~40 lines of `+ __peerd_emit_req …` with peerd's internal `___PEERD_*___` completion markers leaking through.

## This change

- **Remove the persistent `set -x` prepend** — the shell is never traced, so your own commands stay clean.
- **Drop the now-purposeless `__peerd_x` save/restore guards** from the `peerd-fetch` and `__peerd_emit_req` poll loops (nothing to guard once xtrace is never on).
- **`devMode` now only governs install/verify *visibility*** at boot (the `silent` flag), not tracing. Verify results still reach the boot log.
- **Default `devMode` OFF on both channels** (its own Settings copy already calls it *"extra noise"*); regenerated `channel-config.js`. Settings + comment copy updated.

Net result, fresh boot:

```
peerd WebVM · HTTP(S)-native networking (...). Run 'peerd-net' for details.

user@:/$ pip install cowpy
installed cowpy-1.1.5-py3-none-any
user@:/$
```

## Verification

`eslint`, `tsc` (strict), `check:boundary`, `check:tscheck` (473/473), and the full `bun test` suite (2097 pass / 0 fail) all green. No manifest drift. 5 files changed; onboarding code left exactly as #48 shipped it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VrBEb8bRv8LUGM9yjrYrgp