### PR TITLE
release: v0.1.3

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "peerd (dev)",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "An AI assistant that automates tasks in your browser. Local-first: your own API key, no account, no servers, no tracking.",
   "side_panel": {
     "default_path": "sidepanel/sidepanel.html"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "peerd",
   "private": true,
   "type": "module",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Browser-native AI agent harness. Solo dev — Bun is for tests + one-shot vendor scripts only; the extension itself runs no build step.",
   "license": "Apache-2.0",
   "homepage": "https://peerd.ai",


### PR DESCRIPTION
Version bump only — cuts a preview release for the WebVM terminal fix that landed in #52 (persistent `set -x` removed, devMode off by default).

- `package.json` 0.1.2 → 0.1.3 (smallest valid semver patch bump; `v0.1.2` is already tagged).
- `extension/manifest.json` regenerated to match (dev/chrome).
- No code changes.

Once merged, tag `v0.1.3` on main triggers the signed Chrome/Firefox preview artifacts + GitHub Release (store submission stays manual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VrBEb8bRv8LUGM9yjrYrgp

---
_Generated by [Claude Code](https://claude.ai/code/session_01VrBEb8bRv8LUGM9yjrYrgp)_