### PR TITLE
fix(loop): honor Stop between tool-batch waves — don't run queued writes after abort

### DIFF
--- a/extension/peerd-runtime/loop/agent-loop.js
+++ b/extension/peerd-runtime/loop/agent-loop.js
@@ -759,7 +759,15 @@ export async function* runUserTurn(ctx) {
     // to its result the moment it lands (completion order). Hooks, audit
     // and lineage are untouched — every call still goes through the same
     // dispatchOne → toolDispatch pipeline, one invocation per call.
+    let abortedMidBatch = false;
     for (const wave of partitionToolBatch(toolUses, isConcurrencySafe)) {
+      // why recheck per wave: Stop (or a spend-limit halt) can land AFTER the
+      // pre-dispatch guard (:683) while the batch is draining. Each non-READ call
+      // is its own sequential wave, so checking here stops the NEXT side-effecting
+      // wave from dispatching once the user pressed Stop — without this the only
+      // other check is at the loop top, which runs only after the WHOLE batch ran
+      // its side effects. (Already-dispatched calls can't be un-run; we stop here.)
+      if (wasAborted()) { abortedMidBatch = true; break; }
       if (wave.concurrent) {
         for (const tu of wave.calls) {
           yield {
@@ -778,6 +786,9 @@ export async function* runUserTurn(ctx) {
         for (const tu of wave.calls) toolResults.push(blocksById.get(tu.id));
       } else {
         for (const tu of wave.calls) {
+          // belt-and-suspenders: a non-concurrent wave is one call today, but if
+          // that ever changes, don't dispatch a second side effect after Stop.
+          if (wasAborted()) { abortedMidBatch = true; break; }
           yield {
             type: 'tool-use', sessionId, messageId: assistantStub.id,
             toolUseId: tu.id, name: tu.name, input: tu.input,
@@ -786,7 +797,22 @@ export async function* runUserTurn(ctx) {
           yield { type: 'tool-result', sessionId, toolUseId: tu.id, result: dispatchResult };
           toolResults.push(block);
         }
+        if (abortedMidBatch) break;
       }
+    }
+    if (abortedMidBatch) {
+      // Mirror the pre-dispatch abort guard (:683): mark a DELIBERATE stop (not a
+      // resumable tools-pending interruption) and drop the partial tool_result
+      // message, so the turn ends cleanly on the aborted assistant message and
+      // detectInterruptedTurn won't re-drive it.
+      await sessions.updateAssistantMessage(sessionId, assistantStub.id, {
+        stopReason: 'aborted',
+      });
+      yield {
+        type: 'stop', sessionId,
+        messageId: assistantStub.id, stopReason: 'aborted',
+      };
+      return;
     }
 
     // Append the user message that carries tool results back to the

--- a/tests/peerd-runtime/loop/concurrent-dispatch.test.ts
+++ b/tests/peerd-runtime/loop/concurrent-dispatch.test.ts
@@ -234,6 +234,44 @@ describe('runUserTurn — concurrent tool dispatch', () => {
     expect(log).toEqual(['start:a', 'end:a', 'start:b', 'end:b']);
   });
 
+  test('Stop mid-batch halts the remaining side-effecting waves and ends on a deliberate abort', async () => {
+    const store = makeStore();
+    store.seed('s1');
+    // Three writes → three sequential waves (writes are barriers).
+    const calls = [
+      { id: 't_w1', name: 'click' },
+      { id: 't_w2', name: 'click' },
+      { id: 't_w3', name: 'click' },
+    ];
+    const dispatched: string[] = [];
+    const ac = new AbortController();
+    const ctx = baseCtx(store, {
+      callModel: makeToolModel(calls),
+      tools: calls.map((c) => ({ name: c.name, description: '', schema: {} })),
+      classifyToolCall: () => WRITE_VERDICT, // confirmations off → each write just runs
+      signal: ac.signal,
+      toolDispatch: async (call: any) => {
+        dispatched.push(call.id);
+        if (call.id === 't_w1') ac.abort(); // user presses Stop while wave 1 is in flight
+        return { ok: true, content: 'r', meta: {} };
+      },
+    });
+
+    const events = await drain(runUserTurn(ctx));
+
+    // waves 2 + 3 must NOT have dispatched their side effects after Stop.
+    expect(dispatched).toEqual(['t_w1']);
+    // the turn ENDS on a deliberate abort (there's a pre-dispatch segment stop
+    // carrying the model's tool_use; the terminal one must be the abort).
+    const stops = events.filter((e: any) => e.type === 'stop');
+    expect(stops.at(-1)?.stopReason).toBe('aborted');
+    const s = await store.get('s1');
+    // the partial batch is dropped (no tool_result message appended)...
+    expect(s.messages.some((m: any) => Array.isArray(m.toolResults))).toBe(false);
+    // ...and the assistant message is marked aborted so resume won't re-drive it.
+    expect(s.messages.some((m: any) => m.stopReason === 'aborted')).toBe(true);
+  });
+
   test('one failing sibling in a concurrent wave becomes its own error block, not a batch failure', async () => {
     const store = makeStore();
     store.seed('s1');


### PR DESCRIPTION
When an assistant turn emits several side-effecting tool calls, each non-READ call becomes its own **sequential wave** (writes are barriers). The loop checked the abort signal **exactly once** - before the first dispatch - then ran wave after wave with no further check; the next abort check is at the loop top, which runs only *after* the whole batch drains.

So if the user presses **Stop** (or a spend-limit halt fires) while wave 1 is in flight, waves 2..N still dispatch and commit their side effects **after the stop**. Reachable in the shipped default posture (`confirmActions` defaults off) and in **goal mode** (confirms forced off) - i.e. the autonomous path where unattended action is the headline risk. The dispatcher doesn't consult the signal either, so nothing downstream caught it.

**Fix:** recheck `wasAborted()` at the top of each wave (and before each sequential call). On a mid-batch abort, stop dispatching, mark the assistant message `stopReason='aborted'` and yield the terminal stop event - mirroring the existing pre-dispatch guard - and drop the partial `tool_result` message so `detectInterruptedTurn` treats it as a deliberate stop, not a resumable tools-pending interruption.

**Test** (revert-proven): three writes → three waves; Stop fires during wave 1; only wave 1's side effect runs, the turn ends on `stopReason='aborted'`, and no partial `tool_result` message is appended. Full bun suite green (2153).

Surfaced by a security audit of the agent core (the policy/loop/runner surface). The in-flight-tool cancellation (threading the signal *into* the dispatcher so a long-running call can abort) is a separate, larger follow-up.