### PR TITLE
release: v0.1.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 # Finder custom-icon file: its on-disk name is "Icon" + a trailing CR.
 # The line below ends in TWO raw CRs because git strips one CR before
 # the newline when parsing; a bare "Icon" line matches the wrong thing.
-Icon
+Icon
 ._*
 .DocumentRevisions-V100
 .fseventsd
@@ -70,4 +70,3 @@ scripts/cdp/artifacts/
 # the vendored CheerpX/xterm assets kept directly in dist/) into /dist/
 # for Cloudflare Pages.
 /dist/
-scripts/cdp/artifacts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,32 @@ The staged integration of the open-PR backlog onto one verified branch
 
 ---
 
+## [0.1.5] — 2026-06-24
+
+Two sandbox/egress security fixes plus the e2e tier's autonomous
+verify-loop. All changes reviewed by adversarial-swarm passes (security
+fixes held to a no-residual-bypass bar) and verified green before merge.
+
+### Fixed
+- **Notebook realm seal now covers the Cache API** — the sealed worker
+  also runs headless in the offscreen `js_run` host, whose CSP allows
+  `https:`, so `connect-src 'none'` did not backstop there;
+  `CacheStorage.{open,match,has,delete,keys}` are now sealed like the
+  other network primitives, leaving no reachable network verb (#72).
+- **Web-write "approve for this session" is scoped to the consented
+  host** — the non-GET egress confirm named a specific host but cached
+  the grant by tool key alone, so one approval became a blanket pass to
+  any host; the grant key now folds in the host (#73).
+
+### Added
+- **Autonomous e2e verify loop** — `bun run e2e:verify` drives the real
+  extension through every state on one Chrome (~6s), writing a screenshot
+  per state + structured `result.json` (+ a diff image on a visual miss)
+  an agent can self-drive; multi-turn / mode-toggle / vault-lock states
+  added (#70, #77). Per-run artifacts gitignored (#74).
+
+---
+
 ## [0.1.4] — 2026-06-24
 
 Goal-mode hardening, side-panel state fixes, an end-to-end test tier, and

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "peerd (dev)",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "An AI assistant that automates tasks in your browser. Local-first: your own API key, no account, no servers, no tracking.",
   "side_panel": {
     "default_path": "sidepanel/sidepanel.html"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "peerd",
   "private": true,
   "type": "module",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Browser-native AI agent harness. Solo dev — Bun is for tests + one-shot vendor scripts only; the extension itself runs no build step.",
   "license": "Apache-2.0",
   "homepage": "https://peerd.ai",


### PR DESCRIPTION
## What

Cuts **v0.1.5** — bumps `package.json` 0.1.4 → 0.1.5, regenerates the dev manifest, adds the `[0.1.5]` CHANGELOG section, and folds in a small `.gitignore` cleanup.

## Contents (since `v0.1.4`)

**Security**
- **#72** — Notebook realm seal now covers the Cache API (the sealed worker also runs headless in the `js_run` offscreen host where `connect-src 'none'` doesn't backstop; all `CacheStorage` network verbs sealed)
- **#73** — web-write "approve for this session" scoped to the consented host (was a blanket pass to any host)

**Tooling**
- **#70 / #77** — autonomous e2e verify loop (one Chrome, per-state screenshots + structured `result.json`) + multi-turn / mode-toggle / vault-lock states; per-run artifacts gitignored (#74)

Both security fixes were reviewed by full adversarial-swarm panels at a no-residual-bypass bar.

## Also (gitignore hygiene)

`#74` + `#70` both added the `scripts/cdp/artifacts/` line, and `#74` stripped one of the two trailing CRs on the macOS Finder `Icon` line. This restores `Icon\r\r\n` and removes the duplicate artifacts entry.

## Verification

`bun run preflight -- --matrix` — **clean**: drift, ESLint, typecheck, boundary, **2111 Bun tests / 0 fail**, all four **v0.1.5** artifacts built, both store artifacts verified **zero dweb traces**.

## After merge

Tag `v0.1.5` on the merge commit → CI builds the signed artifacts and publishes `peerd-preview-v0.1.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHffCSYFCRUBQSAWCshR4K)_