### PR TITLE
DESIGN-17: resident tab agents (spec) — Model A, with the split staged for JS-safety

### DIFF
--- a/docs/specs/DESIGN-17-resident-agents.md
+++ b/docs/specs/DESIGN-17-resident-agents.md
@@ -257,20 +257,22 @@ here):
   the orchestrator on the frontier model doing only routing + synthesis.
   Specialization up, cost down — the orchestrator stops carrying every
   environment's reasoning.
-- **An actor mesh** — `message_resident` is session→session, so residents can
-  address *each other* (a VM resident asks an App resident to render its output);
-  the orchestrator thins toward a router over a graph of specialists.
-- **Across peers (dweb)** — the same channel extends agent-to-agent over the mesh
-  (`docs/distributed/ROADMAP.md`): a resident addresses a peer's resident, and the
-  actor graph goes distributed.
+- **An in-browser actor mesh** — `message_resident` is session→session, so local
+  residents address *each other* as peers (the VM resident asks the App resident
+  to render its output); the orchestrator thins toward a router over a graph of
+  specialists.
+- **A2A across peers** — the same message primitive extends to *remote* agents
+  over the dweb (`docs/distributed/ROADMAP.md`). Local↔remote is a deliberate
+  line: a peer's agent is a different trust + latency regime than a local
+  resident, even though both are addressed as peers.
 - **Autonomous residents** — once the inbound clamp lands, residents react to
   schedules/events and tend their environments unattended.
 
-**The mature model:** the orchestrator is a thin conversational router; the work
-lives in a graph of persistent, purpose-tuned, isolated actor-agents — one per
-environment, local and eventually across peers — reached only by message. peerd
-shifts from *one agent with many tools* toward *a society of specialized agents,
-each owning its world.*
+**The mature model:** actor-based orchestration of specialized agents in the
+browser — the orchestrator routes, the work lives in a graph of purpose-tuned
+residents acting as peers — with a deliberate line between **local** peers
+(in-browser, trusted, cheap to reach) and **remote** ones over **A2A**
+(agent-to-agent across the dweb).
 
 ## Alternatives considered
 

--- a/docs/specs/DESIGN-17-resident-agents.md
+++ b/docs/specs/DESIGN-17-resident-agents.md
@@ -3,24 +3,25 @@
 > Status: DESIGN. Nothing here is implemented. Feature number 17.
 > On branch `experimental/resident-tab-agents`.
 >
-> Design history (kept deliberately — the rejected path is load-bearing
-> context): this started as a *tab-hosted loop* design (the loop runs in the tab
-> page; the SW is a key/egress proxy — "Model B / the split"). An adversarial
-> review (`docs/SUBAGENTS.md` threat model + a code-grounded swarm) showed the
-> split's headline justification — renderer isolation as a boundary against
-> *prompt-injection* — does not hold: a text-steered loop can only call its
-> already-gated tools, identical wherever the loop runs. The split's one real
-> benefit is **JS-level heap isolation** (a code exploit of the loop reaching the
-> in-memory key / co-resident data), which is desirable but is a *different,
-> later* threat (untrusted **code**, e.g. dweb-delivered dwapps), and the split
-> introduced four SW-side regressions. **Decision: ship Model A now** (loop on
-> the SW heap, bound structurally to the tab); **stage the split as Phase 2** on
-> the *same seam*, for JS-safety, once A is battle-tested and untrusted-code use
-> cases are live. A is not a stepping stone thrown away — **A is the substrate B
-> relocates onto.**
+> Design history (kept — the rejected paths are load-bearing context):
+> (1) Explored a *tab-hosted loop* (loop in the tab page, SW as key/egress proxy
+> — "the split" / Model B). An adversarial swarm showed its headline
+> justification (renderer isolation vs *prompt-injection*) does not hold — a
+> text-steered loop calls the same gated tools wherever it runs — and that it
+> introduced four SW-side regressions. (2) Pivoted to **Model A** (loop on the SW
+> heap, bound to the tab). (3) A second swarm reviewed the Model-A spec and
+> **killed its first mutation-purity mechanism** ("purity by exposure" — the
+> exposure axis is binary main/not-main and cannot express "resident-only", so a
+> one-line `spawn_subagent({tools:['app_delete']})` mutated any instance). This
+> revision fixes that with a **resident-keyed capability tier + per-instance
+> pin**, and corrects two related over-claims (the instance↔resident *binding*
+> needs a routing pointer; the resident turn is not "zero new runtime"). The
+> kept-strong parts — the "A buys B" seam and the keyless content-threat scoping
+> — are unchanged.
 >
 > Read first: `docs/SUBAGENTS.md` (a resident is "a session with parentage" — the
-> shape reused), `docs/specs/DESIGN-11-async-subagents.md` (the wake/mailbox
+> shape reused; and the global-registry / "no owner check" decision this narrows),
+> `docs/specs/DESIGN-11-async-subagents.md` (the wake/mailbox + runaway-guard
 > reused for `tell_instance`), `DESIGN.md` §8.5 (which instances are in scope).
 
 ## Motivation
@@ -30,216 +31,264 @@ Three goals, from the owner:
 1. **Functional purity of instance access** — *"tabs as global objects any
    session can mutate bothers my functional sensibilities."*
 2. **A lean parent context that doesn't re-bloat** as instances accumulate.
-3. **Isolation** — a per-tab, secret-less agent, the do/get/check browser-runner
-   trust model generalized to every stateful tab; eventually hardened against
+3. **Isolation** — a per-tab, secret-less agent (the do/get/check browser-runner
+   trust model generalized to every stateful tab); eventually hardened against
    untrusted **code** (git repos, API responses, dweb-delivered dwapps).
 
-A ships #1 and #2 in full, and #3 against the live threat (untrusted *content*).
-The remaining slice of #3 — JS-level heap isolation against untrusted *code* — is
-Phase 2 (the split), built on A's seam.
+A delivers #2 in full, #3 against the live threat (untrusted *content*), and #1
+**by a resident-keyed capability tier** (below — *not* the binary exposure shed
+the first draft proposed). The remaining slice of #3 — JS-level heap isolation
+against untrusted *code* — is Phase 2 (the split), built on A's seam.
 
 ## What a resident IS (Model A)
 
 A **resident** is a persistent session — `kind:'resident'`, the third
-`SessionKind` member alongside `chat`/`subagent` — **one per tab-hosted instance**
-(WebVM, Notebook, App). Its agent loop runs **on the SW heap**, through the
-existing `turn-driver.js` → `runUserTurn` path, exactly like the main chat and
-every subagent today. Nothing new runs in the tab; the instance still lives in
-its tab and is driven by the existing `vm-client`/`notebook-client`/`app-client`
-RPC. Three things make it a resident:
+`SessionKind` member — **one per tab-hosted instance** (WebVM, Notebook, App).
+Its loop runs **on the SW heap**, through the existing `turn-driver.js` →
+`runUserTurn` path. The instance still lives in its tab, driven by the existing
+`vm-client`/`notebook-client`/`app-client` RPC. Three things make it a resident:
 
-1. its **lifecycle is bound 1:1 to the tab** (the tab-tracker entry);
-2. it **owns the instance's tools** — and is the only session that has them;
+1. it is **bound to its instance** by a persisted `residentSessionId` on the
+   registry record (a *routing* pointer — below);
+2. it is **the only kind of session that may hold instance-mutating tools**, and
+   then only for *its own* instance;
 3. you **reach it only by message** (`tell_instance`).
 
-`js_run` (headless, no tab, ephemeral throwaway compute) is **out** — it stays a
-parent tool. Scope is the three tab-hosted kinds (§8.5).
+`js_run` (headless, ephemeral, no instance) stays a parent tool. Scope is the
+three tab-hosted kinds (§8.5).
 
-## The three moves
+## Move 1 — the binding: an instance→resident routing pointer
 
-### 1. Structural binding — the tab-tracker entry, no pointer
+The resident is bound to its **instance**, not its **tab**. The tab is just the
+current host (reconstitutable via `ensureTab`); the binding must survive the tab
+closing (a VM persists when its tab closes). So:
 
-`tab-tracker.js` already maps `byId: Map<instanceId, {tabId, ready, …}>`, born on
-`onTabReady(id, sender.tab.id)` (`service-worker.js` ~2007) and evicted on
-`tabs.onRemoved → onTabRemoved(tabId)` (~2031). **That map is the binding.** A
-resident session is minted when its instance's tab first goes ready, and archived
-when the tab closes — riding those exact events. No `ownerSessionId` field, no
-resident registry to reconcile, no orphan bookkeeping. The earlier draft's
-imperative ownership pointer is gone: there is nothing to go stale because the
-binding *is* the tracker entry's lifecycle.
+- **The binding is a persisted `residentSessionId` field on the registry record**
+  (`registry-factory.js`), set when the resident is minted. `tell_instance`
+  resolves `instanceId → residentSessionId` from there; the `tab-tracker` is used
+  only to ensure the tab is live when the resident needs to act (`ensureTab`).
+- **This is not the ownership *gate* the earlier draft rejected.** That gate was a
+  *session→instance owner check on every mutation* (with transfer-on-settle and
+  brick-the-instance failure modes). `residentSessionId` is a *one-directional
+  routing pointer* (find the resident to deliver a `tell`); mutation is **not**
+  gated on it (it's gated by the capability tier, Move 2), so it has none of
+  those failure modes — if the resident session is gone, mint a fresh one; the
+  instance is never bricked. The honest correction to v1: there *is* a pointer;
+  it is addressing, not a per-call owner check.
+- **Minting:** lazy — on the first operation that needs a resident for an
+  instance (the create/first-`tell` path), the resident session is created and
+  its id written to the record. Archived when the **instance** is deleted
+  (`vm_delete`/`app_delete`), not when the tab closes (tab close → dormant;
+  record + `residentSessionId` persist; re-adopted on SW boot after
+  `registry.load()`).
 
-### 2. The tool-shed — purity by exposure, not enforcement
+## Move 2 — the capability tier: who may hold instance-mutating tools
 
-The instance-mutating tools (`vm_*`, `js_*` except `js_run`, `app_*`) are added to
-a hidden-set mirroring `MAIN_AGENT_HIDDEN_TOOLS` (`exposure.js`):
-`mainAgentDescriptors` drops them from the main turn and `exposureGate` refuses
-them on `exposure:'main'`. They are granted **only to resident sessions.** So the
-parent (and any normal chat) literally *cannot* mutate an instance — not because
-of a per-call owner check, but because **it doesn't have the tools.** Purity is a
-property of *where the capability lives* (exactly one place: the resident), which
-is cleaner than a gate and needs no registry lookup. The parent's only verbs are
-**create-a-tab**, **`tell_instance`**, **list**. This *is* goal #2 — and unlike
-`INSTANCE_GATED_TOOLS`' progressive disclosure (which re-bloats once a chat has one
-of each kind), a hard shed doesn't erode. The heavy engine prose
-(`system-prompt.txt` Sandboxes + WebVM blocks, ~8.7 KB) moves into each kind's
-byte-stable `*_RESIDENT_PROMPT`, where per-env toolsets can expand aggressively.
+This is goal #1's real mechanism, and it is **enforced at the dispatch gate**,
+not by descriptor hygiene alone (the v1 "purity by exposure" claim was false: the
+exposure axis only knows `main` vs not-`main`, so it cannot keep instance tools
+off a *subagent*).
 
-### 3. The message channel — `tell_instance`
+- **A new authority marker — `resident` — gates the instance-mutating set**
+  (`vm_*`, `app_*`, `js_*` except `js_run`). `exposureGate` (`tools/gates.js`)
+  is extended so these tools are **refused for every ctx whose marker is not
+  `resident`** — `main`, `subagent`, runner, review, and direct dispatch all
+  **fail closed**. The marker is set only by the resident turn path;
+  `buildToolContext` and `spawnSubagent` must **never** set it for a child.
+- **Both spawn surfaces are gated.** The `spawn_subagent` tool *and* the
+  `subagent/spawn` SW route (`routes/sessions.js`, which forwards caller-supplied
+  `tools` verbatim — reachable from a first-party `peerd.runtime.runAgent` shim)
+  must not grant the `resident` marker. A subagent requesting `tools:['app_delete']`
+  is refused at dispatch.
+- **Closures stripped by construction.** The instance clients/registries
+  (`appClient`/`appRegistry`/`vmClient`/`vmRegistry`/`jsClient`/`jsRegistry`) are
+  injected into every ctx today and are absent from `CAPABILITY_CONSUMERS`
+  (`spawn.js`). Add them so a non-resident ctx has **no closure** to call even if
+  a tool name leaked — defense in depth behind the name gate.
+- **Per-instance pin (cross-resident isolation).** Instance-mutating tools are
+  id-addressed against *singleton* registries (`app_delete(args.appId)` deletes
+  *any* app), so the 1:1 tab binding alone does **not** scope a resident to its
+  own instance. The resident's tool ctx **defaults the target to its bound
+  instance id and rejects a mismatching explicit id.** Without this, a resident
+  could mutate a *sibling* instance.
+- **Test the boundary.** A dispatcher test (mirroring `dispatcher.test.js:266`)
+  asserts a subagent spawned with `tools:['app_delete']` and no manifest is
+  refused. This is a P0 deliverable, not a nicety — it is the proof goal #1 holds.
 
