### PR TITLE
fix(egress): scope the web-write "approve for this session" grant by host

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -1856,7 +1856,7 @@ const sessionConfirmGrants = new Map();
  * prior "yes for session" doesn't re-prompt, then falls back to the
  * round-trip. Records new session grants.
  *
- * @param {{ tool: string, sessionId?: string|null }} prompt
+ * @param {{ tool: string, sessionId?: string|null, origins?: string[] }} prompt
  * @returns {Promise<'yes_once'|'yes_session'|'no'>}
  */
 const confirmAction = async (prompt) => {
@@ -1868,13 +1868,22 @@ const confirmAction = async (prompt) => {
   if (prompt.tool === WEB_WRITE_CONFIRM_KEY && settingsStore.get().confirmWebWrites === false) {
     return 'yes_once';
   }
-  if (sid && sessionConfirmGrants.get(sid)?.has(prompt.tool)) {
+  // why scope the web-write grant by host: the prompt names a SPECIFIC host
+  // ("…send a POST request to {host}?"), so "approve for this session" must mean
+  // THIS host this session — not a blanket pass for non-GET egress to any host
+  // for the rest of the session. The prompt already carries origins:[host]; fold
+  // it into the grant key. Every other tool keys by its (already host-specific
+  // or host-agnostic-by-design) tool name.
+  const grantKey = prompt.tool === WEB_WRITE_CONFIRM_KEY
+    ? `${WEB_WRITE_CONFIRM_KEY}|${(Array.isArray(prompt.origins) && prompt.origins[0]) || ''}`
+    : prompt.tool;
+  if (sid && sessionConfirmGrants.get(sid)?.has(grantKey)) {
     return 'yes_session';
   }
   const answer = await confirmCoordinator.confirm(/** @type {any} */ (prompt));
   if (answer === 'yes_session' && sid) {
     if (!sessionConfirmGrants.has(sid)) sessionConfirmGrants.set(sid, new Set());
-    (/** @type {Set<string>} */ (sessionConfirmGrants.get(sid))).add(prompt.tool);
+    (/** @type {Set<string>} */ (sessionConfirmGrants.get(sid))).add(grantKey);
   }
   return answer;
 };

--- a/tests/background/web-write-grant-scope.test.ts
+++ b/tests/background/web-write-grant-scope.test.ts
@@ -1,0 +1,24 @@
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// The web-write session grant ("approve for this session" on a non-GET egress
+// prompt) must be scoped to the HOST the prompt named — not the bare 'web:write'
+// tool key — so one approval for host A does NOT silently authorize body-carrying
+// egress to every other host for the rest of the session. confirmAction lives in
+// service-worker.js (no bun import), so assert against the SOURCE TEXT, like
+// offscreen-gate.test.ts. Reverting to a tool-only grant key fails these.
+const src = readFileSync(
+  join(import.meta.dir, '../../extension/background/service-worker.js'),
+  'utf8',
+);
+
+describe('service worker — web-write session grant is host-scoped', () => {
+  test('the web-write grant key folds in the prompt origin', () => {
+    expect(src).toMatch(/grantKey\s*=\s*prompt\.tool\s*===\s*WEB_WRITE_CONFIRM_KEY[\s\S]{0,140}?prompt\.origins\b/);
+  });
+  test('both the grant check and the grant record use grantKey, not prompt.tool', () => {
+    expect(src).toMatch(/sessionConfirmGrants\.get\(sid\)\?\.has\(grantKey\)/);
+    expect(src).toMatch(/\.add\(grantKey\)/);
+  });
+});


### PR DESCRIPTION
The non-GET web-egress confirm prompt names a **specific host** ("…send a POST request to **{host}**?"), but `confirmAction` keyed the session-grant cache by the shared tool key alone (`WEB_WRITE_CONFIRM_KEY = 'web:write'`), dropping the host. So "approve for this session" became a blanket pass: one approval authorized body-carrying egress to **any** host for the rest of the session - not the host the user saw and consented to.

## Fix
Fold the host the prompt already carries (`origins[0]`) into the session-grant key (`web:write|<host>`), so "this session" means "**this host** this session" - matching what the prompt text told the user. Every other tool keys by its tool name as before.

## Test
`confirmAction` is service-worker-internal (no bun import), so a source assertion (same pattern as `offscreen-gate.test.ts`) pins that the web-write grant key folds in the origin and that both the grant check and the grant record use it. **Revert-proven** (restoring the tool-only key fails it). Typecheck + lint clean.