### PR TITLE
fix(engine): serialize Notebook default-resolution per session (no double-create)

### DIFF
--- a/extension/background/notebook-client.js
+++ b/extension/background/notebook-client.js
@@ -8,6 +8,7 @@
 // vocabulary.
 
 import browser from '/vendor/browser-polyfill.js';
+import { createKeyedQueue } from '/peerd-engine/index.js';
 
 const MESSAGE_TIMEOUT_MS = 60_000;
 
@@ -42,6 +43,21 @@ export const createJsClient = ({ registry, tracker }) => {
     });
     await registry.setDefaultForSession(sessionId, created.id);
     return created.id;
+  };
+
+  // why a keyed queue (mirrors vm-client.js): the agent loop dispatches
+  // consecutive READ-class js tools (js_read_file, js_list_files) CONCURRENTLY,
+  // so two implicit-target calls in a fresh chat could BOTH see "no default
+  // notebook yet" and race to create two — one becomes an orphan (leaked tab +
+  // OPFS scratch) and the reads target different scratch dirs. Serialize lazy
+  // default-resolution per session so concurrent first-commands share the one
+  // created Notebook. Explicit-id / no-session lookups are pure reads — they
+  // skip the lane.
+  const queue = createKeyedQueue();
+  /** @param {{ sessionId?: string, notebookId?: string }} [opts] */
+  const resolveIdQueued = (opts = {}) => {
+    if (opts.notebookId || !opts.sessionId) return resolveId(opts);
+    return queue.enqueue(`resolve:${opts.sessionId}`, () => resolveId(opts));
   };
 
   /** @param {string} notebookId @param {{ type: string, [k: string]: unknown }} message */
@@ -84,7 +100,7 @@ export const createJsClient = ({ registry, tracker }) => {
 
     /** @param {string} code @param {{ sessionId?: string, notebookId?: string, timeoutMs?: number }} [opts] */
     eval: async (code, opts = {}) => {
-      const id = await resolveId(opts);
+      const id = await resolveIdQueued(opts);
       const response = await callTab(id, {
         type: 'js/eval',
         code,
@@ -95,7 +111,7 @@ export const createJsClient = ({ registry, tracker }) => {
 
     /** @param {string} path @param {string} content @param {{ sessionId?: string, notebookId?: string }} [opts] */
     writeFile: async (path, content, opts = {}) => {
-      const id = await resolveId(opts);
+      const id = await resolveIdQueued(opts);
       await callTab(id, {
         type: 'js/write-file',
         path,
@@ -105,14 +121,14 @@ export const createJsClient = ({ registry, tracker }) => {
 
     /** @param {string} path @param {{ sessionId?: string, notebookId?: string }} [opts] */
     readFile: async (path, opts = {}) => {
-      const id = await resolveId(opts);
+      const id = await resolveIdQueued(opts);
       const response = await callTab(id, { type: 'js/read-file', path });
       return response.content;
     },
 
     /** @param {{ sessionId?: string, notebookId?: string }} [opts] */
     listFiles: async (opts = {}) => {
-      const id = await resolveId(opts);
+      const id = await resolveIdQueued(opts);
       const response = await callTab(id, { type: 'js/list-files' });
       return response.files;
     },

--- a/tests/background/notebook-resolve-lane.test.ts
+++ b/tests/background/notebook-resolve-lane.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// notebook-client.js auto-creates a default Notebook on the first implicit-
+// target call. Without serialization, two concurrent first-commands — the agent
+// loop dispatches consecutive READ-class js tools (js_read_file, js_list_files)
+// concurrently — both see "no default yet" and create TWO Notebooks; one is
+// orphaned (leaked tab + OPFS scratch) and the reads target different scratch
+// dirs. The fix mirrors vm-client.js's per-session resolve lane.
+//
+// notebook-client imports the webextension-polyfill (not bun-importable), so
+// assert against the SOURCE TEXT, like offscreen-gate.test.ts. The lane
+// PRIMITIVE (createKeyedQueue) is behavior-tested in command-queue.test.ts;
+// these pin that notebook-client actually routes implicit resolution through it.
+const src = readFileSync(
+  join(import.meta.dir, '../../extension/background/notebook-client.js'),
+  'utf8',
+);
+
+describe('notebook-client — implicit resolve is serialized per session', () => {
+  test('lazy default-resolution runs behind a resolve:<sessionId> queue lane', () => {
+    expect(src).toMatch(/createKeyedQueue/);
+    expect(src).toMatch(/queue\.enqueue\(`resolve:\$\{opts\.sessionId\}`/);
+  });
+  test('every implicit-target method resolves through the queued lane, not the bare resolve', () => {
+    // the bare resolveId(opts) must NOT be the method path (it would race)
+    expect(src).not.toMatch(/const id = await resolveId\(opts\)/);
+    const queued = src.match(/const id = await resolveIdQueued\(opts\)/g) || [];
+    expect(queued.length).toBeGreaterThanOrEqual(4); // eval, writeFile, readFile, listFiles
+  });
+});


### PR DESCRIPTION
`notebook-client.resolveId` auto-creates a default Notebook when a call has no explicit `notebookId` and the session has no default yet. The agent loop dispatches consecutive READ-class js tools (`js_read_file`, `js_list_files`) **concurrently**, so two implicit-target calls in a fresh chat can both observe "no default yet" (`getDefaultForSession` returns null before either create's `setDefault` lands) and race to create **two** Notebooks — one orphaned (leaked tab + OPFS scratch), and the two reads land on different scratch dirs.

`vm-client.js` already solved this with a per-session resolve lane (`createKeyedQueue` + a `resolve:<sessionId>` enqueue, with a comment explaining exactly this race). `notebook-client` copied the lazy auto-create **without** the lane. This mirrors it: route implicit-target resolution through the queue so concurrent first-commands share the one created Notebook. Explicit-id / no-session lookups are pure reads and skip the lane. (`app-client` is already safe — its `resolveId` throws instead of auto-creating.)

## Test
A source assertion pins that every implicit-target method routes through the queued lane (notebook-client imports the webextension-polyfill, so it isn't bun-importable — same pattern as `offscreen-gate.test.ts`). The lane primitive itself (`createKeyedQueue`) is behavior-tested in `command-queue.test.ts`. **Revert-proven.** Full bun suite green (2119), typecheck + lint clean.