### PR TITLE
fix(home): surface a failed dweb 'Start the network' instead of doing nothing

### DIFF
--- a/extension/home/network-section.js
+++ b/extension/home/network-section.js
@@ -401,10 +401,22 @@ export const NetworkSection = () => {
 
   /** @param {Send} send */
   const start = async (send) => {
-    starting = true; if (!dead) m.redraw();
-    try { await send({ type: 'dweb/base/start' }); } catch (e) { error = /** @type {{ message?: string }} */ (e)?.message || String(e); }
+    starting = true; error = null; if (!dead) m.redraw();
+    // Surface a FAILED start. The offscreen host answers a thrown handler with
+    // a RESOLVED { ok:false, error } reply (not a rejection), so `await send()`
+    // alone swallows it and the button silently snaps back to "Start the
+    // network" — the "does nothing" bug. Capture both the ok:false reply and a
+    // real throw, and re-apply it AFTER refresh (which pulls fresh info and
+    // would otherwise clear error to null).
+    /** @type {string | null} */
+    let startErr = null;
+    try {
+      const r = await send({ type: 'dweb/base/start' });
+      if (r && r.ok === false) startErr = r.error || 'start failed';
+    } catch (e) { startErr = /** @type {{ message?: string }} */ (e)?.message || String(e); }
     starting = false;
     await refresh(send);
+    if (startErr) { error = startErr; if (!dead) m.redraw(); }
   };
 
   /** The kill switch: shut down ALL dweb networking + persist it off. @param {Send} send */
@@ -412,10 +424,16 @@ export const NetworkSection = () => {
     // Destructive — drops every live connection — so confirm before the kill.
     if (typeof confirm === 'function'
       && !confirm('Shut down all peer-to-peer networking? This drops every live connection and keeps it off (it won’t come back on unlock) until you start it again.')) return;
-    stopping = true; if (!dead) m.redraw();
-    try { await send({ type: 'dweb/base/stop' }); } catch (e) { error = /** @type {{ message?: string }} */ (e)?.message || String(e); }
+    stopping = true; error = null; if (!dead) m.redraw();
+    /** @type {string | null} */
+    let stopErr = null;
+    try {
+      const r = await send({ type: 'dweb/base/stop' });
+      if (r && r.ok === false) stopErr = r.error || 'stop failed';
+    } catch (e) { stopErr = /** @type {{ message?: string }} */ (e)?.message || String(e); }
     stopping = false;
     await refresh(send);
+    if (stopErr) { error = stopErr; if (!dead) m.redraw(); }
   };
 
   return {

--- a/extension/tests/index.js
+++ b/extension/tests/index.js
@@ -94,3 +94,4 @@ import './unit/sidepanel/message-list.test.js';
 // --- home (chassis): the full-tab Library page ---
 import './unit/home/library-section.test.js';
 import './unit/home/contacts-section.test.js';
+import './unit/home/network-section.test.js';

--- a/extension/tests/unit/home/network-section.test.js
+++ b/extension/tests/unit/home/network-section.test.js
@@ -1,0 +1,126 @@
+// @ts-check
+import m from '/vendor/mithril/mithril.js';
+import { describe, it, expect } from '../../framework.js';
+import { NetworkSection } from '/home/network-section.js';
+
+// A "live" base-network info snapshot (shape mirrors offscreen/dweb-base.js
+// info()). Only what the view reads.
+const LIVE_INFO = {
+  running: true, did: 'did:key:zSelfAbcdefgh', lobby: 'peerd/base/1',
+  peers: [], peerCount: 0, linkedCount: 0, presentCount: 0, dhtSize: 0,
+  rendezvous: 'up', bootstrapUrl: 'wss://bootstrap.peerd.ai/rendezvous',
+};
+
+/** @typedef {{ type: string } & Record<string, any>} Msg */
+/** @typedef {Record<string, (msg: Msg) => any>} Overrides */
+/** @typedef {((msg: Msg) => Promise<any>) & { calls: Msg[] }} FakeSend */
+
+// Fake one-shot send(): records calls, answers dweb/distributed/info with a
+// not-running snapshot by default, lets a test override any route. Mirrors the
+// library-section test's makeSend.
+/** @param {Overrides} [overrides] */
+const makeSend = (overrides = {}) => {
+  /** @type {Msg[]} */
+  const calls = [];
+  /** @type {FakeSend} */
+  const send = Object.assign(
+    /** @param {Msg} msg */
+    async (msg) => {
+      calls.push(msg);
+      const override = overrides[msg.type];
+      if (override) return override(msg);
+      if (msg.type === 'dweb/distributed/info') return { running: false };
+      return { ok: true };
+    },
+    { calls },
+  );
+  return send;
+};
+
+const flush = async () => {
+  await new Promise((r) => setTimeout(r, 0));
+  m.redraw.sync();
+};
+
+/** @param {FakeSend} send */
+const mountView = async (send) => {
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  m.mount(root, { view: () => m(NetworkSection, { send }) });
+  await flush();
+  return { root, unmount: () => { m.mount(root, null); root.remove(); } };
+};
+
+/**
+ * @param {ParentNode} root
+ * @param {string} sel
+ * @param {string} text
+ * @returns {HTMLElement | undefined}
+ */
+const byText = (root, sel, text) =>
+  /** @type {HTMLElement[]} */ ([...root.querySelectorAll(sel)]).find((b) => b.textContent === text);
+
+/**
+ * @param {ParentNode} root
+ * @param {string} sel
+ * @param {string} text
+ */
+const clickText = (root, sel, text) => {
+  const el = byText(root, sel, text);
+  if (!el) throw new Error(`missing ${sel} with text: ${text}`);
+  el.click();
+};
+
+describe('home.network', () => {
+  it('offline: shows the Start the network button', async () => {
+    const { root, unmount } = await mountView(makeSend());
+    try {
+      expect(byText(root, '.peerd-net-btn', 'Start the network')).toBeTruthy();
+    } finally { unmount(); }
+  });
+
+  // The regression. The offscreen host answers a failed dweb/base/start with a
+  // RESOLVED { ok:false, error } reply (not a rejection); a naive `await send()`
+  // swallows it and the button silently snaps back to "Start the network" with
+  // no feedback — the reported "Start the network does nothing" bug. The error
+  // MUST reach the offline view, and must survive the post-start info refresh
+  // (which clears error on a successful info reply).
+  it('a failed start surfaces the error inline instead of doing nothing', async () => {
+    const send = makeSend({
+      'dweb/base/start': () => ({ ok: false, error: 'signaling: websocket error (wss://bootstrap.peerd.ai/rendezvous)' }),
+      // info still reports not-running after the failed start (and resolves ok,
+      // so refresh would clear `error` unless start re-applies it).
+      'dweb/distributed/info': () => ({ running: false }),
+    });
+    const { root, unmount } = await mountView(send);
+    try {
+      clickText(root, '.peerd-net-btn', 'Start the network');
+      await flush();
+      // wiring fired
+      expect(send.calls.some((c) => c.type === 'dweb/base/start')).toBe(true);
+      // the failure is SURFACED, not swallowed
+      expect(root.textContent).toContain('websocket error');
+      // and the button is usable again (not stuck on "Starting…")
+      expect(byText(root, '.peerd-net-btn', 'Starting…')).toBeFalsy();
+      expect(byText(root, '.peerd-net-btn', 'Start the network')).toBeTruthy();
+    } finally { unmount(); }
+  });
+
+  it('a successful start dispatches dweb/base/start and shows the live view', async () => {
+    let started = false;
+    const send = makeSend({
+      'dweb/base/start': () => { started = true; return { ok: true }; },
+      'dweb/distributed/info': () => (started ? LIVE_INFO : { running: false }),
+    });
+    const { root, unmount } = await mountView(send);
+    try {
+      clickText(root, '.peerd-net-btn', 'Start the network');
+      await flush();
+      expect(send.calls.some((c) => c.type === 'dweb/base/start')).toBe(true);
+      // left the offline view for the live one (facts row present, no Start btn)
+      expect(root.querySelector('.peerd-net-facts')).toBeTruthy();
+      expect(root.textContent).toContain('Lobby');
+      expect(byText(root, '.peerd-net-btn', 'Start the network')).toBeFalsy();
+    } finally { unmount(); }
+  });
+});


### PR DESCRIPTION
**Symptom:** the "Start the network" button does nothing.

**Root cause (two layers):**
1. *Infra (the actual breakage):* `bootstrap.peerd.ai` returns **HTTP 429** at the Cloudflare layer (before the worker runs), so the signaling websocket (`wss://bootstrap.peerd.ai/rendezvous`) can't connect. Needs a signaling-node/CF fix — out of scope here.
2. *Code (why it's silent):* the offscreen base-host answers a thrown handler with a **resolved** `{ ok:false, error }` reply (offscreen/dweb-base.js:403). `NetworkSection`'s `start`/`stop` only `await send()` and catch *throws*, so the `ok:false` was swallowed and the button snapped back with no feedback (and `refresh` then cleared any error).

**Fix:** check `r.ok === false` in `start`/`stop`, and re-apply the start error after the post-start info refresh so it isn't clobbered. The button now shows "The network isn't live yet (signaling: websocket error …)."

**Regression test:** `extension/tests/unit/home/network-section.test.js` — "a failed start surfaces the error inline" **fails without this fix** (verified: 586/1 without, 587/0 with), plus offline-render and happy-path coverage.