### PR TITLE
fix(goal): durable Stop, resume sequencing, and cap-boundary correctness

### DIFF
--- a/extension/background/routes/sessions.js
+++ b/extension/background/routes/sessions.js
@@ -31,8 +31,10 @@ export const makeSessionRoutes = (deps) => {
       // a turn streaming elsewhere (turn slots are per-session).
       const sessionId = await sessionCache.sessionGet('currentSessionId');
       // Stop ends the whole goal run (not just the in-flight turn) so it can't
-      // auto-continue after the abort.
-      if (sessionId && haltGoalRun) haltGoalRun(/** @type {any} */ (sessionId));
+      // auto-continue after the abort. Awaited: haltGoalRun durably removes the
+      // run's persisted record, so a Stop can't be undone by a resume() on the
+      // next unlock even if the SW is torn down right after this handler returns.
+      if (sessionId && haltGoalRun) await haltGoalRun(/** @type {any} */ (sessionId));
       if (sessionId && turnSlots.stop(sessionId)) {
         auditLog.append({ type: 'session_ended', details: { reason: 'user_stop' } })
           .catch(() => {});

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -2460,7 +2460,11 @@ const handleToolsCommand = async (/** @type {string} */ arg) => {
 // computes Act+confirm-off from the live run — so start/halt are just the runner
 // surface. resumeGoalRuns re-drives persisted runs after an interactive unlock.
 const startGoalRun = (/** @type {{ sessionId: string, goal: string }} */ req) => /** @type {any} */ (goalRunner)?.start(req);
-const haltGoalRun = (/** @type {string} */ sid) => /** @type {any} */ (goalRunner)?.halt(sid);
+// why stop() not halt(): user-initiated cancels (Stop button, steer-takeover,
+// new-chat, archive) must DURABLY end the run — halt() only marks an in-memory
+// run, so a vault-lock-PAUSED run (evicted from the runner's map but kept in the
+// kv mirror for resume) would survive a Stop and resurrect on the next unlock.
+const haltGoalRun = (/** @type {string} */ sid) => /** @type {any} */ (goalRunner)?.stop(sid);
 const resumeGoalRuns = () => /** @type {any} */ (goalRunner)?.resume();
 const ensureSession = ensureCurrentSession;
 
@@ -2776,15 +2780,22 @@ vault.attemptResume().then((resumed) => {
     // user who explicitly DISABLED it, once, in the cold-start window. load() is
     // idempotent (re-reads kv, recomputes the merged view), so gating on it here
     // just guarantees the setting is hydrated before the gate consults it.
-    settingsStore.load()
+    // why goal resume BEFORE auto-resume: goalRunner.resume() synchronously
+    // re-adds a persisted run to the runner's map (isActive → true) before its
+    // drive() awaits. Sequencing it ahead of maybeAutoResume guarantees the
+    // goalActiveFor guard in maybeAutoResume sees the goal run and bails —
+    // otherwise the two could race to drive the SAME interrupted session.
+    Promise.resolve(goalRunner?.resume())
+      .catch((e) => console.error('[sw] goal resume failed', e))
+      .then(() => settingsStore.load())
       .then(() => sessionCache.sessionGet('currentSessionId'))
       .then((/** @type {any} */ cur) => maybeAutoResume(cur)).catch(() => {});
+  } else {
+    // Vault not resumed (locked): still rehydrate goal runs so the Goal bar is
+    // restored; their next turn pauses on the locked vault and waits for unlock.
+    // No auto-resume here — it needs an unlocked vault to call the model.
+    goalRunner?.resume().catch((e) => console.error('[sw] goal resume failed', e));
   }
-  // why: resume any in-flight Goal run AFTER the vault is back — a run needs
-  // unlocked secrets to call the model. If the SW died mid-run (or the user is
-  // returning to a run that kept going while they were elsewhere), the persisted
-  // run state lets us re-drive the next turn. A no-op if nothing is active.
-  goalRunner?.resume().catch((e) => console.error('[sw] goal resume failed', e));
 }).catch((e) => console.error('[sw] attemptResume failed', e));
 
 // One-time cleanup of Ralph's leftover storage. Ralph (removed 2026-06-22) wrote

--- a/extension/peerd-runtime/loop/goal-runner.js
+++ b/extension/peerd-runtime/loop/goal-runner.js
@@ -118,6 +118,39 @@ export const makeGoalRunner = ({ runTurn, onEvent = () => {}, onRunEnd = () => {
   /** Stop / steer-takeover: end the run without declaring success. @param {string} sid */
   const halt = (sid) => { const r = runs.get(sid); if (r) { r.halted = true; persist(); } };
 
+  // Durably drop ONE session's record from the mirror (read-modify-write).
+  // why not persist(): persist() writes a snapshot of the in-memory MAP, which a
+  // PAUSED run (vault-lock) is no longer in — so it can't remove a paused run's
+  // record, and a live run's persist() is fire-and-forget. forget() is keyed by
+  // sid and reaches the record either way. Best-effort, like persist(). No kv → no-op.
+  /** @param {string} sid */
+  const forget = async (sid) => {
+    if (!kv) return;
+    try {
+      const stored = await kv.get(GOAL_RUNS_KEY);
+      if (stored && typeof stored === 'object' && Object.hasOwn(stored, sid)) {
+        const next = { ...stored };
+        delete next[sid];
+        await kv.set(GOAL_RUNS_KEY, next);
+      }
+    } catch { /* best-effort — a lost write just means it may resume once more */ }
+  };
+
+  /**
+   * Durable user-initiated Stop (Stop button, steer-takeover, new-chat, archive).
+   * Halts any live run AND awaits removal of the persisted record, so a Stop can't
+   * be silently undone by resume() on the next vault unlock. Unlike halt() (the
+   * internal supersede/error mark, in-memory only), this is keyed by sid and works
+   * even when the run was PAUSED and evicted from the map, or when a live run's
+   * fire-and-forget persist() hasn't committed yet.
+   * @param {string} sid
+   */
+  const stop = async (sid) => {
+    const r = runs.get(sid);
+    if (r) r.halted = true;  // its drive() loop sees !alive() and exits to the terminal finally
+    await forget(sid);
+  };
+
   /** @param {string} sid @param {'running'|'done'|'halted'|'capped'} phase */
   const emit = (sid, phase) => {
     const r = runs.get(sid);
@@ -228,9 +261,16 @@ export const makeGoalRunner = ({ runTurn, onEvent = () => {}, onRunEnd = () => {
       if (!sid || runs.has(sid)) continue;
       const rec = /** @type {{ goal?: unknown, iteration?: unknown, startedAt?: unknown }} */ (raw);
       if (!rec || typeof rec.goal !== 'string' || !rec.goal) continue;
+      // why clamp at the cap: persist() records the iteration ABOUT to run, so a
+      // crash resumes there. But if the SW died DURING the final allowed turn, the
+      // stored iteration === maxIterations and drive()'s `iteration < maxIterations`
+      // would be false immediately — declaring 'capped' for a turn that never
+      // actually ran. Rewind one so that interrupted final turn re-runs once.
+      const storedIteration = Number(rec.iteration) || 0;
+      const iteration = storedIteration >= maxIterations ? Math.max(0, maxIterations - 1) : storedIteration;
       runs.set(sid, {
         goal: rec.goal,
-        iteration: Number(rec.iteration) || 0,
+        iteration,
         completed: false, halted: false, summary: null, lastError: null,
         startedAt: Number(rec.startedAt) || now(),
       });
@@ -240,5 +280,5 @@ export const makeGoalRunner = ({ runTurn, onEvent = () => {}, onRunEnd = () => {
     return { resumed };
   };
 
-  return Object.freeze({ start, halt, complete, isActive, get, drive, resume });
+  return Object.freeze({ start, halt, stop, complete, isActive, get, drive, resume });
 };

--- a/extension/peerd-runtime/loop/turn-driver.js
+++ b/extension/peerd-runtime/loop/turn-driver.js
@@ -567,6 +567,11 @@ const maybeAutoResume = async (sessionId) => {
     if (!sessionId || vault.isLocked()) return;
     // Don't race a live turn — the loop is mid-stream, not interrupted.
     if (turnSlots.isBusy(sessionId)) return;
+    // Don't double-drive a session a Goal run owns: goalRunner.resume() re-drives
+    // its OWN interrupted turn after an SW respawn, so auto-resume firing for the
+    // same session would contend the turn slot (a spurious aborted turn / a
+    // narrowly-windowed goal-run halt). The goal loop is the authority here.
+    if (goalActiveFor?.(sessionId)) return;
     const session = await sessions.get(sessionId);
     const verdict = detectInterruptedTurn(session);
     if (!verdict.resumable) return;

--- a/tests/peerd-runtime/goal-runner.test.ts
+++ b/tests/peerd-runtime/goal-runner.test.ts
@@ -187,6 +187,26 @@ describe('makeGoalRunner — persistence + resume (survives SW restart / other c
     const kv = makeKv();
     expect((await makeGoalRunner({ runTurn: async () => {}, kv }).resume())).toEqual({ resumed: 0 });
   });
+
+  it('resume() re-runs a final turn interrupted at the cap, not dropping it as capped', async () => {
+    const kv = makeKv();
+    // SW died DURING the last allowed turn → stored iteration === maxIterations.
+    kv.store.set(GOAL_RUNS_KEY, { s: { goal: 'finish it', iteration: 3, startedAt: 1 } });
+    const calls: TurnArgs[] = [];
+    const events: any[] = [];
+    const runner = makeGoalRunner({
+      runTurn: async (a: TurnArgs) => { calls.push(a); },
+      onEvent: (ev) => events.push(ev),
+      maxIterations: 3,
+      kv,
+    });
+    await runner.resume();
+    await settle(() => !runner.isActive('s'));
+    // The interrupted final turn re-ran exactly once, THEN the run caps — without
+    // the clamp the loop would exit immediately (0 turns) and still report capped.
+    expect(calls.length).toBe(1);
+    expect(events[events.length - 1].phase).toBe('capped');
+  });
 });
 
 describe('makeGoalRunner — outcome hardening (no runaway on failure)', () => {
@@ -248,5 +268,35 @@ describe('makeGoalRunner — outcome hardening (no runaway on failure)', () => {
     await settle(() => !runner.isActive('s'));
     expect(ends).toHaveLength(1);
     expect(kv.store.get(GOAL_RUNS_KEY)).toEqual({});
+  });
+
+  it('stop() on a vault-lock-PAUSED run drops its kv record so it does NOT resurrect on resume()', async () => {
+    const kv = makeKv();
+    let throwOnce = true;
+    const calls: TurnArgs[] = [];
+    let runner: ReturnType<typeof makeGoalRunner>;
+    runner = makeGoalRunner({
+      runTurn: async (a: TurnArgs) => {
+        calls.push(a);
+        if (throwOnce) { throwOnce = false; const e: any = new Error('locked'); e.name = 'VaultLockedError'; throw e; }
+      },
+      kv,
+    });
+    await runner.start({ sessionId: 's', goal: 'keep going' });
+    await settle(() => !runner.isActive('s'));
+    // Paused: evicted from the in-memory map, but the record survives in kv.
+    expect(runner.get('s')).toBe(null);
+    expect(kv.store.get(GOAL_RUNS_KEY).s).toMatchObject({ goal: 'keep going' });
+
+    // The user clicks Stop on the (still-visible) paused run. halt() alone would
+    // be a no-op (not in the map); stop() durably forgets the record.
+    await runner.stop('s');
+    expect(kv.store.get(GOAL_RUNS_KEY)).toEqual({});
+
+    // resume() must NOT re-drive a stopped run.
+    const before = calls.length;
+    await runner.resume();
+    await settle(() => true, 5);
+    expect(calls.length).toBe(before);
   });
 });

--- a/tests/peerd-runtime/loop/turn-driver.test.ts
+++ b/tests/peerd-runtime/loop/turn-driver.test.ts
@@ -66,6 +66,18 @@ test('maybeAutoResume no-ops when the session is already streaming', async () =>
   expect(read).toBe(false);
 });
 
+test('maybeAutoResume no-ops when a Goal run owns the session (no double-drive)', async () => {
+  let read = false;
+  const d = makeTurnDriver(deps({
+    // The goal loop re-drives its own interrupted turn on resume; auto-resume
+    // must bail BEFORE reading the session so the two can't contend the slot.
+    goalActiveFor: (sid: string) => sid === 's1',
+    sessions: { get: async () => { read = true; return {}; } },
+  }));
+  await d.maybeAutoResume('s1');
+  expect(read).toBe(false);
+});
+
 test('maybeAutoResume does not resume a turn that is not resumable', async () => {
   let noted = false;
   const d = makeTurnDriver(deps({


### PR DESCRIPTION
Hardens the goal-mode autonomous loop (the post-Ralph subsystem, never adversarially audited until now) against four lifecycle defects. Found by a verified bug-hunt over the freshly-merged surface; each fix is revert-proven.

## Fixes

**#2 (MED) — Stop on a vault-lock-PAUSED run was a silent no-op, and the run resurrected on unlock.**
`halt()` only marked an *in-memory* run. When the vault auto-locks between turns, the run is set `paused` and **evicted from the runner's map** (its kv record kept so `resume()` can re-drive it on unlock). So `halt()` couldn't find it - Stop, new-chat, and archive were all no-ops, and the autonomous loop came back on the next unlock. New durable `stop()`: forgets the persisted record *keyed by sid* (read-modify-write), so it reaches a paused run too. `haltGoalRun` routes to `stop()`; `agent/stop` awaits it.

**#7 (LOW) — `halt()`'s persist was fire-and-forget**, so an SW teardown between Stop and the kv write also resurrected the run. The awaited durable `stop()` closes that window.

**#6 (LOW) — SW death during the *final* allowed turn reported 'capped' and dropped that turn.** `persist()` records the iteration *about to run*, so a crash on turn N rehydrates at N. On the final turn that means `iteration === cap`, and `drive()`'s `iteration < cap` loop exits immediately - declaring 'capped' for a turn that never executed. `resume()` now rewinds one at the cap so the interrupted final turn re-runs once.

**#5 (LOW) — boot double-drive.** On respawn, both `maybeAutoResume` and `goalRunner.resume()` could drive the same interrupted session (a spurious aborted turn / a narrowly-windowed goal-run halt). `maybeAutoResume` now bails when a goal run owns the session (`goalActiveFor`), and boot resumes goal runs **before** auto-resume so the guard sees them.

## Tests (revert-proven)
- `goal-runner.test.ts`: durable `stop()` on a paused run drops the kv record (no resurrect); final-turn re-run at the cap.
- `turn-driver.test.ts`: `maybeAutoResume` no-ops when a goal run owns the session.

Full bun suite green (2100), typecheck + lint + dweb-boundary + tscheck clean, no generated-file drift.