### PR TITLE
fix(goal): rehydrate the Goal bar / Stop when a surface (re)connects mid-run

### DIFF
--- a/extension/background/routes/sessions.js
+++ b/extension/background/routes/sessions.js
@@ -31,8 +31,10 @@ export const makeSessionRoutes = (deps) => {
       // a turn streaming elsewhere (turn slots are per-session).
       const sessionId = await sessionCache.sessionGet('currentSessionId');
       // Stop ends the whole goal run (not just the in-flight turn) so it can't
-      // auto-continue after the abort.
-      if (sessionId && haltGoalRun) haltGoalRun(/** @type {any} */ (sessionId));
+      // auto-continue after the abort. Awaited: haltGoalRun durably removes the
+      // run's persisted record, so a Stop can't be undone by a resume() on the
+      // next unlock even if the SW is torn down right after this handler returns.
+      if (sessionId && haltGoalRun) await haltGoalRun(/** @type {any} */ (sessionId));
       if (sessionId && turnSlots.stop(sessionId)) {
         auditLog.append({ type: 'session_ended', details: { reason: 'user_stop' } })
           .catch(() => {});

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -2071,6 +2071,14 @@ browser.runtime.onConnect.addListener((port) => {
       try { port.postMessage({ type: 'confirm/request', prompt: pendingPrompt }); }
       catch { /* port closing */ }
     }
+    // Same idea for a LIVE goal run: its goal/state events only reached ports
+    // connected when they fired, and the snapshot carries no goal-run field. So
+    // replay each active run to this fresh surface — otherwise a reopened panel
+    // (or one that reconnected after an SW respawn) shows no Goal bar / Stop for a
+    // run still driving autonomously, leaving the user without the visible stop.
+    for (const ev of (goalRunner?.activeStates?.() ?? [])) {
+      try { port.postMessage(ev); } catch { /* port closing */ }
+    }
     port.onDisconnect.addListener(() => {
       uiPorts.remove(port);
       broadcastSurfaces();

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -2460,7 +2460,11 @@ const handleToolsCommand = async (/** @type {string} */ arg) => {
 // computes Act+confirm-off from the live run — so start/halt are just the runner
 // surface. resumeGoalRuns re-drives persisted runs after an interactive unlock.
 const startGoalRun = (/** @type {{ sessionId: string, goal: string }} */ req) => /** @type {any} */ (goalRunner)?.start(req);
-const haltGoalRun = (/** @type {string} */ sid) => /** @type {any} */ (goalRunner)?.halt(sid);
+// why stop() not halt(): user-initiated cancels (Stop button, steer-takeover,
+// new-chat, archive) must DURABLY end the run — halt() only marks an in-memory
+// run, so a vault-lock-PAUSED run (evicted from the runner's map but kept in the
+// kv mirror for resume) would survive a Stop and resurrect on the next unlock.
+const haltGoalRun = (/** @type {string} */ sid) => /** @type {any} */ (goalRunner)?.stop(sid);
 const resumeGoalRuns = () => /** @type {any} */ (goalRunner)?.resume();
 const ensureSession = ensureCurrentSession;
 
@@ -2776,15 +2780,22 @@ vault.attemptResume().then((resumed) => {
     // user who explicitly DISABLED it, once, in the cold-start window. load() is
     // idempotent (re-reads kv, recomputes the merged view), so gating on it here
     // just guarantees the setting is hydrated before the gate consults it.
-    settingsStore.load()
+    // why goal resume BEFORE auto-resume: goalRunner.resume() synchronously
+    // re-adds a persisted run to the runner's map (isActive → true) before its
+    // drive() awaits. Sequencing it ahead of maybeAutoResume guarantees the
+    // goalActiveFor guard in maybeAutoResume sees the goal run and bails —
+    // otherwise the two could race to drive the SAME interrupted session.
+    Promise.resolve(goalRunner?.resume())
+      .catch((e) => console.error('[sw] goal resume failed', e))
+      .then(() => settingsStore.load())
       .then(() => sessionCache.sessionGet('currentSessionId'))
       .then((/** @type {any} */ cur) => maybeAutoResume(cur)).catch(() => {});
+  } else {
+    // Vault not resumed (locked): still rehydrate goal runs so the Goal bar is
+    // restored; their next turn pauses on the locked vault and waits for unlock.
+    // No auto-resume here — it needs an unlocked vault to call the model.
+    goalRunner?.resume().catch((e) => console.error('[sw] goal resume failed', e));
   }
-  // why: resume any in-flight Goal run AFTER the vault is back — a run needs
-  // unlocked secrets to call the model. If the SW died mid-run (or the user is
-  // returning to a run that kept going while they were elsewhere), the persisted
-  // run state lets us re-drive the next turn. A no-op if nothing is active.
-  goalRunner?.resume().catch((e) => console.error('[sw] goal resume failed', e));
 }).catch((e) => console.error('[sw] attemptResume failed', e));
 
 // One-time cleanup of Ralph's leftover storage. Ralph (removed 2026-06-22) wrote

--- a/extension/peerd-runtime/loop/goal-runner.js
+++ b/extension/peerd-runtime/loop/goal-runner.js
@@ -118,6 +118,39 @@ export const makeGoalRunner = ({ runTurn, onEvent = () => {}, onRunEnd = () => {
   /** Stop / steer-takeover: end the run without declaring success. @param {string} sid */
   const halt = (sid) => { const r = runs.get(sid); if (r) { r.halted = true; persist(); } };
 
+  // Durably drop ONE session's record from the mirror (read-modify-write).
+  // why not persist(): persist() writes a snapshot of the in-memory MAP, which a
+  // PAUSED run (vault-lock) is no longer in — so it can't remove a paused run's
+  // record, and a live run's persist() is fire-and-forget. forget() is keyed by
+  // sid and reaches the record either way. Best-effort, like persist(). No kv → no-op.
+  /** @param {string} sid */
+  const forget = async (sid) => {
+    if (!kv) return;
+    try {
+      const stored = await kv.get(GOAL_RUNS_KEY);
+      if (stored && typeof stored === 'object' && Object.hasOwn(stored, sid)) {
+        const next = { ...stored };
+        delete next[sid];
+        await kv.set(GOAL_RUNS_KEY, next);
+      }
+    } catch { /* best-effort — a lost write just means it may resume once more */ }
+  };
+
+  /**
+   * Durable user-initiated Stop (Stop button, steer-takeover, new-chat, archive).
+   * Halts any live run AND awaits removal of the persisted record, so a Stop can't
+   * be silently undone by resume() on the next vault unlock. Unlike halt() (the
+   * internal supersede/error mark, in-memory only), this is keyed by sid and works
+   * even when the run was PAUSED and evicted from the map, or when a live run's
+   * fire-and-forget persist() hasn't committed yet.
+   * @param {string} sid
+   */
+  const stop = async (sid) => {
+    const r = runs.get(sid);
+    if (r) r.halted = true;  // its drive() loop sees !alive() and exits to the terminal finally
+    await forget(sid);
+  };
+
   /** @param {string} sid @param {'running'|'done'|'halted'|'capped'} phase */
   const emit = (sid, phase) => {
     const r = runs.get(sid);
@@ -228,9 +261,16 @@ export const makeGoalRunner = ({ runTurn, onEvent = () => {}, onRunEnd = () => {
       if (!sid || runs.has(sid)) continue;
       const rec = /** @type {{ goal?: unknown, iteration?: unknown, startedAt?: unknown }} */ (raw);
       if (!rec || typeof rec.goal !== 'string' || !rec.goal) continue;
+      // why clamp at the cap: persist() records the iteration ABOUT to run, so a
+      // crash resumes there. But if the SW died DURING the final allowed turn, the
+      // stored iteration === maxIterations and drive()'s `iteration < maxIterations`
+      // would be false immediately — declaring 'capped' for a turn that never
+      // actually ran. Rewind one so that interrupted final turn re-runs once.
+      const storedIteration = Number(rec.iteration) || 0;
+      const iteration = storedIteration >= maxIterations ? Math.max(0, maxIterations - 1) : storedIteration;
       runs.set(sid, {
         goal: rec.goal,
-        iteration: Number(rec.iteration) || 0,
+        iteration,
         completed: false, halted: false, summary: null, lastError: null,
         startedAt: Number(rec.startedAt) || now(),
       });
@@ -240,5 +280,5 @@ export const makeGoalRunner = ({ runTurn, onEvent = () => {}, onRunEnd = () => {
     return { resumed };
   };
 
-  return Object.freeze({ start, halt, complete, isActive, get, drive, resume });
+  return Object.freeze({ start, halt, stop, complete, isActive, get, drive, resume });
 };

--- a/extension/peerd-runtime/loop/goal-runner.js
+++ b/extension/peerd-runtime/loop/goal-runner.js
@@ -103,6 +103,28 @@ export const makeGoalRunner = ({ runTurn, onEvent = () => {}, onRunEnd = () => {
   const isActive = (sid) => { const r = runs.get(sid); return !!r && !r.completed && !r.halted; };
 
   /**
+   * The 'running' goal/state payloads for every LIVE run — for replaying to a
+   * port that just (re)connected. The loop's emit() only reaches ports connected
+   * at the time it fires, and the SW state snapshot carries no goal-run field, so
+   * without this replay a panel that reopened (or reconnected after an SW respawn)
+   * shows NO Goal bar / Stop for a run still driving autonomously. Same shape the
+   * live loop emits, so it folds through the panel's existing goal/state reducer.
+   * @returns {object[]}
+   */
+  const activeStates = () => {
+    const out = [];
+    for (const sid of runs.keys()) {
+      if (!isActive(sid)) continue;
+      const r = /** @type {GoalRun} */ (runs.get(sid));
+      out.push({
+        type: 'goal/state', sessionId: sid, phase: 'running', active: true,
+        iteration: r.iteration, maxIterations, goal: r.goal, summary: r.summary ?? null,
+      });
+    }
+    return out;
+  };
+
+  /**
    * complete_goal hook: the agent declared the goal met. Returns whether there
    * was a LIVE run to end (false → the tool was called outside an active run).
    * @param {string} sid @param {string} [summary] @returns {boolean}
@@ -280,5 +302,5 @@ export const makeGoalRunner = ({ runTurn, onEvent = () => {}, onRunEnd = () => {
     return { resumed };
   };
 
-  return Object.freeze({ start, halt, stop, complete, isActive, get, drive, resume });
+  return Object.freeze({ start, halt, stop, complete, isActive, get, activeStates, drive, resume });
 };

--- a/extension/peerd-runtime/loop/turn-driver.js
+++ b/extension/peerd-runtime/loop/turn-driver.js
@@ -567,6 +567,11 @@ const maybeAutoResume = async (sessionId) => {
     if (!sessionId || vault.isLocked()) return;
     // Don't race a live turn — the loop is mid-stream, not interrupted.
     if (turnSlots.isBusy(sessionId)) return;
+    // Don't double-drive a session a Goal run owns: goalRunner.resume() re-drives
+    // its OWN interrupted turn after an SW respawn, so auto-resume firing for the
+    // same session would contend the turn slot (a spurious aborted turn / a
+    // narrowly-windowed goal-run halt). The goal loop is the authority here.
+    if (goalActiveFor?.(sessionId)) return;
     const session = await sessions.get(sessionId);
     const verdict = detectInterruptedTurn(session);
     if (!verdict.resumable) return;

--- a/tests/background/goal-connect-replay.test.ts
+++ b/tests/background/goal-connect-replay.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// The goal-run connect-time replay (#3/#4) lives in service-worker.js's
+// onConnect handler, which can't be imported under bun (no chrome/browser
+// globals) — so, like offscreen-gate.test.ts, assert against the SOURCE TEXT.
+// The behavioral half (WHAT activeStates() returns) is pinned in
+// goal-runner.test.ts; this pins that onConnect actually REPLAYS it to the
+// freshly-connected port, mirroring the pendingConfirm replay right above it.
+// Without the replay, a panel that reopened (or reconnected after an SW
+// respawn) shows no Goal bar / Stop for a run still driving — reverting the
+// onConnect loop fails the assertions here.
+const src = readFileSync(
+  join(import.meta.dir, '../../extension/background/service-worker.js'),
+  'utf8',
+);
+
+describe('service worker — goal-run replay on port (re)connect (#3/#4)', () => {
+  test('onConnect replays every live goal run to the fresh surface', () => {
+    expect(src).toMatch(/goalRunner\?\.activeStates\?\.\(\)/);
+    // the replay posts each active-run event to THIS port (not a broadcast)
+    expect(src).toMatch(/for \(const ev of \(goalRunner\?\.activeStates[\s\S]{0,160}?port\.postMessage\(ev\)/);
+  });
+});

--- a/tests/peerd-runtime/goal-runner.test.ts
+++ b/tests/peerd-runtime/goal-runner.test.ts
@@ -112,6 +112,31 @@ describe('makeGoalRunner — the goal loop', () => {
     expect(goals).toEqual(['first', 'second']);
   });
 
+  it('activeStates() yields running-run payloads for connect-time replay, and none once terminal', async () => {
+    const calls: TurnArgs[] = [];
+    let release: () => void = () => {};
+    let runner: ReturnType<typeof makeGoalRunner>;
+    runner = makeGoalRunner({
+      // Hold the turn open so the run stays LIVE while we inspect activeStates().
+      runTurn: async (a: TurnArgs) => { calls.push(a); await new Promise<void>((r) => { release = r; }); },
+      maxIterations: 5,
+    });
+    await runner.start({ sessionId: 'sA', goal: 'build it' });
+    await settle(() => calls.length === 1);
+    // A live run is replayable as a 'running' goal/state event (the shape the
+    // panel's reducer folds — so a reconnecting surface restores the Goal bar).
+    const live = runner.activeStates();
+    expect(live).toHaveLength(1);
+    expect(live[0]).toMatchObject({
+      type: 'goal/state', sessionId: 'sA', phase: 'running', active: true, goal: 'build it',
+    });
+    // Once it ends, it is no longer replayed.
+    runner.complete('sA', 'done');
+    release();
+    await settle(() => !runner.isActive('sA'));
+    expect(runner.activeStates()).toEqual([]);
+  });
+
   it('the continuation prompt carries the goal and points at complete_goal', () => {
     const p = goalContinuationPrompt('build a drum machine');
     expect(p).toContain('build a drum machine');

--- a/tests/peerd-runtime/goal-runner.test.ts
+++ b/tests/peerd-runtime/goal-runner.test.ts
@@ -187,6 +187,26 @@ describe('makeGoalRunner — persistence + resume (survives SW restart / other c
     const kv = makeKv();
     expect((await makeGoalRunner({ runTurn: async () => {}, kv }).resume())).toEqual({ resumed: 0 });
   });
+
+  it('resume() re-runs a final turn interrupted at the cap, not dropping it as capped', async () => {
+    const kv = makeKv();
+    // SW died DURING the last allowed turn → stored iteration === maxIterations.
+    kv.store.set(GOAL_RUNS_KEY, { s: { goal: 'finish it', iteration: 3, startedAt: 1 } });
+    const calls: TurnArgs[] = [];
+    const events: any[] = [];
+    const runner = makeGoalRunner({
+      runTurn: async (a: TurnArgs) => { calls.push(a); },
+      onEvent: (ev) => events.push(ev),
+      maxIterations: 3,
+      kv,
+    });
+    await runner.resume();
+    await settle(() => !runner.isActive('s'));
+    // The interrupted final turn re-ran exactly once, THEN the run caps — without
+    // the clamp the loop would exit immediately (0 turns) and still report capped.
+    expect(calls.length).toBe(1);
+    expect(events[events.length - 1].phase).toBe('capped');
+  });
 });
 
 describe('makeGoalRunner — outcome hardening (no runaway on failure)', () => {
@@ -248,5 +268,35 @@ describe('makeGoalRunner — outcome hardening (no runaway on failure)', () => {
     await settle(() => !runner.isActive('s'));
     expect(ends).toHaveLength(1);
     expect(kv.store.get(GOAL_RUNS_KEY)).toEqual({});
+  });
+
+  it('stop() on a vault-lock-PAUSED run drops its kv record so it does NOT resurrect on resume()', async () => {
+    const kv = makeKv();
+    let throwOnce = true;
+    const calls: TurnArgs[] = [];
+    let runner: ReturnType<typeof makeGoalRunner>;
+    runner = makeGoalRunner({
+      runTurn: async (a: TurnArgs) => {
+        calls.push(a);
+        if (throwOnce) { throwOnce = false; const e: any = new Error('locked'); e.name = 'VaultLockedError'; throw e; }
+      },
+      kv,
+    });
+    await runner.start({ sessionId: 's', goal: 'keep going' });
+    await settle(() => !runner.isActive('s'));
+    // Paused: evicted from the in-memory map, but the record survives in kv.
+    expect(runner.get('s')).toBe(null);
+    expect(kv.store.get(GOAL_RUNS_KEY).s).toMatchObject({ goal: 'keep going' });
+
+    // The user clicks Stop on the (still-visible) paused run. halt() alone would
+    // be a no-op (not in the map); stop() durably forgets the record.
+    await runner.stop('s');
+    expect(kv.store.get(GOAL_RUNS_KEY)).toEqual({});
+
+    // resume() must NOT re-drive a stopped run.
+    const before = calls.length;
+    await runner.resume();
+    await settle(() => true, 5);
+    expect(calls.length).toBe(before);
   });
 });

--- a/tests/peerd-runtime/loop/turn-driver.test.ts
+++ b/tests/peerd-runtime/loop/turn-driver.test.ts
@@ -66,6 +66,18 @@ test('maybeAutoResume no-ops when the session is already streaming', async () =>
   expect(read).toBe(false);
 });
 
+test('maybeAutoResume no-ops when a Goal run owns the session (no double-drive)', async () => {
+  let read = false;
+  const d = makeTurnDriver(deps({
+    // The goal loop re-drives its own interrupted turn on resume; auto-resume
+    // must bail BEFORE reading the session so the two can't contend the slot.
+    goalActiveFor: (sid: string) => sid === 's1',
+    sessions: { get: async () => { read = true; return {}; } },
+  }));
+  await d.maybeAutoResume('s1');
+  expect(read).toBe(false);
+});
+
 test('maybeAutoResume does not resume a turn that is not resumable', async () => {
   let noted = false;
   const d = makeTurnDriver(deps({


### PR DESCRIPTION
**Stacks on #55** (shares the goal-runner frozen-API line, so it's based on that branch — the diff here is just the rehydration change; GitHub will retarget to `main` once #55 merges).

A live goal run's `goal/state` events only reach ports connected at the moment they fire, and the SW state snapshot carries **no goal-run field**. So after a service-worker respawn *or* a plain side-panel reopen, a run that is **still driving turns autonomously** shows no Goal bar and no Stop button - the user loses the visible stop control until the next iteration's emit (a full turn away), or never if the run is paused.

Fix mirrors the existing `pendingConfirm` / agent-tab connect-time replay: the runner exposes `activeStates()` (the `running` `goal/state` payloads for every live run), and `onConnect` replays them to the freshly-connected port, folding through the panel's existing `goal/state` reducer. No snapshot widening, no reducer change. (#3, #4)

## Tests (revert-proven)
- `goal-runner.test.ts`: `activeStates()` yields a live run's replay payload and nothing once terminal.
- `goal-connect-replay.test.ts`: source-assertion that `onConnect` posts `activeStates()` to the port (the wiring half, which can't be imported under bun - same pattern as `offscreen-gate.test.ts`).

Full bun suite green (2102), typecheck + lint + dweb-boundary + tscheck clean, no drift.