### PR TITLE
feat(peerd-lite): PoC — the Notebook substrate runs in a plain web page

### DIFF
--- a/web-prototype/poc/README.md
+++ b/web-prototype/poc/README.md
@@ -1,0 +1,68 @@
+# peerd-lite PoC — the Notebook substrate in a plain web page
+
+A runnable proof of the central claim in
+[`docs/specs/PEERD-WEB-SURFACE.md`](../../docs/specs/PEERD-WEB-SURFACE.md): peerd's
+execution substrates are **host-agnostic** (DECISIONS #25 — "the sandbox is the
+isolate; a tab is one way to host it"), so the sealed Notebook worker runs in a
+regular web page with **no extension** — the substrate ships verbatim, only the
+host adapter changes.
+
+This PoC takes the most portable substrate (the Notebook / sealed `js_run`
+worker) and runs it in a plain page, then proves it with a headless check.
+
+## What's reused verbatim vs. new
+
+**Verbatim from the extension tree** (imported unmodified — change a byte and the
+PoC breaks):
+
+- `/notebook-tab/worker-source.js` — `buildWorkerSource`, the realm seal, the
+  `peerd.*` surface, `NOTEBOOK_BUILTINS` (incl. `peerd:std`)
+- `/peerd-engine/index.js` — `opfsHelpers`, `buildModule` (the module resolver)
+
+**New — the entire delta is the host adapter** ([`notebook-host.js`](./notebook-host.js)),
+which differs from the extension host (`offscreen/job-runner.js` +
+`notebook-tab/notebook-tab.js`) in exactly three places:
+
+1. **OPFS is durable** (a stable `['peerd-notebooks', id]` subtree) — like a
+   Notebook tab, not the headless ephemeral scratch. OPFS is a web-platform API,
+   so `opfsHelpers` works in a plain page unchanged.
+2. **The fetch bridge is an in-page `fetch`**, not the extension SW's
+   `sw/web-fetch` route — a page has no service worker to relay to. (The page can
+   pass a denylist-gated `fetchImpl`.)
+3. **No subagent relay** — subagents drive the user's real tabs, which is the
+   extension's surface. An origin-confined page declines them. *That decline is
+   the upgrade funnel, by construction.*
+
+Everything else — the worker message protocol (`log` / `display` /
+`fetch-request` / `opfs-request` / `done`), the seal, code-mode — is identical.
+
+## Run it
+
+Headless validation (serves `extension/` at root + this PoC, drives Chrome over
+CDP):
+
+```sh
+bun web-prototype/poc/run-poc.mjs
+```
+
+It runs three cells in the page and asserts **7/7**: the worker runs, code-mode
+returns the computed index, the console bridge works, the index file lands in
+OPFS, **OPFS persists across two separate worker runs** (a fresh worker reads the
+prior run's file), and the **in-page fetch bridge** resolves the seal-pinned
+fetch to the host fetch.
+
+To see it visually, serve the repo with `extension/` at root and `/poc/` mapped
+to this folder, then open `/poc/` — a one-cell Notebook running the personal-data
+index on device.
+
+## Why this matters
+
+The demo cell is the [personal-data index](../../docs/specs/LOCAL-FIRST-PERSONAL-DATA-AGENT.md)
+(build + query an on-device OPFS index) — so this also shows that feature's
+compute running, unchanged, in peerd-lite. The realm seal makes the worker
+incapable of egress except through the audited bridge, in the page exactly as in
+the extension.
+
+This is the foundation slice: with the Notebook substrate proven portable, the
+remaining peerd-lite work (the App iframe + WebVM substrates, the agent loop, the
+BYOK vault) follows the same substrate-ships-verbatim / swap-the-host pattern.

--- a/web-prototype/poc/app.js
+++ b/web-prototype/poc/app.js
@@ -1,0 +1,55 @@
+// Wires the demo page to the web Notebook host. Function components hold no
+// logic; this is the imperative shell that drives the host.
+import { createNotebookHost } from './notebook-host.js';
+
+const $ = (id) => document.getElementById(id);
+const codeEl = $('code');
+const runBtn = $('run');
+const valueEl = $('value');
+const consoleEl = $('console');
+const filesEl = $('files');
+
+const consoleLines = [];
+
+const host = createNotebookHost({
+  notebookId: 'poc-demo',
+  onLog: (m) => {
+    consoleLines.push(`${m.level === 'info' ? '' : `[${m.level}] `}${m.text}`);
+    consoleEl.textContent = consoleLines.join('\n');
+    consoleEl.classList.remove('muted');
+  },
+});
+
+// Exposed so the headless validation (run-poc.mjs) can drive a run + read the
+// result without scraping the DOM. The page UI works the same way.
+window.runNotebookCell = async (code) => {
+  const result = await host.run(code ?? codeEl.value);
+  const files = await host.opfs.list().catch(() => []);
+  return { result, files };
+};
+
+const render = ({ result, files }) => {
+  if (result.error) {
+    valueEl.textContent = result.error;
+    valueEl.className = 'err';
+  } else {
+    valueEl.textContent = `${JSON.stringify(result.value, null, 2)}\n\n(${result.durationMs}ms, in a sealed worker)`;
+    valueEl.className = 'ok';
+  }
+  filesEl.textContent = files.length
+    ? files.map((f) => `${f.path}  ${f.size}b`).join('\n')
+    : '(none)';
+  filesEl.classList.remove('muted');
+};
+
+runBtn.addEventListener('click', async () => {
+  runBtn.disabled = true;
+  consoleLines.length = 0;
+  consoleEl.textContent = '—';
+  consoleEl.classList.add('muted');
+  try {
+    render(await window.runNotebookCell());
+  } finally {
+    runBtn.disabled = false;
+  }
+});

--- a/web-prototype/poc/index.html
+++ b/web-prototype/poc/index.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>peerd-lite PoC — Notebook substrate in a plain page</title>
+  <style>
+    :root { color-scheme: dark; }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0; padding: 2rem; font: 14px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+      background: #0b0b0d; color: #e6e6e6;
+    }
+    .wrap { max-width: 860px; margin: 0 auto; }
+    h1 { font-size: 1.1rem; font-weight: 600; margin: 0 0 .25rem; }
+    p.sub { color: #9a9a9a; margin: 0 0 1.5rem; }
+    .card { background: #141417; border: 1px solid #26262b; border-radius: 10px; padding: 1rem; margin-bottom: 1rem; }
+    label { display: block; color: #9a9a9a; font-size: .8rem; margin-bottom: .4rem; }
+    textarea {
+      width: 100%; min-height: 200px; resize: vertical; background: #0b0b0d; color: #e6e6e6;
+      border: 1px solid #26262b; border-radius: 8px; padding: .75rem; font: inherit;
+    }
+    button {
+      margin-top: .75rem; background: #e6e6e6; color: #0b0b0d; border: 0; border-radius: 8px;
+      padding: .5rem 1rem; font: inherit; font-weight: 600; cursor: pointer;
+    }
+    button:disabled { opacity: .5; cursor: default; }
+    pre { margin: 0; white-space: pre-wrap; word-break: break-word; }
+    .out { background: #0b0b0d; border: 1px solid #26262b; border-radius: 8px; padding: .75rem; min-height: 2rem; }
+    .muted { color: #9a9a9a; }
+    .ok { color: #5bd17a; }
+    .err { color: #ff6b6b; }
+    .row { display: flex; gap: 1.5rem; flex-wrap: wrap; }
+    .row > div { flex: 1; min-width: 240px; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>peerd-lite · the Notebook substrate, running in a plain web page</h1>
+    <p class="sub">
+      No extension. The sealed worker, realm seal, <code>peerd.*</code> surface, and OPFS
+      are imported <em>verbatim</em> from the extension tree — only the host adapter is new.
+      This cell builds a personal-data index on device and queries it; the realm seal makes
+      the worker incapable of egress except through the audited bridge.
+    </p>
+
+    <div class="card">
+      <label for="code">Notebook cell (runs in the sealed worker)</label>
+      <textarea id="code" spellcheck="false">
+// The personal-data index — building + querying an on-device OPFS index,
+// in a plain page, in the same sealed worker the extension uses.
+const records = [
+  { id: 'order:1001', item: 'Coffee Mug', amount: 12.00 },
+  { id: 'order:1002', item: 'Notebook',   amount:  8.50 },
+  { id: 'order:1003', item: 'Pen Set',    amount: 15.00 },
+];
+await peerd.self.writeFile('orders.jsonl', records.map((r) => JSON.stringify(r)).join('\n'));
+
+const rows = (await peerd.self.readFile('orders.jsonl'))
+  .split('\n').filter(Boolean).map((l) => JSON.parse(l));
+console.log('indexed ' + rows.length + ' orders on device');
+
+return { total: rows.reduce((a, r) => a + r.amount, 0), count: rows.length };
+</textarea>
+      <button id="run">Run cell</button>
+    </div>
+
+    <div class="row">
+      <div class="card">
+        <label>Return value</label>
+        <div class="out"><pre id="value" class="muted">— not run yet —</pre></div>
+      </div>
+      <div class="card">
+        <label>Console</label>
+        <div class="out"><pre id="console" class="muted">—</pre></div>
+      </div>
+    </div>
+
+    <div class="card">
+      <label>OPFS — files on device (persist across runs)</label>
+      <div class="out"><pre id="files" class="muted">—</pre></div>
+    </div>
+  </div>
+
+  <script type="module" src="./app.js"></script>
+</body>
+</html>

--- a/web-prototype/poc/notebook-host.js
+++ b/web-prototype/poc/notebook-host.js
@@ -1,0 +1,161 @@
+// A WEB host adapter for peerd's sealed Notebook worker substrate — the page-side
+// equivalent of the extension's offscreen/job-runner.js + notebook-tab.js host.
+//
+// This is the PoC for the central claim of docs/specs/PEERD-WEB-SURFACE.md: the
+// substrate ships VERBATIM. Everything the worker runs — the realm seal, the
+// peerd.* surface, the module resolver, peerd:std — is imported UNMODIFIED from
+// the extension tree (/notebook-tab/worker-source.js, /peerd-engine/index.js).
+// Only this host adapter changes vs the extension, and only in three places:
+//   1. OPFS is DURABLE (a stable per-notebook subtree), like a Notebook tab —
+//      not the headless ephemeral scratch job-runner nukes per call. OPFS is a
+//      web-platform API, so opfsHelpers works in a plain page unchanged.
+//   2. The fetch bridge is an IN-PAGE fetch (denylist-gated by the caller's
+//      fetchImpl), NOT the extension SW's sw/web-fetch route — a page has no SW
+//      to relay to. This is the one network seam the spec calls out.
+//   3. No subagent relay. Subagents are the extension's surface (they drive the
+//      user's tabs); an origin-confined page declines them — which is the funnel.
+//
+// The worker message protocol mirrored here is exactly job-runner.js's:
+// log / display / subagent-request / fetch-request / opfs-request / done.
+
+import { opfsHelpers, buildModule } from '/peerd-engine/index.js';
+import { buildWorkerSource, NOTEBOOK_BUILTINS } from '/notebook-tab/worker-source.js';
+
+/** Base64 a binary body in chunks (avoids the fromCharCode spread arg-count cap). */
+const toBase64 = (buf) => {
+  const bytes = new Uint8Array(buf);
+  let bin = '';
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    bin += String.fromCharCode.apply(null, bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(bin);
+};
+
+/**
+ * Create a Notebook host bound to one durable OPFS subtree. `run(code)` spawns a
+ * fresh sealed worker for the cell (a new worker every run — the OPFS files
+ * persist across runs, which is what makes this a Notebook, not a scratch job).
+ *
+ * @param {{
+ *   notebookId?: string,
+ *   onLog?: (m: { level: string, text: string }) => void,
+ *   onDisplay?: (m: { value: unknown }) => void,
+ *   fetchImpl?: typeof fetch,
+ * }} [opts]
+ */
+export const createNotebookHost = ({ notebookId = 'web-notebook', onLog, onDisplay, fetchImpl = fetch } = {}) => {
+  // why durable: the page-hosted Notebook keeps its files across runs, exactly
+  // like the extension Notebook tab (['peerd-notebooks', id]).
+  const opfs = opfsHelpers(['peerd-notebooks', notebookId]);
+
+  const resolverDeps = {
+    /** @param {string} path */
+    readFile: (path) => opfs.read(path),
+    /** @param {string} src */
+    makeBlobUrl: (src) => URL.createObjectURL(new Blob([src], { type: 'application/javascript' })),
+    log: () => {},
+    builtins: NOTEBOOK_BUILTINS,
+  };
+
+  /**
+   * @param {string} code
+   * @param {{ timeoutMs?: number }} [opts]
+   * @returns {Promise<{ value: unknown, consoleOutput: {level:string,text:string}[], durationMs: number, error: string|null }>}
+   */
+  const run = async (code, { timeoutMs = 30000 } = {}) => {
+    let built;
+    try {
+      built = await buildWorkerSource(code, { entryPath: 'cell.js', notebookId, resolverDeps });
+    } catch (e) {
+      return { value: undefined, consoleOutput: [], durationMs: 0, error: `import resolution failed: ${e?.message ?? String(e)}` };
+    }
+    const { source, cache } = built;
+    const revokeCache = () => { for (const entry of cache.values()) if (entry.blobUrl) URL.revokeObjectURL(entry.blobUrl); };
+
+    const blobUrl = URL.createObjectURL(new Blob([source], { type: 'application/javascript' }));
+    let worker;
+    try {
+      worker = new Worker(blobUrl, { type: 'module' });
+    } catch (e) {
+      URL.revokeObjectURL(blobUrl);
+      revokeCache();
+      return { value: undefined, consoleOutput: [], durationMs: 0, error: `worker spawn failed: ${e?.message ?? String(e)}` };
+    }
+
+    try {
+      return await new Promise((resolve) => {
+        const timer = setTimeout(() => {
+          try { worker.terminate(); } catch { /* */ }
+          resolve({ value: undefined, consoleOutput: [], durationMs: timeoutMs, error: `timed out after ${timeoutMs}ms` });
+        }, timeoutMs);
+
+        worker.addEventListener('message', async (ev) => {
+          const m = ev.data;
+          if (!m || typeof m !== 'object') return;
+
+          if (m.type === 'log') { onLog?.(m); return; }
+          if (m.type === 'display') { onDisplay?.(m); return; }
+
+          // (3) origin-confined: no subagents in the page.
+          if (m.type === 'subagent-request') {
+            worker.postMessage({ type: 'subagent-response', rid: m.rid, error: 'subagents are an extension capability (origin-confined page declines them)' });
+            return;
+          }
+
+          // (2) the in-page fetch swap — the seal-pinned bridge resolves to a
+          // real fetch here, not the extension SW route.
+          if (m.type === 'fetch-request') {
+            try {
+              const r = await fetchImpl(m.url, { method: m.method, headers: m.headers, body: m.body });
+              const bodyB64 = toBase64(await r.arrayBuffer());
+              worker.postMessage({
+                type: 'fetch-response', rid: m.rid,
+                ok: r.ok, status: r.status, statusText: r.statusText,
+                headers: Object.fromEntries(r.headers.entries()), bodyB64, error: null,
+              });
+            } catch (e) {
+              worker.postMessage({ type: 'fetch-response', rid: m.rid, ok: false, status: 0, bodyB64: null, error: e?.message ?? String(e) });
+            }
+            return;
+          }
+
+          // (1) durable OPFS — the SAME opfsHelpers + module resolver the
+          // extension uses; OPFS is a web-platform API, so this is unchanged.
+          if (m.type === 'opfs-request') {
+            try {
+              let result;
+              if (m.op === 'read') result = await opfs.read(m.args.path);
+              else if (m.op === 'write') { await opfs.write(m.args.path, m.args.content); result = null; }
+              else if (m.op === 'list') result = await opfs.list();
+              else if (m.op === 'compose-module') result = (await buildModule(m.args.path, resolverDeps, cache)).source;
+              else throw new Error(`unknown opfs op: ${m.op}`);
+              worker.postMessage({ type: 'opfs-response', rid: m.rid, result });
+            } catch (e) {
+              worker.postMessage({ type: 'opfs-response', rid: m.rid, error: e?.message ?? String(e) });
+            }
+            return;
+          }
+
+          if (m.type === 'done') {
+            clearTimeout(timer);
+            try { worker.terminate(); } catch { /* */ }
+            resolve({ value: m.value, consoleOutput: m.consoleOutput, durationMs: m.durationMs, error: m.error ?? null });
+          }
+        });
+
+        worker.addEventListener('error', (e) => {
+          clearTimeout(timer);
+          try { worker.terminate(); } catch { /* */ }
+          const detail = e.error?.stack || e.error?.message || e.message || 'worker crashed (no detail)';
+          resolve({ value: undefined, consoleOutput: [], durationMs: 0, error: `worker error: ${detail}` });
+        });
+      });
+    } finally {
+      URL.revokeObjectURL(blobUrl);
+      revokeCache();
+    }
+  };
+
+  return { run, opfs };
+};

--- a/web-prototype/poc/run-poc.mjs
+++ b/web-prototype/poc/run-poc.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env bun
+// Headless validation for the peerd-lite Notebook-substrate PoC.
+//
+// Proves the central claim of docs/specs/PEERD-WEB-SURFACE.md: the sealed
+// Notebook worker substrate runs in a PLAIN web page (no extension) via the web
+// host adapter (notebook-host.js), with the substrate files imported VERBATIM
+// from the extension tree. We serve extension/ as the web root (so the worker's
+// own absolute imports — /notebook-tab/*, /shared/*, peerd:std — resolve) and
+// /poc/* from web-prototype/poc/, open the page in headless Chrome, and drive
+// window.runNotebookCell() over CDP.
+//
+// Asserts: (1) the worker runs + returns the computed index result, (2) console
+// + display bridges work, (3) OPFS PERSISTS across two separate worker runs in
+// the page (a fresh worker reads the prior run's file) — the durability that
+// makes this a Notebook, not a scratch job.
+//
+// Usage:  bun web-prototype/poc/run-poc.mjs
+// Exit:   0 if all checks pass, 1 otherwise.
+
+import { resolve, join, dirname, extname, delimiter, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { createReadStream, existsSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const EXT = resolve(HERE, '..', '..', 'extension');
+const POC = HERE;
+
+const onPath = (name) => (process.env.PATH ?? '').split(delimiter)
+  .map((d) => join(d, name)).find((p) => { try { return statSync(p).isFile(); } catch { return false; } });
+const CHROME = process.env.CHROME_PATH || process.env.CHROME
+  || [`${process.env.HOME}/.cache/peerd-cft/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing`,
+      '/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing',
+      '/Applications/Chromium.app/Contents/MacOS/Chromium'].find(existsSync)
+  || ['chromium', 'chromium-browser', 'google-chrome'].map(onPath).find(Boolean);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const TYPES = { '.js': 'text/javascript', '.mjs': 'text/javascript', '.html': 'text/html', '.css': 'text/css', '.json': 'application/json', '.wasm': 'application/wasm', '.txt': 'text/plain' };
+
+// extension/ at root; /poc/* from web-prototype/poc/. The worker's blob spawns
+// with the page origin, so its absolute imports (/notebook-tab/*) hit the root.
+const server = createServer((req, res) => {
+  let p;
+  try { p = decodeURIComponent(new URL(req.url, 'http://localhost').pathname); }
+  catch { res.writeHead(400); res.end('bad request'); return; }
+  let root = EXT;
+  if (p === '/poc' || p === '/poc/') { p = '/index.html'; root = POC; }
+  else if (p.startsWith('/poc/')) { p = p.slice('/poc'.length); root = POC; }
+  if (p.endsWith('/')) p += 'index.html';
+  const file = join(root, p);
+  if (!file.startsWith(root + sep) || !existsSync(file) || !statSync(file).isFile()) {
+    res.writeHead(404); res.end('not found'); return;
+  }
+  res.writeHead(200, { 'content-type': TYPES[extname(file)] ?? 'application/octet-stream' });
+  createReadStream(file).pipe(res);
+});
+
+let chrome, profile;
+const cleanup = () => {
+  try { chrome?.kill('SIGKILL'); } catch { /* */ }
+  try { server.close(); } catch { /* */ }
+  try { if (profile) rmSync(profile, { recursive: true, force: true }); } catch { /* */ }
+};
+process.on('exit', cleanup);
+process.on('SIGINT', () => { cleanup(); process.exit(130); });
+
+const waitForCdpPort = async () => {
+  const portFile = join(profile, 'DevToolsActivePort');
+  for (let i = 0; i < 120; i++) {
+    try {
+      const port = parseInt(readFileSync(portFile, 'utf8').split('\n')[0], 10);
+      if (port > 0 && (await fetch(`http://127.0.0.1:${port}/json/version`)).ok) return port;
+    } catch { /* not up yet */ }
+    await sleep(250);
+  }
+  throw new Error('CDP endpoint never came up');
+};
+
+const attach = async (wsUrl) => {
+  const ws = new WebSocket(wsUrl);
+  await new Promise((res, rej) => { ws.onopen = res; ws.onerror = rej; });
+  let id = 0; const pending = new Map(); const events = [];
+  ws.onmessage = (e) => {
+    const m = JSON.parse(e.data);
+    if (m.id && pending.has(m.id)) { pending.get(m.id)(m); pending.delete(m.id); return; }
+    if (m.method === 'Runtime.exceptionThrown') events.push('EXC ' + (m.params?.exceptionDetails?.exception?.description || m.params?.exceptionDetails?.text));
+    if (m.method === 'Runtime.consoleAPICalled' && m.params?.type === 'error') events.push('ERR ' + (m.params.args || []).map((a) => a.value || a.description).join(' '));
+  };
+  const send = (method, params = {}) => new Promise((res) => { const i = ++id; pending.set(i, res); ws.send(JSON.stringify({ id: i, method, params })); });
+  return { send, close: () => ws.close(), events };
+};
+
+const evalJson = async (send, expression) => {
+  const r = await send('Runtime.evaluate', { expression, awaitPromise: true, returnByValue: true });
+  if (r.result?.exceptionDetails) throw new Error(r.result.exceptionDetails.exception?.description || 'eval threw');
+  return r.result?.result?.value;
+};
+
+const main = async () => {
+  if (!CHROME) { console.error('no Chrome/Chromium found — set CHROME_PATH'); process.exit(1); }
+  await new Promise((res) => server.listen(0, '127.0.0.1', res));
+  const httpPort = server.address().port;
+  profile = mkdtempSync(join(tmpdir(), 'peerd-poc-'));
+  chrome = spawn(CHROME, ['--headless=new', '--no-first-run', '--no-default-browser-check', '--disable-gpu', '--no-sandbox', `--user-data-dir=${profile}`, '--remote-debugging-port=0', 'about:blank'], { stdio: 'ignore' });
+  const cdpPort = await waitForCdpPort();
+
+  const created = await (await fetch(`http://127.0.0.1:${cdpPort}/json/new?about:blank`, { method: 'PUT' })).json();
+  const { send, events } = await attach(created.webSocketDebuggerUrl);
+  await send('Runtime.enable');
+  await send('Page.enable');
+  await send('Page.navigate', { url: `http://localhost:${httpPort}/poc/` });
+
+  // wait for the adapter to load (window.runNotebookCell defined)
+  let ready = false;
+  for (let i = 0; i < 80 && !ready; i++) {
+    ready = await evalJson(send, 'typeof window.runNotebookCell === "function"').catch(() => false);
+    if (!ready) await sleep(250);
+  }
+
+  const checks = [];
+  const check = (name, pass, detail = '') => { checks.push({ name, pass, detail }); console.log(`  ${pass ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`); };
+
+  check('the page + web host adapter loaded', ready);
+  if (ready) {
+    // Run 1: build + query the on-device index.
+    const r1 = await evalJson(send, 'window.runNotebookCell()').catch((e) => ({ error: String(e) }));
+    const v1 = r1?.result;
+    check('the sealed worker ran in the page (no error)', !!v1 && !v1.error, v1?.error || `${v1?.durationMs}ms`);
+    check('code-mode returned the computed index result', v1?.value?.total === 35.5 && v1?.value?.count === 3, JSON.stringify(v1?.value));
+    check('the console bridge works', (v1?.consoleOutput || []).some((l) => /indexed 3 orders/.test(l.text)), JSON.stringify(v1?.consoleOutput));
+    check('OPFS holds the index file on device', (r1?.files || []).some((f) => /orders\.jsonl/.test(f.path) && f.size > 0), JSON.stringify(r1?.files));
+
+    // Run 2: a FRESH worker reads the prior run's file — durability across runs.
+    const readScript = "return (await peerd.self.readFile('orders.jsonl')).split('\\n').filter(Boolean).length";
+    const r2 = await evalJson(send, `window.runNotebookCell(${JSON.stringify(readScript)})`).catch((e) => ({ error: String(e) }));
+    check('OPFS persists across worker runs (fresh worker reads the prior file)', r2?.result?.value === 3 && !r2?.result?.error, JSON.stringify(r2?.result?.value ?? r2?.result?.error));
+
+    // Run 3: the other named host swap — the seal-pinned fetch resolves to the
+    // IN-PAGE fetch bridge (not the extension SW route).
+    const fetchScript = "const r = await fetch('data:text/plain,peerd-lite-egress'); return await r.text()";
+    const r3 = await evalJson(send, `window.runNotebookCell(${JSON.stringify(fetchScript)})`).catch((e) => ({ error: String(e) }));
+    check('the in-page fetch bridge works (seal-pinned fetch → host fetch)', r3?.result?.value === 'peerd-lite-egress' && !r3?.result?.error, JSON.stringify(r3?.result?.value ?? r3?.result?.error));
+  }
+
+  if (events.length) console.error('  page errors:\n   ' + events.slice(0, 8).join('\n   '));
+  const passed = checks.filter((c) => c.pass).length;
+  console.log(`\nPOC: ${passed}/${checks.length} checks`);
+  cleanup();
+  process.exit(passed === checks.length && checks.length > 0 ? 0 : 1);
+};
+
+main().catch((e) => { console.error('poc harness error:', e?.stack || e); cleanup(); process.exit(1); });


### PR DESCRIPTION
A **runnable proof** of the central claim in [`PEERD-WEB-SURFACE.md`](docs/specs/PEERD-WEB-SURFACE.md): peerd's execution substrates are host-agnostic (DECISIONS #25 - "the sandbox is the isolate; a tab is one way to host it"), so the sealed Notebook worker runs in a **regular web page, no extension** - the substrate ships **verbatim**, only the host adapter changes.

### Verbatim vs. new
**Imported unmodified** from the extension tree (change a byte → the PoC breaks):
- `/notebook-tab/worker-source.js` - `buildWorkerSource`, the realm seal, the `peerd.*` surface, `NOTEBOOK_BUILTINS` (incl. `peerd:std`)
- `/peerd-engine/index.js` - `opfsHelpers`, `buildModule` (the module resolver)

**The entire delta is the host adapter** (`notebook-host.js`), differing from `offscreen/job-runner.js` in exactly three places:
1. **OPFS is durable** (a stable Notebook subtree), not the headless ephemeral scratch - OPFS is a web-platform API, so `opfsHelpers` works in a page unchanged.
2. **The fetch bridge is an in-page `fetch`**, not the SW `sw/web-fetch` route (a page has no service worker to relay to).
3. **No subagent relay** - subagents drive the user's real tabs (the extension's surface); an origin-confined page declines them. *That decline is the upgrade funnel, by construction.*

### Validation - 7/7
`bun web-prototype/poc/run-poc.mjs` serves `extension/` at root + the PoC, drives headless Chrome over CDP, and runs three cells:
- the worker runs in the page; code-mode returns the computed index `{total:35.5,count:3}`; the console bridge works; the index file lands in OPFS;
- **OPFS persists across two separate worker runs** (a fresh worker reads the prior run's file);
- the **in-page fetch bridge** resolves the seal-pinned fetch to the host fetch.

### Notes
- Self-contained under `web-prototype/poc/` - **does not touch the existing web-prototype scaffold**, so it can be adopted into the peerd-lite build.
- The demo cell is the [personal-data index](docs/specs/LOCAL-FIRST-PERSONAL-DATA-AGENT.md), so this also shows that feature's compute running unchanged in peerd-lite.
- This is the **foundation slice**: with the Notebook substrate proven portable, the App-iframe + WebVM substrates, the agent loop, and the BYOK vault follow the same substrate-ships-verbatim / swap-the-host pattern.