### PR TITLE
chore: gitignore the e2e verify-loop run artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 # Finder custom-icon file: its on-disk name is "Icon" + a trailing CR.
 # The line below ends in TWO raw CRs because git strips one CR before
 # the newline when parsing; a bare "Icon" line matches the wrong thing.
-Icon
+Icon
 ._*
 .DocumentRevisions-V100
 .fseventsd
@@ -52,6 +52,10 @@ web-ext-artifacts/
 /scratch/
 /tmp/
 *.log
+# Per-run output of the e2e verify loop (screenshots + result.json + diff
+# images), regenerated every `bun run e2e:verify`. The committed REFERENCE
+# images live in scripts/cdp/baselines/ — those are tracked.
+scripts/cdp/artifacts/
 
 # Claude Code harness state — session worktrees (.claude/worktrees/),
 # launch configs, etc. Local/transient; never source. Un-ignore a


### PR DESCRIPTION
`scripts/cdp/artifacts/` (the per-run screenshots + `result.json` + diff images) is regenerated on every `bun run e2e:verify` and should never be committed - committing it would mean a fresh PNG set in every diff. The committed **reference** images stay tracked in `scripts/cdp/baselines/`.

The same one-line entry rides in the verify-loop PR (#70), but splitting it out so it lands **independently** - until it does, the artifacts show as untracked on any branch cut from `main`, which is a `git add -A` footgun and clutters the VS Code Changes view.

One line; no code change.