### PR TITLE
test(e2e): restore dropped goal-state user-message assertion (fixes #76)

### DIFF
--- a/scripts/cdp/states.mjs
+++ b/scripts/cdp/states.mjs
@@ -91,6 +91,7 @@ export const STATES = [
       rec.check('loop drove >1 autonomous turn', calls >= 3, `model calls: ${calls}`);
       rec.check('complete_goal ended it cleanly (not the cap)', !out.capped && calls < 10, `capped=${out.capped} calls=${calls}`);
       rec.check('run reaches terminal: Goal bar cleared + idle', out.goalBar === false && out.busy === false);
+      rec.check('submitted goal text round-trips as the first user message', !!out.userText && out.userText.includes('tidy the repo'), JSON.stringify(out.userText));
       await rec.shot('final');
     },
   },


### PR DESCRIPTION
## What

Restores the `out.userText` assertion in the goal state that was dropped during the #70 consolidation — flagged by the adversarial swarm in issue #76.

## Change

One line in `scripts/cdp/states.mjs`: adds a `rec.check(...)` asserting that the submitted goal text (`'tidy the repo'`) round-trips as a visible first user message in the transcript. The probe already captured `out.userText`; it just never asserted on it.

Test-only, no harness or runtime changes.

Fixes #76.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRkfTpVuxjGSuLqN8zP91u

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRkfTpVuxjGSuLqN8zP91u)_