### PR TITLE
test(pda): live harvest e2e — agent reads a real page, then indexes it

### DIFF
--- a/scripts/cdp/states.mjs
+++ b/scripts/cdp/states.mjs
@@ -17,6 +17,7 @@
 // The recorder is what makes the loop legible to an agent: every state leaves a
 // screenshot to look at and a structured pass/fail with the "why".
 
+import { createServer } from 'node:http';
 import { rpc, evalIn, waitFor, sseText, sseToolCall, PASSPHRASE } from './e2e-harness.mjs';
 
 // A compact transcript probe shared by the functional states.
@@ -59,6 +60,40 @@ return { total, count: rows.length, source: 'on-device OPFS index' };
 // back to the model) so the state can prove the sealed worker REALLY computed the
 // answer — not that the faked final turn merely claims it.
 let pdaToolResultBody = '';
+
+// --- harvest: the FULL personal-data flow, incl. reading a real page ---------
+// An authenticated-shaped order page, DOM-walk-friendly: the order lines are
+// ANCHOR text so walk-injected.js emits real interactable refs (refCount > 0, or
+// captureSeedSnapshot returns null and the runner can't fast-path).
+const ORDERS_HTML = [
+  '<!doctype html><html><head><title>My Orders</title></head><body>',
+  '<h1>My Orders</h1><ul>',
+  '<li><a href="/o/1001">Order #1001 - Coffee Mug - $12.00</a></li>',
+  '<li><a href="/o/1002">Order #1002 - Notebook - $8.50</a></li>',
+  '<li><a href="/o/1003">Order #1003 - Pen Set - $15.00</a></li>',
+  '</ul></body></html>',
+].join('\n');
+
+// The append+query the agent runs AFTER reading the page (records shaped from the
+// harvested orders; total = 12 + 8.50 + 15 = 35.50).
+const HARVEST_SCRIPT = `
+const records = [
+  { id: 'order:1001', item: 'Coffee Mug', amount: 12 },
+  { id: 'order:1002', item: 'Notebook', amount: 8.5 },
+  { id: 'order:1003', item: 'Pen Set', amount: 15 },
+];
+await peerd.self.writeFile('records/orders.jsonl', records.map((r) => JSON.stringify(r)).join('\\n'));
+const rows = (await peerd.self.readFile('records/orders.jsonl')).split('\\n').filter(Boolean).map((l) => JSON.parse(l));
+return { total: rows.reduce((a, r) => a + r.amount, 0), count: rows.length, source: 'harvested on-device index' };
+`;
+
+// The harvest discriminator: a RUNNER (do/get) model request carries RUNNER_PROMPT
+// as its system message; the main agent's does not. We capture the runner's
+// request to PROVE it really read the fixture (the DOM-walk snapshot of the order
+// page rides in that request), and sequence the main agent's turns separately so
+// a variable runner-call count never shifts them.
+let harvestRunnerSawPage = '';
+let harvestMainTurn = 0;
 
 export const STATES = [
   // --- visual: the pre-unlock setup screen (must capture BEFORE unlock) -------
@@ -158,6 +193,70 @@ export const STATES = [
         `js_run tool result: ${pdaResult.slice(0, 200)}`);
       rec.check('the on-device answer renders to the user', !!out.assistantText && /50/.test(out.assistantText), JSON.stringify(out.assistantText));
       await rec.shot('final');
+    },
+  },
+
+  // --- functional: HARVEST — the agent reads a real page, then indexes it ------
+  {
+    name: 'harvest', kind: 'functional', phase: 'post-unlock',
+    responder: (callIndex, request) => {
+      let sys = '';
+      try { sys = JSON.parse(request?.postData || '{}')?.messages?.[0]?.content || ''; } catch { /* keep '' */ }
+      // A do/get RUNNER turn: it ran against the fixture tab and its model request
+      // carries the REAL DOM-walk snapshot of the order page. Capture it (proof of
+      // a real read) and answer as the runner would for a get (final text = the
+      // extracted value; fastPath + a seed ends the runner in this one call).
+      if (sys.includes('You are a browser-runner')) {
+        harvestRunnerSawPage = (request && request.postData) || '';
+        return { sse: sseText('Order #1001 — Coffee Mug — $12.00\nOrder #1002 — Notebook — $8.50\nOrder #1003 — Pen Set — $15.00') };
+      }
+      // Main agent turns (sequenced independently so a variable runner-call count
+      // can't shift them): read the orders → index them on-device → report.
+      const t = harvestMainTurn++;
+      if (t === 0) return { sse: sseToolCall('get', { query: 'List every order shown on this page, with its item and price' }) };
+      if (t === 1) return { sse: sseToolCall('js_run', { code: HARVEST_SCRIPT }) };
+      return { sse: sseText('You spent $35.50 across 3 orders — Coffee Mug, Notebook, Pen Set — harvested from the page and indexed on-device.') };
+    },
+    async run(ctx, rec) {
+      harvestRunnerSawPage = '';
+      harvestMainTurn = 0;
+      // Serve the order page over localhost HTTP and open it as a REAL active tab
+      // (data: URLs are refused by chrome.scripting, so the DOM-walk snapshot the
+      // runner needs would be empty). Same createServer + /json/new + /json/activate
+      // pattern the harness uses for the side panel.
+      const server = createServer((_req, res) => { res.writeHead(200, { 'content-type': 'text/html' }); res.end(ORDERS_HTML); });
+      await new Promise((r) => server.listen(0, '127.0.0.1', r));
+      const fxPort = /** @type {{ port: number }} */ (server.address()).port;
+      let fxTab = null;
+      try {
+        fxTab = await (await fetch(`http://127.0.0.1:${ctx.port}/json/new?http://127.0.0.1:${fxPort}/`, { method: 'PUT' })).json();
+        await fetch(`http://127.0.0.1:${ctx.port}/json/activate/${fxTab.id}`);
+        await new Promise((r) => setTimeout(r, 800)); // let the page load + tabs.onActivated settle
+
+        const sent = await rpc(ctx.page, { type: 'agent/send', text: 'Index my orders from the page I have open and tell me what I spent.' });
+        rec.check('agent/send accepted', !!sent?.ok, JSON.stringify(sent));
+        // get needs the fixture tab ACTIVE to read it; once the runner HAS read it
+        // (its request captured), bring the side panel back to front so its Mithril
+        // view un-throttles and renders the rest of the turn — a backgrounded tab
+        // throttles rAF-driven redraws, so the panel DOM would otherwise stay stale.
+        await waitFor(() => harvestRunnerSawPage.length > 0, { budgetMs: 25_000, pollMs: 100 });
+        await ctx.page.send('Page.bringToFront').catch(() => {});
+        let out = {};
+        await waitFor(async () => { out = await probe(ctx); return out.assistantText && !out.busy; }, { budgetMs: 30_000 });
+
+        const calls = ctx.modelCallCount();
+        rec.check('agent ran the get→js_run loop incl. the runner subagent (>=4 model calls)', calls >= 4, `model calls: ${calls}`);
+        // load-bearing harvest proof: the REAL runner read the fixture — the page's
+        // own order data rode into the runner's model request via the DOM-walk snapshot.
+        rec.check('the runner REALLY read the page (real order data in its DOM-walk snapshot)',
+          harvestRunnerSawPage.includes('Coffee Mug') && harvestRunnerSawPage.includes('12.00'),
+          harvestRunnerSawPage.slice(0, 220));
+        rec.check('the harvested on-device answer renders', !!out.assistantText && /35\.50/.test(out.assistantText), JSON.stringify(out.assistantText));
+        await rec.shot('final');
+      } finally {
+        try { if (fxTab?.id) await fetch(`http://127.0.0.1:${ctx.port}/json/close/${fxTab.id}`); } catch { /* */ }
+        server.close();
+      }
     },
   },
 

