### PR TITLE
feat(eval): build-over-build benchmark loop — drive eval/lab over the real extension via CDP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 # Finder custom-icon file: its on-disk name is "Icon" + a trailing CR.
 # The line below ends in TWO raw CRs because git strips one CR before
 # the newline when parsing; a bare "Icon" line matches the wrong thing.
-Icon
+Icon
 ._*
 .DocumentRevisions-V100
 .fseventsd
@@ -56,6 +56,9 @@ web-ext-artifacts/
 # images), regenerated every `bun run e2e:verify`. The committed REFERENCE
 # images live in scripts/cdp/baselines/ — those are tracked.
 scripts/cdp/artifacts/
+# Per-run benchmark scorecards (commit-tagged JSON from `bun run eval:bench`).
+# Local + tied to YOUR model/key/page state; pick one as a baseline by path.
+scripts/cdp/bench-results/
 
 # Claude Code harness state — session worktrees (.claude/worktrees/),
 # launch configs, etc. Local/transient; never source. Un-ignore a

--- a/extension/eval/runner.js
+++ b/extension/eval/runner.js
@@ -322,13 +322,13 @@ const scoreLine = (card) => `passRate ${card.passRate}%  (${card.passed}/${card.
 // The selected suite's tasks (simple = the fast 30; robust = +25 precision probes).
 const selectedTasks = () => /** @type {Record<string, { tasks: any[] }>} */ (SUITES)[$('suite')?.value || 'simple']?.tasks ?? TASKS;
 
-/** @param {string} [runnerCfg] */
-async function runSuite(runnerCfg) {
+/** @param {string} [runnerCfg] @param {any[]} [tasksOverride] */
+async function runSuite(runnerCfg, tasksOverride) {
   wireListeners();
   await ensureSubject();
   /** @type {any[]} */
   const results = [];
-  const tasks = selectedTasks();
+  const tasks = tasksOverride ?? selectedTasks();
   log(`  suite: ${$('suite')?.value || 'simple'} (${tasks.length} tasks)`);
   for (const task of tasks) {
     try { results.push(await runTask(task, runnerCfg)); }
@@ -648,6 +648,58 @@ $('clearBaseline').addEventListener('click', () => {
   if (lastCard) renderDelta(lastCard);
   refreshBaselineUi();
 });
+
+// ---- programmatic driver hook (build-over-build benchmark loop) -----------
+// why: the in-house CDP harness (scripts/cdp/run-eval-bench.mjs) needs to START
+// a run and READ the structured scorecard WITHOUT scraping the DOM, so it can
+// score one BUILD against a baseline in default settings — "drive eval/lab to
+// measure builds, not just models." The buttons stay the human path; this is the
+// one automation seam. A full suite outlasts a single awaited CDP call, so the
+// driver fires run() then POLLS lastCard/lastError — hence the result lands on
+// the object, not a return value. `taskIds` runs an exact subset (deterministic
+// smoke); `limit` runs a first-N subset (cost control). No-ops if a run is
+// already in flight.
+const evalDriver = {
+  ready: true,
+  running: false,
+  /** @type {ReturnType<typeof aggregate> | null} */
+  lastCard: null,
+  /** @type {any[] | null} */
+  lastResults: null,
+  /** @type {string | null} */
+  lastError: null,
+  /** @param {{ suite?: string, limit?: number, taskIds?: string[], runnerCfg?: string }} [opts] */
+  run(opts = {}) {
+    if (evalDriver.running) return;
+    const { suite, limit, taskIds, runnerCfg } = opts;
+    evalDriver.running = true;
+    evalDriver.lastCard = null; evalDriver.lastResults = null; evalDriver.lastError = null;
+    if (suite) { const sel = $('suite'); if (sel) sel.value = suite; }
+    void (async () => {
+      try {
+        /** @type {any[] | undefined} */
+        let tasks;
+        if (Array.isArray(taskIds) && taskIds.length) {
+          const all = selectedTasks();
+          tasks = taskIds.map((id) => all.find((t) => t.id === id)).filter(Boolean);
+        } else if (typeof limit === 'number' && limit > 0) {
+          tasks = selectedTasks().slice(0, limit);
+        }
+        const { card, results } = await runSuite(runnerCfg, tasks);
+        lastCard = card; // module-level too → the Pin button can pin a driver run
+        evalDriver.lastResults = results;
+        evalDriver.lastCard = card;
+        refreshBaselineUi();
+      } catch (e) {
+        evalDriver.lastError = /** @type {{ message?: string }} */ (e)?.message ?? String(e);
+      } finally {
+        evalDriver.running = false;
+      }
+    })();
+  },
+};
+/** @type {any} */ (window).__peerdEval = evalDriver;
+
 preflight();
 populateModelSelects(); // fills cloud models, then refreshLocalStatus() adds the local model if downloaded
 refreshBaselineUi();

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "test:e2e:visual": "bun scripts/cdp/run-e2e-verify.mjs --visual",
     "test:e2e:visual:update": "UPDATE_BASELINES=1 bun scripts/cdp/run-e2e-verify.mjs --visual",
     "e2e:chrome": "bun scripts/cdp/ensure-chrome-for-testing.mjs",
+    "eval:bench": "bun scripts/cdp/run-eval-bench.mjs",
+    "eval:bench:smoke": "bun scripts/cdp/run-eval-bench.mjs --smoke",
     "typecheck": "tsc",
     "lint": "eslint extension",
     "package": "bun packaging/package.ts",

--- a/scripts/cdp/e2e-harness.mjs
+++ b/scripts/cdp/e2e-harness.mjs
@@ -379,6 +379,23 @@ export async function unlockAndReady(page, { provider = 'ollama', model = 'qwen3
   log(`provider set to ${provider} (keyless)`);
 }
 
+/**
+ * Open an arbitrary extension page (e.g. the eval harness) as a new tab and
+ * return an attached page CDP connection — same `/json/new` + attach +
+ * Runtime/Page.enable dance launchPeerd uses for the side panel, so any
+ * in-extension page can be driven, not just the panel.
+ * @param {object} ctx   the launchPeerd ctx (uses ctx.sw.id + ctx.port)
+ * @param {string} path  extension-relative path, e.g. 'eval/runner.html'
+ */
+export async function openExtPage(ctx, path) {
+  const url = `chrome-extension://${ctx.sw.id}/${String(path).replace(/^\//, '')}`;
+  const created = await (await fetch(`http://127.0.0.1:${ctx.port}/json/new?${encodeURI(url)}`, { method: 'PUT' })).json();
+  const page = await attach(created.webSocketDebuggerUrl);
+  await page.send('Runtime.enable');
+  await page.send('Page.enable');
+  return page;
+}
+
 // ---- check reporting --------------------------------------------------------
 
 /** A small named-check collector; finish(ctx) reports + throws on any failure. */

