### PR TITLE
fix(home): packaged builds black-screen the home page (eval Lab pruned but hard-imported)

### DIFF
--- a/.github/workflows/package-and-release.yml
+++ b/.github/workflows/package-and-release.yml
@@ -179,6 +179,14 @@ jobs:
         # smoke, goal mode, stop, error — against ONE Chrome (env-independent;
         # visual states are excluded here as their baselines are per-machine).
         run: bun run test:e2e:all
+      - name: Packaged page boot (each #app page mounts in the PRUNED build)
+        env:
+          CHROME_PATH: ${{ steps.cft.outputs.chrome-path }}
+        # The runtime backstop to check:imports — loads the actual PACKAGED tree
+        # (both channels) and asserts every #app page mounts. e2e above loads the
+        # UNPACKED source, so this is the only tier that observes prune-induced
+        # blank pages (the v0.2.0 home black-screen class).
+        run: bun run check:pages
 
   package:
     name: package ${{ matrix.channel }}/${{ matrix.browser }}

--- a/.github/workflows/package-and-release.yml
+++ b/.github/workflows/package-and-release.yml
@@ -65,6 +65,8 @@ jobs:
         run: bun run check:tscheck
       - name: Dweb import boundary
         run: bun run check:boundary
+      - name: Packaged import graph (no pruned-but-imported file black-screens a page)
+        run: bun run check:imports
       - name: Generated-file drift (dev manifest + channel-config + tscheck badge)
         run: |
           bun run gen:dev

--- a/extension/home/home.js
+++ b/extension/home/home.js
@@ -20,7 +20,7 @@ import { LibrarySection } from './library-section.js';
 import { NetworkSection } from './network-section.js';
 import { DiscoverSection } from './discover-section.js';
 import { ContactsSection } from './contacts-section.js';
-import { EvalSection } from './eval-section.js';
+// EvalSection (the Lab) is LAZY-loaded — see loadEvalSection below.
 import { INITIAL_STATE, reduceChat, putSubagentSession } from '../sidepanel/chat-reducer.js';
 import { ChatView } from '../sidepanel/components/chat-view.js';
 import { ConfirmModal, NoticeBar } from '../sidepanel/components/app.js';
@@ -47,6 +47,24 @@ let booted = false;          // first state push arrived — until then, show "L
 // were on. Dweb views only restore where DWEB_ENABLED; anything unknown → 'chat'.
 const VIEW_KEY = 'peerd.home.activeView';
 const DWEB_VIEWS = new Set(['discover', 'contacts', 'network']);
+// The Lab (eval-section.js) is loaded ON DEMAND. why: it statically imports the
+// eval/ dir, which packaging prunes from the store build — a static import at the
+// top of home.js would 404 and black-screen the ENTIRE home page (the whole
+// module graph fails to load). Importing it only when the Lab view opens keeps
+// home always-mountable and degrades the Lab to "unavailable" where eval/ is
+// absent (store), while preview (eval/ shipped) loads it normally.
+/** @type {any} */
+let EvalSection = null;
+/** @type {'idle'|'loading'|'ready'|'unavailable'} */
+let evalLoadState = 'idle';
+const loadEvalSection = () => {
+  if (evalLoadState !== 'idle') return;
+  evalLoadState = 'loading';
+  import('./eval-section.js')
+    .then((mod) => { EvalSection = mod.EvalSection; evalLoadState = 'ready'; m.redraw(); })
+    .catch(() => { evalLoadState = 'unavailable'; m.redraw(); });
+};
+
 const ALL_VIEWS = new Set(['chat', 'chats', 'library', 'eval', 'discover', 'contacts', 'network']);
 /** @param {string | null | undefined} v */
 const isValidView = (v) => !!v && ALL_VIEWS.has(v) && (!DWEB_VIEWS.has(v) || DWEB_ENABLED);
@@ -507,7 +525,12 @@ const content = (showDweb) => {
     ]);
   }
   if (activeView === 'library') return m(LibrarySection, { send, dweb: showDweb });