--- a/scripts/cdp/states.mjs
+++ b/scripts/cdp/states.mjs
@@ -38,6 +38,28 @@ const probe = (ctx) => evalIn(ctx.page, `(() => {
 
 const SMOKE_TEXT = 'e2e-smoke-ok';
 
+// The local-first personal-data agent, end to end through the REAL stack: the
+// faked model calls js_run, the sealed worker builds an on-device index in OPFS
+// and queries it, and the agent reports the answer — every byte computed on
+// device (the realm seal makes the worker incapable of egress).
+const PDA_SCRIPT = `
+const records = [
+  { id: 'amazon:o1', date: '2025-02-03', merchant: 'Amazon', amount: 12.5 },
+  { id: 'amazon:o2', date: '2025-06-20', merchant: 'Amazon', amount: 7.5 },
+  { id: 'amazon:o3', date: '2025-11-03', merchant: 'Amazon', amount: 30 },
+];
+await peerd.self.writeFile('records/orders.jsonl', records.map((r) => JSON.stringify(r)).join('\\n'));
+const text = await peerd.self.readFile('records/orders.jsonl');
+const rows = text.split('\\n').filter(Boolean).map((l) => JSON.parse(l));
+const total = rows.reduce((a, r) => a + r.amount, 0);
+return { total, count: rows.length, source: 'on-device OPFS index' };
+`;
+
+// Captures the model's SECOND request body (which carries the js_run tool result
+// back to the model) so the state can prove the sealed worker REALLY computed the
+// answer — not that the faked final turn merely claims it.
+let pdaToolResultBody = '';
+
 export const STATES = [
   // --- visual: the pre-unlock setup screen (must capture BEFORE unlock) -------
   {
@@ -92,6 +114,32 @@ export const STATES = [
       rec.check('complete_goal ended it cleanly (not the cap)', !out.capped && calls < 10, `capped=${out.capped} calls=${calls}`);
       rec.check('run reaches terminal: Goal bar cleared + idle', out.goalBar === false && out.busy === false);
       rec.check('submitted goal text round-trips as the first user message', !!out.userText && out.userText.includes('tidy the repo'), JSON.stringify(out.userText));
+      await rec.shot('final');
+    },
+  },
+
+  // --- functional: the local-first personal-data agent (code-mode over OPFS) --
+  {
+    name: 'personal-data', kind: 'functional', phase: 'post-unlock',
+    responder: (callIndex, request) => {
+      if (callIndex === 0) return { sse: sseToolCall('js_run', { code: PDA_SCRIPT }) };
+      // call 1 carries the js_run tool result back — capture it for the assertion.
+      if (callIndex === 1) pdaToolResultBody = (request && request.postData) || '';
+      return { sse: sseText('You spent $50.00 across 3 orders — computed on-device, nothing left your machine.') };
+    },
+    async run(ctx, rec) {
+      pdaToolResultBody = '';
+      const sent = await rpc(ctx.page, { type: 'agent/send', text: 'Index my orders and tell me what I spent.' });
+      rec.check('agent/send accepted', !!sent?.ok, JSON.stringify(sent));
+      let out = {};
+      await waitFor(async () => { out = await probe(ctx); return out.assistantText && !out.busy; }, { budgetMs: 30_000 });
+      const calls = ctx.modelCallCount();
+      rec.check('the agent ran the js_run tool loop (>=2 model calls)', calls >= 2, `model calls: ${calls}`);
+      // the load-bearing proof: the sealed worker actually built + queried the
+      // OPFS index — its result marker rode back to the model in call 1.
+      rec.check('js_run REALLY computed on-device (worker result marker in the tool reply)',
+        pdaToolResultBody.includes('on-device OPFS index'), pdaToolResultBody.slice(0, 160));
+      rec.check('the on-device answer renders to the user', !!out.assistantText && /50/.test(out.assistantText), JSON.stringify(out.assistantText));
       await rec.shot('final');
     },
   },

--- a/scripts/cdp/states.mjs
+++ b/scripts/cdp/states.mjs
@@ -136,9 +136,11 @@ export const STATES = [
       const calls = ctx.modelCallCount();
       rec.check('the agent ran the js_run tool loop (>=2 model calls)', calls >= 2, `model calls: ${calls}`);
       // the load-bearing proof: the sealed worker actually built + queried the
-      // OPFS index — its result marker rode back to the model in call 1.
-      rec.check('js_run REALLY computed on-device (worker result marker in the tool reply)',
-        pdaToolResultBody.includes('on-device OPFS index'), pdaToolResultBody.slice(0, 160));
+      // OPFS index — the computed total/count only exist in the worker's result
+      // JSON, not in PDA_SCRIPT's source text or the code argument echoed back.
+      rec.check('js_run REALLY computed on-device (computed total in tool result, not script source)',
+        pdaToolResultBody.includes('"total":50') && pdaToolResultBody.includes('"count":3'),
+        pdaToolResultBody.slice(0, 200));
       rec.check('the on-device answer renders to the user', !!out.assistantText && /50/.test(out.assistantText), JSON.stringify(out.assistantText));
       await rec.shot('final');
     },

--- a/scripts/cdp/states.mjs
+++ b/scripts/cdp/states.mjs
@@ -138,9 +138,24 @@ export const STATES = [
       // the load-bearing proof: the sealed worker actually built + queried the
       // OPFS index — the computed total/count only exist in the worker's result
       // JSON, not in PDA_SCRIPT's source text or the code argument echoed back.
+      // why parse, not substring-match the raw body: pdaToolResultBody is the
+      // raw request postData, where the js_run result is a JSON string NESTED in
+      // the request JSON — so its quotes are escaped (\"total\":50) and a raw
+      // `"total":50` check never matches (this is why the check was red). Parse
+      // the request, pull the tool-result message content (now unescaped), and
+      // assert the computed values live THERE — the load-bearing proof the
+      // sealed worker built + queried the OPFS index (total/count exist only in
+      // its result, not in PDA_SCRIPT's source or the echoed code arg).
+      let pdaResult = '';
+      try {
+        const reqBody = JSON.parse(pdaToolResultBody);
+        pdaResult = (reqBody.messages || [])
+          .map((m) => (typeof m.content === 'string' ? m.content : ''))
+          .find((c) => c.includes('on-device OPFS index')) || '';
+      } catch { /* leave '' — the check fails with a clear detail */ }
       rec.check('js_run REALLY computed on-device (computed total in tool result, not script source)',
-        pdaToolResultBody.includes('"total":50') && pdaToolResultBody.includes('"count":3'),
-        pdaToolResultBody.slice(0, 200));
+        /"total"\s*:\s*50\b/.test(pdaResult) && /"count"\s*:\s*3\b/.test(pdaResult),
+        `js_run tool result: ${pdaResult.slice(0, 200)}`);
       rec.check('the on-device answer renders to the user', !!out.assistantText && /50/.test(out.assistantText), JSON.stringify(out.assistantText));
       await rec.shot('final');
     },


### PR DESCRIPTION
**Slice 3** of the local-first personal-data agent ([spec](docs/specs/LOCAL-FIRST-PERSONAL-DATA-AGENT.md)) - the **harvest** half, end to end through the real stack. This closes the last gap: the agent reading a **real** page (not inline records).

A new `harvest` functional state: it serves an order-list page over localhost HTTP and opens it as a real **active tab** (data: URLs are refused by `chrome.scripting`, so the DOM-walk snapshot the runner needs would be empty). Then the agent:
1. calls `get` - which spawns the **real `do`/`get` runner subagent** that reads the page via the `chrome.scripting` DOM-walk,
2. calls `js_run` to index the orders on device,
3. reports the total.

**Faking the runner:** the responder branches on the system prompt - a runner request carries `RUNNER_PROMPT` (`"You are a browser-runner"`), the main agent's doesn't - so it serves the runner's fast-path turn separately from the main turns, robust to a variable runner-call count.

**The proof isn't the hardcoded answer.** The state captures the **runner's own model request** and asserts the fixture's *real* order data (`Coffee Mug`, `12.00`) rode in via the DOM-walk snapshot - proving the page was genuinely read, in-session, through the live runner. (Gotcha handled: activating the fixture tab backgrounds the side panel and throttles its rAF redraws, so once the runner has read the page the state brings the panel back to front before reading the answer.)

Screenshot shows the full chain: `get` ✓ → `js_run` ✓ → "You spent $35.50 across 3 orders — Coffee Mug, Notebook, Pen Set — harvested from the page and indexed on-device."

Full functional suite green: **9 states, 35/35 checks**.

> Stacked on #94. With #92 (helpers, merged), #93 (durable store), #94 (compute), this completes the personal-data agent's live e2e proof: **harvest → on-device index → on-device answer**, with the real page read verified.