### PR TITLE
fix(dweb): drop unparseable data-channel frames + bound the pre-description ICE buffer

### DIFF
--- a/extension/peerd-distributed/transport/peer.js
+++ b/extension/peerd-distributed/transport/peer.js
@@ -86,6 +86,11 @@ export const createPeer = ({
   }
   /** @type {RTCIceCandidateInit[]} */
   const pendingRemote = [];
+  // why a cap: candidates that arrive before the remote description is set are
+  // buffered here; a hostile peer could otherwise trickle UNBOUNDED candidate
+  // frames before ever sending a description, growing this array without limit.
+  // A real ICE gather is a handful of candidates; 64 is generous headroom.
+  const MAX_PENDING_REMOTE = 64;
   /** @param {RTCSessionDescriptionInit} desc */
   const setRemote = async (desc) => {
     await pc.setRemoteDescription(desc);
@@ -97,7 +102,14 @@ export const createPeer = ({
   /** @param {RTCIceCandidateInit | null} candidate */
   const addRemoteCandidate = async (candidate) => {
     if (!candidate) return; // end-of-candidates marker — nothing to add
-    if (!pc.remoteDescription) { pendingRemote.push(candidate); return; }
+    if (!pc.remoteDescription) {
+      if (pendingRemote.length >= MAX_PENDING_REMOTE) {
+        dwarn('webrtc', 'dropping ICE candidate — pre-description buffer full');
+        return;
+      }
+      pendingRemote.push(candidate);
+      return;
+    }
     try { await pc.addIceCandidate(candidate); }
     catch (e) { dwarn('webrtc', `addIceCandidate failed: ${/** @type {{ message?: string }} */ (e)?.message ?? e}`); }
   };
@@ -164,7 +176,16 @@ export const createPeer = ({
     // selected candidate pair off the live pc; the mesh stores the channel,
     // not the peer wrapper, so the pc rides along.
     channel.pc = pc;
-    dc.onmessage = (e) => channel.deliver(decode(e.data));
+    dc.onmessage = (e) => {
+      // why try/catch: e.data is attacker-controlled bytes from a remote peer;
+      // a malformed frame would otherwise throw an uncaught exception out of the
+      // event handler. Best-effort mesh traffic — drop the bad frame, like the
+      // outbound send already drops when the channel isn't open.
+      let m;
+      try { m = decode(e.data); }
+      catch { dwarn('webrtc', 'dropping unparseable data-channel frame'); return; }
+      channel.deliver(m);
+    };
     dc.onopen = () => { dlog('webrtc', '🟢 data channel OPEN — peers connected directly'); resolveChannel(channel); };
     dc.onclose = () => channel.signalClose();
     pc.addEventListener('connectionstatechange', () => {

--- a/tests/peerd-distributed/peer.test.ts
+++ b/tests/peerd-distributed/peer.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect } from 'bun:test';
+import { createPeer } from '../../extension/peerd-distributed/transport/peer.js';
+
+// createPeer runs over WebRTC, but the RTCPeerConnection is injectable, so its
+// inbound-robustness logic is unit-testable with a minimal mock: the
+// pre-description ICE buffer must be bounded (a hostile peer cannot trickle
+// unbounded candidates before sending a description), and a malformed
+// data-channel frame must be dropped, not thrown out of the event handler.
+
+class MockDataChannel {
+  readyState = 'connecting';
+  onmessage: any = null;
+  onopen: any = null;
+  onclose: any = null;
+  send() {}
+  close() { this.readyState = 'closed'; }
+}
+
+class MockRTCPeerConnection {
+  remoteDescription: any = null;
+  connectionState = 'new';
+  iceConnectionState = 'new';
+  addIceCalls: any[] = [];
+  dc = new MockDataChannel();
+  constructor(public config: any) {}
+  addEventListener() {}
+  createDataChannel() { return this.dc; }
+  ondatachannel: any = null;
+  async setRemoteDescription(d: any) { this.remoteDescription = d; }
+  async addIceCandidate(c: any) { this.addIceCalls.push(c); }
+  close() {}
+}
+
+const makePeer = () => createPeer({ initiator: true, RTCPeerConnection: MockRTCPeerConnection as any });
+
+describe('createPeer — inbound robustness', () => {
+  test('the pre-description ICE buffer is bounded (candidates past the cap are dropped)', async () => {
+    const peer = makePeer();
+    const pc = peer.pc as any;
+    // 65 candidates arrive before any remote description → buffered, none applied
+    for (let i = 0; i < 65; i += 1) await peer.addRemoteCandidate({ candidate: `c${i}`, sdpMid: '0' } as any);
+    expect(pc.addIceCalls.length).toBe(0);
+    // setting the remote description flushes the buffer — exactly the cap (64),
+    // the 65th was dropped
+    await peer.setRemote({ type: 'answer', sdp: 'x' } as any);
+    expect(pc.addIceCalls.length).toBe(64);
+  });
+
+  test('a malformed data-channel frame is dropped, not thrown out of the handler', () => {
+    const peer = makePeer();
+    const dc = (peer.pc as any).dc;
+    expect(typeof dc.onmessage).toBe('function');
+    expect(() => dc.onmessage({ data: '{ not valid json' })).not.toThrow();
+    expect(() => dc.onmessage({ data: 'garbage' })).not.toThrow();
+    // a well-formed frame still flows (the guard only catches the parse)
+    expect(() => dc.onmessage({ data: JSON.stringify({ ok: 1 }) })).not.toThrow();
+  });
+});


### PR DESCRIPTION
Two inbound-robustness guards on the WebRTC peer transport (`transport/peer.js`), which parses bytes straight from anonymous remote peers.

- **Unparseable frame → uncaught throw.** The data-channel `onmessage` ran `JSON.parse` with no catch, so a malformed frame from a remote peer threw an uncaught exception out of the event handler. Now the decode is wrapped: a bad frame is best-effort mesh traffic and is dropped (with a warn), exactly as the outbound send already drops when the channel isn't open.
- **Unbounded pre-description ICE buffer.** Candidates that arrive before the remote description is set are buffered; a peer could trickle unbounded candidate frames before ever sending a description, growing the array without limit. The pre-description buffer is now capped (64 - generous headroom over a real ICE gather).

**Tests** (revert-proven; `createPeer`'s `RTCPeerConnection` is injectable, so a minimal mock unit-tests it): a malformed frame is dropped not thrown; the ICE buffer flushes exactly the cap, not past it. Full bun suite green.

Both are local-robustness no-regrets - correct under any eventual inbound-security model. Surfaced by an audit of the dweb's untrusted-inbound surface (the area #35 covers); preview-channel-only code.