### PR TITLE
feat(eval): context-cost metric — measure the main agent's per-turn context build-over-build

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "e2e:chrome": "bun scripts/cdp/ensure-chrome-for-testing.mjs",
     "eval:bench": "bun scripts/cdp/run-eval-bench.mjs",
     "eval:bench:smoke": "bun scripts/cdp/run-eval-bench.mjs --smoke",
+    "eval:context": "bun scripts/cdp/run-eval-context.mjs",
     "typecheck": "tsc",
     "lint": "eslint extension",
     "package": "bun packaging/package.ts",

--- a/scripts/cdp/run-eval-context.mjs
+++ b/scripts/cdp/run-eval-context.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env bun
+// run-eval-context.mjs — measure the MAIN agent's per-turn CONTEXT COST for the
+// current build: the system-prompt size, the number of tools advertised, and the
+// total request size shipped on EVERY turn. The companion to run-eval-bench.mjs:
+// the bench scores task PERFORMANCE; this scores the per-turn context the model
+// must carry to get it. Together they answer the question the actor refactor bet
+// on — "did context shrink, and did task quality survive it?" — build over build.
+//
+// Keyless + free: the system prompt + tool schemas are assembled for REAL and
+// captured off the faked model wire (no provider key, no cost, no real egress),
+// so anyone can run it on any build. The numbers are provider-shaped (captured
+// from the keyless Ollama request) but the system prompt + tool set are
+// provider-agnostic in substance, so the build-over-build DELTA is the signal.
+//
+// Usage:
+//   bun run eval:context                          # snapshot this build, write a record
+//   bun run eval:context --baseline=<prev.json>   # diff vs a prior snapshot
+//   bun run eval:context --show-tools             # also print the advertised tool names
+
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+import { launchPeerd, rpc, unlockAndReady, waitFor, log, sseText } from './e2e-harness.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = resolve(__dirname, 'bench-results');
+
+const argv = process.argv.slice(2);
+const flag = (name, def) => {
+  const hit = argv.find((a) => a === `--${name}` || a.startsWith(`--${name}=`));
+  if (!hit) return def;
+  const eq = hit.indexOf('=');
+  return eq === -1 ? true : hit.slice(eq + 1);
+};
+const BASELINE = flag('baseline', false) ? String(flag('baseline', '')) : '';
+const SHOW_TOOLS = !!flag('show-tools', false);
+
+const shortSha = () => { try { return execSync('git rev-parse --short HEAD').toString().trim(); } catch { return 'nogit'; } };
+
+main();
+
+async function main() {
+  log('CONTEXT snapshot — keyless, no cost. Capturing the main agent\'s per-turn system prompt + tool schemas off the faked wire.');
+  // Capture the FIRST /v1/chat/completions request — that is one full turn's
+  // always-on context (system prompt + the advertised tools).
+  let captured = null;
+  const ctx = await launchPeerd({
+    modelResponder: (i, req) => { if (i === 0 && !captured) captured = (req && req.postData) || ''; return { sse: sseText('ok') }; },
+  });
+  try {
+    await unlockAndReady(ctx.page); // vault + keyless Ollama provider
+    await rpc(ctx.page, { type: 'agent/send', text: 'hello' });
+    await waitFor(() => !!captured, { budgetMs: 25_000 });
+    if (!captured) throw new Error('no model request captured (did the turn fire?)');
+
+    const body = JSON.parse(captured);
+    const sys = (body.messages || []).find((m) => m.role === 'system')?.content || '';
+    const tools = Array.isArray(body.tools) ? body.tools : [];
+    const toolNames = tools.map((t) => t.function?.name || t.name).filter(Boolean).sort();
+    const metrics = {
+      build: shortSha(),
+      at: new Date().toISOString(),
+      systemChars: sys.length,
+      toolCount: tools.length,
+      toolSchemaChars: JSON.stringify(tools).length,
+      perTurnRequestChars: captured.length,
+      approxTokensPerTurn: Math.round(captured.length / 4),
+      toolNames,
+    };
+
+    mkdirSync(OUT_DIR, { recursive: true });
+    const outPath = join(OUT_DIR, `context-${metrics.build}-${metrics.at.replace(/[:.]/g, '-')}.json`);
+    writeFileSync(outPath, JSON.stringify(metrics, null, 2));
+    log(`context record → ${outPath}`);
+    printMetrics(metrics);
+    if (SHOW_TOOLS) log(`tools (${toolNames.length}): ${toolNames.join(', ')}`);
+
+    if (BASELINE) {
+      if (!existsSync(BASELINE)) throw new Error(`baseline not found: ${BASELINE}`);
+      printDelta(JSON.parse(readFileSync(BASELINE, 'utf8')), metrics);
+    }
+    ctx.close();
+    process.exit(0);
+  } catch (e) {
+    console.error('[context]', e?.message || e);
+    try { ctx.close(); } catch { /* */ }
+    process.exit(1);
+  }
+}
+
+function printMetrics(m) {
+  log('=== MAIN-AGENT CONTEXT (per turn) ===');
+  log(`tools ${m.toolCount}  ·  system ${m.systemChars} ch  ·  tool schemas ${m.toolSchemaChars} ch  ·  request ${m.perTurnRequestChars} ch (~${m.approxTokensPerTurn} tok)`);
+}
+
+function printDelta(base, cur) {
+  log('=== Δ vs baseline ===');
+  const d = (k) => cur[k] - (Number(base[k]) || 0);
+  const s = (n) => (n >= 0 ? `+${n}` : `${n}`);
+  const reqD = d('perTurnRequestChars');
+  log(`tools ${s(d('toolCount'))}  ·  system ${s(d('systemChars'))} ch  ·  request ${s(reqD)} ch (~${s(Math.round(reqD / 4))} tok/turn)`);
+  const baseSet = new Set(base.toolNames || []);
+  const curSet = new Set(cur.toolNames || []);
+  const added = (cur.toolNames || []).filter((n) => !baseSet.has(n));
+  const removed = (base.toolNames || []).filter((n) => !curSet.has(n));
+  if (added.length) log(`tools added: ${added.join(', ')}`);
+  if (removed.length) log(`tools removed: ${removed.join(', ')}`);
+  if (!added.length && !removed.length) log('tool set unchanged');
+}


