### PR TITLE
fix(dweb): close the RTCPeerConnection on an abandoned WebRTC dial

### DIFF
--- a/extension/peerd-distributed/transport/rooms.js
+++ b/extension/peerd-distributed/transport/rooms.js
@@ -195,13 +195,18 @@ export const joinRoom = async ({
       dlog('room', `📥 offer from ${from} — answering (trickle)`);
       const { route: r, signaling } = makeSignaling((p) => s.sendSignal(from, p));
       routers.set(from, r);
+      // why ac: on the give-up timeout below, abort tells the transport to close
+      // the abandoned pc (D2 leak). The transport ignores the abort once the
+      // channel has opened, so aborting in finally never harms an admitted link.
+      const ac = new AbortController();
       try {
-        const { channel } = await t.accept({ offer: payload, iceServers, signaling });
+        const { channel } = await t.accept({ offer: payload, iceServers, signaling, signal: ac.signal });
         await admit(await withConnectTimeout(channel, `accept ${from}`), null, 'rendezvous');
       } catch (e) {
         logConnectFail('accept from', from, e);
         audit?.('room_accept_failed', { member: from, error: /** @type {{ message?: string }} */ (e)?.message });
       } finally {
+        ac.abort();
         routers.delete(from);
       }
     });
@@ -224,9 +229,11 @@ export const joinRoom = async ({
       dlog('room', `📞 dialing ${member} (trickle: offer now, candidates streaming)…`);
       const { route, signaling } = makeSignaling((p) => s.sendSignal(member, p));
       routers.set(member, route);
+      // why ac: see s.on('signal') above — close the abandoned pc on timeout (D2).
+      const ac = new AbortController();
       try {
         const channel = await withConnectTimeout(
-          t.connect({ did: `${roomId}/${member}` }, { iceServers, signaling }),
+          t.connect({ did: `${roomId}/${member}` }, { iceServers, signaling, signal: ac.signal }),
           `dial ${member}`,
         );
         await admit(channel, null, 'rendezvous');
@@ -234,6 +241,7 @@ export const joinRoom = async ({
         logConnectFail('dial to', member, e);
         audit?.('room_dial_failed', { member, error: /** @type {{ message?: string }} */ (e)?.message });
       } finally {
+        ac.abort();
         routers.delete(member);
       }
     };
@@ -254,14 +262,18 @@ export const joinRoom = async ({
       const { route, signaling } = makeSignaling((p) =>
         mesh.relay(via, env.from, p.type === 'answer' ? 'answer' : 'ice', sid, p));
       relayRouters.set(sid, route);
+      // why ac: a hostile relayed offerer can answer then stall ICE forever —
+      // close the abandoned pc on the give-up timeout (D2).
+      const ac = new AbortController();
       try {
-        const { channel } = await t.accept({ offer: payload, iceServers, signaling });
+        const { channel } = await t.accept({ offer: payload, iceServers, signaling, signal: ac.signal });
         await admit(await withConnectTimeout(channel, `relay accept ${short(env.from)}`), env.from, via);
         audit?.('relay_join_accepted', { did: env.from, via });
       } catch (e) {
         logConnectFail('relay accept', env.from, e);
         audit?.('relay_accept_failed', { from: env.from, error: /** @type {{ message?: string }} */ (e)?.message });
       } finally {
+        ac.abort();
         relayRouters.delete(sid);
       }
       return;
@@ -277,13 +289,16 @@ export const joinRoom = async ({
     const { route, signaling } = makeSignaling((p) =>
       mesh.relay(via, targetDid, p.type === 'offer' ? 'offer' : 'ice', sid, p));
     relayRouters.set(sid, route);
+    // why ac: close the abandoned pc on the give-up timeout (D2).
+    const ac = new AbortController();
     try {
       const channel = await withConnectTimeout(
-        t.connect({ did: targetDid }, { iceServers, signaling }),
+        t.connect({ did: targetDid }, { iceServers, signaling, signal: ac.signal }),
         `relay dial ${short(targetDid)}`,
       );
       await admit(channel, targetDid, via);
     } finally {
+      ac.abort();
       relayRouters.delete(sid);
     }
   };

--- a/extension/peerd-distributed/transport/signaling-client.js
+++ b/extension/peerd-distributed/transport/signaling-client.js
@@ -216,13 +216,18 @@ export const connectViaSignaling = async ({
     };
   };
 
+  // why ac: when `deadline` wins the race below (the peer never pairs), the
+  // in-flight t.connect/t.accept pc is abandoned — abort closes it (the D2 leak
+  // the rooms.js sites also fix). The transport ignores the abort once the
+  // channel has opened, so aborting in finally never harms a live link.
+  const ac = new AbortController();
   const dance = (async () => {
     const sig = makeSignaling();
     if (session.members.length > 0) {
       // A member is present → we are the joiner → we offer (to the first;
       // 1:1 callers use single-purpose room codes).
       sig.setMember(session.members[0]);
-      const channel = await t.connect({ did: room }, { sameMachine, iceServers, signaling: sig.signaling });
+      const channel = await t.connect({ did: room }, { sameMachine, iceServers, signaling: sig.signaling, signal: ac.signal });
       return { channel, role: 'initiator', transport: 'webrtc' };
     }
     // Room was empty → wait for the first inbound payload (an offer), which
@@ -230,13 +235,14 @@ export const connectViaSignaling = async ({
     const offer = await new Promise((res) => {
       const off = session.on('signal', (/** @type {{ payload: any }} */ { payload }) => { off(); res(payload); });
     });
-    const { channel } = await t.accept({ offer, sameMachine, iceServers, signaling: sig.signaling });
+    const { channel } = await t.accept({ offer, sameMachine, iceServers, signaling: sig.signaling, signal: ac.signal });
     return { channel: await channel, role: 'responder', transport: 'webrtc' };
   })();
 
   try {
     return await Promise.race([dance, deadline]);
   } finally {
+    ac.abort();
     clearTimeout(timer);
     session.close();
   }

--- a/extension/peerd-distributed/transport/transports/webrtc.js
+++ b/extension/peerd-distributed/transport/transports/webrtc.js
@@ -30,6 +30,31 @@ const requireSignaling = (signaling) => {
   }
 };
 
+// Close an abandoned peer's pc when the caller aborts — but ONLY while its
+// channel has not yet opened. why: a dial/accept that never pairs (a ghost
+// roster member, a symmetric-NAT peer, or a hostile peer that answers then
+// stalls ICE) is dropped by rooms.js's give-up timeout, but nothing closes the
+// pc — its ICE agent / STUN gather / listeners then leak until the ~30s ICE
+// 'failed', which STILL never closes the pc (only channel.close() does, and the
+// channel never opened). An abort that races in AFTER the channel opened (late
+// completion past the timeout) must leave the live, admitted link alone — the
+// mesh now owns that channel and closes it itself. pc.close() is idempotent, so
+// a later failDirect/onclose double-close is a no-op; the listener is one-shot.
+// exported for unit test (the leak-fix invariant: close-on-abort, opened-guarded,
+// one-shot) — nothing else imports it; the module's public surface is the transport.
+/**
+ * @param {AbortSignal | undefined} signal
+ * @param {{ pc: RTCPeerConnection }} p
+ * @param {() => boolean} isOpen
+ */
+export const abortClosesPc = (signal, p, isOpen) => {
+  if (!signal) return;
+  signal.addEventListener('abort', () => {
+    if (isOpen()) return;
+    try { p.pc.close(); } catch { /* already closed */ }
+  }, { once: true });
+};
+
 /**
  * @param {{ RTCPeerConnection?: typeof RTCPeerConnection, iceServers?: RTCIceServer[] }} [opts]
  */
@@ -60,9 +85,9 @@ export const createWebrtcTransport = ({ RTCPeerConnection, iceServers = DEFAULT_
     // Resolves to the open Channel (or rejects with DirectPathUnavailableError).
     /**
      * @param {any} peer
-     * @param {{ signaling?: Signaling, sameMachine?: boolean, iceServers?: RTCIceServer[] }} [opts]
+     * @param {{ signaling?: Signaling, sameMachine?: boolean, iceServers?: RTCIceServer[], signal?: AbortSignal }} [opts]
      */
-    async connect(peer, { signaling, sameMachine = false, iceServers: ice } = {}) {
+    async connect(peer, { signaling, sameMachine = false, iceServers: ice, signal } = {}) {
       requireSignaling(signaling);
       const sig = /** @type {Signaling} */ (signaling);
       const p = createPeer({
@@ -79,7 +104,13 @@ export const createWebrtcTransport = ({ RTCPeerConnection, iceServers = DEFAULT_
       // Unsubscribe once the channel settles (open or fail); never let the
       // cleanup chain surface an unhandled rejection (the caller awaits the
       // original channelReady and handles its rejection).
-      p.channelReady.then(() => off(), () => off());
+      let opened = false;
+      p.channelReady.then(() => { opened = true; off(); }, () => off());
+      // why: a caller that gives up on a never-paired dial (rooms.js's connect
+      // timeout) aborts to close the pc — otherwise its ICE agent / STUN gather /
+      // listeners leak. Guarded on `opened`: an abort that races in after the
+      // channel opened (late completion) must never tear down a live link.
+      abortClosesPc(signal, p, () => opened);
 
       const offer = await p.pc.createOffer();
       await p.pc.setLocalDescription(offer);
@@ -93,9 +124,9 @@ export const createWebrtcTransport = ({ RTCPeerConnection, iceServers = DEFAULT_
     // that resolves when the data channel opens (NOT awaited here: it can't
     // open until the initiator applies our answer).
     /**
-     * @param {{ offer?: { sdp?: string }, signaling?: Signaling, sameMachine?: boolean, iceServers?: RTCIceServer[] }} [opts]
+     * @param {{ offer?: { sdp?: string }, signaling?: Signaling, sameMachine?: boolean, iceServers?: RTCIceServer[], signal?: AbortSignal }} [opts]
      */
-    async accept({ offer, signaling, sameMachine = false, iceServers: ice } = {}) {
+    async accept({ offer, signaling, sameMachine = false, iceServers: ice, signal } = {}) {
       requireSignaling(signaling);
       const sig = /** @type {Signaling} */ (signaling);
       const p = createPeer({
@@ -107,7 +138,12 @@ export const createWebrtcTransport = ({ RTCPeerConnection, iceServers = DEFAULT_
       const off = sig.onRemote(async (msg) => {
         if (msg && 'ice' in msg) await p.addRemoteCandidate(msg.ice);
       });
-      p.channelReady.then(() => off(), () => off());
+      // why: see connect() — an answered-but-stalled offer (a hostile peer that
+      // relays the answer then never pairs ICE) leaks the pc; the caller's give-up
+      // timeout aborts and we close it. Guarded on `opened` (late-completion safe).
+      let opened = false;
+      p.channelReady.then(() => { opened = true; off(); }, () => off());
+      abortClosesPc(signal, p, () => opened);
 
       await p.setRemote({ type: 'offer', sdp: offer?.sdp });
       const answer = await p.pc.createAnswer();

--- a/tests/peerd-distributed/webrtc-abort.test.ts
+++ b/tests/peerd-distributed/webrtc-abort.test.ts
@@ -1,0 +1,136 @@
+import { describe, test, expect } from 'bun:test';
+import { abortClosesPc, createWebrtcTransport } from '../../extension/peerd-distributed/transport/transports/webrtc.js';
+import { createInprocTransport } from '../../extension/peerd-distributed/transport/transports/inproc.js';
+
+// A capturing mock RTCPeerConnection (injectable) lets us drive the REAL webrtc
+// transport's connect() to prove the WIRED late-completion guard: once the
+// channel opens, `opened` flips true before the caller's finally-abort runs, so
+// abort must leave the live pc alone. (We only assert the open-then-abort path:
+// a never-opening dial leaves channelReady pending forever, which the bun runner
+// waits on; that direction is covered by the abortClosesPc unit tests above.)
+const instances: any[] = [];
+class MockDataChannel {
+  readyState = 'connecting';
+  onmessage: any = null; onopen: any = null; onclose: any = null;
+  send() {} close() { this.readyState = 'closed'; }
+}
+class MockPC {
+  closed = false; remoteDescription: any = null; localDescription: any = { sdp: 'mock' };
+  connectionState = 'new'; iceConnectionState = 'new'; dc = new MockDataChannel(); ondatachannel: any = null;
+  constructor(public config: any) { instances.push(this); }
+  addEventListener() {} createDataChannel() { return this.dc; }
+  async createOffer() { return { type: 'offer', sdp: 'mock' }; }
+  async createAnswer() { return { type: 'answer', sdp: 'mock' }; }
+  async setLocalDescription(d: any) { this.localDescription = { sdp: d?.sdp ?? 'mock' }; }
+  async setRemoteDescription(d: any) { this.remoteDescription = d; }
+  async addIceCandidate() {}
+  close() { this.closed = true; this.dc.close(); }
+}
+const sigStub = () => ({ send() {}, onRemote: () => () => {} });
+
+// D2: a dial/accept that never pairs (ghost roster member, symmetric NAT, or a
+// hostile peer that answers then stalls ICE) is abandoned by rooms.js's give-up
+// timeout, but nothing closed the RTCPeerConnection → its ICE agent / STUN gather
+// / listeners leaked. abortClosesPc closes the pc on abort, BUT only while the
+// channel has not yet opened (a late completion past the timeout must leave the
+// live, admitted link alone), one-shot and idempotent.
+
+const fakePeer = () => {
+  const state = { closes: 0 };
+  return { p: { pc: { close: () => { state.closes += 1; } } as any }, state };
+};
+
+describe('abortClosesPc — the D2 leak-fix invariant', () => {
+  test('closes the pc on abort while the channel has not opened', () => {
+    const { p, state } = fakePeer();
+    const ac = new AbortController();
+    abortClosesPc(ac.signal, p, () => false);
+    expect(state.closes).toBe(0);
+    ac.abort();
+    expect(state.closes).toBe(1);
+  });
+
+  test('does NOT close once the channel has opened (late-completion guard)', () => {
+    const { p, state } = fakePeer();
+    const ac = new AbortController();
+    abortClosesPc(ac.signal, p, () => true); // already opened
+    ac.abort();
+    expect(state.closes).toBe(0);
+  });
+
+  test('one-shot: a doubled abort closes at most once', () => {
+    const { p, state } = fakePeer();
+    const ac = new AbortController();
+    abortClosesPc(ac.signal, p, () => false);
+    ac.abort();
+    ac.abort();
+    expect(state.closes).toBe(1);
+  });
+
+  test('no signal → no listener, no crash (back-compat for callers that pass none)', () => {
+    const { p, state } = fakePeer();
+    expect(() => abortClosesPc(undefined, p, () => false)).not.toThrow();
+    expect(state.closes).toBe(0);
+  });
+
+  test('a pc.close() that throws (already closed) is swallowed', () => {
+    const ac = new AbortController();
+    abortClosesPc(ac.signal, { pc: { close: () => { throw new Error('already closed'); } } as any }, () => false);
+    expect(() => ac.abort()).not.toThrow();
+  });
+});
+
+describe('webrtc transport — the wired late-completion guard (D2)', () => {
+  test('a channel that opens before abort keeps its live pc', async () => {
+    instances.length = 0;
+    const t = createWebrtcTransport({ RTCPeerConnection: MockPC as any });
+    const ac = new AbortController();
+    const ready = t.connect({ did: 'x' }, { signaling: sigStub() as any, signal: ac.signal });
+    const pc = instances[0];
+    // the channel opens (the real success path) → `opened` flips true
+    pc.dc.readyState = 'open';
+    pc.dc.onopen();
+    await ready;
+    // the caller's finally-abort now no-ops (opened): the live pc survives
+    ac.abort();
+    expect(pc.closed).toBe(false);
+  });
+});
+
+describe('non-webrtc transports ignore the new signal opt (D2 abstraction safety)', () => {
+  test('inproc still links when a signal is passed through', async () => {
+    const t = createInprocTransport();
+    t.listen('did:key:zHere', (ch: any) => { ch.setHandler((m: any) => ch.send({ pong: m.ping })); });
+    const ac = new AbortController();
+    // the connector passes opts through generically; a non-webrtc transport
+    // simply ignores `signal` (its connect destructures nothing named it)
+    const client = await (t.connect as (p: any, o?: any) => Promise<any>)({ did: 'did:key:zHere' }, { signal: ac.signal });
+    const reply = await new Promise((res) => { client.setHandler(res); client.send({ ping: 1 }); });
+    expect(reply).toEqual({ pong: 1 });
+  });
+});
+
+describe('rooms.js + webrtc wire the AbortController at every abandonment site (D2)', () => {
+  test('all four dial/accept sites construct, pass, and abort a controller', async () => {
+    const src = await Bun.file('extension/peerd-distributed/transport/rooms.js').text();
+    expect((src.match(/new AbortController\(\)/g) ?? []).length).toBe(4);
+    expect((src.match(/signal: ac\.signal/g) ?? []).length).toBe(4);
+    expect((src.match(/ac\.abort\(\)/g) ?? []).length).toBe(4);
+  });
+
+  test('the webrtc transport threads signal into connect + accept and guards the helper', async () => {
+    const src = await Bun.file('extension/peerd-distributed/transport/transports/webrtc.js').text();
+    expect(src).toContain('{ once: true }');
+    expect(src).toContain('if (isOpen()) return;');
+    // both connect() and accept() wire the helper, guarded on `opened`
+    expect((src.match(/abortClosesPc\(signal, p, \(\) => opened\)/g) ?? []).length).toBe(2);
+  });
+
+  test('connectViaSignaling (the 1:1 convenience) also closes its abandoned pc', async () => {
+    const src = await Bun.file('extension/peerd-distributed/transport/signaling-client.js').text();
+    expect(src).toContain('new AbortController()');
+    // threaded into both the joiner dial and the responder accept, aborted in finally
+    expect((src.match(/signal: ac\.signal/g) ?? []).length).toBe(2);
+    expect(src).toContain('ac.abort()');
+  });
+});


### PR DESCRIPTION
A dial/accept that never pairs - a stale roster ghost, a symmetric-NAT peer, or a hostile peer that answers the offer then deliberately **stalls ICE** - is dropped by a give-up timeout, but nothing closed the underlying `RTCPeerConnection`. Its ICE agent, `iceCandidatePoolSize=4` STUN gather, and event listeners then leaked until the ~30s ICE `failed` transition - which **still** never closes the pc (only an admitted channel's `close()` does, and the channel never opened). A churny room of ghosts, or a peer that triggers repeated dials, accumulates leaked pcs in the offscreen document.

The webrtc transport returns only the channel-ready Promise, never the pc, so the fix threads an optional **`AbortSignal`** through the transport opts (the "transports ignore opts they don't use" contract): the transport closes the pc on abort, but **only while the channel has not yet opened** - a late completion past the timeout leaves the live, admitted link alone - via a one-shot, idempotent `abortClosesPc` helper. Every abandonment site owns an `AbortController` and aborts it in its `finally`:
- the four `rooms.js` sites (rendezvous dial + accept, relay dial + accept), **and**
- `connectViaSignaling` (the 1:1 convenience in `signaling-client.js`), which races its dance against a deadline and abandoned the in-flight pc identically.

`inproc`/`broadcast` ignore the new opt (no pc, no change).

**No behavior change for legit peers:** a dial that pairs within the timeout sets `opened=true` (registered on `channelReady` *before* the transport returns it, so it flips before the caller's `finally` runs), so the abort no-ops; only never-paired dials (which already failed) now have their pc reclaimed promptly instead of leaking 30s+.

**Tests** (revert-proven): `abortClosesPc` closes on abort-before-open, does **not** close once opened (the late-completion guard), is one-shot, no-ops without a signal, swallows an already-closed throw; a behavioral test drives the **real** transport to prove a channel that opens before abort keeps its live pc; the rooms.js + signaling-client sites are pinned; inproc still links with a signal passed through. Full bun suite green (2127).

Surfaced by an audit of the dweb's untrusted-inbound surface (#35); the `connectViaSignaling` site was caught by an adversarial review of the fix. Preview-channel-only, no-regrets resource-leak fix.