-  if (activeView === 'eval') return m(EvalSection, { send });
+  if (activeView === 'eval') {
+    loadEvalSection();
+    if (evalLoadState === 'ready' && EvalSection) return m(EvalSection, { send });
+    return m('div', { style: 'padding:24px;color:#9ba3ad' },
+      evalLoadState === 'unavailable' ? 'The Lab is not available in this build.' : 'Loading the Lab…');
+  }
   if (activeView === 'discover' && showDweb) return m(DiscoverSection, { send });
   if (activeView === 'contacts' && showDweb) return m(ContactsSection, { send });
   if (activeView === 'network' && showDweb) return m(NetworkSection, { send });

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "check:boundary": "bun packaging/check-dweb-boundary.ts",
     "check:tscheck": "bun packaging/check-tscheck.ts",
     "check:imports": "bun packaging/check-packaged-imports.ts",
+    "check:pages": "bun scripts/cdp/check-packaged-pages.mjs",
     "verify:store": "bun packaging/verify-store-artifact.ts",
     "feeds": "bun packaging/gen-update-feeds.ts",
     "vendor:codemirror": "bun run scripts/vendor-codemirror.ts"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "gen:badge": "bun packaging/gen-tscheck-badge.ts",
     "check:boundary": "bun packaging/check-dweb-boundary.ts",
     "check:tscheck": "bun packaging/check-tscheck.ts",
+    "check:imports": "bun packaging/check-packaged-imports.ts",
     "verify:store": "bun packaging/verify-store-artifact.ts",
     "feeds": "bun packaging/gen-update-feeds.ts",
     "vendor:codemirror": "bun run scripts/vendor-codemirror.ts"

