### PR TITLE
fix(goal): rehydrate the Goal bar / Stop when a surface (re)connects mid-run

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -2071,6 +2071,14 @@ browser.runtime.onConnect.addListener((port) => {
       try { port.postMessage({ type: 'confirm/request', prompt: pendingPrompt }); }
       catch { /* port closing */ }
     }
+    // Same idea for a LIVE goal run: its goal/state events only reached ports
+    // connected when they fired, and the snapshot carries no goal-run field. So
+    // replay each active run to this fresh surface — otherwise a reopened panel
+    // (or one that reconnected after an SW respawn) shows no Goal bar / Stop for a
+    // run still driving autonomously, leaving the user without the visible stop.
+    for (const ev of (goalRunner?.activeStates?.() ?? [])) {
+      try { port.postMessage(ev); } catch { /* port closing */ }
+    }
     port.onDisconnect.addListener(() => {
       uiPorts.remove(port);
       broadcastSurfaces();

--- a/extension/peerd-runtime/loop/goal-runner.js
+++ b/extension/peerd-runtime/loop/goal-runner.js
@@ -103,6 +103,28 @@ export const makeGoalRunner = ({ runTurn, onEvent = () => {}, onRunEnd = () => {
   const isActive = (sid) => { const r = runs.get(sid); return !!r && !r.completed && !r.halted; };
 
   /**
+   * The 'running' goal/state payloads for every LIVE run — for replaying to a
+   * port that just (re)connected. The loop's emit() only reaches ports connected
+   * at the time it fires, and the SW state snapshot carries no goal-run field, so
+   * without this replay a panel that reopened (or reconnected after an SW respawn)
+   * shows NO Goal bar / Stop for a run still driving autonomously. Same shape the
+   * live loop emits, so it folds through the panel's existing goal/state reducer.
+   * @returns {object[]}
+   */
+  const activeStates = () => {
+    const out = [];
+    for (const sid of runs.keys()) {
+      if (!isActive(sid)) continue;
+      const r = /** @type {GoalRun} */ (runs.get(sid));
+      out.push({
+        type: 'goal/state', sessionId: sid, phase: 'running', active: true,
+        iteration: r.iteration, maxIterations, goal: r.goal, summary: r.summary ?? null,
+      });
+    }
+    return out;
+  };
+
+  /**
    * complete_goal hook: the agent declared the goal met. Returns whether there
    * was a LIVE run to end (false → the tool was called outside an active run).
    * @param {string} sid @param {string} [summary] @returns {boolean}
@@ -280,5 +302,5 @@ export const makeGoalRunner = ({ runTurn, onEvent = () => {}, onRunEnd = () => {
     return { resumed };
   };
 
-  return Object.freeze({ start, halt, stop, complete, isActive, get, drive, resume });
+  return Object.freeze({ start, halt, stop, complete, isActive, get, activeStates, drive, resume });
 };

--- a/tests/background/goal-connect-replay.test.ts
+++ b/tests/background/goal-connect-replay.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// The goal-run connect-time replay (#3/#4) lives in service-worker.js's
+// onConnect handler, which can't be imported under bun (no chrome/browser
+// globals) — so, like offscreen-gate.test.ts, assert against the SOURCE TEXT.
+// The behavioral half (WHAT activeStates() returns) is pinned in
+// goal-runner.test.ts; this pins that onConnect actually REPLAYS it to the
+// freshly-connected port, mirroring the pendingConfirm replay right above it.
+// Without the replay, a panel that reopened (or reconnected after an SW
+// respawn) shows no Goal bar / Stop for a run still driving — reverting the
+// onConnect loop fails the assertions here.
+const src = readFileSync(
+  join(import.meta.dir, '../../extension/background/service-worker.js'),
+  'utf8',
+);
+
+describe('service worker — goal-run replay on port (re)connect (#3/#4)', () => {
+  test('onConnect replays every live goal run to the fresh surface', () => {
+    expect(src).toMatch(/goalRunner\?\.activeStates\?\.\(\)/);
+    // the replay posts each active-run event to THIS port (not a broadcast)
+    expect(src).toMatch(/for \(const ev of \(goalRunner\?\.activeStates[\s\S]{0,160}?port\.postMessage\(ev\)/);
+  });
+});

--- a/tests/peerd-runtime/goal-runner.test.ts
+++ b/tests/peerd-runtime/goal-runner.test.ts
@@ -112,6 +112,31 @@ describe('makeGoalRunner — the goal loop', () => {
     expect(goals).toEqual(['first', 'second']);
   });
 
+  it('activeStates() yields running-run payloads for connect-time replay, and none once terminal', async () => {
+    const calls: TurnArgs[] = [];
+    let release: () => void = () => {};
+    let runner: ReturnType<typeof makeGoalRunner>;
+    runner = makeGoalRunner({
+      // Hold the turn open so the run stays LIVE while we inspect activeStates().
+      runTurn: async (a: TurnArgs) => { calls.push(a); await new Promise<void>((r) => { release = r; }); },
+      maxIterations: 5,
+    });
+    await runner.start({ sessionId: 'sA', goal: 'build it' });
+    await settle(() => calls.length === 1);
+    // A live run is replayable as a 'running' goal/state event (the shape the
+    // panel's reducer folds — so a reconnecting surface restores the Goal bar).
+    const live = runner.activeStates();
+    expect(live).toHaveLength(1);
+    expect(live[0]).toMatchObject({
+      type: 'goal/state', sessionId: 'sA', phase: 'running', active: true, goal: 'build it',
+    });
+    // Once it ends, it is no longer replayed.
+    runner.complete('sA', 'done');
+    release();
+    await settle(() => !runner.isActive('sA'));
+    expect(runner.activeStates()).toEqual([]);
+  });
+
   it('the continuation prompt carries the goal and points at complete_goal', () => {
     const p = goalContinuationPrompt('build a drum machine');
     expect(p).toContain('build a drum machine');


### PR DESCRIPTION
## What

Recreates **#56** (jonybur) on top of current `main`. #56 stacked on #55; squash-merging #55 left #56's branch carrying #55's *original* commits, so once GitHub retargeted it to `main` it went **conflicted** (`dirty`). This is #56's **rehydration-only delta**, applied cleanly onto current `main` — no #55 duplication.

## The fix (unchanged from #56)

A live goal run's `goal/state` events only reach ports connected when they fire, and the SW snapshot carries no goal-run field — so after an SW respawn or a plain side-panel reopen during a still-driving autonomous run, the Goal bar/Stop **vanished**. Fix mirrors the existing `pendingConfirm` / agent-tab connect-time replay: the runner exposes `activeStates()` (the `running` `goal/state` payloads for live runs), and `onConnect` replays them to the freshly-connected port, folding through the panel's existing `goal/state` reducer. No snapshot widening, no reducer change.

## Verified on current `main`

`bun run lint` · `bun run typecheck` · `check:boundary` · `check:tscheck` (473/473) · drift — all clean; the two affected suites (`goal-runner.test.ts` + `goal-connect-replay.test.ts`) pass **20/20**.

Approved via a 4-lens adversarial swarm (refute-by-default) + synthesis — **merge, high confidence, zero surviving blockers**: `activeStates()` emits a payload byte-identical to the live `emit()` through the existing idempotent reducer; the `onConnect` replay is synchronous and guarded; `drive()`'s terminal `finally` emits-then-deletes with no async window.

Recreates #56 by **@jonybur** (its branch couldn't be pushed to from this session). Supersedes #56.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHffCSYFCRUBQSAWCshR4K)_