### PR TITLE
fix(goal): order goal-resume before auto-resume on interactive unlock (#60)

### DIFF
--- a/extension/background/routes/session-mutations.js
+++ b/extension/background/routes/session-mutations.js
@@ -46,8 +46,10 @@ export const makeSessionMutationRoutes = (deps) => {
       // why: a "new chat" abandons the current one — end its goal run (if any)
       // so it doesn't keep driving the orphaned session in the background.
       // (A plain session/switch does NOT halt — that's the "keep running while
-      // I'm in another chat" case.)
-      if (previousId) haltGoalRun?.(previousId);
+      // I'm in another chat" case.) Awaited: stop() durably forgets the run's
+      // persisted record, so a "new chat" can't be undone by a resume() on the
+      // next unlock even if the SW is torn down right after this handler (#60).
+      if (previousId) await haltGoalRun?.(previousId);
       await sessionCache.sessionDelete('currentSessionId');
       sessionState.clear();
       pushState();
@@ -85,8 +87,9 @@ export const makeSessionMutationRoutes = (deps) => {
       try {
         await sessions.archive(sessionId);
         // Archiving wraps the chat up — end its goal run (if any) so it can't
-        // keep running on a put-away session.
-        haltGoalRun?.(sessionId);
+        // keep running on a put-away session. Awaited: durably forget the run so
+        // it can't resurrect on the next unlock (#60).
+        await haltGoalRun?.(sessionId);
         // If the archived session was the active one, drop the cache so
         // the next agent/send creates a fresh session.
         const currentId = await sessionCache.sessionGet('currentSessionId');

--- a/extension/background/routes/sessions.js
+++ b/extension/background/routes/sessions.js
@@ -68,7 +68,9 @@ export const makeSessionRoutes = (deps) => {
       // top of the new message.
       if (haltGoalRun) {
         const curSid = await sessionCache.sessionGet('currentSessionId');
-        if (curSid) haltGoalRun(/** @type {any} */ (curSid));
+        // Awaited: durably forget the run so a steer-takeover can't be undone by
+        // a resume() on the next unlock (parity with agent/stop; #60).
+        if (curSid) await haltGoalRun(/** @type {any} */ (curSid));
       }
       // /init is handled in the SW, not sent to the model (feature 01) —
       // check it BEFORE composer expansion so the slash command short-

--- a/extension/background/routes/vault.js
+++ b/extension/background/routes/vault.js
@@ -52,15 +52,23 @@ export const makeVaultRoutes = (deps) => {
         auditLog.append({ type: 'vault_unlocked' }).catch(() => {});
         ensureOffscreen().catch((/** @type {unknown} */ e) => console.error('[sw] ensureOffscreen failed', e));
         maybeStartBaseNetwork('unlock');
-        // #72: auto-resume the current chat if its last turn was interrupted (a
-        // cold SW wake unlocks here; this is the moment to finish what the
-        // eviction cut off). Fire-and-forget; gated + deduped in the helper.
-        sessionCache.sessionGet('currentSessionId').then((/** @type {any} */ cur) => maybeAutoResume(cur)).catch(() => {});
-        // Re-drive any goal run that paused on a mid-run auto-lock — an
-        // interactive unlock is when secrets are back, so the run can continue.
-        // Idempotent (skips sessions with a live run); resumes ALL, not just the
-        // current chat (a goal can run in the background).
-        resumeGoalRuns?.()?.catch?.(() => {});
+        // Re-drive any goal run that paused on a mid-run auto-lock, THEN
+        // auto-resume the current chat. Order matters (symmetric to the #55
+        // SW-boot fix; #60): resumeGoalRuns() synchronously re-adds a paused run
+        // to the runner's map (goalActiveFor → true) before its drive() awaits,
+        // so chaining maybeAutoResume AFTER it guarantees the goalActiveFor guard
+        // in maybeAutoResume sees the goal run and bails. The opposite order let
+        // maybeAutoResume read goalActiveFor=false and re-drive the interrupted
+        // turn, contending the slot and spuriously HALTING the goal run.
+        // Idempotent; resumes ALL runs (a goal can run in a background chat).
+        Promise.resolve(resumeGoalRuns?.())
+          .catch(() => {})
+          // #72: then auto-resume the current chat if its last turn was
+          // interrupted (a cold SW wake unlocks here; finish what the eviction
+          // cut off). Fire-and-forget; gated + deduped in the helper.
+          .then(() => sessionCache.sessionGet('currentSessionId'))
+          .then((/** @type {any} */ cur) => maybeAutoResume(cur))
+          .catch(() => {});
         return { ok: true };
       } catch (e) {
         if (e instanceof WrongPassphraseError) return { ok: false, error: 'wrong-passphrase' };
@@ -187,14 +195,16 @@ export const makeVaultRoutes = (deps) => {
         auditLog.append({ type: 'vault_unlocked', details: { via: 'prf' } }).catch(() => {});
         ensureOffscreen().catch((/** @type {unknown} */ e) => console.error('[sw] ensureOffscreen failed', e));
         maybeStartBaseNetwork('unlock-prf');
-        // #72: auto-resume the current chat if its last turn was interrupted
-        // (see the passphrase unlock path above). Fire-and-forget; gated in helper.
-        sessionCache.sessionGet('currentSessionId').then((/** @type {any} */ cur) => maybeAutoResume(cur)).catch(() => {});
-        // Re-drive any goal run that paused on a mid-run auto-lock — an
-        // interactive unlock is when secrets are back, so the run can continue.
-        // Idempotent (skips sessions with a live run); resumes ALL, not just the
-        // current chat (a goal can run in the background).
-        resumeGoalRuns?.()?.catch?.(() => {});
+        // Re-drive paused goal runs BEFORE auto-resume — see the passphrase
+        // unlock path above (resume re-adds the run so the goalActiveFor guard in
+        // maybeAutoResume bails for a goal-owned session; #60). Idempotent.
+        Promise.resolve(resumeGoalRuns?.())
+          .catch(() => {})
+          // #72: then auto-resume the current chat if its last turn was
+          // interrupted. Fire-and-forget; gated + deduped in the helper.
+          .then(() => sessionCache.sessionGet('currentSessionId'))
+          .then((/** @type {any} */ cur) => maybeAutoResume(cur))
+          .catch(() => {});
         return { ok: true };
       } catch (e) {
         if (e instanceof PrfNotEnrolledError) return { ok: false, error: 'prf-not-enrolled' };

--- a/tests/background/routes-session-mutations.test.ts
+++ b/tests/background/routes-session-mutations.test.ts
@@ -131,3 +131,29 @@ describe('permission/set', () => {
     expect(calls.updated).toEqual([['cur', { permissionMode: 'plan', confirmActions: true }]]);
   });
 });
+
+// #60 (related): new-chat and archive must AWAIT the durable goal Stop, so the
+// run's persisted record is forgotten before the handler returns — otherwise an
+// SW teardown right after could let resume() resurrect the stopped run. A
+// late-resolving haltGoalRun reverts-proves the await (un-awaited → not done yet).
+describe('durable goal Stop is awaited on new-chat / archive (#60)', () => {
+  const slowHalt = () => {
+    let done = false;
+    const haltGoalRun = async () => { await new Promise((r) => setTimeout(r, 20)); done = true; };
+    return { haltGoalRun, isDone: () => done };
+  };
+
+  test('session/reset awaits the durable Stop before returning', async () => {
+    const halt = slowHalt();
+    const { deps } = baseDeps({ haltGoalRun: halt.haltGoalRun });
+    await makeSessionMutationRoutes(deps)['session/reset']();
+    expect(halt.isDone()).toBe(true);
+  });
+
+  test('session/archive awaits the durable Stop before returning', async () => {
+    const halt = slowHalt();
+    const { deps } = baseDeps({ haltGoalRun: halt.haltGoalRun });
+    await makeSessionMutationRoutes(deps)['session/archive']({ sessionId: 'cur' });
+    expect(halt.isDone()).toBe(true);
+  });
+});

--- a/tests/background/routes-sessions.test.ts
+++ b/tests/background/routes-sessions.test.ts
@@ -73,6 +73,14 @@ describe('agent/send slash-command routing', () => {
     await makeSessionRoutes(deps)['agent/send']({ text: 'hello' });
     expect(calls.halted).toEqual(['a']);
   });
+  test('the steer-takeover AWAITS the durable goal Stop (#60)', async () => {
+    // A late-resolving haltGoalRun: the handler must wait for the durable stop
+    // to commit (so it can't resurrect on the next unlock) before returning.
+    let done = false;
+    const { deps } = baseDeps({ haltGoalRun: async () => { await new Promise((r) => setTimeout(r, 20)); done = true; } });
+    await makeSessionRoutes(deps)['agent/send']({ text: 'hello' });
+    expect(done).toBe(true);
+  });
   test('/system and /tools route to their handlers', async () => {
     const { deps, calls } = baseDeps();
     await makeSessionRoutes(deps)['agent/send']({ text: '/system be terse' });

--- a/tests/background/routes-vault.test.ts
+++ b/tests/background/routes-vault.test.ts
@@ -146,3 +146,43 @@ describe('vault routes — payload validation', () => {
     expect(await r['vault/setRecoveryPassphrase']({ passphrase: 'short' })).toEqual({ ok: false, error: 'invalid-passphrase' });
   });
 });
+
+// #60: on an interactive unlock, goal runs must resume BEFORE auto-resume —
+// resume() re-adds a paused run to the runner's map (goalActiveFor → true)
+// before maybeAutoResume checks its guard, so the guard bails for a goal-owned
+// session instead of re-driving its interrupted turn and spuriously halting it.
+// A late-resolving resumeGoalRuns distinguishes the fix (auto-resume waits for
+// resume to settle) from the old inverted order (auto-resume fired first).
+describe('vault unlock — goal resume ordering (#60)', () => {
+  const orderingDeps = (order: string[]) => ({
+    vault: { unlock: async () => {}, unlockWithPrf: async () => {} },
+    auditLog: { append: async () => {} },
+    ensureOffscreen: async () => {},
+    maybeStartBaseNetwork: () => {},
+    base64ToBytes: () => new Uint8Array([1]),
+    sessionCache: { sessionGet: async () => 'cur' },
+    resumeGoalRuns: async () => { await new Promise((r) => setTimeout(r, 30)); order.push('resume'); },
+    maybeAutoResume: () => { order.push('autoresume'); },
+    WrongPassphraseError, VaultNotInitializedError, RecoveryPassphraseNotSetError,
+    PrfNotEnrolledError, PrfUnlockFailedError, VaultLockedError,
+  });
+  const settle = async (order: string[]) => {
+    for (let i = 0; i < 60 && order.length < 2; i++) await new Promise((res) => setTimeout(res, 5));
+  };
+
+  test('vault/unlock awaits goal resume BEFORE auto-resume (passphrase)', async () => {
+    const order: string[] = [];
+    const r = makeVaultRoutes(orderingDeps(order) as any);
+    expect(await r['vault/unlock']({ passphrase: 'pw' })).toEqual({ ok: true });
+    await settle(order);
+    expect(order).toEqual(['resume', 'autoresume']);
+  });
+
+  test('vault/unlockPrf awaits goal resume BEFORE auto-resume (Touch ID / PRF)', async () => {
+    const order: string[] = [];
+    const r = makeVaultRoutes(orderingDeps(order) as any);
+    expect(await r['vault/unlockPrf']({ prfOutput: 'AAAA' })).toEqual({ ok: true });
+    await settle(order);
+    expect(order).toEqual(['resume', 'autoresume']);
+  });
+});


### PR DESCRIPTION
Closes #60 — the follow-up the adversarial review of #55 surfaced.

## The bug (pre-existing, not a #55 regression)

#55 killed boot double-drive by sequencing `goalRunner.resume()` **before** `maybeAutoResume` on the **SW-boot** path. But the **interactive vault-unlock** path (`routes/vault.js`, both the passphrase and PRF/Touch ID handlers) still ran them in the inverted order:

- `resume()` awaits `kv.get` before it re-adds a paused run to the runner's map
- `maybeAutoResume` checks `goalActiveFor` **before** its own await

So a goal run that paused on auto-lock could read `goalActiveFor=false` when `maybeAutoResume` evaluated it — defeating the #55 guard. `maybeAutoResume` re-drives the interrupted turn, `turnSlots.claim` contends, and the goal run is **spuriously halted on unlock**.

## Fix

Chain `resumeGoalRuns()` **before** `maybeAutoResume` in both unlock handlers, symmetric to the #55 boot change. `resume()` synchronously re-adds the run to the map (`goalActiveFor → true`) before it awaits, so the guard now bails for a goal-owned session.

**Related** (also from the #55 review): durable Stop was only awaited on `agent/stop`. `steer-takeover` (agent/send), `new-chat` (session/reset), and `archive` (session/archive) called `haltGoalRun` un-awaited — an SW teardown between the call and the kv write could resurrect those. Now all three await it, so a stopped run is durably forgotten before the handler returns.

(The third #60 item — the cap-rewind one-turn-beyond-`maxIterations` crash window — is deliberately left: it's bounded and self-corrects on the next terminal persist, not worth the added complexity.)

## Tests (revert-proven)
- `routes-vault.test.ts`: both `vault/unlock` and `vault/unlockPrf` await goal-resume before auto-resume — a **late-resolving** `resumeGoalRuns` distinguishes the fix (auto-resume waits) from the old order (auto-resume fired first).
- `routes-session-mutations.test.ts` + `routes-sessions.test.ts`: new-chat, archive, and steer-takeover await the durable Stop.

Full bun suite green (2108), typecheck + lint + dweb-boundary + tscheck clean, no drift.