### PR TITLE
fix(dweb): make DHT node.handle total over malformed RPC

### DIFF
--- a/extension/peerd-distributed/dht/node.js
+++ b/extension/peerd-distributed/dht/node.js
@@ -23,6 +23,14 @@ import { nodeIdOf, byDistanceTo } from './distance.js';
 import { itemKey } from './records.js';
 import { toHex, fromHex } from '/shared/bundle/bytes.js';
 
+// A wire-supplied DHT key/target is always a SHA-256 digest in hex: exactly 64
+// lowercase hex chars (nodeIdOf / itemKey / mutableKey all hash to 32 bytes,
+// toHex emits lowercase). Anything else is a malformed frame — reject it BEFORE
+// fromHex (odd-length throws, `undefined` throws a TypeError) so handle() stays
+// total and the responder can answer {t:'ERR'} instead of black-holing the RESP.
+/** @param {unknown} h */
+const isDhtKeyHex = (h) => typeof h === 'string' && /^[0-9a-f]{64}$/.test(h);
+
 /**
  * @param {{
  *   identity: { did: string },
@@ -71,8 +79,10 @@ export const createDhtNode = ({ identity, selfId, store, providers = null, rpc, 
       case 'PING':
         return { t: 'PONG' };
       case 'FIND_NODE':
+        if (!isDhtKeyHex(msg.target)) return { t: 'ERR', reason: 'bad-target' };
         return { t: 'NODES', nodes: rt.closest(fromHex(msg.target), k).map(wire) };
       case 'FIND_VALUE': {
+        if (!isDhtKeyHex(msg.key)) return { t: 'ERR', reason: 'bad-key' };
         const hit = store.get(msg.key);
         if (hit) return { t: 'VALUE', item: hit };
         return { t: 'NODES', nodes: rt.closest(fromHex(msg.key), k).map(wire) };
@@ -84,6 +94,7 @@ export const createDhtNode = ({ identity, selfId, store, providers = null, rpc, 
       case 'GET_PROVIDERS':
         // Like FIND_VALUE: hand back whatever providers we hold for the key AND
         // the closer contacts, so the caller's iterative walk converges.
+        if (!isDhtKeyHex(msg.key)) return { t: 'ERR', reason: 'bad-key' };
         return { t: 'PROVIDERS', providers: providers ? providers.list(msg.key) : [], nodes: rt.closest(fromHex(msg.key), k).map(wire) };
       default:
         return { t: 'ERR', reason: 'unknown-rpc' };

--- a/extension/peerd-distributed/dht/records.js
+++ b/extension/peerd-distributed/dht/records.js
@@ -75,6 +75,10 @@ export const itemWellFormed = (item) => {
   if (!item || typeof item !== 'object') return false;
   const it = /** @type {Record<string, unknown>} */ (item);
   if (typeof it.publisher !== 'string' || !it.publisher) return false;
+  // publisher must be a decodable did:key — itemKey()/verifyItem() both feed it
+  // straight into decodeDidKey (which throws on anything else), so reject it here
+  // rather than let a malformed STORE throw out of store.put().
+  try { decodeDidKey(it.publisher); } catch { return false; }
   if (typeof it.seq !== 'number' || !Number.isInteger(it.seq) || it.seq < 0) return false;
   if (typeof it.sig !== 'string' || !it.sig) return false;
   if (it.salt != null && (typeof it.salt !== 'string' || it.salt.length > MAX_SALT_LEN)) return false;