### PR DESCRIPTION
## What
A companion to the benchmark loop (#107): **`eval:context`** measures the MAIN agent's per-turn **context cost** for a build — system-prompt size, tool count, total request size — and diffs it build-over-build. The bench scores task *performance*; this scores the per-turn context the model carries to get it. Together they answer the question the actor refactor (#61) bet on: **did context shrink, and did task quality survive it?**

- `scripts/cdp/run-eval-context.mjs`: keyless `launchPeerd` → capture the first model request (system prompt + advertised tools, assembled for real, off the faked wire) → record `{systemChars, toolCount, toolSchemaChars, perTurnRequestChars, toolNames}`, commit-tagged in `bench-results/`, with a `--baseline` diff (incl. tools added/removed).
- `eval:context` npm script. Keyless + free + no real egress, so it runs on any build with no key.

## Why now
#61 (the actor model) shipped on a bet that folding `do/get/check` + per-env tools into `message_actor` shrinks the main agent's context. This makes that measurable on every build. On current main it reports **28 tools / 17,490-char system / ~10k tokens per turn** — down from **~39 tools / ~22k** pre-#61 (-28% tools, -23% context).

## Usage
```
bun run eval:context                         # snapshot this build
bun run eval:context --baseline=<prev.json>  # diff vs a prior snapshot
```

## Verified
Runs green on the actor main; the baseline diff (deltas + tools added/removed) works. Lint clean. No CI gate touched (script-only; `bench-results/` already gitignored by #107).
