### PR TITLE
fix(engine): memoize registry load() so a cold-boot race can't drop a record

### DIFF
--- a/extension/peerd-engine/registry-factory.js
+++ b/extension/peerd-engine/registry-factory.js
@@ -85,6 +85,8 @@ export const createRegistry = (config, { storage }) => {
 
   let state = defaultState();
   let loaded = false;
+  /** @type {Promise<void> | null} the in-flight load(), shared by concurrent callers */
+  let loadPromise = null;
 
   // why a typed accessor: the id→record map sits under the dynamic
   // `collectionKey`, so index access yields the state's union value type;
@@ -93,18 +95,30 @@ export const createRegistry = (config, { storage }) => {
   /** @returns {Record<string, Rec>} */
   const collection = () => /** @type {Record<string, Rec>} */ (state[collectionKey]);
 
-  const load = async () => {
-    if (loaded) return;
-    const raw = await storage.get(storageKey);
-    state = (raw && typeof raw === 'object' && raw.schemaVersion === 1)
-      ? {
-          ...defaultState(),
-          ...raw,
-          [collectionKey]: { ...raw[collectionKey] },
-          sessionDefaults: { ...raw.sessionDefaults },
-        }
-      : defaultState();
-    loaded = true;
+  // why memoize the in-flight read: load() yields at `await storage.get`, and
+  // the `loaded` flag is only set AFTER. Two concurrent callers (a cold-boot
+  // wave — boot runs load() un-awaited and a registry op can arrive before it
+  // resolves) would each reassign the module-level `state` from a pre-write
+  // snapshot, so the later resolver clobbers the earlier op's committed write
+  // (a just-created/deleted record silently vanishes, its OPFS subtree orphaned).
+  // Sharing one promise collapses concurrent loads onto a single read + state.
+  const load = () => {
+    if (loaded) return Promise.resolve();
+    if (!loadPromise) {
+      loadPromise = (async () => {
+        const raw = await storage.get(storageKey);
+        state = (raw && typeof raw === 'object' && raw.schemaVersion === 1)
+          ? {
+              ...defaultState(),
+              ...raw,
+              [collectionKey]: { ...raw[collectionKey] },
+              sessionDefaults: { ...raw.sessionDefaults },
+            }
+          : defaultState();
+        loaded = true;
+      })();
+    }
+    return loadPromise;
   };
 
   const persist = async () => {

--- a/tests/peerd-engine/vm-registry.test.ts
+++ b/tests/peerd-engine/vm-registry.test.ts
@@ -101,4 +101,24 @@ describe('createVmRegistry', () => {
     expect(items[0].name).toBe('persisted');
     expect(await reg2.getDefaultForSession('chat-1')).toBe(rec.id);
   });
+
+  // Cold-registry re-entrancy: load() yields at storage.get before setting the
+  // `loaded` flag, so two concurrent first-ops must share ONE load — otherwise
+  // each reassigns `state` from a pre-write snapshot and the later one clobbers
+  // the earlier op's record (it vanishes, its OPFS subtree orphaned).
+  test('concurrent first ops on a cold registry share one load (no clobber)', async () => {
+    const store = new Map<string, unknown>();
+    let getCount = 0;
+    const storage = {
+      // slow get widens the race window; counted to prove load() reads once
+      get: async (k: string) => { getCount += 1; await new Promise((r) => setTimeout(r, 15)); return store.get(k); },
+      set: async (k: string, v: unknown) => { store.set(k, v); },
+      delete: async (k: string) => { store.delete(k); },
+    };
+    const reg = createVmRegistry({ storage });
+    await Promise.all([reg.create({ name: 'a' }), reg.create({ name: 'b' })]);
+    const items = await reg.list();
+    expect(items.map((x) => x.name).sort()).toEqual(['a', 'b']); // neither create clobbered
+    expect(getCount).toBe(1);                                    // load() read storage exactly once (memoized)
+  });
 });


### PR DESCRIPTION
Every engine registry (VM / Notebook / App) lazily loads its catalog from storage on the first op. `load()` yields at `await storage.get` and only sets the `loaded` flag **afterward**, so two concurrent first-ops — reachable at cold SW boot, where the boot IIFE runs `load()` un-awaited and an inbound registry op can arrive before it resolves — each reassign the module-level `state` from a pre-write snapshot. The later-resolving `load()` overwrites the earlier op's committed write, so a just-created/deleted record silently vanishes from the catalog and its OPFS subtree is orphaned.

## Fix
Memoize the in-flight `load()` promise so concurrent callers share one read + one `state` object. After `loaded`, every op skips the read as before. One added field, one rewritten `load()`.

## Test (revert-proven)
In `vm-registry.test.ts`: two concurrent `create()`s on a cold registry with a slow, counting storage stub — both records persist (no clobber) and `load()` reads storage **exactly once**. Restoring the non-memoized `load()` fails it. Full bun suite green (2120), typecheck + lint clean.

Found by the engine security audit; LOW (cold-boot-only window, no security boundary), but a clean one-field fix for a real data-integrity race.