--- a/scripts/cdp/run-eval-bench.mjs
+++ b/scripts/cdp/run-eval-bench.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env bun
+// scripts/cdp/run-eval-bench.mjs — drive the eval/lab task suite over the REAL
+// extension and score one BUILD, so we can diff build-over-build instead of
+// guessing whether a change helped. Reuse, not a new benchmark tool:
+//   - launchPeerd (e2e-harness.mjs) loads the real unpacked extension in
+//     headless Chrome for Testing,
+//   - this injects a real provider key + selects the model,
+//   - opens eval/runner.html and runs the suite through the page's __peerdEval
+//     hook (the same runSuite the "Run all tasks" button calls),
+//   - writes a commit-tagged scorecard to bench-results/,
+//   - and (optionally) runs the PURE score.compare() against a baseline file to
+//     surface regressions/fixes — the build-over-build signal.
+//
+// REAL runs make real model calls and COST MONEY, and need a real key — exactly
+// the constraint the owner flagged. The score is tied to YOUR model + key + live
+// page state, so a baseline is local + explicit (there's no backend to stash a
+// shared one in).
+//
+// --smoke uses launchPeerd's keyless-Ollama wire fake (no key, no cost, no real
+// model) to verify the DRIVER PLUMBING end to end — open → run → read scorecard.
+// passRate will be ~0 (the faked model can't solve tasks); that's expected, the
+// smoke only asserts a scorecard comes back.
+//
+// Usage:
+//   PEERD_BENCH_KEY=sk-ant-... bun run eval:bench --provider=anthropic --model=claude-haiku-4-5
+//   bun run eval:bench --provider=anthropic --model=claude-haiku-4-5 --baseline=scripts/cdp/bench-results/<prev>.json
+//   bun run eval:bench --smoke           # zero-cost plumbing check
+//
+// Flags:
+//   --provider=anthropic|openrouter|ollama   (default anthropic; smoke → ollama)
+//   --model=<id>                             (default: the provider's default)
+//   --suite=simple|robust                    (default simple)
+//   --limit=N                                run only the first N tasks (cost control)
+//   --baseline=<path.json>                   diff against a prior scorecard; exit 1 on a regression
+//   --budget-min=N                           max minutes to wait for the run (default 45; smoke 5)
+//   --show-tabs                              open the agent's eval window visibly
+//   --smoke                                  keyless plumbing run (implies provider=ollama, limit=1)
+// Key (real mode): PEERD_BENCH_KEY, else ANTHROPIC_API_KEY / OPENROUTER_API_KEY.
+
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+import { launchPeerd, openExtPage, rpc, evalIn, waitFor, log, PASSPHRASE, sseText } from './e2e-harness.mjs';
+import { compare } from '../../extension/eval/score.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = resolve(__dirname, 'bench-results');
+
+// ---- args -------------------------------------------------------------------
+const argv = process.argv.slice(2);
+const flag = (name, def) => {
+  const hit = argv.find((a) => a === `--${name}` || a.startsWith(`--${name}=`));
+  if (!hit) return def;
+  const eq = hit.indexOf('=');
+  return eq === -1 ? true : hit.slice(eq + 1);
+};
+
+const SMOKE = !!flag('smoke', false);
+const PROVIDER = String(flag('provider', SMOKE ? 'ollama' : 'anthropic'));
+const MODEL = flag('model', false) ? String(flag('model', '')) : '';
+const SUITE = String(flag('suite', 'simple'));
+const LIMIT = SMOKE ? 1 : (flag('limit', false) ? Number(flag('limit', 0)) : 0);
+const BASELINE = flag('baseline', false) ? String(flag('baseline', '')) : '';
+const SHOW_TABS = !!flag('show-tabs', false);
+const RUN_BUDGET_MS = Number(flag('budget-min', SMOKE ? 5 : 45)) * 60_000;
+
+const KEY = process.env.PEERD_BENCH_KEY
+  || (PROVIDER === 'anthropic' ? process.env.ANTHROPIC_API_KEY : '')
+  || (PROVIDER === 'openrouter' ? process.env.OPENROUTER_API_KEY : '')
+  || '';
+
+const shortSha = () => { try { return execSync('git rev-parse --short HEAD').toString().trim(); } catch { return 'nogit'; } };
+const isKeyless = (p) => p === 'ollama' || p === 'local-webgpu';
+
+main();
+
+async function main() {
+  if (!SMOKE && !isKeyless(PROVIDER) && !KEY) {
+    console.error('[bench] No provider key. Set PEERD_BENCH_KEY (or ANTHROPIC_API_KEY / OPENROUTER_API_KEY), or run with --smoke for the keyless plumbing check.');
+    process.exit(2);
+  }
+  if (SMOKE) {
+    log('SMOKE — keyless Ollama wire fake. No real model calls, no cost. Verifies the driver plumbing only (passRate will be ~0).');
+  } else {
+    log(`REAL benchmark — provider=${PROVIDER} model=${MODEL || '(provider default)'} suite=${SUITE}${LIMIT ? ` limit=${LIMIT}` : ''}. Makes real API calls and COSTS MONEY.`);
+  }
+
+  // In smoke mode launchPeerd intercepts the keyless model wire; a fixed no-op
+  // answer is fine — we only check the driver yields a scorecard.
+  const ctx = await launchPeerd(SMOKE ? { modelResponder: () => ({ sse: sseText('benchmark smoke: no-op answer.') }) } : {});
+  try {
+    // 1) vault + provider
+    const vault = await rpc(ctx.page, { type: 'vault/initialize', passphrase: PASSPHRASE });
+    if (!vault?.ok) throw new Error(`vault/initialize failed: ${JSON.stringify(vault)}`);
+    await rpc(ctx.page, { type: 'onboarding/complete', peerName: 'peerd', facts: null });
+
+    if (isKeyless(PROVIDER)) {
+      const patch = { providerName: PROVIDER };
+      if (MODEL) patch.providerModel = MODEL;
+      const upd = await rpc(ctx.page, { type: 'settings/update', patch });
+      if (!upd?.ok) throw new Error(`settings/update failed: ${JSON.stringify(upd)}`);
+    } else {
+      const set = await rpc(ctx.page, { type: 'provider/setKey', provider: PROVIDER, plaintext: KEY });
+      if (!set?.ok) throw new Error(`provider/setKey failed: ${JSON.stringify(set)}`);
+      const patch = { providerName: PROVIDER };
+      if (MODEL) patch.providerModel = MODEL;
+      const upd = await rpc(ctx.page, { type: 'settings/update', patch });
+      if (!upd?.ok) throw new Error(`settings/update failed: ${JSON.stringify(upd)}`);
+    }
+
+    const status = await rpc(ctx.page, { type: 'provider/status' });
+    const usable = Array.isArray(status?.providers) && status.providers.some((p) => p.name === PROVIDER && p.hasKey);
+    if (!usable) throw new Error(`provider ${PROVIDER} is not usable after setup (no key?)`);
+    log(`provider ready: ${PROVIDER}${MODEL ? ` (${MODEL})` : ''}`);
+
+    // 2) open the eval harness page + wait for its driver hook
+    const evalPage = await openExtPage(ctx, 'eval/runner.html');
+    if (SHOW_TABS) await evalIn(evalPage, `(() => { const c = document.getElementById('showtabs'); if (c) c.checked = true; })()`);
+    const ready = await waitFor(() => evalIn(evalPage, `!!(window.__peerdEval && window.__peerdEval.ready)`), { budgetMs: 30_000 });
+    if (!ready) throw new Error('eval/runner.html never exposed __peerdEval — is the runner hook present?');
+
+    // 3) start the run (fire-and-forget in the page), then poll — a full suite
+    //    outlasts a single awaited CDP call. Smoke targets ONE network-free
+    //    compute task so the plumbing check is fast + deterministic.
+    const runOpts = { suite: SUITE };
+    if (SMOKE) runOpts.taskIds = ['clock-now'];
+    else if (LIMIT) runOpts.limit = LIMIT;
+    await evalIn(evalPage, `(() => { window.__peerdEval.run(${JSON.stringify(runOpts)}); return true; })()`);
+    log(`run started (suite=${SUITE}${LIMIT ? `, first ${LIMIT}` : ''}); polling for the scorecard (budget ${Math.round(RUN_BUDGET_MS / 60000)} min)…`);
+
+    const card = await waitFor(async () => {
+      const err = await evalIn(evalPage, `window.__peerdEval.lastError`);
+      if (err) throw new Error(`eval run failed in-page: ${err}`);
+      return evalIn(evalPage, `window.__peerdEval.lastCard`);
+    }, { budgetMs: RUN_BUDGET_MS, pollMs: 5_000 });
+    if (!card) throw new Error(`run did not finish within ${Math.round(RUN_BUDGET_MS / 60000)} min`);
+
+    const results = await evalIn(evalPage, `window.__peerdEval.lastResults`);
+
+    // 4) persist, tagged by commit + model
+    mkdirSync(OUT_DIR, { recursive: true });
+    const sha = shortSha();
+    const modelTag = (MODEL || PROVIDER).replace(/[^a-z0-9.-]+/gi, '_');
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const outPath = join(OUT_DIR, `${sha}-${modelTag}-${stamp}.json`);
+    const record = {
+      build: sha, provider: PROVIDER, model: MODEL || null, suite: SUITE,
+      limit: LIMIT || null, smoke: SMOKE, at: new Date().toISOString(), card, results,
+    };
+    writeFileSync(outPath, JSON.stringify(record, null, 2));
+    log(`scorecard → ${outPath}`);
+
+    // 5) headline + optional baseline diff
+    printCard(card);
+    let regressed = false;
+    if (BASELINE) {
+      if (!existsSync(BASELINE)) throw new Error(`baseline not found: ${BASELINE}`);
+      const base = JSON.parse(readFileSync(BASELINE, 'utf8'));
+      printDelta(compare(base.card ?? base, card));
+      regressed = compare(base.card ?? base, card).regressions.length > 0;
+    }
+
+    ctx.close();
+    process.exit(SMOKE ? 0 : (regressed ? 1 : 0));
+  } catch (e) {
+    console.error('[bench]', e?.message || e);
+    try { ctx.close(); } catch { /* */ }
+    process.exit(1);
+  }
+}
+
+function printCard(card) {
+  log('=== SCORECARD ===');
+  log(`passRate ${card.passRate}% (${card.passed}/${card.total})  ·  avg ${card.avgSteps} steps  ·  MAIN ${card.avgFreshTokens} fresh + ${card.avgCacheReadTokens} cache  ·  $${card.avgCostUsd}/task  ·  ${(card.avgDurationMs / 1000).toFixed(1)}s`);
+  if (card.failures?.length) log(`failures (${card.failures.length}): ${card.failures.map((f) => f.id).join(', ')}`);
+}
+
+function printDelta(d) {
+  log('=== Δ vs baseline ===');
+  const s = (n) => (n >= 0 ? `+${n}` : `${n}`);
+  log(`passRate ${s(d.passRateDelta)}%  ·  fresh ${s(d.freshTokensDelta)} tok  ·  $/task ${s(d.costUsdDelta)}  ·  steps ${s(d.stepsDelta)}`);
+  if (d.regressions.length) log(`⚠ REGRESSIONS (${d.regressions.length}): ${d.regressions.join(', ')}`);
+  else log(`✓ no regressions${d.fixes.length ? `  ·  fixed: ${d.fixes.join(', ')}` : ''}`);
+}