--- a/packaging/check-packaged-imports.ts
+++ b/packaging/check-packaged-imports.ts
@@ -33,7 +33,13 @@ const walk = (dir: string, out: string[] = []): string[] => {
 // STATIC import specifiers only — `import … from "x"` / `import "x"`. Deliberately
 // excludes `import("x")` (dynamic, runtime-guarded). Two alternations: the
 // from-form and the bare side-effect form.
-const STATIC_IMPORT = /(?:import|export)[^"'\n]*?from\s*["']([^"']+)["']|(?:^|[;\s])import\s*["']([^"']+)["']/g;
+// Static import specifiers, ANCHORED to line start (m flag) so a mid-line or
+// commented "import"/"from" can't bridge into a false match. The head allows
+// newlines (a static import can span lines: `import {\n a,\n b\n} from '/x'`) but
+// is bounded by `;` and quotes so it can't run across statements. `import(…)`
+// (dynamic) has a `(` after import + no `from`, so neither alternation matches —
+// dynamic imports are runtime-guarded and intentionally skipped.
+const STATIC_IMPORT = /^[ \t]*(?:import|export)\b[^;"']*?\bfrom\s*["']([^"']+)["']|^[ \t]*import\s*["']([^"']+)["']/gm;
 
 /** Resolve a module specifier to an on-disk path under the staged build root. */
 const resolveSpec = (spec: string, fromFile: string, root: string): string | null => {

--- a/packaging/check-packaged-imports.ts
+++ b/packaging/check-packaged-imports.ts
@@ -1,0 +1,110 @@
+// CI guard against the v0.2.0 home black-screen class of bug: a file that
+// packaging PRUNES is still STATICALLY imported by a shipped page, so in the
+// packaged build the import 404s, the page's module graph fails to load, and the
+// page renders blank. The e2e suite runs the UNPACKED source (nothing pruned), so
+// it can never catch this — only resolving imports against the PRUNED build does.
+//
+// For each channel, this stages the real packaged tree (reusing packageArtifact's
+// prune + generated manifest/channel-config), then walks every page's static
+// import graph and asserts every target ships. Dynamic import() is intentionally
+// NOT followed: a lazy import of a pruned module is the CORRECT pattern (it's
+// runtime-guarded), which is exactly how the home Lab was fixed.
+//
+// Run: bun packaging/check-packaged-imports.ts   (also wired into CI + preflight)
+
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join, dirname, resolve, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { packageArtifact } from './package.ts';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const version = String(JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8')).version);
+
+/** Recursively list every file under `dir`. */
+const walk = (dir: string, out: string[] = []): string[] => {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else out.push(p);
+  }
+  return out;
+};
+
+// STATIC import specifiers only — `import … from "x"` / `import "x"`. Deliberately
+// excludes `import("x")` (dynamic, runtime-guarded). Two alternations: the
+// from-form and the bare side-effect form.
+const STATIC_IMPORT = /(?:import|export)[^"'\n]*?from\s*["']([^"']+)["']|(?:^|[;\s])import\s*["']([^"']+)["']/g;
+
+/** Resolve a module specifier to an on-disk path under the staged build root. */
+const resolveSpec = (spec: string, fromFile: string, root: string): string | null => {
+  if (spec.startsWith('/')) return join(root, spec);      // root-absolute (e.g. /vendor/…)
+  if (spec.startsWith('.')) return resolve(dirname(fromFile), spec);
+  return null;                                            // bare specifier — unused in this codebase
+};
+
+/** BFS an entry's static import graph; return every specifier that doesn't ship. */
+const unresolved = (entry: string, root: string): Array<{ spec: string; from: string }> => {
+  const miss: Array<{ spec: string; from: string }> = [];
+  if (!existsSync(entry)) return [{ spec: relative(root, entry), from: '(html entry)' }];
+  const seen = new Set<string>([entry]);
+  const queue: string[] = [entry];
+  while (queue.length) {
+    const file = queue.shift() as string;
+    let src: string;
+    try { src = readFileSync(file, 'utf8'); } catch { continue; }
+    STATIC_IMPORT.lastIndex = 0;
+    let mm: RegExpExecArray | null;
+    while ((mm = STATIC_IMPORT.exec(src))) {
+      const spec = mm[1] ?? mm[2];
+      if (!spec) continue;
+      const r = resolveSpec(spec, file, root);
+      if (!r) continue;
+      if (!existsSync(r)) { miss.push({ spec, from: relative(root, file) }); continue; }
+      if (!seen.has(r)) { seen.add(r); queue.push(r); }
+    }
+  }
+  return miss;
+};
+
+/** Every module entry point that ships: each page's <script src> + the SW. */
+const entryPoints = (root: string): string[] => {
+  const entries = new Set<string>();
+  for (const f of walk(root)) {
+    if (!f.endsWith('.html')) continue;
+    const html = readFileSync(f, 'utf8');
+    const re = /<script[^>]*\bsrc\s*=\s*["']([^"']+)["']/g;
+    let mm: RegExpExecArray | null;
+    while ((mm = re.exec(html))) {
+      const src = mm[1];
+      entries.add(src.startsWith('/') ? join(root, src) : resolve(dirname(f), src));
+    }
+  }
+  try {
+    const sw = JSON.parse(readFileSync(join(root, 'manifest.json'), 'utf8'))?.background?.service_worker;
+    if (typeof sw === 'string') entries.add(join(root, sw));
+  } catch { /* no manifest — staging always writes one */ }
+  return [...entries];
+};
+
+let failed = false;
+for (const channel of ['preview', 'store'] as const) {
+  await packageArtifact({ channel, browser: 'chrome', version, sign: false, verify: false });
+  const root = join(REPO_ROOT, 'artifacts', 'staging', `${channel}-chrome`);
+  const entries = entryPoints(root);
+  let chMiss = 0;
+  for (const entry of entries) {
+    const miss = unresolved(entry, root);
+    if (!miss.length) continue;
+    failed = true;
+    chMiss += miss.length;
+    console.error(`✗ [${channel}] ${relative(root, entry)} — ${miss.length} pruned-but-imported:`);
+    for (const m of miss) console.error(`    ${m.spec}  (from ${m.from})`);
+  }
+  console.log(`[${channel}/chrome] ${entries.length} entry points · ${chMiss} unresolved static import(s)`);
+}
+
+if (failed) {
+  console.error('\nPACKAGED IMPORT CHECK FAILED — a pruned file is still statically imported; that page will 404 + blank in the packaged build. Lazy-import it (guarded) or stop pruning it for that channel.');
+  process.exit(1);
+}
+console.log('packaged import check OK — every page\'s static import graph resolves in both channels.');

--- a/packaging/package.ts
+++ b/packaging/package.ts
@@ -35,12 +35,17 @@ import { signPreviewArtifact } from './sign.ts';
 const STORE_LOADER_TEMPLATE = join(REPO_ROOT, 'packaging', 'templates', 'dweb-loader.store.js');
 
 // Paths (relative to extension/) that never ship in ANY artifact.
-const PRUNE_ALWAYS = ['tests', 'eval', 'manifest.json', 'shared/channel-config.js'];
-// Additionally pruned from store artifacts: the entire dweb module,
-// plus the system-prompt paragraph that describes it (the loader inserts
-// it only when DWEB_ENABLED — a store prompt must make no
-// dweb claims).
-const PRUNE_STORE = ['peerd-distributed', 'peerd-provider/system-prompt-dweb.txt'];
+// why eval/ is NOT here: the home page's Lab (home/eval-section.js) imports
+// eval/ at module load, so pruning it from a channel 404s home.js's import
+// graph and black-screens the home tab. The Lab is a dev tool, so it's pruned
+// from STORE only (below), and eval-section lazy-loads it + degrades gracefully
+// when absent — so store's home still mounts.
+const PRUNE_ALWAYS = ['tests', 'manifest.json', 'shared/channel-config.js'];
+// Additionally pruned from store artifacts: the home Lab (eval/, a preview-only
+// dev tool), the entire dweb module, plus the system-prompt paragraph that
+// describes it (the loader inserts it only when DWEB_ENABLED — a store prompt
+// must make no dweb claims).
+const PRUNE_STORE = ['eval', 'peerd-distributed', 'peerd-provider/system-prompt-dweb.txt'];
 
 const shouldCopy = (src: string, channel: Channel): boolean => {
   const rel = relative(EXTENSION_DIR, src);

--- a/packaging/preflight.ts
+++ b/packaging/preflight.ts
@@ -57,6 +57,7 @@ const main = () => {
   run('typecheck (bun suite + // @ts-check extension files)', 'bun', ['run', 'typecheck']);
   run('typecheck coverage floor', 'bun', ['run', 'check:tscheck']);
   run('dweb boundary', 'bun', ['run', 'check:boundary']);
+  run('packaged import graph (no pruned-but-imported file)', 'bun', ['run', 'check:imports']);
   run('bun tests', 'bun', ['test', './tests']);
   if (args.matrix === true) {
     run('artifact matrix (store artifacts verified)', 'bun', ['packaging/package.ts', '--all', '--no-sign']);

--- a/scripts/cdp/check-packaged-pages.mjs
+++ b/scripts/cdp/check-packaged-pages.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env bun
+// Behavioral packaged-page BOOT check — the runtime backstop to the static
+// check:imports. It loads the PRUNED/packaged tree headless (launchPeerd with a
+// staging dir, not extension/) and asserts every Mithril #app page actually
+// mounts. This catches packaged-build-only RUNTIME breaks the static check can't
+// see — a 404'd dynamic import of a pruned module, a regressed graceful-degrade
+// path, a pruned CSS/asset — and the whole class e2e misses (it loads the
+// UNPACKED source and only ever opens the side panel). This is the test that
+// would have caught the v0.2.0 home black-screen directly: home/home.html's #app
+// would never have gained children in the packaged build.
+//
+// Run: bun run check:pages   (needs Chrome for Testing: bun run e2e:chrome)
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname, resolve, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { packageArtifact } from '../../packaging/package.ts';
+import { launchPeerd, openExtPage, evalIn, waitFor, log } from './e2e-harness.mjs';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const version = String(JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8')).version);
+
+const walk = (dir, out = []) => {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else out.push(p);
+  }
+  return out;
+};
+
+// Pages that mount Mithril at #app — these must never render blank. Auto-
+// discovered from the staged tree, so a future #app page is covered for free.
+const appPages = (root) =>
+  walk(root)
+    .filter((f) => f.endsWith('.html') && readFileSync(f, 'utf8').includes('id="app"'))
+    .map((f) => relative(root, f))
+    .sort();
+
+let failed = false;
+for (const channel of ['preview', 'store']) {
+  await packageArtifact({ channel, browser: 'chrome', version, sign: false, verify: false });
+  const root = join(REPO_ROOT, 'artifacts', 'staging', `${channel}-chrome`);
+  const pages = appPages(root);
+  let ctx = null;
+  try {
+    // Loads the PACKAGED tree (not extension/). launchPeerd already opens +
+    // mounts the side panel as part of setup, so a packaged side-panel break
+    // throws here and is caught below.
+    ctx = await launchPeerd({ extensionDir: root });
+    for (const page of pages) {
+      const p = await openExtPage(ctx, page);
+      const mounted = await waitFor(
+        () => evalIn(p, `(document.getElementById('app')?.childElementCount || 0) > 0`),
+        { budgetMs: 12_000, pollMs: 200 });
+      const errs = (p.events || []).filter((e) => /^EXC|^ERR/.test(e)).slice(0, 6);
+      if (mounted && errs.length === 0) {
+        log(`  ✓ [${channel}] ${page} mounted`);
+      } else {
+        failed = true;
+        log(`  ✗ [${channel}] ${page} — ${mounted ? 'mounted but console errors' : 'NEVER MOUNTED (blank page)'}`);
+        for (const e of errs) log(`      ${e}`);
+      }
+    }
+    log(`[${channel}/chrome] booted ${pages.length} #app page(s)`);
+  } catch (e) {
+    failed = true;
+    log(`✗ [${channel}] launch/boot failed: ${e?.message ?? e}`);
+  } finally {
+    try { ctx?.close(); } catch { /* */ }
+  }
+}
+
+if (failed) {
+  console.error('\nPACKAGED PAGE BOOT CHECK FAILED — a page rendered blank or errored in the packaged build (the v0.2.0 home black-screen class).');
+  process.exit(1);
+}
+log('packaged page boot check OK — every #app page mounts in both channels.');
+process.exit(0);

--- a/scripts/cdp/e2e-harness.mjs
+++ b/scripts/cdp/e2e-harness.mjs
@@ -175,9 +175,12 @@ async function findPeerdSw(port) {
  *   Default: a single assistant text turn ('e2e-smoke-ok').
  * @param {string} [opts.tagsModel]  model name returned by GET /api/tags.
  */
-export async function launchPeerd({ modelResponder, tagsModel = 'qwen3:8b' } = {}) {
-  if (!existsSync(join(EXT, 'manifest.json'))) {
-    throw new Error(`extension/manifest.json missing — run \`bun run gen:dev\` first (${EXT})`);
+export async function launchPeerd({ modelResponder, tagsModel = 'qwen3:8b', extensionDir = EXT } = {}) {
+  // extensionDir defaults to the raw source (the dev/e2e tree); pass a packaged
+  // STAGING dir to load a PRUNED build instead (check-packaged-pages.ts) — the
+  // only way to observe packaged-build-only breakage like the v0.2.0 home blank.
+  if (!existsSync(join(extensionDir, 'manifest.json'))) {
+    throw new Error(`manifest.json missing in ${extensionDir} — run \`bun run gen:dev\` (or package first)`);
   }
   const CHROME = resolveChrome();
   log('chrome:', CHROME);
@@ -188,8 +191,8 @@ export async function launchPeerd({ modelResponder, tagsModel = 'qwen3:8b' } = {
     '--disable-gpu', '--no-sandbox',
     `--user-data-dir=${profile}`,
     '--remote-debugging-port=0',
-    `--disable-extensions-except=${EXT}`,
-    `--load-extension=${EXT}`,
+    `--disable-extensions-except=${extensionDir}`,
+    `--load-extension=${extensionDir}`,
     'about:blank',
   ], { stdio: ['ignore', 'ignore', 'pipe'] });
   let chromeErr = '';


### PR DESCRIPTION
## What
Fixes a **black screen on the home page in packaged builds** (found dogfooding the v0.2.0 preview on Brave).

`home/home.js` statically imported the Lab (`home/eval-section.js` → `eval/`), but packaging **prunes `eval/` from every artifact**. So in any packaged build those imports 404 → `home.js`'s module graph fails to load → `#app` never mounts → black home tab. The side panel doesn't import eval, which is why *only* it worked. The e2e suite runs the **unpacked** source (where `eval/` is present), so it never caught this.

## Fix
- **`home.js`** — lazy-load `EvalSection`: a guarded dynamic `import('./eval-section.js')` when the Lab view opens. home.js no longer has a static dependency on `eval/`, so the page always mounts; the Lab degrades to *"The Lab is not available in this build."* when `eval/` is absent.
- **`packaging/package.ts`** — prune `eval/` from the **store** build only (it's a preview-channel dev tool), not from preview — so the preview Lab keeps working.

## Verified
Static import-graph resolution against the *actual packaged builds*:
- **store**: home graph 0 missing, `eval/` not statically reachable → home mounts, Lab degrades gracefully.
- **preview**: `eval/` present + reachable → home mounts *and* the Lab works.
- `bun test` **2329 pass**, typecheck + lint + gen-drift clean.

## Note
This shipped in v0.2.0 (both channels' home tab black-screens when packaged). The unpacked dev flow (`load unpacked extension/`) is unaffected, which is why it slipped past CI/e2e — worth a follow-up that smoke-tests a *packaged* build's home page in CI.