--- a/extension/peerd-distributed/dht/transport.js
+++ b/extension/peerd-distributed/dht/transport.js
@@ -62,7 +62,11 @@ export const attachDht = ({ mesh, identity, selfId, store, providers = null, dia
     if (env.ch !== CH_DHT || !env.body) return;
     if (env.typ === REQ) {
       // Serve it. env.from is the authenticated neighbour (mesh guaranteed it).
-      const resp = await node.handle(env.from, env.body.msg);
+      // Backstop: a malformed frame must never throw out of this fire-and-forget
+      // callback (unhandled rejection) nor black-hole the RESP — always answer.
+      let resp;
+      try { resp = await node.handle(env.from, env.body.msg); }
+      catch { resp = { t: 'ERR', reason: 'handler-error' }; }
       mesh.send(env.from, await mesh.sign(CH_DHT, RESP, { reqId: env.body.reqId, resp }));
     } else if (env.typ === RESP) {
       const p = pending.get(env.body.reqId);

--- a/tests/peerd-distributed/dht-rpc-guard.test.ts
+++ b/tests/peerd-distributed/dht-rpc-guard.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect } from 'bun:test';
+import { generateIdentity } from '../../extension/peerd-distributed/identity/keypair.js';
+import { createDhtNode } from '../../extension/peerd-distributed/dht/node.js';
+import { createDhtStore } from '../../extension/peerd-distributed/dht/store.js';
+import { nodeIdOf } from '../../extension/peerd-distributed/dht/distance.js';
+import { itemWellFormed, signItem } from '../../extension/peerd-distributed/dht/records.js';
+
+// D1: a malformed ch=1 DHT RPC from an authenticated neighbour must never throw
+// out of node.handle() (it is awaited in a fire-and-forget onEnvelope callback,
+// so a throw is an unhandled rejection AND black-holes the RESP). handle() must
+// stay total — answer {t:'ERR'} — and reject no legitimate frame.
+
+const makeNode = async () => {
+  const identity = await generateIdentity();
+  const selfId = await nodeIdOf(identity.did);
+  const store = createDhtStore();
+  const rpc = async () => { throw new Error('unreachable'); };
+  return { identity, node: createDhtNode({ identity, selfId, store, rpc }) };
+};
+
+const NEIGHBOUR = 'did:key:zSomeAuthenticatedNeighbour';
+
+describe('dht node.handle — total over malformed RPC (D1)', () => {
+  test('FIND_NODE with absent / odd / non-hex / wrong-length / uppercase target → ERR, never throws', async () => {
+    const { node } = await makeNode();
+    for (const target of [undefined, 'a', 'zz', 'AB'.repeat(32), '00'.repeat(31), '00'.repeat(33)]) {
+      expect(await node.handle(NEIGHBOUR, { t: 'FIND_NODE', target })).toEqual({ t: 'ERR', reason: 'bad-target' });
+    }
+  });
+
+  test('FIND_VALUE / GET_PROVIDERS with a bad key → ERR, never throw', async () => {
+    const { node } = await makeNode();
+    for (const t of ['FIND_VALUE', 'GET_PROVIDERS']) {
+      expect(await node.handle(NEIGHBOUR, { t, key: undefined })).toEqual({ t: 'ERR', reason: 'bad-key' });
+      expect(await node.handle(NEIGHBOUR, { t, key: 'nothex' })).toEqual({ t: 'ERR', reason: 'bad-key' });
+    }
+  });
+
+  test('a well-formed 64-hex key still serves normally (no false reject)', async () => {
+    const { node } = await makeNode();
+    expect((await node.handle(NEIGHBOUR, { t: 'FIND_NODE', target: '00'.repeat(32) })).t).toBe('NODES');
+    expect(['VALUE', 'NODES']).toContain((await node.handle(NEIGHBOUR, { t: 'FIND_VALUE', key: 'ab'.repeat(32) })).t);
+  });
+
+  test('STORE with a non-did publisher is rejected (malformed), not thrown', async () => {
+    const { node } = await makeNode();
+    const r = await node.handle(NEIGHBOUR, { t: 'STORE', item: { publisher: 'x', seq: 0, sig: 'aaaa', value: 0 } });
+    expect(r).toEqual({ t: 'STORED', ok: false, reason: 'malformed' });
+  });
+
+  test('a genuinely-signed item still stores (no false reject)', async () => {
+    const { node, identity } = await makeNode();
+    const item = await signItem({ value: { ok: 1 }, seq: 1 }, identity);
+    const r = await node.handle(identity.did, { t: 'STORE', item });
+    expect(r.t).toBe('STORED');
+    expect((r as { ok?: boolean }).ok).toBe(true);
+  });
+});
+
+describe('itemWellFormed — publisher must be a did:key (D1)', () => {
+  test('rejects a non-did publisher', () => {
+    expect(itemWellFormed({ publisher: 'x', seq: 0, sig: 'a' })).toBe(false);
+    expect(itemWellFormed({ publisher: 'did:key:notvalid!!', seq: 0, sig: 'a' })).toBe(false);
+  });
+
+  test('accepts a real signed item', async () => {
+    const identity = await generateIdentity();
+    const item = await signItem({ value: { ok: 1 }, seq: 1 }, identity);
+    expect(itemWellFormed(item)).toBe(true);
+  });
+});
+
+describe('transport REQ backstop wiring (D1)', () => {
+  test('onEnvelope REQ wraps node.handle so a throw becomes {t:ERR}, never an unhandled rejection', async () => {
+    const src = await Bun.file('extension/peerd-distributed/dht/transport.js').text();
+    expect(src).toContain("catch { resp = { t: 'ERR', reason: 'handler-error' }; }");
+    const tryAt = src.indexOf('try { resp = await node.handle');
+    const sendAt = src.indexOf('mesh.send(env.from, await mesh.sign(CH_DHT, RESP');
+    expect(tryAt).toBeGreaterThan(-1);
+    expect(sendAt).toBeGreaterThan(tryAt); // the RESP is sent after the guarded handle
+  });
+});


### PR DESCRIPTION
A ch=1 DHT RPC from an authenticated neighbour fed attacker-controlled fields straight into throwing helpers with no guard:
- an absent / odd-length / non-hex `FIND_NODE` target or `FIND_VALUE`/`GET_PROVIDERS` key threw out of `fromHex`;
- a `STORE` whose `item.publisher` was any non-empty string (never validated as a did:key) passed `itemWellFormed`, then threw out of `store.put` → `itemKey` → `decodeDidKey`.

`node.handle` is awaited inside a **fire-and-forget** mesh `onEnvelope` callback, so each throw became an **unhandled rejection** *and* **black-holed the RESP** - the caller waits out its full timeout for a reply that never comes.

Three defense-in-depth guards keep `handle()` total:
- **node.js** - an `isDhtKeyHex` guard (exactly 64 lowercase hex, the shape every legit SHA-256 key carries) gates each `fromHex` case; a bad key returns a typed `{t:'ERR'}`.
- **records.js** - `itemWellFormed` now rejects a publisher that isn't a decodable did:key (wrapping the existing `decodeDidKey`), closing the STORE throw at source; `store.put` returns `{ok:false,reason:'malformed'}` as it does for any bad item.
- **transport.js** - the `onEnvelope` REQ branch wraps `node.handle` in try/catch and still emits a RESP carrying `{t:'ERR'}`, so no future throwing path can black-hole the reply or surface an unhandled rejection.

**No false-rejects:** every honest target/key is a 64-hex SHA-256 digest and every honest publisher is a did:key (a non-did item would fail `verifyItem` downstream anyway).

**Tests** (revert-proven): malformed `FIND_*`/`GET_PROVIDERS` return ERR not throw; a 64-hex key still serves; a non-did STORE is rejected not thrown; genuine items still store; `itemWellFormed` gates the publisher; the transport backstop is pinned. Full bun suite green (2125).

Surfaced by an audit of the dweb's untrusted-inbound surface (#35); preview-channel-only, no-regrets bound.