### PR TITLE
fix(ui): keep the spend-limit halt banner across unrelated state pushes

### DIFF
--- a/extension/sidepanel/chat-reducer.js
+++ b/extension/sidepanel/chat-reducer.js
@@ -342,7 +342,7 @@ export const reduceChat = (state, msg) => {
     case 'async-tasks/update':
       return { ...state, asyncTasks: { ...state.asyncTasks,
         [/** @type {string} */ (msg.parentSessionId)]: msg.tasks } };
-    case 'state':
+    case 'state': {
       // Full snapshot. Replace, seeding the cost meter from the persisted
       // session tally + the configured limit. (Voice-restore is the surface's
       // job — see the module header.) why preserve pendingConfirm: confirm
@@ -354,10 +354,22 @@ export const reduceChat = (state, msg) => {
       // switched-to (idle) chat — a stale "⏳ Rate limited" control in the wrong
       // conversation. A switched-to chat is never mid-retry from the previous
       // one; an active retry in THIS chat re-asserts via the next pause/delta.
-      return { ...state, ...msg.state, pendingConfirm: state.pendingConfirm, lastError: null, rateLimit: null, cost: { ...state.cost,
+      // why limitReached + the spend-limit lastError are SESSION-scoped (not
+      // per-push): they are a halt state ("raise your limit to continue") that
+      // must persist until the user acts. A 'state' push fires on a Plan/Act
+      // toggle, /system, settings — not just a session switch — so blanket-
+      // clearing them erased the actionable halt guidance while the agent was
+      // still halted. Clear only on an ACTUAL session switch; within the same
+      // session the next send clears them via turn/streaming.
+      const sessionChanged = msg.state?.session?.sessionId !== state.session.sessionId;
+      const stillHalted = !sessionChanged && state.cost.limitReached;
+      const keepSpendError = !sessionChanged && state.lastError === 'spend-limit-reached';
+      return { ...state, ...msg.state, pendingConfirm: state.pendingConfirm,
+        lastError: keepSpendError ? 'spend-limit-reached' : null, rateLimit: null, cost: { ...state.cost,
         session: msg.state?.session?.cost ?? state.cost.session,
         limitUsd: msg.state?.settings?.spendLimitUsd ?? state.cost.limitUsd,
-        limitReached: false } };
+        limitReached: stillHalted } };
+    }
     case 'turn/state':
       // Per-session guard: a turn streaming in a BACKGROUND chat must not snap
       // the view to its transcript. Null current = fresh surface adopting it.

--- a/tests/sidepanel/chat-reducer.test.ts
+++ b/tests/sidepanel/chat-reducer.test.ts
@@ -81,6 +81,26 @@ describe('reduceChat', () => {
     expect(switched.rateLimit).toBe(null);
   });
 
+  // The spend-limit halt ("raise your limit to continue") is a per-SESSION
+  // state, not a per-push one: a 'state' push from a Plan/Act toggle or
+  // /system must NOT erase it while the same session is still halted — but a
+  // switch to a different session clears it.
+  test('a same-session state push preserves the spend-limit halt; a session switch clears it', () => {
+    const halted = reduceChat(withSession('A'), { type: 'turn/spend-limit-reached', sessionId: 'A', limitUsd: 5 });
+    expect(halted.cost.limitReached).toBe(true);
+    expect(halted.lastError).toBe('spend-limit-reached');
+
+    // same session (e.g. a settings / mode-toggle push) → halt preserved
+    const sameSession = reduceChat(halted, { type: 'state', state: { session: { sessionId: 'A', messages: [] } } });
+    expect(sameSession.cost.limitReached).toBe(true);
+    expect(sameSession.lastError).toBe('spend-limit-reached');
+
+    // switching to a different session → halt cleared
+    const switched = reduceChat(halted, { type: 'state', state: { session: { sessionId: 'B', messages: [] } } });
+    expect(switched.cost.limitReached).toBe(false);
+    expect(switched.lastError).toBe(null);
+  });
+
   test('async-tasks/update keys the snapshot by parent session', () => {
     const s1 = reduceChat(INITIAL_STATE, { type: 'async-tasks/update', parentSessionId: 'p1', tasks: [{ taskId: 'as-1' }] });
     expect(s1.asyncTasks.p1).toEqual([{ taskId: 'as-1' }]);


### PR DESCRIPTION
The reducer's `'state'` fold force-cleared `cost.limitReached` + the `'spend-limit-reached'` `lastError` on **every** snapshot push - which fires on a Plan/Act toggle, `/system`, `/tools`, or a settings change, not just a session switch. So the "spend limit reached — raise it in Settings to continue" banner (and its actionable guidance) **silently vanished while the agent was still halted**.

Make both **session-scoped**: clear them only on an actual session switch; within the same session they persist until the next send clears them via `turn/streaming`.

**Test** (revert-proven): a same-session `'state'` push preserves the halt, a session switch clears it - reverting the fix fails the same-session case. Full bun suite green; typecheck + lint + boundary clean.

Closes #32 (the UI hunt's "needs a design decision" item - now unblocked since the transient-state PR it shared a line with merged).