### PR TITLE
Add expectedCount guard for selector click/type

### DIFF
--- a/extension/peerd-runtime/tools/defs/click.js
+++ b/extension/peerd-runtime/tools/defs/click.js
@@ -66,6 +66,11 @@ export const clickTool = {
         type: 'integer',
         description: 'Optional 0-indexed match to click when the SELECTOR matches multiple elements (default 0 = first match). Ignored for ref.',
       },
+      expectedCount: {
+        type: 'integer',
+        minimum: 1,
+        description: 'Optional deterministic guard for selector actions: fail before clicking unless the selector resolves to exactly this many elements.',
+      },
       tabId: {
         type: 'integer',
         description: 'Optional tab id; defaults to the active tab.',
@@ -155,13 +160,16 @@ export const clickTool = {
       return { ok: false, error: 'selector_or_ref_required' };
     }
     const nth = Number.isInteger(args.nth) && args.nth >= 0 ? args.nth : 0;
+    const expectedCount = Number.isInteger(args.expectedCount) && args.expectedCount > 0
+      ? args.expectedCount
+      : null;
 
     let scriptResult;
     try {
       const results = await scripting.executeScript({
         target: { tabId: tab.id },
         func: clickInjected,
-        args: [args.selector, nth],
+        args: [args.selector, nth, null, expectedCount],
       });
       scriptResult = results[0]?.result;
     } catch (e) {
@@ -191,8 +199,9 @@ export const clickTool = {
  * @param {string | null} selector
  * @param {number} nth
  * @param {number | null} [walkId]
+ * @param {number | null} [expectedCount]
  */
-function clickInjected(selector, nth, walkId) {
+function clickInjected(selector, nth, walkId, expectedCount) {
   'use strict';
   /** @type {HTMLElement | null} */
   let el;
@@ -218,6 +227,14 @@ function clickInjected(selector, nth, walkId) {
 
     if (nodes.length === 0) {
       return { ok: false, error: `no_match: ${selector}` };
+    }
+    if (expectedCount != null && nodes.length !== expectedCount) {
+      return {
+        ok: false,
+        error: `matched_count_mismatch: selector matched ${nodes.length} element(s), expected ${expectedCount}`,
+        matchedCount: nodes.length,
+        expectedCount,
+      };
     }
     if (nth >= nodes.length) {
       return {

--- a/extension/peerd-runtime/tools/defs/type.js
+++ b/extension/peerd-runtime/tools/defs/type.js
@@ -62,6 +62,11 @@ export const typeTool = {
         type: 'boolean',
         description: 'If true, dispatch an Enter keydown after typing (submits search boxes).',
       },
+      expectedCount: {
+        type: 'integer',
+        minimum: 1,
+        description: 'Optional deterministic guard for selector actions: fail before typing unless the selector resolves to exactly this many elements.',
+      },
       tabId: {
         type: 'integer',
         description: 'Optional tab id; defaults to the active tab.',
@@ -157,10 +162,13 @@ export const typeTool = {
 
     let scriptResult;
     try {
+      const expectedCount = Number.isInteger(args.expectedCount) && args.expectedCount > 0
+        ? args.expectedCount
+        : null;
       const results = await scripting.executeScript({
         target: { tabId: tab.id },
         func: typeInjected,
-        args: [args.selector, args.text, !!args.submit],
+        args: [args.selector, args.text, !!args.submit, null, expectedCount],
       });
       scriptResult = results[0]?.result;
     } catch (e) {
@@ -175,6 +183,7 @@ export const typeTool = {
         typed: scriptResult.typed,
         submitted: scriptResult.submitted,
         tag: scriptResult.tag,
+        matchedCount: scriptResult.matchedCount,
       }, null, 2),
     };
   },
@@ -185,14 +194,16 @@ export const typeTool = {
  * @param {string} text
  * @param {boolean} submit
  * @param {number | null} [walkId]
+ * @param {number | null} [expectedCount]
  */
-function typeInjected(selector, text, submit, walkId) {
+function typeInjected(selector, text, submit, walkId, expectedCount) {
   // why: serialized by chrome.scripting.executeScript and re-evaluated
   // in the page's classic-script world; the calling module's strict
   // mode doesn't carry across. Opt in here.
   'use strict';
   /** @type {HTMLElement | null} */
   let el;
+  let matchedCount = 1;
   if (walkId != null) {
     // DOM-walk ref resolution: the walk (walk-injected.js) registered
     // walkId → element in this same isolated world. Element gone or
@@ -207,8 +218,21 @@ function typeInjected(selector, text, submit, walkId) {
   } else {
     // why: erased cast — this branch is reached only when walkId is null, so a
     // selector is always present.
-    el = /** @type {HTMLElement | null} */ (document.querySelector(/** @type {string} */ (selector)));
-    if (!el) return { ok: false, error: `no_match: ${selector}` };
+    /** @type {NodeListOf<HTMLElement>} */
+    let nodes;
+    try { nodes = document.querySelectorAll(/** @type {string} */ (selector)); }
+    catch (e) { return { ok: false, error: `invalid_selector: ${/** @type {{ message?: string }} */ (e)?.message ?? String(e)}` }; }
+    if (nodes.length === 0) return { ok: false, error: `no_match: ${selector}` };
+    if (expectedCount != null && nodes.length !== expectedCount) {
+      return {
+        ok: false,
+        error: `matched_count_mismatch: selector matched ${nodes.length} element(s), expected ${expectedCount}`,
+        matchedCount: nodes.length,
+        expectedCount,
+      };
+    }
+    matchedCount = nodes.length;
+    el = nodes[0];
   }
   try {
     if (typeof el.focus === 'function') el.focus();
@@ -278,6 +302,7 @@ function typeInjected(selector, text, submit, walkId) {
       typed: text.slice(0, 200),
       submitted,
       tag,
+      matchedCount,
     };
   } catch (e) {
     return { ok: false, error: `type_threw: ${/** @type {{ message?: string }} */ (e)?.message ?? String(e)}` };

--- a/extension/tests/unit/peerd-runtime/dom-walk.test.js
+++ b/extension/tests/unit/peerd-runtime/dom-walk.test.js
@@ -165,6 +165,22 @@ describe('snapshot → click/type over walk refs — full chain', () => {
     });
   });
 
+  it('click {selector, expectedCount} reports the real matchedCount on success', async () => {
+    await withFixture(async (host) => {
+      const ctx = makeCtx();
+      let clicks = 0;
+      for (const btn of host.querySelectorAll('button')) {
+        /** @type {HTMLButtonElement} */ (btn).disabled = false;
+        btn.addEventListener('click', () => { clicks += 1; });
+      }
+      const r = await clickTool.execute({ selector: '#dom-walk-fixture button', expectedCount: 2, nth: 1 }, ctx);
+      expect(r.ok).toBe(true);
+      expect(contentOf(r)).toContain('"matchedCount": 2');
+      expect(contentOf(r)).toContain('"nth": 1');
+      expect(clicks).toBe(1);
+    });
+  });
+
   it('type {ref} sets the value and fires input events', async () => {
     await withFixture(async (host) => {
       const ctx = makeCtx();

--- a/tests/peerd-runtime/dom/walk-ref-actions.test.ts
+++ b/tests/peerd-runtime/dom/walk-ref-actions.test.ts
@@ -112,4 +112,24 @@ describe('click/type — walk-ref dispatch', () => {
     expect(r.error).toContain('debugger_unavailable');
     expect(r.error).toContain('Re-run snapshot');
   });
+
+  test('click {selector, expectedCount} forwards a pre-action cardinality guard', async () => {
+    const { ctx, injections } = makeCtx((req: any) => [{ result: { ok: true, clicked: true, tag: 'button', text: 'Delete', matchedCount: 3, nth: 0 } }]);
+    const r = await clickTool.execute({ selector: '.delete-row', expectedCount: 3 }, ctx);
+    expect(r.ok).toBe(true);
+    if (!r.ok) throw new Error('expected ok result');
+    // [selector, nth, walkId=null, expectedCount]
+    expect(injections[0].args).toEqual(['.delete-row', 0, null, 3]);
+    expect(r.content).toContain('"matchedCount": 3');
+  });
+
+  test('type {selector, expectedCount} forwards a pre-action cardinality guard', async () => {
+    const { ctx, injections } = makeCtx((req: any) => [{ result: { ok: true, typed: 'Ada', submitted: false, tag: 'input', matchedCount: 1 } }]);
+    const r = await typeTool.execute({ selector: 'input[name="assignee"]', text: 'Ada', expectedCount: 1 }, ctx);
+    expect(r.ok).toBe(true);
+    if (!r.ok) throw new Error('expected ok result');
+    // [selector, text, submit, walkId=null, expectedCount]
+    expect(injections[0].args).toEqual(['input[name="assignee"]', 'Ada', false, null, 1]);
+    expect(r.content).toContain('"matchedCount": 1');
+  });
 });


### PR DESCRIPTION
This is a small implementation slice for #36: it adds a deterministic pre-action cardinality guard to selector-based `click` and `type` calls.

What changed:
- `click({ selector, expectedCount })` now fails before clicking if the selector resolves to a different number of elements
- `type({ selector, expectedCount })` does the same before typing
- mismatch responses include `matchedCount` and `expectedCount` for the runner/main agent to reason about
- action results surface `matchedCount` on successful selector actions
- tests pin that the guard is forwarded into the page-side injection path

Why this shape:
- keeps existing ref/walkId behavior unchanged
- gives the runner a low-level primitive it can use when it falls back to CSS selectors or when list/repeating targets need an exact count
- fails closed before DOM mutation on over-match/under-match

Validation:
- `npx --yes bun test tests/peerd-runtime/dom/walk-ref-actions.test.ts`
- `npx --yes bun test tests/peerd-runtime/runner.test.ts tests/peerd-runtime/dom/walk-ref-actions.test.ts tests/peerd-runtime/dom/action-result.test.ts`
- after `npx --yes bun install --frozen-lockfile`: `npx --yes bun test ./tests` → 2162 pass / 0 fail

Closes part of #36.