### PR DESCRIPTION
## What
Turns "did this build help?" into a number you can diff commit-to-commit, by driving the existing eval/lab harness over the REAL extension via the in-house CDP harness (no Playwright — house rule).

- `eval/runner.js`: a programmatic `window.__peerdEval` hook (start a run, read the structured scorecard) so a driver needn't scrape the DOM; the buttons stay the human path. `runSuite` takes an optional task subset.
- `scripts/cdp/e2e-harness.mjs`: `openExtPage()` — open any extension page over CDP, not just the side panel.
- `scripts/cdp/run-eval-bench.mjs`: loads the unpacked extension headless, injects a provider key, runs the suite via the hook, writes a commit-tagged scorecard to `bench-results/`, and diffs a baseline via the pure `score.compare()`. `--smoke` is a zero-cost keyless plumbing check.
- `eval:bench` / `eval:bench:smoke` scripts; `bench-results/` gitignored.

## Why
peerd has no deploy step and no backend to stash a shared baseline in, so the regression loop is local + explicit (your score is tied to your model/key/page). This automates the otherwise-manual eval loop and persists scorecards so one build is comparable to another over time.

## Usage
`PEERD_BENCH_KEY=… bun run eval:bench --provider=anthropic --model=claude-haiku-4-5 [--baseline=scripts/cdp/bench-results/<prev>.json]`

A REAL run makes real model calls and costs money — by design. `bun run eval:bench:smoke` validates the plumbing with no key and no cost.

## Verified
Full bun suite, typecheck, lint, ts-check floor, gen drift — all clean. Ran `--smoke` end to end against the live extension (drives `eval/runner.html`, reads back a structured scorecard; the baseline-diff path too).
