### PR TITLE
feat(runner): Playwright-API facade — a selector-first web mode to A/B vs ref-DOM

### DIFF
--- a/extension/background/settings-patch.js
+++ b/extension/background/settings-patch.js
@@ -145,6 +145,13 @@ export const normalizeSettingsPatch = (patch, {
     // on the inherited model if this one underperforms.
     next.runnerModel = patch.runnerModel.trim().slice(0, 200);
   }
+  if (typeof patch.runnerWebMode === 'string') {
+    // How the do/get/check runner drives the web: 'ref' (default — a11y-tree
+    // snapshot + element refs) or 'playwright' (selector-first page_* tools).
+    // An A/B knob for measuring which the model drives better; anything but the
+    // exact 'playwright' opt-in falls back to 'ref' (fail-safe to the default).
+    next.runnerWebMode = patch.runnerWebMode === 'playwright' ? 'playwright' : 'ref';
+  }
   // Idle vault auto-lock interval (ms). 0 = never; otherwise clamp to a
   // sane range [1min, 24h]. The caller applies this to the live vault so
   // the change takes effect without an SW restart.

--- a/extension/peerd-runtime/runner/index.js
+++ b/extension/peerd-runtime/runner/index.js
@@ -69,6 +69,30 @@ export const DO_TOOLSET = [
 // snapshot/read_page, and get/check must be able to read it.
 export const READ_TOOLSET = ['snapshot', 'read_page', 'read_state', 'query_dom', 'read_pdf'];
 
+// Playwright mode (settings.runnerWebMode === 'playwright'): the A/B alternative
+// to the ref-first toolsets above. SELECTOR-first driving with Playwright-named
+// tools and NO a11y snapshot/refs — the model finds selectors via read_page /
+// query_dom and acts with page_goto/page_click/page_fill (which mirror
+// navigate/click/type with locator strictness). Lets us measure whether the
+// Playwright API the model knows from training beats peerd's ref-first tools,
+// instead of guessing. (No 'view' here — it lives on its own branch; add it when
+// the two land together.)
+export const PLAYWRIGHT_DO_TOOLSET = [
+  'read_page', 'read_state', 'query_dom', 'watch_changes',
+  'page_goto', 'page_click', 'page_fill', 'page_keys', 'read_pdf',
+];
+export const PLAYWRIGHT_READ_TOOLSET = ['read_page', 'read_state', 'query_dom', 'read_pdf'];
+
+// why {any}: settings rides on the dispatch/runner ctx (service-worker spreads
+// settingsStore.get() onto it) but isn't on the typed ToolContext spine — read
+// it loosely, the same erased-cast style the rest of this file uses for ctx.
+/** @param {any} ctx */
+export const isPlaywrightMode = (ctx) => ctx?.settings?.runnerWebMode === 'playwright';
+/** Resolve the do toolset for the active web mode. @param {any} ctx */
+export const doToolsetFor = (ctx) => (isPlaywrightMode(ctx) ? PLAYWRIGHT_DO_TOOLSET : DO_TOOLSET);
+/** Resolve the read toolset for the active web mode. @param {any} ctx */
+export const readToolsetFor = (ctx) => (isPlaywrightMode(ctx) ? PLAYWRIGHT_READ_TOOLSET : READ_TOOLSET);
+
 // Tools that ONLY work via CDP and have NO scripting fallback. On the
 // no-CDP channel (Firefox, store-Chrome, or advanced automation off) they
 // can only ever return `debugger_unavailable`, so we drop them from the
@@ -193,6 +217,53 @@ export const RUNNER_PROMPT = [
   'You do not persist anything for a future call. This is a fresh, single-shot',
   'run.',
 ].join('\n');
+
+// PLAYWRIGHT mode prompt: swap ONLY the identity/tools/how-to head for the
+// selector-first workflow, and reuse RUNNER_PROMPT's security tail (UNTRUSTED
+// CONTENT → injection drill → REFUSALS → WHAT TO RETURN) VERBATIM by slicing it
+// off the assembled string. Deriving the tail (not copying it) makes drift
+// impossible: the injection defense is byte-identical in both modes, and editing
+// it in RUNNER_PROMPT updates both. The double newline rejoins the head to the
+// tail exactly as the original blank line did.
+const PLAYWRIGHT_RUNNER_HEAD = [
+  'You are a browser-runner: a focused sub-agent that operates ONE browser tab',
+  'on behalf of a primary agent. You were spawned with a single goal (the user',
+  'message) and a single tab. When you finish, you return ONE thing: a concise',
+  'plain-text summary. Nothing you return is shown to a human directly — it is',
+  'read by the primary agent as data.',
+  '',
+  'YOUR TOOLS',
+  'You operate your one tab with a Playwright-style API: read_page, read_state,',
+  'query_dom, watch_changes, page_goto, page_click, page_fill, page_keys,',
+  'read_pdf. You have NO other capabilities — no memory, no file access, no',
+  'network beyond your tab, no ability to spawn agents, no code execution. You',
+  'cannot switch tabs or open new ones. The tools default to your one tab.',
+  '',
+  'HOW TO WORK',
+  '- This is the SELECTOR-first mode: target elements by CSS selector, the way',
+  '  Playwright does — there is no accessibility-tree snapshot or element refs.',
+  '- read_page to see the page HTML/text and find the selectors you need; use',
+  '  query_dom to probe a selector (it reports how many elements match, with',
+  '  roles/labels) before acting.',
+  '- page_goto(url) navigates. page_click(selector) clicks. page_fill(selector,',
+  '  text) types into a field. After each action, OBSERVE (read_page or',
+  '  watch_changes) before the next step.',
+  '- Selectors are STRICT: page_click/page_fill fail unless the selector matches',
+  '  exactly one element. If query_dom shows several matches, narrow the selector',
+  '  — or pass nth (0-indexed) to page_click to choose one deliberately.',
+  '- If an action returns "debugger_unavailable", the trusted-input path is off',
+  '  on this channel — page_click/page_fill still work via the scripting',
+  '  fallback, but a site demanding real user input may ignore synthetic events.',
+  '- If the tab is a PDF (URL ends in .pdf, or read_page comes back empty on what',
+  '  is clearly a document), use read_pdf to get its text.',
+  '- For a native <select>, page_fill the option\'s visible LABEL; the tool',
+  '  resolves it to the right option.',
+  '- Work step by step. Do NOT guess element identities — read_page / query_dom',
+  '  and observe. Be efficient: shortest path to the goal, then stop.',
+].join('\n');
+
+export const PLAYWRIGHT_RUNNER_PROMPT =
+  `${PLAYWRIGHT_RUNNER_HEAD}\n\n${RUNNER_PROMPT.slice(RUNNER_PROMPT.indexOf('UNTRUSTED CONTENT'))}`;
 
 // do: VERIFY the outcome against the goal before reporting done. Acting and then
 // claiming success without re-observing is the premature-"done" failure where
@@ -394,6 +465,10 @@ export const runRunner = async (args, toolCtx, { goal, toolset, promptSuffix = '
   const hasCdp = !!ctx.debuggerPool;
   const channelNote = hasCdp ? '' : NO_CDP_CHANNEL_NOTE;
   const taskContext = [channelNote, seed].filter(Boolean).join('\n\n');
+  // why: the system prompt teaches the toolset the runner was given — so it must
+  // match the web mode (selector-first playwright vs ref-first). The toolset
+  // itself is chosen by the caller (doToolsetFor/readToolsetFor in do/get/check).
+  const basePrompt = isPlaywrightMode(ctx) ? PLAYWRIGHT_RUNNER_PROMPT : RUNNER_PROMPT;
 
   /**
    * @param {{ tools: string[] | undefined, suffix: string, modelOverride?: string, steps?: number }} p
@@ -407,7 +482,7 @@ export const runRunner = async (args, toolCtx, { goal, toolset, promptSuffix = '
     // never invoke runRunner without a toolset), so the filtered shape is
     // behavior-identical to passing `tools` straight through.
     tools: hasCdp ? tools : (tools ?? []).filter((t) => !CDP_ONLY_NO_FALLBACK.includes(t)),
-    systemPromptOverride: RUNNER_PROMPT + suffix,
+    systemPromptOverride: basePrompt + suffix,
     tabId: tab.id,
     maxSteps: steps,
     ...(modelOverride ? { model: modelOverride } : {}),

--- a/extension/peerd-runtime/tools/defs/check.js
+++ b/extension/peerd-runtime/tools/defs/check.js
@@ -6,7 +6,7 @@
 // + a one-sentence rationale grounded in what it saw. This is also the
 // LLM-judge primitive the eval harness uses. See docs/DO-GET-CHECK-DESIGN.md.
 
-import { runRunner, READ_TOOLSET, READ_MAX_STEPS, CHECK_SUFFIX, parseCheckVerdict } from '../../runner/index.js';
+import { runRunner, readToolsetFor, READ_MAX_STEPS, CHECK_SUFFIX, parseCheckVerdict } from '../../runner/index.js';
 import { wrapUntrustedRunner } from '../prompt-wrap.js';
 
 /**
@@ -62,7 +62,7 @@ export const checkTool = {
     const runnerModel = /** @type {{ runnerModel?: string }} */ (ctx).runnerModel;
     const r = /** @type {RunnerResult} */ (await runRunner(args, ctx, {
       goal: args.assertion,
-      toolset: READ_TOOLSET,
+      toolset: readToolsetFor(ctx),
       promptSuffix: CHECK_SUFFIX,
       maxSteps: READ_MAX_STEPS,
       fastPath: true,

--- a/extension/peerd-runtime/tools/defs/do.js
+++ b/extension/peerd-runtime/tools/defs/do.js
@@ -7,7 +7,7 @@
 // element refs, or the action trace — only the summary. See
 // docs/DO-GET-CHECK-DESIGN.md and peerd-runtime/runner/index.js.
 
-import { runRunner, DO_TOOLSET, DO_MAX_STEPS, DO_SUFFIX } from '../../runner/index.js';
+import { runRunner, doToolsetFor, DO_MAX_STEPS, DO_SUFFIX } from '../../runner/index.js';
 import { wrapUntrustedRunner } from '../prompt-wrap.js';
 
 /**
@@ -73,7 +73,7 @@ export const doTool = {
     }
     // DO_SUFFIX makes the runner re-observe and verify the end state before it
     // reports done — closes the premature-"done" failure (DO-GET-CHECK §8.1).
-    const r = /** @type {RunnerResult} */ (await runRunner(args, ctx, { goal: args.instruction, toolset: DO_TOOLSET, promptSuffix: DO_SUFFIX, maxSteps: DO_MAX_STEPS }));
+    const r = /** @type {RunnerResult} */ (await runRunner(args, ctx, { goal: args.instruction, toolset: doToolsetFor(ctx), promptSuffix: DO_SUFFIX, maxSteps: DO_MAX_STEPS }));
     if (!r.ok) return { ok: false, error: r.error };
     // why: the runner's summary is UNTRUSTED — wrap it so the main agent treats
     // it as data, not commands (a prompt-injected page can steer what it says).

--- a/extension/peerd-runtime/tools/defs/get.js
+++ b/extension/peerd-runtime/tools/defs/get.js
@@ -6,7 +6,7 @@
 // returns just that value. You never see the accessibility tree or page text —
 // only the answer. See docs/DO-GET-CHECK-DESIGN.md.
 
-import { runRunner, READ_TOOLSET, READ_MAX_STEPS, GET_SUFFIX } from '../../runner/index.js';
+import { runRunner, readToolsetFor, READ_MAX_STEPS, GET_SUFFIX } from '../../runner/index.js';
 import { wrapUntrustedRunner } from '../prompt-wrap.js';
 
 /**
@@ -62,7 +62,7 @@ export const getTool = {
     const runnerModel = /** @type {{ runnerModel?: string }} */ (ctx).runnerModel;
     const r = /** @type {RunnerResult} */ (await runRunner(args, ctx, {
       goal: args.query,
-      toolset: READ_TOOLSET,
+      toolset: readToolsetFor(ctx),
       promptSuffix: GET_SUFFIX,
       maxSteps: READ_MAX_STEPS,
       fastPath: true,

--- a/extension/peerd-runtime/tools/exposure.js
+++ b/extension/peerd-runtime/tools/exposure.js
@@ -37,6 +37,9 @@ export const MAIN_AGENT_HIDDEN_TOOLS = Object.freeze(new Set([
   // read_pdf returns untrusted PDF text — same boundary as read_page; the
   // runner reaches it through get/do.
   'read_pdf',
+  // Playwright-vocabulary page tools — runner-only, same as the ref tools they
+  // mirror; the runner reaches them through do/get/check in playwright mode.
+  'page_goto', 'page_click', 'page_fill',
 ]));
 
 /** Is this tool hidden from the main agent (runner-only)? Pure. @param {string} name */

--- a/extension/peerd-runtime/tools/manifests.js
+++ b/extension/peerd-runtime/tools/manifests.js
@@ -49,6 +49,11 @@ export const TOOL_MANIFEST_PRESETS = Object.freeze({
       // runner internals: DO_TOOLSET ∪ READ_TOOLSET (see invariant above)
       'snapshot', 'read_page', 'read_state', 'watch_changes',
       'click', 'type', 'navigate', 'query_dom', 'page_keys', 'read_pdf',
+      // playwright-mode runner internals: PLAYWRIGHT_DO_TOOLSET's action tools
+      // (the read tools above are shared). Both modes' internals coexist in the
+      // allow-set so `do` can act whichever web mode is on — otherwise a
+      // manifested session in playwright mode spawns the runner action-less.
+      'page_goto', 'page_click', 'page_fill',
       // memory
       'remember', 'read_memory',
       // sovereignty / sessions introspection

--- a/extension/peerd-runtime/tools/web/index.js
+++ b/extension/peerd-runtime/tools/web/index.js
@@ -11,12 +11,14 @@ export { readArticleTool }  from './read.js';
 export { webSearchTool }    from './search.js';
 export { submitFormTool }   from './form.js';
 export { captureTool }      from './screenshot.js';
+export { pageGotoTool, pageClickTool, pageFillTool, PLAYWRIGHT_TOOLS } from './playwright.js';
 
 import { callApiTool }     from './api.js';
 import { readArticleTool } from './read.js';
 import { webSearchTool }   from './search.js';
 import { submitFormTool }  from './form.js';
 import { captureTool }     from './screenshot.js';
+import { PLAYWRIGHT_TOOLS } from './playwright.js';
 
 /** @type {import('/shared/tool-types.js').Tool[]} */
 export const WEB_TOOLS = [
@@ -25,6 +27,7 @@ export const WEB_TOOLS = [
   webSearchTool,
   submitFormTool,
   captureTool,
+  ...PLAYWRIGHT_TOOLS,
 ];
 
 // Policy exposed for tests + future skill authors.

--- a/extension/peerd-runtime/tools/web/playwright.js
+++ b/extension/peerd-runtime/tools/web/playwright.js
@@ -1,0 +1,103 @@
+// @ts-check
+// Playwright-vocabulary page tools — page_goto / page_click / page_fill.
+//
+// A thin, SELECTOR-first facade over navigate/click/type whose names and shape
+// match the Playwright API models already know from their training data. It
+// exists to settle an experiment by MEASUREMENT, not vibes: does the agent drive
+// the web better when the tools are named + shaped like Playwright (read the
+// HTML, target a CSS selector) than with peerd's ref-first a11y-snapshot tools?
+// The runner swaps to these in playwright mode (settings.runnerWebMode ===
+// 'playwright'); the ref-first tools are the default. A/B the two modes through
+// the eval benchmark.
+//
+// LOCATOR STRICTNESS is the one genuine reliability win Playwright semantics
+// bring, so it's the default here: page_click/page_fill refuse when the selector
+// matches != 1 element (instead of silently acting on the first), via the
+// existing expectedCount guard on click/type (#103). Pass an explicit nth to
+// target one of several matches deliberately (Playwright's .nth(i)).
+//
+// Everything else DELEGATES to the underlying tool's execute, so the gate
+// pipeline, CDP/scripting fallback, untrusted-content handling, and result shape
+// are identical — these are a vocabulary layer, not a reimplementation.
+
+import { clickTool } from '../defs/click.js';
+import { typeTool } from '../defs/type.js';
+import { navigateTool } from '../defs/navigate.js';
+
+// no nth → require exactly one match (Playwright locator strictness); explicit
+// nth → the agent is choosing among matches, so don't also pin the count.
+/** @param {{ selector?: string, nth?: number }} args */
+export const playwrightClickArgs = (args) => ({
+  selector: args?.selector,
+  ...(typeof args?.nth === 'number' ? { nth: args.nth } : { expectedCount: 1 }),
+});
+
+// page_fill always targets a single field (type has no nth) — strict by default.
+/** @param {{ selector?: string, text?: string }} args */
+export const playwrightFillArgs = (args) => ({
+  selector: args?.selector,
+  text: args?.text,
+  expectedCount: 1,
+});
+
+/** @type {import('/shared/tool-types.js').Tool} */
+export const pageGotoTool = {
+  name: 'page_goto',
+  primitive: 'tab',
+  description: 'Navigate the tab to a URL (Playwright page.goto). http(s) only.',
+  schema: {
+    type: 'object',
+    properties: { url: { type: 'string', description: 'Absolute http(s) URL to load.' } },
+    required: ['url'],
+  },
+  sideEffect: 'write',
+  origins: navigateTool.origins,
+  execute: (args, ctx) => navigateTool.execute({ url: args?.url }, ctx),
+};
+
+/** @type {import('/shared/tool-types.js').Tool} */
+export const pageClickTool = {
+  name: 'page_click',
+  primitive: 'tab',
+  description: [
+    'Click the element matching a CSS selector (Playwright page.click). Get',
+    'selectors from read_page or query_dom. STRICT: fails unless the selector',
+    'matches exactly one element — pass nth (0-indexed) to choose among several',
+    'deliberately.',
+  ].join(' '),
+  schema: {
+    type: 'object',
+    properties: {
+      selector: { type: 'string', description: 'CSS selector for the element to click.' },
+      nth: { type: 'integer', description: 'Optional 0-indexed match when the selector matches several (disables the single-match guard).' },
+    },
+    required: ['selector'],
+  },
+  sideEffect: 'write',
+  origins: clickTool.origins,
+  execute: (args, ctx) => clickTool.execute(playwrightClickArgs(args), ctx),
+};
+
+/** @type {import('/shared/tool-types.js').Tool} */
+export const pageFillTool = {
+  name: 'page_fill',
+  primitive: 'tab',
+  description: [
+    'Fill the input/textarea/contenteditable matching a CSS selector with text',
+    '(Playwright page.fill). Get selectors from read_page or query_dom. STRICT:',
+    'fails unless the selector matches exactly one element.',
+  ].join(' '),
+  schema: {
+    type: 'object',
+    properties: {
+      selector: { type: 'string', description: 'CSS selector for the field.' },
+      text: { type: 'string', description: 'The value to set.' },
+    },
+    required: ['selector', 'text'],
+  },
+  sideEffect: 'write',
+  origins: typeTool.origins,
+  execute: (args, ctx) => typeTool.execute(playwrightFillArgs(args), ctx),
+};
+
+export const PLAYWRIGHT_TOOLS = [pageGotoTool, pageClickTool, pageFillTool];

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -33,7 +33,7 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // sessions/store.js, vm-tab.js). The dev-only peerd-distributed/demo/
 // harness (pruned from every package, wired into nothing) was removed
 // rather than typed.
-const COVERED_FLOOR = 473;
+const COVERED_FLOOR = 475;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/tests/peerd-runtime/playwright-facade.test.ts
+++ b/tests/peerd-runtime/playwright-facade.test.ts
@@ -1,0 +1,60 @@
+// The Playwright-vocabulary facade: page_goto/page_click/page_fill map to the
+// ref-first tools with locator strictness, and a runnerWebMode setting swaps the
+// runner between ref-first and selector-first driving (the A/B). The security
+// tail of the prompt must NOT drift between modes.
+
+import { describe, test, expect } from 'bun:test';
+import { playwrightClickArgs, playwrightFillArgs } from '../../extension/peerd-runtime/tools/web/playwright.js';
+import {
+  isPlaywrightMode, doToolsetFor, readToolsetFor,
+  DO_TOOLSET, READ_TOOLSET, PLAYWRIGHT_DO_TOOLSET, PLAYWRIGHT_READ_TOOLSET,
+  RUNNER_PROMPT, PLAYWRIGHT_RUNNER_PROMPT,
+} from '../../extension/peerd-runtime/runner/index.js';
+
+describe('playwright facade — locator strictness', () => {
+  test('page_click without nth requires exactly one match', () => {
+    expect(playwrightClickArgs({ selector: '.x' })).toEqual({ selector: '.x', expectedCount: 1 });
+  });
+  test('page_click with nth targets one match and drops the single-match guard', () => {
+    expect(playwrightClickArgs({ selector: '.x', nth: 2 })).toEqual({ selector: '.x', nth: 2 });
+  });
+  test('page_fill is always strict (a single field)', () => {
+    expect(playwrightFillArgs({ selector: '#f', text: 'hi' })).toEqual({ selector: '#f', text: 'hi', expectedCount: 1 });
+  });
+});
+
+describe('playwright facade — mode swap', () => {
+  test('default (no setting / unknown value) is ref mode', () => {
+    expect(isPlaywrightMode(undefined)).toBe(false);
+    expect(isPlaywrightMode({ settings: {} })).toBe(false);
+    expect(isPlaywrightMode({ settings: { runnerWebMode: 'ref' } })).toBe(false);
+    expect(doToolsetFor({ settings: {} })).toBe(DO_TOOLSET);
+    expect(readToolsetFor({ settings: {} })).toBe(READ_TOOLSET);
+  });
+  test('the playwright setting swaps both toolsets', () => {
+    const ctx = { settings: { runnerWebMode: 'playwright' } };
+    expect(isPlaywrightMode(ctx)).toBe(true);
+    expect(doToolsetFor(ctx)).toBe(PLAYWRIGHT_DO_TOOLSET);
+    expect(readToolsetFor(ctx)).toBe(PLAYWRIGHT_READ_TOOLSET);
+  });
+  test('playwright toolsets are selector-first: page_* in, snapshot/ref tools out', () => {
+    for (const t of ['page_goto', 'page_click', 'page_fill']) expect(PLAYWRIGHT_DO_TOOLSET).toContain(t);
+    for (const t of ['snapshot', 'click', 'type']) expect(PLAYWRIGHT_DO_TOOLSET).not.toContain(t);
+    expect(PLAYWRIGHT_READ_TOOLSET).not.toContain('snapshot');
+  });
+});
+
+describe('playwright facade — the injection-defense tail cannot drift', () => {
+  test('both prompts carry the byte-identical untrusted-content / injection-drill tail', () => {
+    const marker = 'UNTRUSTED CONTENT';
+    const refTail = RUNNER_PROMPT.slice(RUNNER_PROMPT.indexOf(marker));
+    const pwTail = PLAYWRIGHT_RUNNER_PROMPT.slice(PLAYWRIGHT_RUNNER_PROMPT.indexOf(marker));
+    expect(refTail.length).toBeGreaterThan(500);
+    expect(pwTail).toBe(refTail);
+  });
+  test('the playwright head teaches selectors, not refs', () => {
+    expect(PLAYWRIGHT_RUNNER_PROMPT).toContain('SELECTOR-first');
+    expect(PLAYWRIGHT_RUNNER_PROMPT).toContain('page_click');
+    expect(PLAYWRIGHT_RUNNER_PROMPT).not.toContain('accessibility tree with element refs');
+  });
+});

--- a/tests/peerd-runtime/tool-manifests.test.ts
+++ b/tests/peerd-runtime/tool-manifests.test.ts
@@ -21,7 +21,9 @@ import { makeToolsCommand } from '../../extension/peerd-runtime/tools/manifest-c
 import { exposureGate as exposureGateRaw } from '../../extension/peerd-runtime/tools/gates.js';
 import { mainAgentDescriptors } from '../../extension/peerd-runtime/tools/exposure.js';
 import { narrowTools, makeSpawnSubagent } from '../../extension/peerd-runtime/subagent/spawn.js';
-import { DO_TOOLSET, READ_TOOLSET } from '../../extension/peerd-runtime/runner/index.js';
+import {
+  DO_TOOLSET, READ_TOOLSET, PLAYWRIGHT_DO_TOOLSET, PLAYWRIGHT_READ_TOOLSET,
+} from '../../extension/peerd-runtime/runner/index.js';
 import { createSessionStore } from '../../extension/peerd-runtime/sessions/store.js';
 // why: real JSDoc contracts from source — LoopEvent shapes the mock loop's
 // yields, Session widens setToolManifest's inferred union return.
@@ -51,13 +53,21 @@ describe('TOOL_MANIFEST_PRESETS — data invariants', () => {
   test('research carries the FULL runner toolset — do/get/check dispatch to a runner whose set intersects the manifest', () => {
     const allow = new Set(TOOL_MANIFEST_PRESETS.research.allow);
     for (const name of ['do', 'get', 'check']) expect(allow.has(name)).toBe(true);
-    for (const name of [...DO_TOOLSET, ...READ_TOOLSET]) expect(allow.has(name)).toBe(true);
+    // BOTH web modes' runner internals — else `do` spawns action-less when a
+    // manifested session is in that mode (ref OR playwright).
+    for (const name of [
+      ...DO_TOOLSET, ...READ_TOOLSET, ...PLAYWRIGHT_DO_TOOLSET, ...PLAYWRIGHT_READ_TOOLSET,
+    ]) expect(allow.has(name)).toBe(true);
   });
 
   test('browse-only carries the READ runner toolset for get/check, and no do/mutating internals', () => {
     const allow = new Set(TOOL_MANIFEST_PRESETS['browse-only'].allow);
-    for (const name of ['get', 'check', ...READ_TOOLSET]) expect(allow.has(name)).toBe(true);
-    for (const name of ['do', 'click', 'type', 'page_keys', 'watch_changes']) {
+    for (const name of ['get', 'check', ...READ_TOOLSET, ...PLAYWRIGHT_READ_TOOLSET]) {
+      expect(allow.has(name)).toBe(true);
+    }
+    // read-only: no action internals from EITHER mode.
+    for (const name of ['do', 'click', 'type', 'page_keys', 'watch_changes',
+      'page_goto', 'page_click', 'page_fill']) {
       expect(allow.has(name)).toBe(false);
     }
   });


### PR DESCRIPTION
## What
A selector-first web-driving mode for the do/get/check runner, to A/B against the default ref-first (a11y-snapshot) mode.

- `page_goto` / `page_click` / `page_fill`: a thin Playwright-vocabulary facade that DELEGATES to `navigate`/`click`/`type` (so the gate chain, denylist re-check, CDP/scripting fallback, and result shape are all inherited — a naming layer, not a reimplementation). **Locator strictness** is the one real win: `page_click`/`page_fill` fail unless the selector matches exactly one element (via #103's `expectedCount` guard); pass `nth` to `page_click` to target one of several deliberately. Runner-only.
- `runner/index.js`: `PLAYWRIGHT_DO_TOOLSET` / `PLAYWRIGHT_READ_TOOLSET` (selector-first, no snapshot/refs) + a `runnerWebMode` setting (`ref` default | `playwright`) that swaps the runner's toolset and prompt. `PLAYWRIGHT_RUNNER_PROMPT` swaps only the identity/tools/how-to head and **derives the security tail** (untrusted-content + injection drill) verbatim from `RUNNER_PROMPT` — so the injection defense can never drift (drift-guard test included).
- The `research` manifest preset + its invariant test now cover both modes' runner internals, so `do` can act in either mode under a `/tools` manifest.

## Why
Settles "does the Playwright API the model knows from training beat peerd's ref-first tools?" by measurement, not guessing.

## How to A/B
Run the eval benchmark with `runnerWebMode='ref'` vs `'playwright'` and compare scorecards.

## Verified
Full suite, typecheck, lint, ts-check floor (475), gen drift clean; live e2e smoke. Tests cover locator strictness, the mode swap, the security-tail drift guard, and the manifest-preset invariant. An adversarial-review pass caught + fixed a HIGH bug (under a tool manifest, `do` went read-only in playwright mode) before this PR.

## Notes
Default ships unchanged (ref mode). No `view` in the playwright toolset — it's in the `feat/web-view-snapshot` PR; add it when both land. A `--runner-mode` flag for the bench driver (`feat/eval-bench-loop`) is a one-line follow-up to A/B through the benchmark.
