### PR TITLE
fix(dweb): cap bundle size before buffering (OOM guard)

### DIFF
--- a/extension/peerd-distributed/content/manifest.js
+++ b/extension/peerd-distributed/content/manifest.js
@@ -34,6 +34,43 @@ const signingBytes = (manifest) =>
 
 export { manifestHash };
 
+// why a cap before buffering: a bundle is fetched and reassembled fully in
+// memory before the loader's own MAX_TOTAL_CHARS cap can fire. The publisher
+// signs their OWN manifest, so the hash + signature checks do NOT bound its
+// size — a hostile manifest can declare a multi-GB payload, or a short chunk
+// list whose entries all reference ONE chunk so reassembly amplifies it
+// thousand-fold. Bound it on the FETCH path, before any chunk is pulled.
+// Aligns with apps/loader.js MAX_TOTAL_CHARS.
+export const MAX_BUNDLE_BYTES = 50_000_000;
+
+/**
+ * Reject an over-large or amplified manifest BEFORE any chunk is fetched or the
+ * payload is reassembled. Sums the declared chunk sizes over EVERY entry
+ * (duplicates included — reassembly maps over all of manifest.chunks, so N refs
+ * to one chunk reassemble to N×size even though the chunk is fetched once), and
+ * binds manifest.size to that sum so the size field cannot under-report to slip
+ * past a naive size check. A legit manifest never trips this: chunks are
+ * non-overlapping slices, so size === sum(chunk.size) by construction.
+ *
+ * @param {Manifest} manifest
+ */
+export const assertBundleWithinLimits = (manifest) => {
+  const chunks = manifest?.chunks;
+  if (!Array.isArray(chunks)) throw new Error('manifest has no chunk list');
+  let declared = 0;
+  for (const c of chunks) {
+    const size = c?.size;
+    if (!Number.isInteger(size) || size < 0) throw new Error('manifest chunk size invalid');
+    declared += size;
+    if (declared > MAX_BUNDLE_BYTES) {
+      throw new Error(`bundle too large: chunks declare more than ${MAX_BUNDLE_BYTES} bytes`);
+    }
+  }
+  if (!Number.isInteger(manifest.size) || manifest.size !== declared) {
+    throw new Error(`manifest size ${manifest?.size} does not match its chunk list (${declared})`);
+  }
+};
+
 /**
  * Build (and optionally sign) a manifest for a payload.
  *

--- a/extension/peerd-distributed/content/swarm.js
+++ b/extension/peerd-distributed/content/swarm.js
@@ -16,7 +16,7 @@
 // against the signed manifest's hash, so a malicious provider can't corrupt a
 // byte — it can only fail to serve, which failover covers.
 
-import { manifestHash, verifyManifest } from './manifest.js';
+import { manifestHash, verifyManifest, assertBundleWithinLimits } from './manifest.js';
 import { sha256hex } from './chunk.js';
 import { parsePeerdUri } from './uri.js';
 import { fromBase64, concat } from '/shared/bundle/bytes.js';
@@ -105,6 +105,9 @@ export const swarmFetch = async ({ uri, providers, channelFor, onProgress, timeo
     if (await manifestHash(manifest) !== hash) throw new Error('manifest hash mismatch — address does not match payload');
     const v = await verifyManifest(manifest);
     if (!v.ok) throw new Error(`manifest signature invalid: ${v.reason}`);
+    // 2b. Bound the (attacker-signed) manifest before buffering anything — a
+    // valid signature does not bound its declared size or chunk count.
+    assertBundleWithinLimits(manifest);
     onProgress?.({ phase: 'manifest', publisher: v.publisher, total: manifest.chunks.length, providers: clients.length });
 
     // 3. Stripe unique chunks across providers — α concurrent, per-chunk failover.

--- a/extension/peerd-distributed/content/transfer.js
+++ b/extension/peerd-distributed/content/transfer.js
@@ -13,7 +13,7 @@
 //   { t:'CHUNK_REQ', hash }         -> { t:'CHUNK', hash, bytes(base64) }
 //                                   or { t:'NOCHUNK', hash }
 
-import { manifestHash, verifyManifest } from './manifest.js';
+import { manifestHash, verifyManifest, assertBundleWithinLimits } from './manifest.js';
 import { sha256hex } from './chunk.js';
 import { parsePeerdUri } from './uri.js';
 import { toBase64, fromBase64, concat } from '/shared/bundle/bytes.js';
@@ -124,6 +124,9 @@ export const fetchBundle = async ({ uri, channel, onProgress, timeoutMs = 15000 
   if (computed !== hash) throw new Error('manifest hash mismatch — content address does not match payload');
   const v = await verifyManifest(manifest);
   if (!v.ok) throw new Error(`manifest signature invalid: ${v.reason}`);
+  // 2b. Bound the (attacker-signed) manifest before buffering anything — a
+  // valid signature does not bound its declared size or chunk count.
+  assertBundleWithinLimits(manifest);
   onProgress?.({ phase: 'manifest', publisher: v.publisher, total: manifest.chunks.length });
 
   // 3. Fetch unique chunk hashes in parallel (dedup so identical chunks

--- a/tests/peerd-distributed/bundle-limits.test.ts
+++ b/tests/peerd-distributed/bundle-limits.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect } from 'bun:test';
+import { assertBundleWithinLimits, MAX_BUNDLE_BYTES } from '../../extension/peerd-distributed/content/manifest.js';
+
+// A hostile publisher signs their OWN manifest, so the hash + signature checks
+// never bound its declared size or chunk list. assertBundleWithinLimits is the
+// pre-fetch ceiling that keeps a bundle from being buffered/reassembled into a
+// multi-GB allocation (an OOM DoS of the offscreen document).
+
+const chunk = (size: number, hash = 'a'.repeat(64)) => ({ hash, size });
+
+describe('assertBundleWithinLimits — bundle OOM guard', () => {
+  test('accepts a legit manifest (size === sum of chunk sizes, within cap)', () => {
+    const chunks = [chunk(262144, 'a'.repeat(64)), chunk(100, 'b'.repeat(64))];
+    expect(() => assertBundleWithinLimits({ size: 262244, chunks } as any)).not.toThrow();
+  });
+
+  test('rejects a multi-GB bundle (many distinct chunks) before any fetch', () => {
+    const big = Array.from({ length: 20000 }, (_, i) => chunk(262144, String(i).padEnd(64, '0')));
+    expect(() => assertBundleWithinLimits({ size: 20000 * 262144, chunks: big } as any)).toThrow(/too large/);
+  });
+
+  test('rejects the reassembly amplification: thousands of refs to ONE chunk', () => {
+    // fetched once (deduped), but reassembly maps over every entry → ~10GB
+    const amp = Array.from({ length: 40000 }, () => chunk(262144, 'a'.repeat(64)));
+    expect(() => assertBundleWithinLimits({ size: 40000 * 262144, chunks: amp } as any)).toThrow(/too large/);
+  });
+
+  test('rejects a manifest that under-reports size to dodge a naive size check', () => {
+    const chunks = [chunk(262144), chunk(262144)];
+    expect(() => assertBundleWithinLimits({ size: 100, chunks } as any)).toThrow(/does not match/);
+  });
+
+  test('rejects non-integer / negative chunk sizes', () => {
+    expect(() => assertBundleWithinLimits({ size: 0, chunks: [chunk(-1)] } as any)).toThrow(/chunk size invalid/);
+    expect(() => assertBundleWithinLimits({ size: 0, chunks: [chunk(1.5)] } as any)).toThrow(/chunk size invalid/);
+  });
+
+  test('rejects a missing chunk list', () => {
+    expect(() => assertBundleWithinLimits({ size: 0 } as any)).toThrow(/no chunk list/);
+  });
+
+  test('the cap aligns with the loader budget', () => {
+    expect(MAX_BUNDLE_BYTES).toBe(50_000_000);
+  });
+});
+
+describe('both fetch paths enforce the cap before buffering', () => {
+  test('fetchBundle and swarmFetch call the guard after verification, before the chunk fetch', async () => {
+    const files = [
+      'extension/peerd-distributed/content/transfer.js',
+      'extension/peerd-distributed/content/swarm.js',
+    ];
+    for (const f of files) {
+      const src = await Bun.file(f).text();
+      expect(src).toContain('assertBundleWithinLimits(manifest)');
+      const verifyAt = src.indexOf('verifyManifest(manifest)');
+      const capAt = src.indexOf('assertBundleWithinLimits(manifest)');
+      const fetchAt = src.indexOf('uniqueHashes');
+      expect(verifyAt).toBeGreaterThan(-1);
+      expect(capAt).toBeGreaterThan(verifyAt); // after the signature check
+      expect(capAt).toBeLessThan(fetchAt); // before the chunks are pulled
+    }
+  });
+});


### PR DESCRIPTION
A content bundle is fetched and reassembled **fully in memory** before the app loader's `MAX_TOTAL_CHARS` cap can fire - so the cap sat one layer too late. The publisher signs their **own** manifest, so the content-hash and signature checks don't bound its declared size or chunk list. Two ways a hostile manifest reaches a multi-GB allocation in the offscreen document:

- declare a multi-GB payload across many chunks, or
- a short chunk list whose entries **all reference one chunk** - fetched once (deduped), but reassembly maps over every entry, expanding a single 256KB chunk thousand-fold.

Either way it OOMs during reassembly, before the loader's cap is consulted.

**Fix:** `assertBundleWithinLimits(manifest)` on the fetch path - right after the signature check, before any chunk is pulled. It sums the declared chunk sizes over **every** entry (duplicates included - that's the amplification vector) against a 50MB ceiling matching the loader budget, and binds `manifest.size` to that sum so the size field can't under-report. Wired into both `fetchBundle` (point-to-point) and `swarmFetch` (multi-provider).

**No false-rejects:** a legit manifest never trips it - chunks are non-overlapping slices, so `size === sum(chunk.size)` by construction. The existing end-to-end transfer tests pass unchanged.

**Tests** (revert-proven): rejects an oversized bundle, the reassembly-amplification, and an under-reported size; a legit manifest passes; a source assertion pins the call into both fetch paths after verification and before the fetch. Full bun suite green (2125).

Surfaced by an audit of the dweb's untrusted-inbound surface (the area #35 covers); preview-channel-only code, no-regrets bound.