-`tell_instance({ to, message, sync? })`; `to` is the instance id. The SW resolves
-`tracker.getTabId(to)` → the resident session → `turnSlots.runWhenIdle(resident,
-fn)` (the existing serializing mailbox: a `tell` runs when the resident is idle,
-**never interrupting an in-flight turn**, DECISIONS #20). The resident's turn is
-just `runAgentTurn({ sessionId: residentSessionId, synthetic, … })` — the
-async-subagent reintegration path, already shipped. The reply re-enters the
-**sender** as a `synthetic:true` wake turn, `wrapUntrusted`-fenced (mandatory for
-App residents — they render attacker content). **Sender correlation is pinned
-SW-side** (a transient `{correlationId → senderSessionId}` map, lifetime one
-round-trip — never a persisted per-message sender pointer in the resident).
+So the parent (and any non-resident session) cannot mutate an instance because the
+tool **fails closed at the gate** for them, and a resident cannot mutate a
+*sibling* because its ctx is **pinned**. Call it **purity by capability topology**
+— a resident-keyed tier + a per-instance pin, both enforced at dispatch. (Reads
+stay global and id-addressable, as `docs/SUBAGENTS.md` has them — only *mutation*
+is tiered; goal #1 is the mutation half, honestly scoped.)
+
+## Move 3 — the message channel: `tell_instance`
+
+`tell_instance({ to, message, sync? })`; `to` is the instance id → resolve
+`residentSessionId` (Move 1) → `turnSlots.runWhenIdle(residentSessionId, fn)`
+(the serializing mailbox: runs when the resident is idle, **never interrupting an
+in-flight turn**, DECISIONS #20). The resident's turn is
+`runAgentTurn({ sessionId: residentSessionId, … })`. The reply re-enters the
+**sender** as a `synthetic:true` wake, `wrapUntrusted`-fenced (mandatory for App
+residents — they render attacker content). Correlation is pinned **SW-side**
+(`{correlationId → senderSessionId}`, the async-subagents per-sender shape).
+
+- **P0 fail-closed sender gate.** The `ctx.inbound`/unattended clamp the
+  unattended path needs is **SPEC-only today (zero code)**, and *synthetic parent
+  turns already exist* (`goal-runner.js`, `async-subagents.js` re-enter with
+  `wrapUntrusted`'d page bytes) — a synthetic parent is a non-attended sender that
+  exists **now**. So P0 gates the tool edge on
+  **`!synthetic && senderSessionId === getActiveSessionId()`** (attended,
+  first-party). The unattended path (peer messages, scheduled tasks) is **blocked
+  at P0** and unlocks only when the shared clamp lands (P1+).
+- **Runaway guard.** `tell_instance` reuses the async-subagents `RATE_CAP` /
+  `OUTSTANDING_CAP` per sender (a resident↔resident or parent↔resident ping-pong
+  must be bounded — see cost, below).
 
 ## The resident-runtime boundary — why A is B's foundation
 
-This is the design's spine and the reason A is not throwaway. peerd's turn
-machinery is already split exactly where the A↔B seam needs to be:
+peerd's turn machinery is already split where the A↔B seam needs it. **Verified:**
+the `turn-driver` wrapper genuinely owns spend/clamp/scheduler/key/egress and
+calls `runUserTurn` (the inner loop) which reaches none of them by closure (it
+emits `usage` *events* the wrapper consumes).
 
 ```
 turn-driver.js  (the WRAPPER — stays SW-side in BOTH A and B)
    ├─ makeTurnCostTracker / maybeHalt / spendLimitUsd   ← spend cap
-   ├─ the inbound clamp (ctx.inbound, when it lands)     ← unattended gate
-   ├─ turnSlots (claim/release/runWhenIdle)              ← scheduler / anti-focus-theft
-   ├─ vault.getSecret + safeFetch + webFetch + audit     ← key & egress
+   ├─ ctx.inbound clamp (when it lands)                 ← unattended gate
+   ├─ turnSlots (runWhenIdle / claim / release)         ← scheduler / anti-focus-theft
+   ├─ vault.getSecret + safeFetch + webFetch + audit    ← key & egress
    └─ runUserTurn(...)   ← the INNER LOOP (the only thing B relocates)
 ```
 
-- **Model A:** the resident runs through the whole stack in the SW —
-  `runAgentTurn({ sessionId: resident })`. The wrapper enforces spend, clamp,
-  scheduling; the loop calls `callModel`/egress directly. **Zero new turn
-  runtime** — it reuses the existing driver, parameterized by session id.
-- **Model B (Phase 2):** relocate **only `runUserTurn`** into a per-tab worker.
-  The wrapper — cost meter, clamp, scheduler, key, egress — **stays in the SW**,
-  now talking to the relocated loop over a streaming proxy (`callModel` Port +
-  egress relay + a vault-`unlocked` relay + cross-boundary abort). Because the
-  enforcement never leaves the SW, B does **not** reintroduce the regressions the
-  split's first draft had (uncapped spend, an unclamped inbound path, an invisible
-  second scheduler — all were artifacts of moving the *wrapper*, which we never
-  do).
+- **Model A:** the resident runs the whole stack in the SW. **But not for free:**
+  `runAgentTurn` today hardcodes `exposure:'main'` (which would shed the very
+  tools a resident needs) and frames the turn around
+  `browser.tabs.query({active:true})` (the *user's* foreground tab, not the
+  resident's instance tab). So A needs a **kind-aware branch**: the `resident`
+  exposure marker, a resident descriptor build, the `*_RESIDENT_PROMPT`, and
+  honoring the resident's `activeTabId` instead of the foreground query. The
+  **wrapper** (spend/clamp/scheduler/egress) is reused verbatim; the inner
+  per-turn *setup* is real, bounded new work. ("Zero new turn runtime" was an
+  over-claim; the honest claim is "the enforcement wrapper is reused.")
+- **Model B (Phase 2):** relocate **only `runUserTurn`** into a per-tab worker
+  behind a streaming proxy; the wrapper stays SW-side. Because enforcement never
+  leaves the SW, B does not reintroduce the regressions the split's first draft
+  had (uncapped spend, an unclamped inbound path, an invisible second scheduler).
 
-**The design rule for A, so A supports B:** keep every key/egress/cost/clamp/
-scheduler concern in the turn-driver wrapper (where it already is), and keep the
-resident loop's IO behind the existing injected `REQUIRED_CTX` seam. Then B is the
-single, well-scoped act of filling that ctx from a worker-proxy instead of
-in-process. Spec the seam once; cross it later.
+**Design rule for A, so A supports B:** keep every key/egress/cost/clamp/scheduler
+concern in the wrapper; keep the loop's IO behind the injected `REQUIRED_CTX`
+seam. Then B is one scoped relocation. Spec the seam once; cross it later.
 
 ## What A ships vs what the split (Phase 2) adds
 
 | | Model A (ship now) | The split (Phase 2, JS-safety) |
 |---|---|---|
-| Inner loop runs | SW heap | per-tab worker (spawned by the host page) |
-| Key in the loop's realm | held for `callModel` (SW heap) | **none** — `callModel` proxied |
+| Inner loop runs | SW heap | per-tab worker |
+| Key in the loop's realm | held for `callModel` | none (proxied) |
 | Defends prompt-injection | yes (gated tools) | yes (identical) |
-| Defends a JS exploit of the loop reaching the key | **no** — shared SW heap | **yes** — the actual delta |
-| New build | deny-set + `tell_instance` + `kind:'resident'` | streaming Port + abort + vault relay + worker host |
+| Defends a JS exploit of the loop reaching the key | no (shared SW heap) | **yes — the real delta** |
 | Trigger | now | untrusted **code** live (dweb dwapps) + A battle-tested |
 
-The split's value is real and the owner wants it sooner-not-later — but it is
-precisely the JS-heap-isolation hardening, *not* the injection-boundary claim, and
-it rides A's seam. Until then, A's keyless *tool* context (`restrictCtxCapabilities`
-already strips `getSecret`/`safeFetch` from the tool ctx) is the proportionate
-mitigation for the content threat.
+## Cost model (corrected — not "native and free")
 
-## Hardenings carried from the adversarial review
+A resident is a *separate session*. `makeTurnCostTracker` (`cost/turn-tracker.js`)
+checks `limitUsd` **per session**, so **N residents = N independent caps**: the
+user's attended chat hitting its limit does not stop its residents, and a
+`tell_instance` ping-pong burns two independent caps. P0 must therefore (a) carry
+the `tell_instance` runaway guard (Move 3), and (b) **document** that residents
+multiply the cap by live-resident count. A true cross-session rollup into one
+owning-user budget does not exist today and is an open question (below), not a P0
+claim.
 
-A structurally **avoids** the split's four regressions (the loop is on the SW, so
-spend-cap, scheduler, and clamp are native; a tab discard or App `reloadTab` can't
-nuke a loop that isn't in the tab). Three findings still apply to A and are folded
-in:
+## Hardenings carried from the adversarial reviews
 
-- **Ephemeral confirm for residents.** `sessionConfirmGrants` banks a blanket
-  `yes_session` per session (`service-worker.js:1802`); a *persistent* resident
-  would turn one user approval into standing self-approval it replays every turn.
-  Residents use **per-turn** grants (no `yes_session` banking) — the runner's
-  grant-less posture.
-- **`tell_instance` inherits the inbound-clamp posture.** A `tell` from the user's
-  own attended chat is first-party. A `tell` from an **unattended/cross-trust**
-  sender (a scheduled task, a peer message) is inbound and must ride the
-  `ctx.inbound` clamp that `FEATURE-SCHEDULED-TASKS.md` /
-  `FEATURE-FIRST-CLASS-MESSAGING.md` are building. There must be **one** clamp;
-  `tell_instance`'s non-attended path gates on it.
-- **SW-side reply correlation** (above) — never a persisted sender pointer.
+A structurally avoids the split's four regressions (loop is on the SW). Folded in:
+
+- **Ephemeral resident confirm.** `sessionConfirmGrants` banks a blanket
+  `yes_session` per session; a *persistent* resident would replay one approval
+  every turn. Residents use **per-turn** grants (the runner's grant-less posture).
+- **`tell_instance` P0 fail-closed** on synthetic/unattended senders (Move 3).
+- **SW-side reply correlation** (Move 3) — never a persisted sender pointer.
 
 ## Context shedding (goal #2)
 
-Parent keeps create + `tell_instance` + list (~5 tools); the ~23 instance tools
-move onto residents (minus `js_run`). Net: ~4.5–6 k tokens off every parent turn,
-non-eroding. Recompute the per-resident prompt cost if residents go always-warm vs
-lazy (below).
+Parent keeps create + `tell_instance` + list; the ~23 instance tools move behind
+the `resident` tier (minus `js_run`). Non-eroding (unlike `INSTANCE_GATED_TOOLS`
+progressive disclosure). Net ~4.5–6 k tokens off every parent turn; the engine
+prose moves into per-kind `*_RESIDENT_PROMPT`. (Honest: the per-resident prompt
+re-incurs that prose per live resident — net positive for the parent, recompute
+for always-warm residents.)
 
 ## Lifecycle
 
-- **Binding: structural** (tracker entry). **Execution: lazy** — the resident is a
-  persistent session but its loop only *runs* on a `tell` (idle/no-tokens between).
-- **Persistence:** the resident session persists in IDB (`sessions/store.js`); the
-  instance persists via registries + OPFS + per-VM disks; on SW boot
-  `registry.load()` + `tabTracker.bootstrap()` re-adopt live tabs. A `tell` to a
-  resident whose tab is gone re-spawns it via `ensureTab` (the resident is data,
-  the tab is reconstitutable).
-- **Death:** `tabs.onRemoved` → resident sleeps (session + instance survive) or, on
-  `vm_delete`/`app_delete`, archives. Generalize `onTabClosed → queue.interrupt`
-  (VM-only today, `:2031`) to all kinds so a closing tab cancels in-flight work.
+Bound to the instance (Move 1); **lazy execution** (the loop runs only on a
+`tell`). Persists in IDB; instance persists via registries/OPFS/disks; SW boot
+re-adopts via `registry.load()` + `tabTracker.bootstrap()`; a `tell` to a
+tabless instance re-spawns the tab via `ensureTab`. Generalize
+`onTabClosed → queue.interrupt` (VM-only at `:2031`) to all kinds.
 
 ## Security / invariants
 
-- **Keyless tool context** (`restrictCtxCapabilities`) — against the content
-  threat. The **shared SW heap is the known soft spot** (`docs/SUBAGENTS.md` names
-  it); A accepts it as proportionate for untrusted *content* and Phase 2 closes it
-  for untrusted *code*.
-- **`confirm`/`audit` are SW-authoritative** (native in A; proxied in B). Residents
-  never self-approve (ephemeral grants).
-- **`webFetch` (allowlist-free, open-web) is the real exfil surface** — deny
-  open-web tools to untrusted-input residents, as the runner does.
-- **The isolate is the untrusted-code boundary** in both A and B (the loop never
-  runs in the guest/worker/iframe).
+- **Mutation is resident-tiered + per-instance-pinned** (Move 2), enforced at
+  `exposureGate` + the closure strip. The dispatcher test is the proof.
+- **Keyless tool context** (`restrictCtxCapabilities`) against the content threat;
+  the shared SW heap is the named soft spot, closed for untrusted *code* in P2.
+- **`confirm`/`audit` SW-authoritative**; residents never self-approve.
+- **`webFetch` (allowlist-free) is the real exfil surface** — deny open-web tools
+  to untrusted-input residents, as the runner does.
+- **The isolate is the untrusted-code boundary** in both A and B.
 - Reply `wrapUntrusted`; depth/trust/audit unchanged.
 
 ## Specifically NOT to do
 
-- Resurrect an `ownerSessionId` pointer — the binding is the tracker entry.
-- Build the streaming proxy now — that's Phase 2; A reuses the SW turn-driver.
-- Move the cost meter / clamp / scheduler off the SW — ever (that's what creates
-  the regressions; the wrapper stays SW-side in both models).
-- Give residents standing `yes_session` grants.
-- Treat `js_run` as an instance; run the loop in the isolate.
+- Implement the mutation shed as descriptor-hygiene only (the v1 kill) — it must
+  be a `resident`-keyed **dispatch-gate refusal** + a per-instance pin.
+- Grant the `resident` marker on either spawn surface.
+- Re-introduce a per-call *session→instance owner check* (the rejected gate). The
+  `residentSessionId` field is a *routing* pointer, not a mutation gate.
+- Build the streaming proxy now (that's P2).
+- Move cost/clamp/scheduler off the SW — ever.
+- Give residents standing `yes_session`; treat `js_run` as an instance; run the
+  loop in the isolate.
 
 ## Open questions
 
-- **Which kinds get residents by default?** WebVM has the strongest case; Apps /
-  Notebooks may not be worth the message hop — per-kind.
-- **The inbound clamp** is a shared dependency (scheduled-tasks /
-  first-class-messaging); `tell_instance`'s unattended path gates on it.
-- **The user talking to a resident** in the side panel — `kind:'resident'` is a
-  first-class session; does it appear in a switcher, or only via the tab?
-- **Phase-2 trigger criteria** — what concretely counts as "untrusted code live"
-  (the first dweb dwapp execution path?) that flips the split on.
+- **Which kinds get residents by default** (WebVM strongest; per-kind).
+- **Cross-session spend rollup** — do residents share the owning user's budget, or
+  is per-session-cap-× -tab-count acceptable? (No rollup exists today.)
+- **The inbound clamp** is the shared dependency that unlocks `tell_instance`'s
+  unattended path; P0 ships attended-only without it.
+- **The user talking to a resident** — does `kind:'resident'` appear in a switcher
+  or only via the tab?
+- **Phase-2 trigger** — what concretely flips the split on (first dweb dwapp
+  execution path?).
 
 ## Phasing
 
-1. **P0 — Model A core.** `kind:'resident'`; structural tab-tracker binding; the
-   tool-shed deny-set; `tell_instance` (SW-side correlation + mailbox); residents
-   run through the existing `runAgentTurn`. Ephemeral confirm. Behind a flag.
-   *Battle-test + release this.*
-2. **P1 — persistence + the conversational surface.** Durable resident sessions;
-   the side-panel "talk to this instance" affordance; per-kind `*_RESIDENT_PROMPT`.
+1. **P0 — Model A core.** `kind:'resident'` (a `SessionKind` union change → audit
+   kind-switches, the `/chats` filter, store-load default); the **`resident`
+   exposure tier + dispatch-gate refusal + closure strip + per-instance pin +
+   the dispatcher test** (Move 2 — the security spine); the instance→resident
+   `residentSessionId` binding; `tell_instance` (SW correlation + mailbox +
+   runaway guard + the `!synthetic && active` fail-closed gate); the kind-aware
+   resident turn branch (exposure/descriptors/`*_RESIDENT_PROMPT`/`activeTabId`);
+   ephemeral confirm; resident-spawn wired across all three trackers. Behind a
+   flag. *Battle-test + release.* (Honest build surface — this is not "zero new
+   runtime".)
+2. **P1 — persistence + the conversational surface** (durable resident sessions;
+   the side-panel "talk to this instance" affordance; the unattended `tell`
+   path once the clamp lands).
 3. **P2 — the split (Model B), for JS-safety.** Relocate `runUserTurn` into a
-   per-tab worker behind the proxy (streaming `callModel` Port, egress relay,
-   vault-`unlocked` relay, cross-boundary abort), wrapper staying SW-side.
-   Triggered by untrusted-code use cases + a battle-tested A. *Desirable
-   sooner-not-later — the seam is designed for it from P0.*
+   per-tab worker behind the proxy (streaming Port, egress relay,
+   vault-`unlocked` relay, cross-boundary abort); wrapper stays SW-side.
+   Triggered by untrusted-code use cases + a battle-tested A.
 4. **P3 — durable resume** across vault unlock / browser restart (DESIGN-08).
 
 ## The seam is the bet
 
 A ships the actor model and the lean parent now, regression-free, by reusing the
-SW turn-driver and a one-table tool-shed. The split is then **one well-scoped
-relocation** — move the inner loop into a per-tab worker, leave the enforcement
-wrapper in the SW — for the day untrusted *code* runs. **Design the seam once
+SW turn-driver wrapper and a resident-keyed capability tier. The split is then one
+well-scoped relocation — move the inner loop into a per-tab worker, leave
+enforcement in the SW — for the day untrusted *code* runs. **Design the seam once
 (P0); cross it when the threat arrives (P2).** That's why A directly buys B.

--- a/docs/specs/DESIGN-17-resident-agents.md
+++ b/docs/specs/DESIGN-17-resident-agents.md
@@ -1,479 +1,245 @@
-# DESIGN-17 — resident tab agents: the tab IS the agent (loop in the host page, key in the SW)
+# DESIGN-17 — resident tab agents: a per-tab session that owns its instance
 
 > Status: DESIGN. Nothing here is implemented. Feature number 17.
-> Major refactor — built on the `experimental/resident-tab-agents` branch.
-> Read first, in order: `docs/SUBAGENTS.md` (this OVERTURNS its §"The two
-> surfaces" claim that "the agent loop runs [in the SW], same heap as any
-> subagent" and its §"Isolation is a SESSION boundary, not a RESOURCE
-> boundary"); `docs/specs/DESIGN-11-async-subagents.md` (the wake/mailbox
-> substrate reused for `tell_instance`); `DESIGN.md` §8.5 + `docs/DECISIONS.md`
-> #25 (the sandbox taxonomy — which instances are in scope) and #24 (Notebook
-> durable-state-to-OPFS, the model the App loop must follow); the existing
-> tab→SW proxy (`vm-tab.js swFetch` → `routes/engine.js` `sw/web-fetch`;
-> `notebook-tab.js`'s `subagent/spawn` relay) is the precedent the model-call
-> proxy generalizes.
+> On branch `experimental/resident-tab-agents`.
 >
-> The one-line thesis: **a tab-hosted engine instance runs its own agent loop,
-> in its own host page, and the only agent that may drive that instance IS that
-> loop — structurally, because the loop lives where the instance lives.** No
-> ownership pointer to track (the binding is the tab-tracker entry); the
-> provider key never enters the tab (the loop proxies model calls + egress to
-> the SW); the parent reaches a tab only by message. This is the do/get/check
-> browser-runner trust model, generalized from one disposable browser tab to
-> every stateful tab — and made persistent.
+> Design history (kept deliberately — the rejected path is load-bearing
+> context): this started as a *tab-hosted loop* design (the loop runs in the tab
+> page; the SW is a key/egress proxy — "Model B / the split"). An adversarial
+> review (`docs/SUBAGENTS.md` threat model + a code-grounded swarm) showed the
+> split's headline justification — renderer isolation as a boundary against
+> *prompt-injection* — does not hold: a text-steered loop can only call its
+> already-gated tools, identical wherever the loop runs. The split's one real
+> benefit is **JS-level heap isolation** (a code exploit of the loop reaching the
+> in-memory key / co-resident data), which is desirable but is a *different,
+> later* threat (untrusted **code**, e.g. dweb-delivered dwapps), and the split
+> introduced four SW-side regressions. **Decision: ship Model A now** (loop on
+> the SW heap, bound structurally to the tab); **stage the split as Phase 2** on
+> the *same seam*, for JS-safety, once A is battle-tested and untrusted-code use
+> cases are live. A is not a stepping stone thrown away — **A is the substrate B
+> relocates onto.**
+>
+> Read first: `docs/SUBAGENTS.md` (a resident is "a session with parentage" — the
+> shape reused), `docs/specs/DESIGN-11-async-subagents.md` (the wake/mailbox
+> reused for `tell_instance`), `DESIGN.md` §8.5 (which instances are in scope).
 
 ## Motivation
 
-The owner's three observations (DESIGN-17 conversation), now the three goals:
+Three goals, from the owner:
 
-1. *"Tabs as global objects any session can mutate bothers my functional
-   sensibilities."* → **Functional purity of instance access.**
-2. *"Context bloat from all these tool calls and instructions."* → **A lean
-   parent context that doesn't re-bloat as instances accumulate.**
-3. *"We already split a narrow browser runner for isolation — generalize it …
-   code could pull things (git repos, API endpoints, dweb-delivered code) that
-   may not be trusted."* → **Isolation: a per-tab, secret-less, egress-proxied
-   agent, extending the runner's untrusted-input trust model to every tab.**
+1. **Functional purity of instance access** — *"tabs as global objects any
+   session can mutate bothers my functional sensibilities."*
+2. **A lean parent context that doesn't re-bloat** as instances accumulate.
+3. **Isolation** — a per-tab, secret-less agent, the do/get/check browser-runner
+   trust model generalized to every stateful tab; eventually hardened against
+   untrusted **code** (git repos, API responses, dweb-delivered dwapps).
 
-### Why not the ownership gate (the rejected v1 of this spec)
+A ships #1 and #2 in full, and #3 against the live threat (untrusted *content*).
+The remaining slice of #3 — JS-level heap isolation against untrusted *code* — is
+Phase 2 (the split), built on A's seam.
 
-The first draft of DESIGN-17 proposed an `ownerSessionId` mutation gate: stamp
-an owner on each instance record, refuse cross-session mutation. The owner
-rejected it, correctly: **that is imperative ownership-bookkeeping** — a mutable
-field you stamp, read, and reconcile, with a tail of failure modes
-(transfer-on-settle, brick-the-instance-on-subagent-exit, stale pointers) that
-exist *only because the agent and the instance are two things joined by a
-pointer that can go stale.* Make the binding **structural** — the agent lives
-*in* the tab, 1:1, born and dying with it — and that entire category of bug
-stops being expressible. There is no pointer to dangle. This is the better
-architecture, and the grounding confirmed the binding substrate already exists
-(`tab-tracker.js`, below).
+## What a resident IS (Model A)
 
-This spec is therefore **Model B**: the loop runs in the tab's host page. It was
-chosen over the ownership gate (above) and over **Model A** (loop stays on the
-SW heap, merely bound 1:1 to the tab lifecycle). Model A is a serious, cheaper
-alternative; it is given a fair hearing in "Why the loop lives in the tab," and
-the open question of whether B's extra cost is worth it is flagged for the
-adversarial review.
+A **resident** is a persistent session — `kind:'resident'`, the third
+`SessionKind` member alongside `chat`/`subagent` — **one per tab-hosted instance**
+(WebVM, Notebook, App). Its agent loop runs **on the SW heap**, through the
+existing `turn-driver.js` → `runUserTurn` path, exactly like the main chat and
+every subagent today. Nothing new runs in the tab; the instance still lives in
+its tab and is driven by the existing `vm-client`/`notebook-client`/`app-client`
+RPC. Three things make it a resident:
 
-## Scope: the three tab-hosted kinds. js_run is out.
+1. its **lifecycle is bound 1:1 to the tab** (the tab-tracker entry);
+2. it **owns the instance's tools** — and is the only session that has them;
+3. you **reach it only by message** (`tell_instance`).
 
-Per `DESIGN.md` §8.5, the candidates are the **three tab-hosted, persistent**
-kinds — **WebVM, Notebook, App**. The **headless `js_run` worker** has no tab,
-is ephemeral-per-job, and is the agent's *own throwaway compute* (`primitive:
-'notebook'` but no instance, no lifecycle). It **stays on the parent**, a
-stateless tool, unchanged. Anything in this spec about "the tab loop" excludes
-`js_run`.
+`js_run` (headless, no tab, ephemeral throwaway compute) is **out** — it stays a
+parent tool. Scope is the three tab-hosted kinds (§8.5).
 
-## The core decision
+## The three moves
 
-Three moves, each landing on existing code:
+### 1. Structural binding — the tab-tracker entry, no pointer
 
-1. **The binding is structural — the tab-tracker entry.** `tab-tracker.js`
-   already maps `byId: Map<instanceId, {tabId, ready, …}>`, born on
-   `onTabReady(id, sender.tab.id)` (wired at `service-worker.js` ~2007) and
-   evicted on `tabs.onRemoved → onTabRemoved(tabId)` (~2031). *That map is the
-   resident binding.* The agent's lifecycle hangs off those exact events — no
-   `ownerSessionId`, no resident registry, no orphan reconciliation. "Born on
-   tab create, dies on tab close" is already the tracker's contract.
+`tab-tracker.js` already maps `byId: Map<instanceId, {tabId, ready, …}>`, born on
+`onTabReady(id, sender.tab.id)` (`service-worker.js` ~2007) and evicted on
+`tabs.onRemoved → onTabRemoved(tabId)` (~2031). **That map is the binding.** A
+resident session is minted when its instance's tab first goes ready, and archived
+when the tab closes — riding those exact events. No `ownerSessionId` field, no
+resident registry to reconcile, no orphan bookkeeping. The earlier draft's
+imperative ownership pointer is gone: there is nothing to go stale because the
+binding *is* the tracker entry's lifecycle.
 
-2. **The loop runs in the tab's HOST PAGE** (`vm-tab.js` / `notebook-tab.js` /
-   `app-tab.js` — all `chrome-extension://` origin module scripts). It does
-   **not** run in the SW, and it does **not** run in the untrusted isolate (the
-   CheerpX guest, the sealed Notebook worker, or the App's opaque-origin
-   iframe). The isolate is keyless by design; the host page drives it (it
-   already does — `vm-tab.js runViaShell`, `app-tab.js` posting `app-body` into
-   the iframe). Optionally the loop runs in a **dedicated Worker the host page
-   owns** (off the UI thread; see "The worker option").
+### 2. The tool-shed — purity by exposure, not enforcement
 
-3. **The SW is demoted to an on-demand key/egress service.** The loop never
-   holds the provider key (vault DK). It proxies the model call + all egress +
-   audit + confirm to the SW, which is the *only* holder of `vault.getSecret`
-   and `safeFetch`. The SW is woken by the tab's message (MV3 restarts it on
-   demand); it does not need to be alive between calls.
+The instance-mutating tools (`vm_*`, `js_*` except `js_run`, `app_*`) are added to
+a hidden-set mirroring `MAIN_AGENT_HIDDEN_TOOLS` (`exposure.js`):
+`mainAgentDescriptors` drops them from the main turn and `exposureGate` refuses
+them on `exposure:'main'`. They are granted **only to resident sessions.** So the
+parent (and any normal chat) literally *cannot* mutate an instance — not because
+of a per-call owner check, but because **it doesn't have the tools.** Purity is a
+property of *where the capability lives* (exactly one place: the resident), which
+is cleaner than a gate and needs no registry lookup. The parent's only verbs are
+**create-a-tab**, **`tell_instance`**, **list**. This *is* goal #2 — and unlike
+`INSTANCE_GATED_TOOLS`' progressive disclosure (which re-bloats once a chat has one
+of each kind), a hard shed doesn't erode. The heavy engine prose
+(`system-prompt.txt` Sandboxes + WebVM blocks, ~8.7 KB) moves into each kind's
+byte-stable `*_RESIDENT_PROMPT`, where per-env toolsets can expand aggressively.
 
-A resident agent is still the **r** letter — an agent loop — bound to an **e**
-instance. It is **not** a new engine kind and not a `subagent-tab/` page. The
-§8.5 taxonomy is untouched; this is a *host-lifecycle* feature.
+### 3. The message channel — `tell_instance`
 
-## What already exists (the owner was half-right)
+`tell_instance({ to, message, sync? })`; `to` is the instance id. The SW resolves
+`tracker.getTabId(to)` → the resident session → `turnSlots.runWhenIdle(resident,
+fn)` (the existing serializing mailbox: a `tell` runs when the resident is idle,
+**never interrupting an in-flight turn**, DECISIONS #20). The resident's turn is
+just `runAgentTurn({ sessionId: residentSessionId, synthetic, … })` — the
+async-subagent reintegration path, already shipped. The reply re-enters the
+**sender** as a `synthetic:true` wake turn, `wrapUntrusted`-fenced (mandatory for
+App residents — they render attacker content). **Sender correlation is pinned
+SW-side** (a transient `{correlationId → senderSessionId}` map, lifetime one
+round-trip — never a persisted per-message sender pointer in the resident).
 
-The owner said "we already have `peerd.runAgent` / `spawn_subagent` for exactly
-this." Half true, and the half that's true is load-bearing:
+## The resident-runtime boundary — why A is B's foundation
 
-- **The request bridge ships.** `peerd.runtime.runAgent` (in the Notebook
-  worker, `worker-source.js:150`) posts `{type:'subagent-request', rid, args}`
-  to its host page; the host page (`notebook-tab.js:206-234`) relays
-  `browser.runtime.sendMessage({type:'subagent/spawn', …})` to the SW route
-  (`routes/sessions.js:261`), which runs the loop and posts the result back.
-  `offscreen/job-runner.js:112` does the identical relay. **But today the loop
-  runs in the SW** — the host page is a *pure relay*. `docs/SUBAGENTS.md` states
-  it flatly: "the agent loop runs there, same heap as any subagent." **Model B
-  inverts exactly this sentence.** The plumbing (request relay, key-in-SW,
-  result-back) is reusable; the loop-in-the-tab is net-new.
-- **The egress proxy ships, verbatim reusable.** `vm-tab.js swFetch` →
-  `routes/engine.js` `sw/web-fetch` → `webFetch`/`vmHttpFetch` (denylist + SSRF
-  + audit). A tab loop proxying `webFetch` is a *solved problem* — copy it.
-- **The loop is fully DI'd.** `agent-loop.js runUserTurn`'s `REQUIRED_CTX =
-  ['callModel','getSecret','safeFetch','sessions','getSystemPrompt',
-  'appendAudit']` — every IO surface injected, nothing imported. And `callModel`
-  (`registry.js:172`) is a *pure router* that takes `getSecret`+`safeFetch` as
-  call args (the adapter reads the key only inside `callAnthropic`,
-  `anthropic.js:114`). **So the loop body needs zero changes** — the tab injects
-  SW-proxied `callModel`/`getSecret`; the DK never has to leave the SW.
-- **The keyless-loop posture is codebase-native.** `restrictCtxCapabilities` +
-  `CAPABILITY_CONSUMERS` (`spawn.js:102`) already strip `getSecret`/`safeFetch`
-  (empty consumer lists → always removed) from a narrowed child's tool context —
-  the do/get/check runner already reasons over untrusted pages with no key/egress
-  closure in scope. Model B generalizes that from "the child's tool ctx" to "the
-  whole loop, including the model call."
+This is the design's spine and the reason A is not throwaway. peerd's turn
+machinery is already split exactly where the A↔B seam needs to be:
 
-## Why the loop lives in the TAB, not the SW (Model A) — honest
-
-Model A (loop on the SW heap, bound 1:1 to the tab-tracker entry) delivers goals
-**#1 and #2 for free** and most of #3, at a fraction of the cost: it needs no
-streaming proxy, no cross-boundary abort, no vault-lock deferral re-plumbing —
-the loop keeps direct `callModel`. The structural binding (move #1) and the
-parent tool-shed (goal #2) are *independent of where the loop runs.* So why pay
-for B?
-
-B earns its cost on the parts of goal #3 that A cannot reach:
-
-- **True realm isolation, not stripped closures on a shared heap.** A's
-  capability stripping is real but the loop still executes on the SW heap
-  alongside every other session's data and the live instance graph; safety rests
-  on `restrictCtxCapabilities` being complete. B's loop is in a *different
-  renderer*, with no SW heap in scope at all — for the **untrusted-input future
-  the owner named** (a VM cloning an attacker's git repo, an App running
-  dweb-delivered code), that's the difference between "stripped closures" and "a
-  process boundary." This is the strongest argument and the reason B exists.
-- **No shared SW heap; true parallelism.** A puts N residents on the *one*
-  single-threaded SW heap — N concurrent resident turns serialize, and "N agents
-  mutating one heap" is the very shared-mutable-state smell goal #1 is escaping.
-  B gives each resident its own realm/process: real parallelism, real isolation.
-- **Instance-op locality.** B's loop calls `runViaShell` *in-process* (the VM is
-  in the same tab) — no SW round-trip per shell command, where A drives each
-  `vm/run` over a message. B trades that for a round-trip per *model* call; for an
-  instance-heavy resident (the common case) it's a net win.
-- **Resumability for free.** B's loop state lives in the durable tab, so an SW
-  restart pauses-and-resumes rather than losing the turn. (A can get this too via
-  explicit persist/resume — `goal-runner.js` already does — so it's a modest
-  edge, not decisive.)
-
-**Rejected — the offscreen document as the loop home.** It's the *most* durable
-context (no 30 s death) and has network, but it is a *single shared context*:
-N residents there means a `map<instanceId → agent>` you maintain and check — the
-exact ownership-bookkeeping move #1 rejects. The offscreen doc fails goal #1.
-Only a *per-tab* home makes the binding structural.
-
-## The key/egress proxy — what crosses, what stays local
-
-The loop's only key/egress-bearing dependencies are **`callModel`** (the sole
-vault-toucher) and **`safeFetch`/`webFetch`** (egress). The split:
-
-| Proxy to the SW (never in the tab) | Local to the tab loop |
-|---|---|
-| **`callModel`** — SW injects `getSecret`+`safeFetch`, runs the adapter, streams events back. The DK never leaves the SW. | The loop body (`runUserTurn` reducer), `getSystemPrompt` (string assembly — the resident's specialized prompt) |
-| **`webFetch`/`safeFetch`** — reuse `sw/web-fetch` verbatim (denylist + SSRF + audit) | **Instance ops** — `runViaShell` (VM), `runEval` (Notebook), OPFS-write+reload (App). The instance is co-located; no hop. |
-| **`appendAudit`** — fire-and-forget, one-shot | The tool-dispatch *policy* for instance-only ops (Plan/Act) — the host page is trusted extension code |
-| **`confirm`** — request/response, one-shot | session reducer state in memory (persisted via proxied/coordinated writes — see Lifecycle) |
-
-`getSecret` is **never** in the tab loop's context — it isn't needed there (it's
-only a `callModel` dep, and `callModel` is now proxied).
-
-## The hard part (where the engineering actually is)
-
-Be honest: the key-proxy is the *easy*, precedented half. The real new build is
-three things, none of which exist today:
-
-1. **A STREAMING `callModel` SW proxy.** `callModel` returns
-   `AsyncGenerator<ProviderEvent>` (`text-delta`, `tool-use-*`, `reasoning-*`,
-   `usage`, `message-stop`, `rate-limit-pause`). The existing `sw/web-fetch`
-   route returns a *single buffered base64 body* — **it is not a streaming
-   template.** Model B needs a long-lived `chrome.runtime.connect` **Port** that
-   chunks provider events from the SW back to the tab loop. This is the
-   principal new surface and the riskiest part of the spike.
-2. **A cross-boundary `AbortSignal`.** The loop's Stop / spend-limit / steer
-   contract depends on `ctx.signal` reaching the provider `fetch` to cut the SSE
-   socket. A tab-host loop's local `AbortController` cannot reach the SW's fetch
-   — Model B needs an explicit abort message (tab→SW) that aborts the SW-side
-   provider stream. Without it, Stop cannot cut a live model stream.
-3. **Vault-lock deferral in the tab loop.** The DK is gone at 45-min idle
-   (`vault.js` `DEFAULT_AUTO_LOCK_MS`); `getSecret` throws `VaultLockedError`. A
-   tab outlives the 30 s SW death but **not** the vault lock. The loop must adopt
-   async-subagents' pattern (`async-subagents.js`: hold, subscribe to vault
-   `'unlocked'`, resume) rather than throw mid-turn.
-
-Plus an accepted cost, not a build: **the full prompt** (messages + system +
-tool descriptors) crosses the tab↔SW boundary on *every* model step. For
-untrusted-input tabs this is exactly the desired chokepoint; it is also a real
-per-step serialization cost (`messages` can be large — attachments, snapshots).
-
-## The spike — per kind, grounded
-
-The loop is the same DI'd `runUserTurn` in all three; only the host page wiring
-and the instance-op surface differ. **Notebook is the binding case** — write the
-spike against it first (reasons below).
-
-### Notebook (the binding case) — `notebook-tab.js`
-`notebook-tab/index.html:22` sets page-level **`connect-src 'none'`**. So a loop
-in the Notebook host page **physically cannot fetch the model API** — the
-SW-key-proxy is not a trust preference here, it is a hard CSP requirement. If the
-streaming model proxy works under `connect-src 'none'`, it works everywhere.
-The loop lives in the *page* (the sealed worker is realm-sealed —
-`notebook-neutralizers.js` deletes `fetch`/`WebSocket`/… — and cannot host it).
-Insertion: the kickoff IIFE after `js/tab-ready` (~`notebook-tab.js:503`); the
-loop drives code via the existing `runEval` and reuses the existing
-`subagent/spawn`/`sw/web-fetch` relays for the proxied calls.
-
-### WebVM — `vm-tab.js` (the spike sketch)
-The host page already drives a WASM-confined CheerpX guest and proxies the
-guest's egress (`swFetch` → `sw/web-fetch`). The loop inserts right after
-`boot()` step 11 (`browser.runtime.sendMessage({type:'vm/tab-ready', vmId})`,
-~`vm-tab.js:1402`), *replacing* the SW driving discrete `vm/run` calls with the
-page running the loop and calling `runViaShell` in-process. Sketch:
-
-```js
-// vm-tab.js — after boot() reaches 'ready', stand up the resident loop.
-// The provider key is NEVER in this page: callModel + egress proxy to the SW.
-const sw = (type, payload) => browser.runtime.sendMessage({ type, ...payload });
-
-// (1) The streaming model proxy — a Port, because callModel yields events.
-const proxiedCallModel = (args) => {
-  const port = browser.runtime.connect({ name: 'callModel' });   // NEW SW route
-  return (async function* () {
-    port.postMessage({ kind: 'start', args: stripIO(args) });    // no getSecret/safeFetch cross
-    for await (const ev of portEvents(port)) {                   // text-delta / tool-use / usage / stop
-      if (ev.kind === 'error') throw reviveError(ev.error);
-      if (ev.kind === 'end') return;
-      yield ev.event;
-    }
-  })();
-  // abort: the loop's signal → port.postMessage({kind:'abort'}) → SW aborts the provider fetch
-};
-
-// (2) Instance ops run LOCALLY — no SW hop. The dispatcher for vm_* tools
-//     calls runViaShell directly; only egress-bearing tools (vm_import) proxy.
-const residentDispatch = makeResidentDispatch({
-  webvm: { run: runViaShell, writeFile, import: (url) => sw('sw/web-fetch', { url }) },
-  webFetch: (req) => sw('sw/web-fetch', req),
-  appendAudit: (e) => sw('audit/append', e),       // proxied (NEW thin route)
-  confirm: (q) => sw('confirm/ask', q),            // proxied (reuses confirmAction)
-});
-
-// (3) The loop body is unchanged runUserTurn — only its IO is the proxy.
-const resident = makeResidentLoop({
-  sessionId: residentSessionIdFor(vmId),           // its own persisted session
-  systemPrompt: VM_RESIDENT_PROMPT,                // expanded, env-specialized, byte-stable
-  callModel: proxiedCallModel,
-  toolDispatch: residentDispatch,
-  // getSecret / safeFetch are absent by construction — the key cannot be here.
-});
-
-// (4) Inbound wake — tell_instance lands as a targeted message; the local
-//     turn-slot serializes it so it never interrupts in-flight work.
-browser.runtime.onMessage.addListener((msg) => {
-  if (msg.type === 'vm/tell' && msg.vmId === vmId) resident.enqueue(msg.message);
-});
+```
+turn-driver.js  (the WRAPPER — stays SW-side in BOTH A and B)
+   ├─ makeTurnCostTracker / maybeHalt / spendLimitUsd   ← spend cap
+   ├─ the inbound clamp (ctx.inbound, when it lands)     ← unattended gate
+   ├─ turnSlots (claim/release/runWhenIdle)              ← scheduler / anti-focus-theft
+   ├─ vault.getSecret + safeFetch + webFetch + audit     ← key & egress
+   └─ runUserTurn(...)   ← the INNER LOOP (the only thing B relocates)
 ```
 
-### App — `app-tab.js`
-The loop lives in the host page (extension origin). The App's `runner.html`
-iframe is opaque-origin and **chrome-stripped** ("MV3 strips ALL `chrome.*` APIs
-from sandboxed pages") — keyless, no `runtime.sendMessage` — so the loop cannot
-live there; the host mutates the app by `postMessage('app-body')` + OPFS write +
-`chrome.tabs.reload`, which is the *existing* mechanism. **App-specific
-constraint:** the agent-edit update path is `app-client.reloadTab` (a *full page
-reload*), which nukes an in-memory loop. The App resident must persist its loop
-state to OPFS and rehydrate on reload — exactly the Notebook DECISIONS #24
-"durable state → OPFS, never a module global" model. Insertion: after
-`app/tab-ready` (`app-tab.js:394`).
+- **Model A:** the resident runs through the whole stack in the SW —
+  `runAgentTurn({ sessionId: resident })`. The wrapper enforces spend, clamp,
+  scheduling; the loop calls `callModel`/egress directly. **Zero new turn
+  runtime** — it reuses the existing driver, parameterized by session id.
+- **Model B (Phase 2):** relocate **only `runUserTurn`** into a per-tab worker.
+  The wrapper — cost meter, clamp, scheduler, key, egress — **stays in the SW**,
+  now talking to the relocated loop over a streaming proxy (`callModel` Port +
+  egress relay + a vault-`unlocked` relay + cross-boundary abort). Because the
+  enforcement never leaves the SW, B does **not** reintroduce the regressions the
+  split's first draft had (uncapped spend, an unclamped inbound path, an invisible
+  second scheduler — all were artifacts of moving the *wrapper*, which we never
+  do).
 
-## The message channel — `tell_instance`
+**The design rule for A, so A supports B:** keep every key/egress/cost/clamp/
+scheduler concern in the turn-driver wrapper (where it already is), and keep the
+resident loop's IO behind the existing injected `REQUIRED_CTX` seam. Then B is the
+single, well-scoped act of filling that ctx from a worker-proxy instead of
+in-process. Spec the seam once; cross it later.
 
-The parent (or any session, or the user) has **no direct path** into a tab —
-message-only. That's the actor boundary, and it's structural: the parent doesn't
-*have* the instance tools (goal #2), so its only verb is "tell."
+## What A ships vs what the split (Phase 2) adds
 
-- **Tool:** `tell_instance({ to, message, sync? })`. `to` is the instance id.
-- **Delivery:** the SW resolves `tracker.getTabId(to)` and does a *targeted*
-  `browser.tabs.sendMessage(tabId, {type:'<kind>/tell', id, message})` — targeted
-  sends already work in every client. The tab's existing raw `onMessage` switch
-  gets one new case (the sanctioned exception path; tabs don't use the
-  dispatcher).
-- **Mailbox:** the tab loop has its own local turn-slot; an inbound `tell`
-  `enqueue`s and runs when idle, mirroring `turnSlots.runWhenIdle` so it **never
-  interrupts in-flight work** (DECISIONS #20). N senders serialize behind one
-  slot — the single-consumer actor mailbox, now *per tab* instead of per SW
-  session.
-- **Reply:** re-enters the *sender* as a `synthetic:true` wake turn (the
-  DESIGN-11 path), `wrapUntrusted`-fenced. **Mandatory for App residents** (an App
-  renders attacker content; its agent's report is model-authored over hostile
-  bytes). Only the "resident `<id>` replied" framing is trusted.
-- **`sync:true`:** a fresh read-only query, never a blocking wait on the
-  resident's slot (deadlock / focus-theft). Same resolution as the runner. Or
-  drop `sync` (open question).
+| | Model A (ship now) | The split (Phase 2, JS-safety) |
+|---|---|---|
+| Inner loop runs | SW heap | per-tab worker (spawned by the host page) |
+| Key in the loop's realm | held for `callModel` (SW heap) | **none** — `callModel` proxied |
+| Defends prompt-injection | yes (gated tools) | yes (identical) |
+| Defends a JS exploit of the loop reaching the key | **no** — shared SW heap | **yes** — the actual delta |
+| New build | deny-set + `tell_instance` + `kind:'resident'` | streaming Port + abort + vault relay + worker host |
+| Trigger | now | untrusted **code** live (dweb dwapps) + A battle-tested |
+
+The split's value is real and the owner wants it sooner-not-later — but it is
+precisely the JS-heap-isolation hardening, *not* the injection-boundary claim, and
+it rides A's seam. Until then, A's keyless *tool* context (`restrictCtxCapabilities`
+already strips `getSecret`/`safeFetch` from the tool ctx) is the proportionate
+mitigation for the content threat.
+
+## Hardenings carried from the adversarial review
+
+A structurally **avoids** the split's four regressions (the loop is on the SW, so
+spend-cap, scheduler, and clamp are native; a tab discard or App `reloadTab` can't
+nuke a loop that isn't in the tab). Three findings still apply to A and are folded
+in:
+
+- **Ephemeral confirm for residents.** `sessionConfirmGrants` banks a blanket
+  `yes_session` per session (`service-worker.js:1802`); a *persistent* resident
+  would turn one user approval into standing self-approval it replays every turn.
+  Residents use **per-turn** grants (no `yes_session` banking) — the runner's
+  grant-less posture.
+- **`tell_instance` inherits the inbound-clamp posture.** A `tell` from the user's
+  own attended chat is first-party. A `tell` from an **unattended/cross-trust**
+  sender (a scheduled task, a peer message) is inbound and must ride the
+  `ctx.inbound` clamp that `FEATURE-SCHEDULED-TASKS.md` /
+  `FEATURE-FIRST-CLASS-MESSAGING.md` are building. There must be **one** clamp;
+  `tell_instance`'s non-attended path gates on it.
+- **SW-side reply correlation** (above) — never a persisted sender pointer.
 
 ## Context shedding (goal #2)
 
-The parent sheds **all** vm/notebook/app instance tools — the hard structural
-division, so the savings don't erode as instances accumulate (unlike
-`INSTANCE_GATED_TOOLS`' progressive disclosure, which re-bloats once a chat has
-one of each kind). The parent keeps a tiny stub: **create-a-tab**, **`tell_instance`**,
-**list**. The heavy engine prose (the §Sandboxes + WebVM blocks in
-`system-prompt.txt`, ~8.7 KB) moves into each resident's byte-stable
-`*_RESIDENT_PROMPT`, where the per-env toolset can expand *aggressively* (verbose,
-specialized) because it never touches the parent window. `js_run` stays on the
-parent. Honest accounting: net positive for the parent, but a persistent resident
-prompt re-incurs the specialized prose per resident — recompute if residents are
-always-warm vs lazy.
+Parent keeps create + `tell_instance` + list (~5 tools); the ~23 instance tools
+move onto residents (minus `js_run`). Net: ~4.5–6 k tokens off every parent turn,
+non-eroding. Recompute the per-resident prompt cost if residents go always-warm vs
+lazy (below).
 
 ## Lifecycle
 
-- **Binding: structural** (the tab-tracker entry). No ownership map.
-- **Execution: lazy.** The loop is the tab's, persistently (one resident session
-  per tab, `kind:'resident'`), but it only *runs* when it has a message —
-  idle/no-tokens between. Structural identity ≠ always-running loop.
-- **Persistence:** the resident session persists in IDB; the instance persists
-  via registries + OPFS + per-VM disks; on SW boot `registry.load()` +
-  `tabTracker.bootstrap()` re-adopt live tabs (the tab loop re-announces on its
-  next SW call — the SW remembers only `{id, tabId, ready}`). App residents
-  rehydrate loop state from OPFS on `reloadTab`.
-- **Death:** `tabs.onRemoved` → the resident sleeps (instance + session survive)
-  or, on explicit `vm_delete`/`app_delete`, archives. Generalize
-  `onTabClosed → queue.interrupt` (VM-only today, `service-worker.js:2031`) to all
-  three kinds so a closing tab cancels the resident's in-flight SW proxy calls.
-- **Orphans dissolve.** No pointer means no stale pointer: instance-without-tab is
-  the normal dormant state; tab-closed-instance-alive reconstitutes via
-  `ensureTab` on the next message; there is no "session owns a dead instance"
-  case because the binding is the tab, not a field.
-
-## Durability (corrected — a minor bounded benefit, not a primary reason)
-
-The earlier "the SW dies every 30 s, so the tab is necessary" framing was
-overstated. Corrected, from the code:
-
-- **Tab outlives the SW: confirmed.** `service-worker.js:2737`: "Chrome kills
-  the SW after 30 s idle but leaves tabs alone."
-- **The keepalive already exists** (the owner's "messy tick that works"):
-  `offscreen.js` holds a `sw-keepalive` Port + 20 s heartbeat. So the SW is held
-  alive *during work* today.
-- **The benefit is bounded.** The tab preserves the loop's *state* (resumable),
-  but *forward progress* needs an alive **and unlocked** SW — the **vault lock**
-  (45 min) is the real wall, and it binds regardless of where the loop runs (defer
-  like async-subagents). Tabs are also discardable under memory pressure
-  (`offscreen.js:49` notes the same for the offscreen doc). And Model A can
-  resume via persistence too. So durability is a *modest* edge for B — real, but
-  **not** why B is chosen (realm isolation + no-shared-heap + parallelism are).
-
-## The worker option
-
-The loop can run on the host page's main thread, or in a **dedicated Worker the
-host page spawns**. The worker variant: dies with the tab (still structurally
-bound), runs off the UI thread (doesn't compete with VM/app rendering), and —
-because `chrome.*` isn't exposed in a dedicated worker — *physically cannot* reach
-the vault, forcing the no-key discipline by construction (it proxies through the
-host page → SW). Cost: an extra postMessage hop (worker → host → SW). Recommend
-the worker variant for WebVM/App (heavy rendering) and bench it against
-main-thread for Notebook. This is the literal reading of the owner's "its own
-worker."
+- **Binding: structural** (tracker entry). **Execution: lazy** — the resident is a
+  persistent session but its loop only *runs* on a `tell` (idle/no-tokens between).
+- **Persistence:** the resident session persists in IDB (`sessions/store.js`); the
+  instance persists via registries + OPFS + per-VM disks; on SW boot
+  `registry.load()` + `tabTracker.bootstrap()` re-adopt live tabs. A `tell` to a
+  resident whose tab is gone re-spawns it via `ensureTab` (the resident is data,
+  the tab is reconstitutable).
+- **Death:** `tabs.onRemoved` → resident sleeps (session + instance survive) or, on
+  `vm_delete`/`app_delete`, archives. Generalize `onTabClosed → queue.interrupt`
+  (VM-only today, `:2031`) to all kinds so a closing tab cancels in-flight work.
 
 ## Security / invariants
 
-- **The DK never enters the tab.** `callModel` is proxied; `getSecret` is SW-only;
-  the loop's ctx has no key/egress closure (the `restrictCtxCapabilities` posture,
-  now structural).
-- **`confirm` + `appendAudit` MUST stay SW-proxied.** If a keyless tab could
-  self-approve egress or skip audit, the isolation thesis collapses — an
-  untrusted-input tab could authorize its own exfil. Cheap (one-shot), so this is
-  fine.
-- **`webFetch` (open-web, allowlist-free) is the real exfil surface**, distinct
-  from `safeFetch` (provider-credentialed). Both proxy to the SW; for an
-  untrusted-input tab, deny open-web tools entirely (the runner already does —
-  generalize it).
-- **The isolate never hosts the loop** (CheerpX guest / sealed worker / opaque
-  iframe are keyless by design; that's the point).
-- **Capability re-admission:** a resident holding `vm_import`/`app_create`
-  re-admits `webFetch`/`dweb` closures — but those are now *proxied to the SW*,
-  which gates them; the closure in the tab is a relay, not the capability.
-- **Cross-boundary abort** is a security control, not just UX: Stop / spend-limit
-  must cut a live model stream.
-- **Unchanged:** depth cap, trust-mode inheritance, the egress chokepoint as the
-  one network boundary, per-action audit.
+- **Keyless tool context** (`restrictCtxCapabilities`) — against the content
+  threat. The **shared SW heap is the known soft spot** (`docs/SUBAGENTS.md` names
+  it); A accepts it as proportionate for untrusted *content* and Phase 2 closes it
+  for untrusted *code*.
+- **`confirm`/`audit` are SW-authoritative** (native in A; proxied in B). Residents
+  never self-approve (ephemeral grants).
+- **`webFetch` (allowlist-free, open-web) is the real exfil surface** — deny
+  open-web tools to untrusted-input residents, as the runner does.
+- **The isolate is the untrusted-code boundary** in both A and B (the loop never
+  runs in the guest/worker/iframe).
+- Reply `wrapUntrusted`; depth/trust/audit unchanged.
 
 ## Specifically NOT to do
 
-- Run the loop in the isolate (guest/worker/iframe) — keyless by design; it's the
-  untrusted thing.
-- Run the loop in the offscreen doc — shared multiplexed context; reintroduces the
-  ownership map (fails goal #1).
-- Resurrect the `ownerSessionId` pointer — the binding is the tab-tracker entry.
-- Rely on CSP to keep the vm/app tabs keyless — only the Notebook page has
-  `connect-src 'none'`; for VM/App the key must be withheld **by construction**
-  (never injected), not by CSP.
-- Keep `vm/run` as the loop's driver — it becomes an in-process `runViaShell`
-  call; the SW brokers only the model call + egress.
-- Let App `reloadTab` nuke loop state — persist to OPFS + rehydrate (DECISIONS #24).
-- Reuse `sw/web-fetch` for the model call — it's one-shot/buffered; the model call
-  must stream over a Port.
+- Resurrect an `ownerSessionId` pointer — the binding is the tracker entry.
+- Build the streaming proxy now — that's Phase 2; A reuses the SW turn-driver.
+- Move the cost meter / clamp / scheduler off the SW — ever (that's what creates
+  the regressions; the wrapper stays SW-side in both models).
+- Give residents standing `yes_session` grants.
+- Treat `js_run` as an instance; run the loop in the isolate.
 
 ## Open questions
 
-- **Is B worth its cost over Model A?** The streaming proxy + abort + vault-defer +
-  per-step serialization are B-only. A delivers goals #1/#2 and most of #3 far
-  cheaper. B's case is realm isolation for the untrusted-input future + no shared
-  SW heap + parallelism. *This is the question for the adversarial review.*
-- **Streaming transport:** a `chrome.runtime.connect` Port (recommended) vs chunked
-  `sendMessage`s vs `ReadableStream` transfer. The Port is the only one that cleanly
-  preserves backpressure + abort.
-- **Which kinds get residents by default?** The savings/isolation case is strongest
-  for WebVM; Apps/Notebooks may not be worth the per-step proxy cost — per-kind,
-  not all-or-nothing.
-- **App OPFS-rehydrate model** — how much loop state survives a `reloadTab`, and
-  does an agent-edit-mid-turn corrupt it?
-- **One inbound clamp.** A resident woken by `tell_instance` is an inbound/unattended
-  turn — the same shape `FEATURE-SCHEDULED-TASKS.md` and
-  `FEATURE-FIRST-CLASS-MESSAGING.md` each contend with. There should be **one**
-  `ctx.inbound` clamp across all three; defer to whichever lands it.
-- **Per-step serialization ceiling** — at what prompt size does crossing the tab↔SW
-  boundary every step become the bottleneck?
+- **Which kinds get residents by default?** WebVM has the strongest case; Apps /
+  Notebooks may not be worth the message hop — per-kind.
+- **The inbound clamp** is a shared dependency (scheduled-tasks /
+  first-class-messaging); `tell_instance`'s unattended path gates on it.
 - **The user talking to a resident** in the side panel — `kind:'resident'` is a
-  first-class session; does it appear in `/chats`, or only via the tab?
+  first-class session; does it appear in a switcher, or only via the tab?
+- **Phase-2 trigger criteria** — what concretely counts as "untrusted code live"
+  (the first dweb dwapp execution path?) that flips the split on.
 
 ## Phasing
 
-1. **P0 — the streaming `callModel` SW proxy + ONE tab-host loop (Notebook).**
-   Notebook is the binding case (`connect-src 'none'` forces the proxy). Prove the
-   Port-streamed model call + cross-boundary abort + vault-lock deferral end to
-   end, behind a feature flag. *This is the riskiest, most load-bearing slice —
-   nothing else matters if the streaming proxy doesn't hold.*
-2. **P1 — WebVM + App loops, `tell_instance`, parent tool-shed.** Generalize the
-   loop to the other two host pages (App with OPFS-rehydrate); ship the message
-   channel; move vm/notebook/app tools off the parent.
-3. **P2 — persistence + the conversational surface.** `kind:'resident'`,
-   side-panel "talk to this instance," the worker variant.
-4. **P3 — durable resume across vault unlock / browser restart** (DESIGN-08
-   continuation). Maybe never; the in-session resident is already useful.
+1. **P0 — Model A core.** `kind:'resident'`; structural tab-tracker binding; the
+   tool-shed deny-set; `tell_instance` (SW-side correlation + mailbox); residents
+   run through the existing `runAgentTurn`. Ephemeral confirm. Behind a flag.
+   *Battle-test + release this.*
+2. **P1 — persistence + the conversational surface.** Durable resident sessions;
+   the side-panel "talk to this instance" affordance; per-kind `*_RESIDENT_PROMPT`.
+3. **P2 — the split (Model B), for JS-safety.** Relocate `runUserTurn` into a
+   per-tab worker behind the proxy (streaming `callModel` Port, egress relay,
+   vault-`unlocked` relay, cross-boundary abort), wrapper staying SW-side.
+   Triggered by untrusted-code use cases + a battle-tested A. *Desirable
+   sooner-not-later — the seam is designed for it from P0.*
+4. **P3 — durable resume** across vault unlock / browser restart (DESIGN-08).
 
-## Why not Model A / the gate (the honest counter-case)
+## The seam is the bet
 
-The cheapest thing that delivers goals #1 and #2 is **Model A + a parent
-tool-shed**: bind the loop 1:1 to the tab-tracker entry but keep it on the SW
-heap, and move the engine tools off the parent. No streaming proxy, no abort
-plumbing, no vault re-plumbing. It gets structural binding, the lean parent, and
-— via `restrictCtxCapabilities` — a keyless tool context. For most of what the
-owner wants, A is enough, and a reviewer should push hard on whether B's delta is
-worth the streaming-proxy build.
-
-B earns the difference only on the third goal taken seriously: when the instances
-will host genuinely untrusted inputs (untrusted git repos, API responses,
-dweb-delivered code — the future the owner named), the difference between
-"stripped closures on the shared SW heap" and "the loop in its own renderer with
-no key in scope" is the difference between a convention and a boundary. And N
-residents on N renderers instead of N on one single-threaded SW heap is the
-honest expression of "tabs shouldn't be global mutable objects." If that future
-is real, build B. If it isn't yet, A is the lazier truth — and this spec should
-lose to it.
-
-**The tab is the agent. Make the binding structural, keep the key in the SW, and
-prove the streaming proxy before anything else.**
+A ships the actor model and the lean parent now, regression-free, by reusing the
+SW turn-driver and a one-table tool-shed. The split is then **one well-scoped
+relocation** — move the inner loop into a per-tab worker, leave the enforcement
+wrapper in the SW — for the day untrusted *code* runs. **Design the seam once
+(P0); cross it when the threat arrives (P2).** That's why A directly buys B.

--- a/docs/specs/DESIGN-17-resident-agents.md
+++ b/docs/specs/DESIGN-17-resident-agents.md
@@ -22,7 +22,7 @@
 > Read first: `docs/SUBAGENTS.md` (a resident is "a session with parentage" — the
 > shape reused; and the global-registry / "no owner check" decision this narrows),
 > `docs/specs/DESIGN-11-async-subagents.md` (the wake/mailbox + runaway-guard
-> reused for `tell_instance`), `DESIGN.md` §8.5 (which instances are in scope).
+> reused for `message_resident`), `DESIGN.md` §8.5 (which instances are in scope).
 
 ## Motivation
 
@@ -52,7 +52,7 @@ Its loop runs **on the SW heap**, through the existing `turn-driver.js` →
    registry record (a *routing* pointer — below);
 2. it is **the only kind of session that may hold instance-mutating tools**, and
    then only for *its own* instance;
-3. you **reach it only by message** (`tell_instance`).
+3. you **reach it only by message** (`message_resident`).
 
 `js_run` (headless, ephemeral, no instance) stays a parent tool. Scope is the
 three tab-hosted kinds (§8.5).
@@ -64,7 +64,7 @@ current host (reconstitutable via `ensureTab`); the binding must survive the tab
 closing (a VM persists when its tab closes). So:
 
 - **The binding is a persisted `residentSessionId` field on the registry record**
-  (`registry-factory.js`), set when the resident is minted. `tell_instance`
+  (`registry-factory.js`), set when the resident is minted. `message_resident`
   resolves `instanceId → residentSessionId` from there; the `tab-tracker` is used
   only to ensure the tab is live when the resident needs to act (`ensureTab`).
 - **This is not the ownership *gate* the earlier draft rejected.** That gate was a
@@ -122,9 +122,9 @@ tool **fails closed at the gate** for them, and a resident cannot mutate a
 stay global and id-addressable, as `docs/SUBAGENTS.md` has them — only *mutation*
 is tiered; goal #1 is the mutation half, honestly scoped.)
 
-## Move 3 — the message channel: `tell_instance`
+## Move 3 — the message channel: `message_resident`
 
-`tell_instance({ to, message, sync? })`; `to` is the instance id → resolve
+`message_resident({ to, message, sync? })`; `to` is the instance id → resolve
 `residentSessionId` (Move 1) → `turnSlots.runWhenIdle(residentSessionId, fn)`
 (the serializing mailbox: runs when the resident is idle, **never interrupting an
 in-flight turn**, DECISIONS #20). The resident's turn is
@@ -141,7 +141,7 @@ residents — they render attacker content). Correlation is pinned **SW-side**
   **`!synthetic && senderSessionId === getActiveSessionId()`** (attended,
   first-party). The unattended path (peer messages, scheduled tasks) is **blocked
   at P0** and unlocks only when the shared clamp lands (P1+).
-- **Runaway guard.** `tell_instance` reuses the async-subagents `RATE_CAP` /
+- **Runaway guard.** `message_resident` reuses the async-subagents `RATE_CAP` /
   `OUTSTANDING_CAP` per sender (a resident↔resident or parent↔resident ping-pong
   must be bounded — see cost, below).
 
@@ -195,8 +195,8 @@ seam. Then B is one scoped relocation. Spec the seam once; cross it later.
 A resident is a *separate session*. `makeTurnCostTracker` (`cost/turn-tracker.js`)
 checks `limitUsd` **per session**, so **N residents = N independent caps**: the
 user's attended chat hitting its limit does not stop its residents, and a
-`tell_instance` ping-pong burns two independent caps. P0 must therefore (a) carry
-the `tell_instance` runaway guard (Move 3), and (b) **document** that residents
+`message_resident` ping-pong burns two independent caps. P0 must therefore (a) carry
+the `message_resident` runaway guard (Move 3), and (b) **document** that residents
 multiply the cap by live-resident count. A true cross-session rollup into one
 owning-user budget does not exist today and is an open question (below), not a P0
 claim.
@@ -208,12 +208,12 @@ A structurally avoids the split's four regressions (loop is on the SW). Folded i
 - **Ephemeral resident confirm.** `sessionConfirmGrants` banks a blanket
   `yes_session` per session; a *persistent* resident would replay one approval
   every turn. Residents use **per-turn** grants (the runner's grant-less posture).
-- **`tell_instance` P0 fail-closed** on synthetic/unattended senders (Move 3).
+- **`message_resident` P0 fail-closed** on synthetic/unattended senders (Move 3).
 - **SW-side reply correlation** (Move 3) — never a persisted sender pointer.
 
 ## Context shedding (goal #2)
 
-Parent keeps create + `tell_instance` + list; the ~23 instance tools move behind
+Parent keeps create + `message_resident` + list; the ~23 instance tools move behind
 the `resident` tier (minus `js_run`). Non-eroding (unlike `INSTANCE_GATED_TOOLS`
 progressive disclosure). Net ~4.5–6 k tokens off every parent turn; the engine
 prose moves into per-kind `*_RESIDENT_PROMPT`. (Honest: the per-resident prompt
@@ -257,7 +257,7 @@ tabless instance re-spawns the tab via `ensureTab`. Generalize
 - **Which kinds get residents by default** (WebVM strongest; per-kind).
 - **Cross-session spend rollup** — do residents share the owning user's budget, or
   is per-session-cap-× -tab-count acceptable? (No rollup exists today.)
-- **The inbound clamp** is the shared dependency that unlocks `tell_instance`'s
+- **The inbound clamp** is the shared dependency that unlocks `message_resident`'s
   unattended path; P0 ships attended-only without it.
 - **The user talking to a resident** — does `kind:'resident'` appear in a switcher
   or only via the tab?
@@ -270,7 +270,7 @@ tabless instance re-spawns the tab via `ensureTab`. Generalize
    kind-switches, the `/chats` filter, store-load default); the **`resident`
    exposure tier + dispatch-gate refusal + closure strip + per-instance pin +
    the dispatcher test** (Move 2 — the security spine); the instance→resident
-   `residentSessionId` binding; `tell_instance` (SW correlation + mailbox +
+   `residentSessionId` binding; `message_resident` (SW correlation + mailbox +
    runaway guard + the `!synthetic && active` fail-closed gate); the kind-aware
    resident turn branch (exposure/descriptors/`*_RESIDENT_PROMPT`/`activeTabId`);
    ephemeral confirm; resident-spawn wired across all three trackers. Behind a

--- a/docs/specs/DESIGN-17-resident-agents.md
+++ b/docs/specs/DESIGN-17-resident-agents.md
@@ -1,0 +1,479 @@
+# DESIGN-17 — resident tab agents: the tab IS the agent (loop in the host page, key in the SW)
+
+> Status: DESIGN. Nothing here is implemented. Feature number 17.
+> Major refactor — built on the `experimental/resident-tab-agents` branch.
+> Read first, in order: `docs/SUBAGENTS.md` (this OVERTURNS its §"The two
+> surfaces" claim that "the agent loop runs [in the SW], same heap as any
+> subagent" and its §"Isolation is a SESSION boundary, not a RESOURCE
+> boundary"); `docs/specs/DESIGN-11-async-subagents.md` (the wake/mailbox
+> substrate reused for `tell_instance`); `DESIGN.md` §8.5 + `docs/DECISIONS.md`
+> #25 (the sandbox taxonomy — which instances are in scope) and #24 (Notebook
+> durable-state-to-OPFS, the model the App loop must follow); the existing
+> tab→SW proxy (`vm-tab.js swFetch` → `routes/engine.js` `sw/web-fetch`;
+> `notebook-tab.js`'s `subagent/spawn` relay) is the precedent the model-call
+> proxy generalizes.
+>
+> The one-line thesis: **a tab-hosted engine instance runs its own agent loop,
+> in its own host page, and the only agent that may drive that instance IS that
+> loop — structurally, because the loop lives where the instance lives.** No
+> ownership pointer to track (the binding is the tab-tracker entry); the
+> provider key never enters the tab (the loop proxies model calls + egress to
+> the SW); the parent reaches a tab only by message. This is the do/get/check
+> browser-runner trust model, generalized from one disposable browser tab to
+> every stateful tab — and made persistent.
+
+## Motivation
+
+The owner's three observations (DESIGN-17 conversation), now the three goals:
+
+1. *"Tabs as global objects any session can mutate bothers my functional
+   sensibilities."* → **Functional purity of instance access.**
+2. *"Context bloat from all these tool calls and instructions."* → **A lean
+   parent context that doesn't re-bloat as instances accumulate.**
+3. *"We already split a narrow browser runner for isolation — generalize it …
+   code could pull things (git repos, API endpoints, dweb-delivered code) that
+   may not be trusted."* → **Isolation: a per-tab, secret-less, egress-proxied
+   agent, extending the runner's untrusted-input trust model to every tab.**
+
+### Why not the ownership gate (the rejected v1 of this spec)
+
+The first draft of DESIGN-17 proposed an `ownerSessionId` mutation gate: stamp
+an owner on each instance record, refuse cross-session mutation. The owner
+rejected it, correctly: **that is imperative ownership-bookkeeping** — a mutable
+field you stamp, read, and reconcile, with a tail of failure modes
+(transfer-on-settle, brick-the-instance-on-subagent-exit, stale pointers) that
+exist *only because the agent and the instance are two things joined by a
+pointer that can go stale.* Make the binding **structural** — the agent lives
+*in* the tab, 1:1, born and dying with it — and that entire category of bug
+stops being expressible. There is no pointer to dangle. This is the better
+architecture, and the grounding confirmed the binding substrate already exists
+(`tab-tracker.js`, below).
+
+This spec is therefore **Model B**: the loop runs in the tab's host page. It was
+chosen over the ownership gate (above) and over **Model A** (loop stays on the
+SW heap, merely bound 1:1 to the tab lifecycle). Model A is a serious, cheaper
+alternative; it is given a fair hearing in "Why the loop lives in the tab," and
+the open question of whether B's extra cost is worth it is flagged for the
+adversarial review.
+
+## Scope: the three tab-hosted kinds. js_run is out.
+
+Per `DESIGN.md` §8.5, the candidates are the **three tab-hosted, persistent**
+kinds — **WebVM, Notebook, App**. The **headless `js_run` worker** has no tab,
+is ephemeral-per-job, and is the agent's *own throwaway compute* (`primitive:
+'notebook'` but no instance, no lifecycle). It **stays on the parent**, a
+stateless tool, unchanged. Anything in this spec about "the tab loop" excludes
+`js_run`.
+
+## The core decision
+
+Three moves, each landing on existing code:
+
+1. **The binding is structural — the tab-tracker entry.** `tab-tracker.js`
+   already maps `byId: Map<instanceId, {tabId, ready, …}>`, born on
+   `onTabReady(id, sender.tab.id)` (wired at `service-worker.js` ~2007) and
+   evicted on `tabs.onRemoved → onTabRemoved(tabId)` (~2031). *That map is the
+   resident binding.* The agent's lifecycle hangs off those exact events — no
+   `ownerSessionId`, no resident registry, no orphan reconciliation. "Born on
+   tab create, dies on tab close" is already the tracker's contract.
+
+2. **The loop runs in the tab's HOST PAGE** (`vm-tab.js` / `notebook-tab.js` /
+   `app-tab.js` — all `chrome-extension://` origin module scripts). It does
+   **not** run in the SW, and it does **not** run in the untrusted isolate (the
+   CheerpX guest, the sealed Notebook worker, or the App's opaque-origin
+   iframe). The isolate is keyless by design; the host page drives it (it
+   already does — `vm-tab.js runViaShell`, `app-tab.js` posting `app-body` into
+   the iframe). Optionally the loop runs in a **dedicated Worker the host page
+   owns** (off the UI thread; see "The worker option").
+
+3. **The SW is demoted to an on-demand key/egress service.** The loop never
+   holds the provider key (vault DK). It proxies the model call + all egress +
+   audit + confirm to the SW, which is the *only* holder of `vault.getSecret`
+   and `safeFetch`. The SW is woken by the tab's message (MV3 restarts it on
+   demand); it does not need to be alive between calls.
+
+A resident agent is still the **r** letter — an agent loop — bound to an **e**
+instance. It is **not** a new engine kind and not a `subagent-tab/` page. The
+§8.5 taxonomy is untouched; this is a *host-lifecycle* feature.
+
+## What already exists (the owner was half-right)
+
+The owner said "we already have `peerd.runAgent` / `spawn_subagent` for exactly
+this." Half true, and the half that's true is load-bearing:
+
+- **The request bridge ships.** `peerd.runtime.runAgent` (in the Notebook
+  worker, `worker-source.js:150`) posts `{type:'subagent-request', rid, args}`
+  to its host page; the host page (`notebook-tab.js:206-234`) relays
+  `browser.runtime.sendMessage({type:'subagent/spawn', …})` to the SW route
+  (`routes/sessions.js:261`), which runs the loop and posts the result back.
+  `offscreen/job-runner.js:112` does the identical relay. **But today the loop
+  runs in the SW** — the host page is a *pure relay*. `docs/SUBAGENTS.md` states
+  it flatly: "the agent loop runs there, same heap as any subagent." **Model B
+  inverts exactly this sentence.** The plumbing (request relay, key-in-SW,
+  result-back) is reusable; the loop-in-the-tab is net-new.
+- **The egress proxy ships, verbatim reusable.** `vm-tab.js swFetch` →
+  `routes/engine.js` `sw/web-fetch` → `webFetch`/`vmHttpFetch` (denylist + SSRF
+  + audit). A tab loop proxying `webFetch` is a *solved problem* — copy it.
+- **The loop is fully DI'd.** `agent-loop.js runUserTurn`'s `REQUIRED_CTX =
+  ['callModel','getSecret','safeFetch','sessions','getSystemPrompt',
+  'appendAudit']` — every IO surface injected, nothing imported. And `callModel`
+  (`registry.js:172`) is a *pure router* that takes `getSecret`+`safeFetch` as
+  call args (the adapter reads the key only inside `callAnthropic`,
+  `anthropic.js:114`). **So the loop body needs zero changes** — the tab injects
+  SW-proxied `callModel`/`getSecret`; the DK never has to leave the SW.
+- **The keyless-loop posture is codebase-native.** `restrictCtxCapabilities` +
+  `CAPABILITY_CONSUMERS` (`spawn.js:102`) already strip `getSecret`/`safeFetch`
+  (empty consumer lists → always removed) from a narrowed child's tool context —
+  the do/get/check runner already reasons over untrusted pages with no key/egress
+  closure in scope. Model B generalizes that from "the child's tool ctx" to "the
+  whole loop, including the model call."
+
+## Why the loop lives in the TAB, not the SW (Model A) — honest
+
+Model A (loop on the SW heap, bound 1:1 to the tab-tracker entry) delivers goals
+**#1 and #2 for free** and most of #3, at a fraction of the cost: it needs no
+streaming proxy, no cross-boundary abort, no vault-lock deferral re-plumbing —
+the loop keeps direct `callModel`. The structural binding (move #1) and the
+parent tool-shed (goal #2) are *independent of where the loop runs.* So why pay
+for B?
+
+B earns its cost on the parts of goal #3 that A cannot reach:
+
+- **True realm isolation, not stripped closures on a shared heap.** A's
+  capability stripping is real but the loop still executes on the SW heap
+  alongside every other session's data and the live instance graph; safety rests
+  on `restrictCtxCapabilities` being complete. B's loop is in a *different
+  renderer*, with no SW heap in scope at all — for the **untrusted-input future
+  the owner named** (a VM cloning an attacker's git repo, an App running
+  dweb-delivered code), that's the difference between "stripped closures" and "a
+  process boundary." This is the strongest argument and the reason B exists.
+- **No shared SW heap; true parallelism.** A puts N residents on the *one*
+  single-threaded SW heap — N concurrent resident turns serialize, and "N agents
+  mutating one heap" is the very shared-mutable-state smell goal #1 is escaping.
+  B gives each resident its own realm/process: real parallelism, real isolation.
+- **Instance-op locality.** B's loop calls `runViaShell` *in-process* (the VM is
+  in the same tab) — no SW round-trip per shell command, where A drives each
+  `vm/run` over a message. B trades that for a round-trip per *model* call; for an
+  instance-heavy resident (the common case) it's a net win.
+- **Resumability for free.** B's loop state lives in the durable tab, so an SW
+  restart pauses-and-resumes rather than losing the turn. (A can get this too via
+  explicit persist/resume — `goal-runner.js` already does — so it's a modest
+  edge, not decisive.)
+
+**Rejected — the offscreen document as the loop home.** It's the *most* durable
+context (no 30 s death) and has network, but it is a *single shared context*:
+N residents there means a `map<instanceId → agent>` you maintain and check — the
+exact ownership-bookkeeping move #1 rejects. The offscreen doc fails goal #1.
+Only a *per-tab* home makes the binding structural.
+
+## The key/egress proxy — what crosses, what stays local
+
+The loop's only key/egress-bearing dependencies are **`callModel`** (the sole
+vault-toucher) and **`safeFetch`/`webFetch`** (egress). The split:
+
+| Proxy to the SW (never in the tab) | Local to the tab loop |
+|---|---|
+| **`callModel`** — SW injects `getSecret`+`safeFetch`, runs the adapter, streams events back. The DK never leaves the SW. | The loop body (`runUserTurn` reducer), `getSystemPrompt` (string assembly — the resident's specialized prompt) |
+| **`webFetch`/`safeFetch`** — reuse `sw/web-fetch` verbatim (denylist + SSRF + audit) | **Instance ops** — `runViaShell` (VM), `runEval` (Notebook), OPFS-write+reload (App). The instance is co-located; no hop. |
+| **`appendAudit`** — fire-and-forget, one-shot | The tool-dispatch *policy* for instance-only ops (Plan/Act) — the host page is trusted extension code |
+| **`confirm`** — request/response, one-shot | session reducer state in memory (persisted via proxied/coordinated writes — see Lifecycle) |
+
+`getSecret` is **never** in the tab loop's context — it isn't needed there (it's
+only a `callModel` dep, and `callModel` is now proxied).
+
+## The hard part (where the engineering actually is)
+
+Be honest: the key-proxy is the *easy*, precedented half. The real new build is
+three things, none of which exist today:
+
+1. **A STREAMING `callModel` SW proxy.** `callModel` returns
+   `AsyncGenerator<ProviderEvent>` (`text-delta`, `tool-use-*`, `reasoning-*`,
+   `usage`, `message-stop`, `rate-limit-pause`). The existing `sw/web-fetch`
+   route returns a *single buffered base64 body* — **it is not a streaming
+   template.** Model B needs a long-lived `chrome.runtime.connect` **Port** that
+   chunks provider events from the SW back to the tab loop. This is the
+   principal new surface and the riskiest part of the spike.
+2. **A cross-boundary `AbortSignal`.** The loop's Stop / spend-limit / steer
+   contract depends on `ctx.signal` reaching the provider `fetch` to cut the SSE
+   socket. A tab-host loop's local `AbortController` cannot reach the SW's fetch
+   — Model B needs an explicit abort message (tab→SW) that aborts the SW-side
+   provider stream. Without it, Stop cannot cut a live model stream.
+3. **Vault-lock deferral in the tab loop.** The DK is gone at 45-min idle
+   (`vault.js` `DEFAULT_AUTO_LOCK_MS`); `getSecret` throws `VaultLockedError`. A
+   tab outlives the 30 s SW death but **not** the vault lock. The loop must adopt
+   async-subagents' pattern (`async-subagents.js`: hold, subscribe to vault
+   `'unlocked'`, resume) rather than throw mid-turn.
+
+Plus an accepted cost, not a build: **the full prompt** (messages + system +
+tool descriptors) crosses the tab↔SW boundary on *every* model step. For
+untrusted-input tabs this is exactly the desired chokepoint; it is also a real
+per-step serialization cost (`messages` can be large — attachments, snapshots).
+
+## The spike — per kind, grounded
+
+The loop is the same DI'd `runUserTurn` in all three; only the host page wiring
+and the instance-op surface differ. **Notebook is the binding case** — write the
+spike against it first (reasons below).
+
+### Notebook (the binding case) — `notebook-tab.js`
+`notebook-tab/index.html:22` sets page-level **`connect-src 'none'`**. So a loop
+in the Notebook host page **physically cannot fetch the model API** — the
+SW-key-proxy is not a trust preference here, it is a hard CSP requirement. If the
+streaming model proxy works under `connect-src 'none'`, it works everywhere.
+The loop lives in the *page* (the sealed worker is realm-sealed —
+`notebook-neutralizers.js` deletes `fetch`/`WebSocket`/… — and cannot host it).
+Insertion: the kickoff IIFE after `js/tab-ready` (~`notebook-tab.js:503`); the
+loop drives code via the existing `runEval` and reuses the existing
+`subagent/spawn`/`sw/web-fetch` relays for the proxied calls.
+
+### WebVM — `vm-tab.js` (the spike sketch)
+The host page already drives a WASM-confined CheerpX guest and proxies the
+guest's egress (`swFetch` → `sw/web-fetch`). The loop inserts right after
+`boot()` step 11 (`browser.runtime.sendMessage({type:'vm/tab-ready', vmId})`,
+~`vm-tab.js:1402`), *replacing* the SW driving discrete `vm/run` calls with the
+page running the loop and calling `runViaShell` in-process. Sketch:
+
+```js
+// vm-tab.js — after boot() reaches 'ready', stand up the resident loop.
+// The provider key is NEVER in this page: callModel + egress proxy to the SW.
+const sw = (type, payload) => browser.runtime.sendMessage({ type, ...payload });
+
+// (1) The streaming model proxy — a Port, because callModel yields events.
+const proxiedCallModel = (args) => {
+  const port = browser.runtime.connect({ name: 'callModel' });   // NEW SW route
+  return (async function* () {
+    port.postMessage({ kind: 'start', args: stripIO(args) });    // no getSecret/safeFetch cross
+    for await (const ev of portEvents(port)) {                   // text-delta / tool-use / usage / stop
+      if (ev.kind === 'error') throw reviveError(ev.error);
+      if (ev.kind === 'end') return;
+      yield ev.event;
+    }
+  })();
+  // abort: the loop's signal → port.postMessage({kind:'abort'}) → SW aborts the provider fetch
+};
+
+// (2) Instance ops run LOCALLY — no SW hop. The dispatcher for vm_* tools
+//     calls runViaShell directly; only egress-bearing tools (vm_import) proxy.
+const residentDispatch = makeResidentDispatch({
+  webvm: { run: runViaShell, writeFile, import: (url) => sw('sw/web-fetch', { url }) },
+  webFetch: (req) => sw('sw/web-fetch', req),
+  appendAudit: (e) => sw('audit/append', e),       // proxied (NEW thin route)
+  confirm: (q) => sw('confirm/ask', q),            // proxied (reuses confirmAction)
+});
+
+// (3) The loop body is unchanged runUserTurn — only its IO is the proxy.
+const resident = makeResidentLoop({
+  sessionId: residentSessionIdFor(vmId),           // its own persisted session
+  systemPrompt: VM_RESIDENT_PROMPT,                // expanded, env-specialized, byte-stable
+  callModel: proxiedCallModel,
+  toolDispatch: residentDispatch,
+  // getSecret / safeFetch are absent by construction — the key cannot be here.
+});
+
+// (4) Inbound wake — tell_instance lands as a targeted message; the local
+//     turn-slot serializes it so it never interrupts in-flight work.
+browser.runtime.onMessage.addListener((msg) => {
+  if (msg.type === 'vm/tell' && msg.vmId === vmId) resident.enqueue(msg.message);
+});
+```
+
+### App — `app-tab.js`
+The loop lives in the host page (extension origin). The App's `runner.html`
+iframe is opaque-origin and **chrome-stripped** ("MV3 strips ALL `chrome.*` APIs
+from sandboxed pages") — keyless, no `runtime.sendMessage` — so the loop cannot
+live there; the host mutates the app by `postMessage('app-body')` + OPFS write +
+`chrome.tabs.reload`, which is the *existing* mechanism. **App-specific
+constraint:** the agent-edit update path is `app-client.reloadTab` (a *full page
+reload*), which nukes an in-memory loop. The App resident must persist its loop
+state to OPFS and rehydrate on reload — exactly the Notebook DECISIONS #24
+"durable state → OPFS, never a module global" model. Insertion: after
+`app/tab-ready` (`app-tab.js:394`).
+
+## The message channel — `tell_instance`
+
+The parent (or any session, or the user) has **no direct path** into a tab —
+message-only. That's the actor boundary, and it's structural: the parent doesn't
+*have* the instance tools (goal #2), so its only verb is "tell."
+
+- **Tool:** `tell_instance({ to, message, sync? })`. `to` is the instance id.
+- **Delivery:** the SW resolves `tracker.getTabId(to)` and does a *targeted*
+  `browser.tabs.sendMessage(tabId, {type:'<kind>/tell', id, message})` — targeted
+  sends already work in every client. The tab's existing raw `onMessage` switch
+  gets one new case (the sanctioned exception path; tabs don't use the
+  dispatcher).
+- **Mailbox:** the tab loop has its own local turn-slot; an inbound `tell`
+  `enqueue`s and runs when idle, mirroring `turnSlots.runWhenIdle` so it **never
+  interrupts in-flight work** (DECISIONS #20). N senders serialize behind one
+  slot — the single-consumer actor mailbox, now *per tab* instead of per SW
+  session.
+- **Reply:** re-enters the *sender* as a `synthetic:true` wake turn (the
+  DESIGN-11 path), `wrapUntrusted`-fenced. **Mandatory for App residents** (an App
+  renders attacker content; its agent's report is model-authored over hostile
+  bytes). Only the "resident `<id>` replied" framing is trusted.
+- **`sync:true`:** a fresh read-only query, never a blocking wait on the
+  resident's slot (deadlock / focus-theft). Same resolution as the runner. Or
+  drop `sync` (open question).
+
+## Context shedding (goal #2)
+
+The parent sheds **all** vm/notebook/app instance tools — the hard structural
+division, so the savings don't erode as instances accumulate (unlike
+`INSTANCE_GATED_TOOLS`' progressive disclosure, which re-bloats once a chat has
+one of each kind). The parent keeps a tiny stub: **create-a-tab**, **`tell_instance`**,
+**list**. The heavy engine prose (the §Sandboxes + WebVM blocks in
+`system-prompt.txt`, ~8.7 KB) moves into each resident's byte-stable
+`*_RESIDENT_PROMPT`, where the per-env toolset can expand *aggressively* (verbose,
+specialized) because it never touches the parent window. `js_run` stays on the
+parent. Honest accounting: net positive for the parent, but a persistent resident
+prompt re-incurs the specialized prose per resident — recompute if residents are
+always-warm vs lazy.
+
+## Lifecycle
+
+- **Binding: structural** (the tab-tracker entry). No ownership map.
+- **Execution: lazy.** The loop is the tab's, persistently (one resident session
+  per tab, `kind:'resident'`), but it only *runs* when it has a message —
+  idle/no-tokens between. Structural identity ≠ always-running loop.
+- **Persistence:** the resident session persists in IDB; the instance persists
+  via registries + OPFS + per-VM disks; on SW boot `registry.load()` +
+  `tabTracker.bootstrap()` re-adopt live tabs (the tab loop re-announces on its
+  next SW call — the SW remembers only `{id, tabId, ready}`). App residents
+  rehydrate loop state from OPFS on `reloadTab`.
+- **Death:** `tabs.onRemoved` → the resident sleeps (instance + session survive)
+  or, on explicit `vm_delete`/`app_delete`, archives. Generalize
+  `onTabClosed → queue.interrupt` (VM-only today, `service-worker.js:2031`) to all
+  three kinds so a closing tab cancels the resident's in-flight SW proxy calls.
+- **Orphans dissolve.** No pointer means no stale pointer: instance-without-tab is
+  the normal dormant state; tab-closed-instance-alive reconstitutes via
+  `ensureTab` on the next message; there is no "session owns a dead instance"
+  case because the binding is the tab, not a field.
+
+## Durability (corrected — a minor bounded benefit, not a primary reason)
+
+The earlier "the SW dies every 30 s, so the tab is necessary" framing was
+overstated. Corrected, from the code:
+
+- **Tab outlives the SW: confirmed.** `service-worker.js:2737`: "Chrome kills
+  the SW after 30 s idle but leaves tabs alone."
+- **The keepalive already exists** (the owner's "messy tick that works"):
+  `offscreen.js` holds a `sw-keepalive` Port + 20 s heartbeat. So the SW is held
+  alive *during work* today.
+- **The benefit is bounded.** The tab preserves the loop's *state* (resumable),
+  but *forward progress* needs an alive **and unlocked** SW — the **vault lock**
+  (45 min) is the real wall, and it binds regardless of where the loop runs (defer
+  like async-subagents). Tabs are also discardable under memory pressure
+  (`offscreen.js:49` notes the same for the offscreen doc). And Model A can
+  resume via persistence too. So durability is a *modest* edge for B — real, but
+  **not** why B is chosen (realm isolation + no-shared-heap + parallelism are).
+
+## The worker option
+
+The loop can run on the host page's main thread, or in a **dedicated Worker the
+host page spawns**. The worker variant: dies with the tab (still structurally
+bound), runs off the UI thread (doesn't compete with VM/app rendering), and —
+because `chrome.*` isn't exposed in a dedicated worker — *physically cannot* reach
+the vault, forcing the no-key discipline by construction (it proxies through the
+host page → SW). Cost: an extra postMessage hop (worker → host → SW). Recommend
+the worker variant for WebVM/App (heavy rendering) and bench it against
+main-thread for Notebook. This is the literal reading of the owner's "its own
+worker."
+
+## Security / invariants
+
+- **The DK never enters the tab.** `callModel` is proxied; `getSecret` is SW-only;
+  the loop's ctx has no key/egress closure (the `restrictCtxCapabilities` posture,
+  now structural).
+- **`confirm` + `appendAudit` MUST stay SW-proxied.** If a keyless tab could
+  self-approve egress or skip audit, the isolation thesis collapses — an
+  untrusted-input tab could authorize its own exfil. Cheap (one-shot), so this is
+  fine.
+- **`webFetch` (open-web, allowlist-free) is the real exfil surface**, distinct
+  from `safeFetch` (provider-credentialed). Both proxy to the SW; for an
+  untrusted-input tab, deny open-web tools entirely (the runner already does —
+  generalize it).
+- **The isolate never hosts the loop** (CheerpX guest / sealed worker / opaque
+  iframe are keyless by design; that's the point).
+- **Capability re-admission:** a resident holding `vm_import`/`app_create`
+  re-admits `webFetch`/`dweb` closures — but those are now *proxied to the SW*,
+  which gates them; the closure in the tab is a relay, not the capability.
+- **Cross-boundary abort** is a security control, not just UX: Stop / spend-limit
+  must cut a live model stream.
+- **Unchanged:** depth cap, trust-mode inheritance, the egress chokepoint as the
+  one network boundary, per-action audit.
+
+## Specifically NOT to do
+
+- Run the loop in the isolate (guest/worker/iframe) — keyless by design; it's the
+  untrusted thing.
+- Run the loop in the offscreen doc — shared multiplexed context; reintroduces the
+  ownership map (fails goal #1).
+- Resurrect the `ownerSessionId` pointer — the binding is the tab-tracker entry.
+- Rely on CSP to keep the vm/app tabs keyless — only the Notebook page has
+  `connect-src 'none'`; for VM/App the key must be withheld **by construction**
+  (never injected), not by CSP.
+- Keep `vm/run` as the loop's driver — it becomes an in-process `runViaShell`
+  call; the SW brokers only the model call + egress.
+- Let App `reloadTab` nuke loop state — persist to OPFS + rehydrate (DECISIONS #24).
+- Reuse `sw/web-fetch` for the model call — it's one-shot/buffered; the model call
+  must stream over a Port.
+
+## Open questions
+
+- **Is B worth its cost over Model A?** The streaming proxy + abort + vault-defer +
+  per-step serialization are B-only. A delivers goals #1/#2 and most of #3 far
+  cheaper. B's case is realm isolation for the untrusted-input future + no shared
+  SW heap + parallelism. *This is the question for the adversarial review.*
+- **Streaming transport:** a `chrome.runtime.connect` Port (recommended) vs chunked
+  `sendMessage`s vs `ReadableStream` transfer. The Port is the only one that cleanly
+  preserves backpressure + abort.
+- **Which kinds get residents by default?** The savings/isolation case is strongest
+  for WebVM; Apps/Notebooks may not be worth the per-step proxy cost — per-kind,
+  not all-or-nothing.
+- **App OPFS-rehydrate model** — how much loop state survives a `reloadTab`, and
+  does an agent-edit-mid-turn corrupt it?
+- **One inbound clamp.** A resident woken by `tell_instance` is an inbound/unattended
+  turn — the same shape `FEATURE-SCHEDULED-TASKS.md` and
+  `FEATURE-FIRST-CLASS-MESSAGING.md` each contend with. There should be **one**
+  `ctx.inbound` clamp across all three; defer to whichever lands it.
+- **Per-step serialization ceiling** — at what prompt size does crossing the tab↔SW
+  boundary every step become the bottleneck?
+- **The user talking to a resident** in the side panel — `kind:'resident'` is a
+  first-class session; does it appear in `/chats`, or only via the tab?
+
+## Phasing
+
+1. **P0 — the streaming `callModel` SW proxy + ONE tab-host loop (Notebook).**
+   Notebook is the binding case (`connect-src 'none'` forces the proxy). Prove the
+   Port-streamed model call + cross-boundary abort + vault-lock deferral end to
+   end, behind a feature flag. *This is the riskiest, most load-bearing slice —
+   nothing else matters if the streaming proxy doesn't hold.*
+2. **P1 — WebVM + App loops, `tell_instance`, parent tool-shed.** Generalize the
+   loop to the other two host pages (App with OPFS-rehydrate); ship the message
+   channel; move vm/notebook/app tools off the parent.
+3. **P2 — persistence + the conversational surface.** `kind:'resident'`,
+   side-panel "talk to this instance," the worker variant.
+4. **P3 — durable resume across vault unlock / browser restart** (DESIGN-08
+   continuation). Maybe never; the in-session resident is already useful.
+
+## Why not Model A / the gate (the honest counter-case)
+
+The cheapest thing that delivers goals #1 and #2 is **Model A + a parent
+tool-shed**: bind the loop 1:1 to the tab-tracker entry but keep it on the SW
+heap, and move the engine tools off the parent. No streaming proxy, no abort
+plumbing, no vault re-plumbing. It gets structural binding, the lean parent, and
+— via `restrictCtxCapabilities` — a keyless tool context. For most of what the
+owner wants, A is enough, and a reviewer should push hard on whether B's delta is
+worth the streaming-proxy build.
+
+B earns the difference only on the third goal taken seriously: when the instances
+will host genuinely untrusted inputs (untrusted git repos, API responses,
+dweb-delivered code — the future the owner named), the difference between
+"stripped closures on the shared SW heap" and "the loop in its own renderer with
+no key in scope" is the difference between a convention and a boundary. And N
+residents on N renderers instead of N on one single-threaded SW heap is the
+honest expression of "tabs shouldn't be global mutable objects." If that future
+is real, build B. If it isn't yet, A is the lazier truth — and this spec should
+lose to it.
+
+**The tab is the agent. Make the binding structural, keep the key in the SW, and
+prove the streaming proxy before anything else.**

--- a/docs/specs/DESIGN-17-resident-agents.md
+++ b/docs/specs/DESIGN-17-resident-agents.md
@@ -1,294 +1,255 @@
 # DESIGN-17 — resident tab agents: a per-tab session that owns its instance
 
 > Status: DESIGN. Nothing here is implemented. Feature number 17.
-> On branch `experimental/resident-tab-agents`.
->
-> Design history (kept — the rejected paths are load-bearing context):
-> (1) Explored a *tab-hosted loop* (loop in the tab page, SW as key/egress proxy
-> — "the split" / Model B). An adversarial swarm showed its headline
-> justification (renderer isolation vs *prompt-injection*) does not hold — a
-> text-steered loop calls the same gated tools wherever it runs — and that it
-> introduced four SW-side regressions. (2) Pivoted to **Model A** (loop on the SW
-> heap, bound to the tab). (3) A second swarm reviewed the Model-A spec and
-> **killed its first mutation-purity mechanism** ("purity by exposure" — the
-> exposure axis is binary main/not-main and cannot express "resident-only", so a
-> one-line `spawn_subagent({tools:['app_delete']})` mutated any instance). This
-> revision fixes that with a **resident-keyed capability tier + per-instance
-> pin**, and corrects two related over-claims (the instance↔resident *binding*
-> needs a routing pointer; the resident turn is not "zero new runtime"). The
-> kept-strong parts — the "A buys B" seam and the keyless content-threat scoping
-> — are unchanged.
->
-> Read first: `docs/SUBAGENTS.md` (a resident is "a session with parentage" — the
-> shape reused; and the global-registry / "no owner check" decision this narrows),
-> `docs/specs/DESIGN-11-async-subagents.md` (the wake/mailbox + runaway-guard
-> reused for `message_resident`), `DESIGN.md` §8.5 (which instances are in scope).
+> Branch `experimental/resident-tab-agents`. Read first: `docs/SUBAGENTS.md`
+> (a resident is "a session with parentage"; this narrows its global-registry
+> decision), `docs/specs/DESIGN-11-async-subagents.md` (the wake/mailbox +
+> runaway-guard reused for `message_resident`), `DESIGN.md` §8.5 (which instances
+> are in scope).
 
-## Motivation
+## The problem
 
-Three goals, from the owner:
+Two problems, one shape:
 
-1. **Functional purity of instance access** — *"tabs as global objects any
-   session can mutate bothers my functional sensibilities."*
-2. **A lean parent context that doesn't re-bloat** as instances accumulate.
-3. **Isolation** — a per-tab, secret-less agent (the do/get/check browser-runner
-   trust model generalized to every stateful tab); eventually hardened against
-   untrusted **code** (git repos, API responses, dweb-delivered dwapps).
+- **Context.** The main agent carries every execution environment's tooling and
+  instructions at once — the ~23 `vm_*`/`js_*`/`app_*` tools plus their
+  per-environment prompt guidance ride every turn. As one session spins up a VM,
+  then an App, then a Notebook, that surface only grows, and most of it is
+  irrelevant to whatever the agent is reasoning about right now. This is a
+  context-optimization problem, and progressive disclosure
+  (`INSTANCE_GATED_TOOLS`) only softens it — once a chat has one of each kind, the
+  context is back.
+- **Structure.** Tab-hosted instances (WebVM, Notebook, App) are global mutable
+  objects: any session reaches into any instance by id and mutates it. Nothing
+  *owns* an instance — there's shared state and a convention not to clobber it.
 
-A delivers #2 in full, #3 against the live threat (untrusted *content*), and #1
-**by a resident-keyed capability tier** (below — *not* the binary exposure shed
-the first draft proposed). The remaining slice of #3 — JS-level heap isolation
-against untrusted *code* — is Phase 2 (the split), built on A's seam.
+## Goals
 
-## What a resident IS (Model A)
+**Set up a clearer actor structure.** Each tab-hosted instance is owned by one
+agent — a **resident** — that holds that environment's tools and is the only thing
+that drives it. You don't mutate an instance; you **message its resident**
+(`message_resident`). That one move solves both problems: the per-environment
+tooling leaves the main agent (context optimized, and *non-eroding* because it
+never comes back), and "who may touch this instance" becomes structural instead
+of conventional.
 
-A **resident** is a persistent session — `kind:'resident'`, the third
-`SessionKind` member — **one per tab-hosted instance** (WebVM, Notebook, App).
-Its loop runs **on the SW heap**, through the existing `turn-driver.js` →
-`runUserTurn` path. The instance still lives in its tab, driven by the existing
-`vm-client`/`notebook-client`/`app-client` RPC. Three things make it a resident:
+Two forward benefits the actor boundary buys, and which justify the structure
+beyond the immediate win:
+
+- **Security.** A per-instance agent that holds only its environment's tools and
+  no provider key is the do/get/check browser-runner trust model generalized to
+  every tab. The boundary is the natural seam to later harden against untrusted
+  *code* (dweb-delivered dwapps) — see Phase 2.
+- **Purpose-tuned agents.** Each resident is specialized to its environment: an
+  expanded, tuned system prompt, and a narrow toolset that can grow aggressively
+  without taxing anyone else's context. The VM resident can be a shell expert; the
+  App resident a UI builder; and (later) each can run a fit-for-purpose model
+  tier — none of it bloating the orchestrator.
+
+The rest of this doc is the design that delivers the above on Model A (loop on the
+SW heap), and the one seam that lets it later harden into Model B (loop in a
+per-tab worker) without a re-architecture.
+
+## What a resident IS
+
+A **resident** is a persistent session — `kind:'resident'`, a third `SessionKind`
+member — **one per tab-hosted instance**. Its loop runs **on the SW heap**,
+through the existing `turn-driver.js` → `runUserTurn` path. The instance lives in
+its tab, driven by the existing `vm-client`/`notebook-client`/`app-client` RPC.
+Three things make it a resident:
 
 1. it is **bound to its instance** by a persisted `residentSessionId` on the
-   registry record (a *routing* pointer — below);
+   registry record (a *routing* pointer — Move 1);
 2. it is **the only kind of session that may hold instance-mutating tools**, and
-   then only for *its own* instance;
-3. you **reach it only by message** (`message_resident`).
+   then only for *its own* instance (Move 2);
+3. you **reach it only by message** (Move 3).
 
 `js_run` (headless, ephemeral, no instance) stays a parent tool. Scope is the
 three tab-hosted kinds (§8.5).
 
 ## Move 1 — the binding: an instance→resident routing pointer
 
-The resident is bound to its **instance**, not its **tab**. The tab is just the
-current host (reconstitutable via `ensureTab`); the binding must survive the tab
-closing (a VM persists when its tab closes). So:
+The resident is bound to its **instance**, not its **tab** — the tab is just the
+current host (reconstitutable via `ensureTab`), and the binding must survive the
+tab closing (a VM persists when its tab closes).
 
 - **The binding is a persisted `residentSessionId` field on the registry record**
   (`registry-factory.js`), set when the resident is minted. `message_resident`
   resolves `instanceId → residentSessionId` from there; the `tab-tracker` is used
-  only to ensure the tab is live when the resident needs to act (`ensureTab`).
-- **This is not the ownership *gate* the earlier draft rejected.** That gate was a
-  *session→instance owner check on every mutation* (with transfer-on-settle and
-  brick-the-instance failure modes). `residentSessionId` is a *one-directional
-  routing pointer* (find the resident to deliver a `tell`); mutation is **not**
-  gated on it (it's gated by the capability tier, Move 2), so it has none of
-  those failure modes — if the resident session is gone, mint a fresh one; the
-  instance is never bricked. The honest correction to v1: there *is* a pointer;
-  it is addressing, not a per-call owner check.
+  only to ensure the tab is live when the resident needs to act.
+- **This is a routing pointer, not a per-call owner gate.** A session→instance
+  owner check on every mutation would carry transfer-on-settle and
+  brick-the-instance failure modes; `residentSessionId` is one-directional
+  addressing — mutation is gated by the capability tier (Move 2), not by this
+  field — so if the resident session is gone, mint a fresh one and the instance is
+  never bricked.
 - **Minting:** lazy — on the first operation that needs a resident for an
-  instance (the create/first-`tell` path), the resident session is created and
-  its id written to the record. Archived when the **instance** is deleted
-  (`vm_delete`/`app_delete`), not when the tab closes (tab close → dormant;
-  record + `residentSessionId` persist; re-adopted on SW boot after
+  instance. Archived when the **instance** is deleted, not when the tab closes
+  (tab close → dormant; record + pointer persist; re-adopted on SW boot after
   `registry.load()`).
 
 ## Move 2 — the capability tier: who may hold instance-mutating tools
 
-This is goal #1's real mechanism, and it is **enforced at the dispatch gate**,
-not by descriptor hygiene alone (the v1 "purity by exposure" claim was false: the
-exposure axis only knows `main` vs not-`main`, so it cannot keep instance tools
-off a *subagent*).
+The actor structure's real mechanism, **enforced at the dispatch gate** (not by
+descriptor hygiene — the exposure axis is binary `main`/not-`main` and cannot keep
+instance tools off a *subagent*, so a deny-set alone is bypassable by a one-line
+`spawn_subagent({tools:['app_delete']})`).
 
 - **A new authority marker — `resident` — gates the instance-mutating set**
-  (`vm_*`, `app_*`, `js_*` except `js_run`). `exposureGate` (`tools/gates.js`)
-  is extended so these tools are **refused for every ctx whose marker is not
-  `resident`** — `main`, `subagent`, runner, review, and direct dispatch all
-  **fail closed**. The marker is set only by the resident turn path;
-  `buildToolContext` and `spawnSubagent` must **never** set it for a child.
-- **Both spawn surfaces are gated.** The `spawn_subagent` tool *and* the
-  `subagent/spawn` SW route (`routes/sessions.js`, which forwards caller-supplied
-  `tools` verbatim — reachable from a first-party `peerd.runtime.runAgent` shim)
-  must not grant the `resident` marker. A subagent requesting `tools:['app_delete']`
-  is refused at dispatch.
+  (`vm_*`, `app_*`, `js_*` except `js_run`). `exposureGate` (`tools/gates.js`) is
+  extended so these tools are **refused for every ctx whose marker is not
+  `resident`** — `main`, `subagent`, runner, review, direct dispatch all **fail
+  closed**. The marker is set only by the resident turn path; `buildToolContext`
+  and `spawnSubagent` must **never** set it for a child.
+- **Both spawn surfaces are gated** — the `spawn_subagent` tool *and* the
+  `subagent/spawn` SW route (`routes/sessions.js`, which forwards caller `tools`
+  verbatim, reachable from a first-party `peerd.runtime.runAgent` shim).
 - **Closures stripped by construction.** The instance clients/registries
-  (`appClient`/`appRegistry`/`vmClient`/`vmRegistry`/`jsClient`/`jsRegistry`) are
-  injected into every ctx today and are absent from `CAPABILITY_CONSUMERS`
-  (`spawn.js`). Add them so a non-resident ctx has **no closure** to call even if
-  a tool name leaked — defense in depth behind the name gate.
-- **Per-instance pin (cross-resident isolation).** Instance-mutating tools are
-  id-addressed against *singleton* registries (`app_delete(args.appId)` deletes
-  *any* app), so the 1:1 tab binding alone does **not** scope a resident to its
-  own instance. The resident's tool ctx **defaults the target to its bound
-  instance id and rejects a mismatching explicit id.** Without this, a resident
-  could mutate a *sibling* instance.
+  (`appClient`/`vmClient`/`jsClient` + registries) are injected into every ctx
+  and absent from `CAPABILITY_CONSUMERS` (`spawn.js`); add them so a non-resident
+  ctx has **no closure** to call even if a tool name leaked.
+- **Per-instance pin (cross-resident isolation).** Instance tools are id-addressed
+  against *singleton* registries (`app_delete(args.appId)` deletes *any* app), so
+  the binding alone does not scope a resident to its own instance. The resident's
+  tool ctx **defaults the target to its bound instance id and rejects a
+  mismatching explicit id.**
 - **Test the boundary.** A dispatcher test (mirroring `dispatcher.test.js:266`)
   asserts a subagent spawned with `tools:['app_delete']` and no manifest is
-  refused. This is a P0 deliverable, not a nicety — it is the proof goal #1 holds.
+  refused. This is a P0 deliverable — the proof the structure holds.
 
-So the parent (and any non-resident session) cannot mutate an instance because the
-tool **fails closed at the gate** for them, and a resident cannot mutate a
-*sibling* because its ctx is **pinned**. Call it **purity by capability topology**
-— a resident-keyed tier + a per-instance pin, both enforced at dispatch. (Reads
-stay global and id-addressable, as `docs/SUBAGENTS.md` has them — only *mutation*
-is tiered; goal #1 is the mutation half, honestly scoped.)
+So a non-resident cannot mutate (the tool fails closed at the gate) and a resident
+cannot mutate a sibling (its ctx is pinned). Reads stay global and id-addressable
+(`docs/SUBAGENTS.md`); only *mutation* is tiered.
 
 ## Move 3 — the message channel: `message_resident`
 
 `message_resident({ to, message, sync? })`; `to` is the instance id → resolve
-`residentSessionId` (Move 1) → `turnSlots.runWhenIdle(residentSessionId, fn)`
-(the serializing mailbox: runs when the resident is idle, **never interrupting an
+`residentSessionId` (Move 1) → `turnSlots.runWhenIdle(residentSessionId, fn)` (the
+serializing mailbox: runs when the resident is idle, **never interrupting an
 in-flight turn**, DECISIONS #20). The resident's turn is
 `runAgentTurn({ sessionId: residentSessionId, … })`. The reply re-enters the
 **sender** as a `synthetic:true` wake, `wrapUntrusted`-fenced (mandatory for App
 residents — they render attacker content). Correlation is pinned **SW-side**
 (`{correlationId → senderSessionId}`, the async-subagents per-sender shape).
 
-- **P0 fail-closed sender gate.** The `ctx.inbound`/unattended clamp the
-  unattended path needs is **SPEC-only today (zero code)**, and *synthetic parent
-  turns already exist* (`goal-runner.js`, `async-subagents.js` re-enter with
-  `wrapUntrusted`'d page bytes) — a synthetic parent is a non-attended sender that
-  exists **now**. So P0 gates the tool edge on
-  **`!synthetic && senderSessionId === getActiveSessionId()`** (attended,
-  first-party). The unattended path (peer messages, scheduled tasks) is **blocked
-  at P0** and unlocks only when the shared clamp lands (P1+).
-- **Runaway guard.** `message_resident` reuses the async-subagents `RATE_CAP` /
-  `OUTSTANDING_CAP` per sender (a resident↔resident or parent↔resident ping-pong
-  must be bounded — see cost, below).
+- **P0 fail-closed sender gate.** The unattended/`ctx.inbound` clamp this would
+  ride is **SPEC-only today**, and *synthetic parent turns already exist*
+  (`goal-runner.js`, `async-subagents.js` re-enter with `wrapUntrusted`'d page
+  bytes) — a synthetic parent is a non-attended sender that exists **now**. So P0
+  gates on **`!synthetic && senderSessionId === getActiveSessionId()`**
+  (attended, first-party). The unattended path (peer messages, scheduled tasks) is
+  **blocked at P0** until the shared clamp lands.
+- **Runaway guard.** Reuse the async-subagents `RATE_CAP`/`OUTSTANDING_CAP` per
+  sender (a parent↔resident ping-pong must be bounded — see cost).
 
-## The resident-runtime boundary — why A is B's foundation
+## The seam: how this same design later hardens (Phase 2)
 
-peerd's turn machinery is already split where the A↔B seam needs it. **Verified:**
-the `turn-driver` wrapper genuinely owns spend/clamp/scheduler/key/egress and
-calls `runUserTurn` (the inner loop) which reaches none of them by closure (it
-emits `usage` *events* the wrapper consumes).
+peerd's turn machinery is already split where it needs to be. **Verified:** the
+`turn-driver` wrapper owns spend/clamp/scheduler/key/egress and calls
+`runUserTurn` (the inner loop), which reaches none of them by closure (it emits
+`usage` *events* the wrapper consumes).
 
 ```
-turn-driver.js  (the WRAPPER — stays SW-side in BOTH A and B)
+turn-driver.js  (the WRAPPER — stays SW-side, ALWAYS)
    ├─ makeTurnCostTracker / maybeHalt / spendLimitUsd   ← spend cap
    ├─ ctx.inbound clamp (when it lands)                 ← unattended gate
    ├─ turnSlots (runWhenIdle / claim / release)         ← scheduler / anti-focus-theft
    ├─ vault.getSecret + safeFetch + webFetch + audit    ← key & egress
-   └─ runUserTurn(...)   ← the INNER LOOP (the only thing B relocates)
+   └─ runUserTurn(...)   ← the INNER LOOP
 ```
 
-- **Model A:** the resident runs the whole stack in the SW. **But not for free:**
-  `runAgentTurn` today hardcodes `exposure:'main'` (which would shed the very
-  tools a resident needs) and frames the turn around
-  `browser.tabs.query({active:true})` (the *user's* foreground tab, not the
-  resident's instance tab). So A needs a **kind-aware branch**: the `resident`
-  exposure marker, a resident descriptor build, the `*_RESIDENT_PROMPT`, and
-  honoring the resident's `activeTabId` instead of the foreground query. The
-  **wrapper** (spend/clamp/scheduler/egress) is reused verbatim; the inner
-  per-turn *setup* is real, bounded new work. ("Zero new turn runtime" was an
-  over-claim; the honest claim is "the enforcement wrapper is reused.")
-- **Model B (Phase 2):** relocate **only `runUserTurn`** into a per-tab worker
-  behind a streaming proxy; the wrapper stays SW-side. Because enforcement never
-  leaves the SW, B does not reintroduce the regressions the split's first draft
-  had (uncapped spend, an unclamped inbound path, an invisible second scheduler).
+- **Now (the loop on the SW heap):** the resident runs the whole stack in the SW.
+  Not "zero new runtime" — `runAgentTurn` today hardcodes `exposure:'main'` (which
+  would shed the tools a resident needs) and frames the turn around the *user's*
+  foreground tab, so the resident path needs a kind-aware branch (the `resident`
+  marker, a resident descriptor build, the tuned prompt, honoring the resident's
+  `activeTabId`). The **wrapper** is reused verbatim; the inner per-turn *setup* is
+  bounded new work.
+- **Later (the security forward-benefit):** relocate **only `runUserTurn`** into a
+  per-tab worker behind a streaming proxy; the wrapper stays SW-side. That closes
+  the one isolation gap the SW-heap loop leaves — a JS-level exploit of the loop
+  reaching the in-memory key — which matters once instances run untrusted *code*
+  (dweb dwapps). Because enforcement never leaves the SW, the relocation cannot
+  reintroduce the regressions an early draft of it had (uncapped spend, an
+  unclamped inbound path, an invisible second scheduler).
 
-**Design rule for A, so A supports B:** keep every key/egress/cost/clamp/scheduler
-concern in the wrapper; keep the loop's IO behind the injected `REQUIRED_CTX`
-seam. Then B is one scoped relocation. Spec the seam once; cross it later.
+Against the *content* threat the keyless tool context (`restrictCtxCapabilities`
+already strips `getSecret`/`safeFetch`) is the proportionate posture; the worker
+relocation is for the *code* threat. **Design the seam once now; cross it when the
+threat arrives.**
 
-## What A ships vs what the split (Phase 2) adds
+## Cost
 
-| | Model A (ship now) | The split (Phase 2, JS-safety) |
-|---|---|---|
-| Inner loop runs | SW heap | per-tab worker |
-| Key in the loop's realm | held for `callModel` | none (proxied) |
-| Defends prompt-injection | yes (gated tools) | yes (identical) |
-| Defends a JS exploit of the loop reaching the key | no (shared SW heap) | **yes — the real delta** |
-| Trigger | now | untrusted **code** live (dweb dwapps) + A battle-tested |
-
-## Cost model (corrected — not "native and free")
-
-A resident is a *separate session*. `makeTurnCostTracker` (`cost/turn-tracker.js`)
-checks `limitUsd` **per session**, so **N residents = N independent caps**: the
-user's attended chat hitting its limit does not stop its residents, and a
-`message_resident` ping-pong burns two independent caps. P0 must therefore (a) carry
-the `message_resident` runaway guard (Move 3), and (b) **document** that residents
-multiply the cap by live-resident count. A true cross-session rollup into one
-owning-user budget does not exist today and is an open question (below), not a P0
-claim.
-
-## Hardenings carried from the adversarial reviews
-
-A structurally avoids the split's four regressions (loop is on the SW). Folded in:
-
-- **Ephemeral resident confirm.** `sessionConfirmGrants` banks a blanket
-  `yes_session` per session; a *persistent* resident would replay one approval
-  every turn. Residents use **per-turn** grants (the runner's grant-less posture).
-- **`message_resident` P0 fail-closed** on synthetic/unattended senders (Move 3).
-- **SW-side reply correlation** (Move 3) — never a persisted sender pointer.
-
-## Context shedding (goal #2)
-
-Parent keeps create + `message_resident` + list; the ~23 instance tools move behind
-the `resident` tier (minus `js_run`). Non-eroding (unlike `INSTANCE_GATED_TOOLS`
-progressive disclosure). Net ~4.5–6 k tokens off every parent turn; the engine
-prose moves into per-kind `*_RESIDENT_PROMPT`. (Honest: the per-resident prompt
-re-incurs that prose per live resident — net positive for the parent, recompute
-for always-warm residents.)
+A resident is a separate session; `makeTurnCostTracker` checks `limitUsd`
+**per session**, so **N residents = N independent caps** (the user's chat hitting
+its limit does not stop its residents; a ping-pong burns two caps). P0 carries the
+`message_resident` runaway guard (Move 3) and **documents** the
+cap-×-live-residents reality. A cross-session rollup into one owning-user budget
+does not exist today (open question).
 
 ## Lifecycle
 
 Bound to the instance (Move 1); **lazy execution** (the loop runs only on a
-`tell`). Persists in IDB; instance persists via registries/OPFS/disks; SW boot
-re-adopts via `registry.load()` + `tabTracker.bootstrap()`; a `tell` to a
-tabless instance re-spawns the tab via `ensureTab`. Generalize
+message). Persists in IDB; instance persists via registries/OPFS/disks; SW boot
+re-adopts via `registry.load()` + `tabTracker.bootstrap()`; a message to a tabless
+instance re-spawns the tab via `ensureTab`. Generalize
 `onTabClosed → queue.interrupt` (VM-only at `:2031`) to all kinds.
 
 ## Security / invariants
 
 - **Mutation is resident-tiered + per-instance-pinned** (Move 2), enforced at
   `exposureGate` + the closure strip. The dispatcher test is the proof.
-- **Keyless tool context** (`restrictCtxCapabilities`) against the content threat;
-  the shared SW heap is the named soft spot, closed for untrusted *code* in P2.
-- **`confirm`/`audit` SW-authoritative**; residents never self-approve.
+- **Keyless tool context** against the content threat; the shared SW heap is the
+  named soft spot, closed for untrusted *code* by the Phase-2 relocation.
+- **`confirm`/`audit` SW-authoritative**; residents never self-approve (per-turn
+  grants, not standing `yes_session`).
 - **`webFetch` (allowlist-free) is the real exfil surface** — deny open-web tools
   to untrusted-input residents, as the runner does.
-- **The isolate is the untrusted-code boundary** in both A and B.
-- Reply `wrapUntrusted`; depth/trust/audit unchanged.
+- **The isolate is the untrusted-code boundary**; reply `wrapUntrusted`;
+  depth/trust/audit unchanged.
 
 ## Specifically NOT to do
 
-- Implement the mutation shed as descriptor-hygiene only (the v1 kill) — it must
-  be a `resident`-keyed **dispatch-gate refusal** + a per-instance pin.
+- Implement the mutation shed as descriptor-hygiene only — it must be a
+  `resident`-keyed **dispatch-gate refusal** + a per-instance pin.
 - Grant the `resident` marker on either spawn surface.
-- Re-introduce a per-call *session→instance owner check* (the rejected gate). The
-  `residentSessionId` field is a *routing* pointer, not a mutation gate.
-- Build the streaming proxy now (that's P2).
+- Use a per-call *session→instance owner check* (`residentSessionId` is routing,
+  not a gate).
+- Build the streaming worker proxy before the *code* threat is live.
 - Move cost/clamp/scheduler off the SW — ever.
-- Give residents standing `yes_session`; treat `js_run` as an instance; run the
-  loop in the isolate.
+- Treat `js_run` as an instance; run the loop in the isolate.
 
 ## Open questions
 
-- **Which kinds get residents by default** (WebVM strongest; per-kind).
-- **Cross-session spend rollup** — do residents share the owning user's budget, or
-  is per-session-cap-× -tab-count acceptable? (No rollup exists today.)
-- **The inbound clamp** is the shared dependency that unlocks `message_resident`'s
-  unattended path; P0 ships attended-only without it.
+- **Which kinds get residents** (WebVM strongest; per-kind).
+- **Cross-session spend rollup** vs per-session-cap-×-tab-count.
+- **The inbound clamp** (shared dependency) unlocks the unattended message path;
+  P0 ships attended-only.
 - **The user talking to a resident** — does `kind:'resident'` appear in a switcher
   or only via the tab?
-- **Phase-2 trigger** — what concretely flips the split on (first dweb dwapp
-  execution path?).
+- **Phase-2 trigger** — what concretely flips on the worker relocation.
 
 ## Phasing
 
-1. **P0 — Model A core.** `kind:'resident'` (a `SessionKind` union change → audit
-   kind-switches, the `/chats` filter, store-load default); the **`resident`
-   exposure tier + dispatch-gate refusal + closure strip + per-instance pin +
-   the dispatcher test** (Move 2 — the security spine); the instance→resident
-   `residentSessionId` binding; `message_resident` (SW correlation + mailbox +
-   runaway guard + the `!synthetic && active` fail-closed gate); the kind-aware
-   resident turn branch (exposure/descriptors/`*_RESIDENT_PROMPT`/`activeTabId`);
-   ephemeral confirm; resident-spawn wired across all three trackers. Behind a
-   flag. *Battle-test + release.* (Honest build surface — this is not "zero new
-   runtime".)
-2. **P1 — persistence + the conversational surface** (durable resident sessions;
-   the side-panel "talk to this instance" affordance; the unattended `tell`
-   path once the clamp lands).
-3. **P2 — the split (Model B), for JS-safety.** Relocate `runUserTurn` into a
-   per-tab worker behind the proxy (streaming Port, egress relay,
-   vault-`unlocked` relay, cross-boundary abort); wrapper stays SW-side.
-   Triggered by untrusted-code use cases + a battle-tested A.
+1. **P0 — the actor structure.** `kind:'resident'`; the `resident` capability tier
+   (dispatch-gate refusal + closure strip + per-instance pin + the dispatcher
+   test); the `residentSessionId` binding; `message_resident` (mailbox + SW
+   correlation + runaway guard + the `!synthetic && active` gate); the kind-aware
+   resident turn branch; ephemeral confirm; resident-spawn across the three
+   trackers. Behind a flag. *Battle-test + release.*
+2. **P1 — persistence + the conversational surface** (durable residents; the
+   side-panel "talk to this instance" affordance; the unattended path once the
+   clamp lands; per-kind tuned prompts/model tiers).
+3. **P2 — the worker relocation, for JS-safety against untrusted code.** Move
+   `runUserTurn` into a per-tab worker behind the proxy; wrapper stays SW-side.
 4. **P3 — durable resume** across vault unlock / browser restart (DESIGN-08).
 
-## The seam is the bet
+## Alternatives considered
 
-A ships the actor model and the lean parent now, regression-free, by reusing the
-SW turn-driver wrapper and a resident-keyed capability tier. The split is then one
-well-scoped relocation — move the inner loop into a per-tab worker, leave
-enforcement in the SW — for the day untrusted *code* runs. **Design the seam once
-(P0); cross it when the threat arrives (P2).** That's why A directly buys B.
+- **Loop in the tab (worker) from day one** — rejected as the *default*: against
+  the content threat it buys nothing over the SW-heap loop (a text-steered loop
+  calls the same gated tools wherever it runs), and the relocation is real work.
+  Kept as Phase 2 for the *code* threat, on this same seam.
+- **A per-call ownership gate** (`session === record.owner` on every mutation) —
+  rejected: imperative bookkeeping with transfer-on-settle / brick failure modes.
+  Replaced by the capability tier + the routing pointer.

--- a/docs/specs/DESIGN-17-resident-agents.md
+++ b/docs/specs/DESIGN-17-resident-agents.md
@@ -244,6 +244,34 @@ instance re-spawns the tab via `ensureTab`. Generalize
    `runUserTurn` into a per-tab worker behind the proxy; wrapper stays SW-side.
 4. **P3 — durable resume** across vault unlock / browser restart (DESIGN-08).
 
+## Future steps — the substrate, and the mature model
+
+This design is the foundation for a longer arc (forward-looking, not committed
+here):
+
+- **Per-tab security isolation** (Phase 2) — the actor boundary makes JS-heap
+  isolation against untrusted *code* a single loop relocation; the substrate for
+  executing untrusted dweb-delivered dwapps.
+- **Purpose-tuned models per actor** — each resident on a fit-for-purpose tier:
+  the shell/VM resident fast and cheap, the App resident a strong coding model,
+  the orchestrator on the frontier model doing only routing + synthesis.
+  Specialization up, cost down — the orchestrator stops carrying every
+  environment's reasoning.
+- **An actor mesh** — `message_resident` is session→session, so residents can
+  address *each other* (a VM resident asks an App resident to render its output);
+  the orchestrator thins toward a router over a graph of specialists.
+- **Across peers (dweb)** — the same channel extends agent-to-agent over the mesh
+  (`docs/distributed/ROADMAP.md`): a resident addresses a peer's resident, and the
+  actor graph goes distributed.
+- **Autonomous residents** — once the inbound clamp lands, residents react to
+  schedules/events and tend their environments unattended.
+
+**The mature model:** the orchestrator is a thin conversational router; the work
+lives in a graph of persistent, purpose-tuned, isolated actor-agents — one per
+environment, local and eventually across peers — reached only by message. peerd
+shifts from *one agent with many tools* toward *a society of specialized agents,
+each owning its world.*
+
 ## Alternatives considered
 
 - **Loop in the tab (worker) from day one** — rejected as the *default*: against


### PR DESCRIPTION
Spec-only PR (no code) for manual review — `docs/specs/DESIGN-17-resident-agents.md`. **Draft on an experimental branch; not for merge yet.**

## The problem
The main agent carries every execution environment's tooling + instructions at once (~23 `vm_*`/`js_*`/`app_*` tools and their prompt guidance ride every turn, and the surface only grows as a session uses more kinds) — a context-optimization problem. And tab-hosted instances are global mutable objects any session can poke by id — no actor owns an instance.

## The goal
**A clearer actor structure.** Each tab-hosted instance is owned by one agent — a **resident** — that holds that environment's tools and is the only thing that drives it. You don't mutate an instance; you `message_resident`. The per-environment tooling leaves the main agent (context optimized, non-eroding), and "who may touch this instance" becomes structural. Forward benefits the boundary buys: **security** (a keyless per-instance agent — the runner trust model generalized; the seam to later harden against untrusted *code*) and **purpose-tuned agents** (each resident specialized to its environment — tuned prompt, narrow toolset, later a fit-for-purpose model tier).

## The design, in brief
A per-tab `kind:'resident'` session, loop on the SW heap (reuses `turn-driver` → `runUserTurn`), bound to its instance by a `residentSessionId` routing pointer, holding instance tools behind a **resident-keyed capability tier** enforced at `exposureGate` (the security spine), addressed by `message_resident`. The `turn-driver` **wrapper** (cost/clamp/scheduler/key/egress) stays SW-side; only `runUserTurn` later relocates into a per-tab worker (Phase 2, for JS-safety against untrusted code) — so that hardening is one scoped relocation, not a re-architecture.

## Where this leads (the substrate / mature model)
The actor structure is the foundation for: **per-tab security isolation** (executing untrusted dweb dwapps); **purpose-tuned models per actor** (orchestrator on the frontier model just routing/synthesizing; residents on fit-for-purpose tiers); an **in-browser actor mesh** (`message_resident` is session→session, so local residents address each other as peers); and **A2A across peers** over the dweb, with a deliberate line between local residents (trusted, cheap) and remote agents (different trust + latency). Mature model: **actor-based orchestration of specialized agents in the browser, acting as peers — with a clear line between local agents and remote ones over A2A.**

## Where I'd most value your read
- **The capability tier** (Move 2): is the `resident`-keyed dispatch-gate refusal + closure strip + per-instance pin the right authority model? Both spawn surfaces (`spawn_subagent` + the `subagent/spawn` route) must fail closed.
- **The binding** (Move 1): `residentSessionId` as a routing pointer vs a per-call owner gate.
- **`message_resident` at P0:** fail-closed on synthetic/unattended senders (they exist today via `goal-runner`); the unattended path waits on the shared inbound clamp.
- **Cost:** N residents = N independent per-session caps today — acceptable, or a cross-session rollup?
- **Phase-2 trigger:** what concretely flips on the worker relocation?

The spec has been through two code-grounded adversarial reviews; alternatives considered (the tab-worker loop, the per-call owner gate) are noted at the end of the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)