### PR TITLE
fix(tests): stop the click-cardinality test from hanging the in-browser CI run

### DIFF
--- a/extension/tests/unit/peerd-runtime/dom-walk.test.js
+++ b/extension/tests/unit/peerd-runtime/dom-walk.test.js
@@ -40,6 +40,11 @@ const walkNodes = (out) => /** @type {WalkNode[]} */ (/** @type {unknown} */ (ou
 
 // A fixture corner of the test page: a small form with the roles the
 // walk must classify. withFixture() removes it after each test.
+// why type="button" on the hidden button: a bare <button> defaults to type=submit, and
+// it sits inside this <form>. The click-tool test below targets it (nth:1), and
+// clickInjected fires a native el.click() — a submit button would submit the form and
+// NAVIGATE the test-runner page, reloading runner.html mid-suite so the result marker is
+// never written (the in-browser run hangs at "Loading…" instead of failing cleanly).
 const FIXTURE_HTML = `
   <h2>Pizza order</h2>
   <form aria-label="Order form">
@@ -51,7 +56,7 @@ const FIXTURE_HTML = `
     </select>
     <a id="dw-help" href="#help">Help</a>
     <button id="dw-send" type="button" disabled>Send order</button>
-    <div id="dw-hidden-wrap" hidden><button>Invisible</button></div>
+    <div id="dw-hidden-wrap" hidden><button type="button">Invisible</button></div>
     <input id="dw-secret" type="password" aria-label="Passphrase" value="hunter2">
   </form>`;
 
@@ -177,7 +182,12 @@ describe('snapshot → click/type over walk refs — full chain', () => {
       expect(r.ok).toBe(true);
       expect(contentOf(r)).toContain('"matchedCount": 2');
       expect(contentOf(r)).toContain('"nth": 1');
-      expect(clicks).toBe(1);
+      // why >0, not ===1: clickInjected deliberately dispatches a synthetic click event
+      // AND calls native el.click() (so it activates both framework listeners and native
+      // behaviour), so a plain addEventListener('click') counter fires more than once per
+      // tool-click. The test only needs to confirm the nth:1 element actually received the
+      // click — not pin the dispatch count.
+      expect(clicks).toBeGreaterThan(0);
     });
   });
 


### PR DESCRIPTION
## What & why

The in-browser tests (headless Chrome) job has been hanging on main since #103. It gets stuck at `summary: Loading…`, and it's the only job that fails. Anything branched off main inherits it, including #61.

The cause is the new test `click {selector, expectedCount} reports the real matchedCount on success`. Two things go wrong, both from its `nth:1` target, `<button>Invisible</button>`:

1. The hang. That button has no `type`, so it defaults to `submit`, and it sits inside the fixture `<form>`. `clickInjected` calls a native `el.click()`, which submits the form and navigates the test-runner page. `runner.html` reloads partway through the suite, so the result marker never gets written. The full suite runs long enough that the reload always lands first. The short isolated suite usually wins that race, which is why it fails fast locally but hangs in CI.
2. A wrong assertion. `expect(clicks).toBe(1)` actually sees `2`, because `clickInjected` fires a synthetic click event and then calls native `el.click()`, so a plain click listener runs twice.

The fix stays in the test: give the button `type="button"` so it can't submit, and assert `clicks > 0` instead of pinning the count. The `click` tool and the new `expectedCount` guard are untouched.

@caioribeiroclw-pixel, this sits on top of your #103. Could you confirm the test was meant to check the cardinality reporting and not a form submit specifically? Glad to change it if you had something else in mind for that target.

One thing worth a separate look, not in this PR: the double dispatch means the real click tool fires a normal page click handler twice per call. That predates #103.

## Checklist

- [x] Tests updated. The dom-walk in-browser suite passes (9 of 9, no hang)
- [x] Typecheck and lint clean
- [x] No hand-edited generated files
- [x] Not a danger zone (test fixture only)

## Notes for reviewers

One file changed, and both edits carry a `why` comment. Reproduced it directly: with the original submit button the isolated suite returns `ok=true, clicks=2` and the long suite reloads to the loading state; with `type="button"` and `clicks > 0` the suite is green.