### PR TITLE
test(packaging): catch the whole packaged-build black-screen class (boot every page × both browsers + author-time lint)

### DIFF
--- a/.github/workflows/package-and-release.yml
+++ b/.github/workflows/package-and-release.yml
@@ -179,13 +179,33 @@ jobs:
         # smoke, goal mode, stop, error — against ONE Chrome (env-independent;
         # visual states are excluded here as their baselines are per-machine).
         run: bun run test:e2e:all
-      - name: Packaged page boot (each #app page mounts in the PRUNED build)
+
+  # The behavioral packaged-build gate. Its OWN job (stable name) on purpose:
+  # check:pages is the only tier that loads the REAL pruned artifact and so the
+  # only one that catches the v0.2.0 black-screen class — it must be able to gate
+  # merges WITHOUT being coupled to the flakier faked-wire e2e suite above. Add
+  # this job to the branch-protection required-checks list once it has a green
+  # history (mirrors the note on `inbrowser`).
+  packaged-pages:
+    name: packaged page boot
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.9"
+      - uses: browser-actions/setup-chrome@v2
+      - run: bun install
+      - name: Provision Chrome for Testing
+        id: cft
+        run: echo "chrome-path=$(bun scripts/cdp/ensure-chrome-for-testing.mjs | tail -1)" >> "$GITHUB_OUTPUT"
+      - name: Boot every packaged page (no blank page / missing same-origin resource)
         env:
           CHROME_PATH: ${{ steps.cft.outputs.chrome-path }}
-        # The runtime backstop to check:imports — loads the actual PACKAGED tree
-        # (both channels) and asserts every #app page mounts. e2e above loads the
-        # UNPACKED source, so this is the only tier that observes prune-induced
-        # blank pages (the v0.2.0 home black-screen class).
+        # Packages both channels, loads the PRUNED tree, boots every shipped page,
+        # and fails on a blank page OR any failed same-origin resource load (CSS/
+        # font/wasm/dynamic-import 404) — the silent half of the black-screen class
+        # the e2e suite (unpacked source) structurally cannot see.
         run: bun run check:pages
 
   package:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,6 +38,39 @@
 
 import globals from 'globals';
 
+// no-restricted-imports patterns, shared so the eval-bridge exemption below can
+// re-list every rule EXCEPT the eval one (a flat-config override REPLACES the
+// whole rule, so the patterns it keeps must be spelled out).
+const CROSS_MODULE_IMPORT = {
+  // any `peerd-<name>/<deeper>` path that isn't the module's own top-level index.js
+  regex: '(^|/)peerd-[a-z]+/(?!index\\.js$).+',
+  message: 'Cross-module imports must go through /peerd-<name>/index.js. See docs/architecture.md §4.',
+};
+// The dweb module is stricter: NOTHING outside it may import it — not even its
+// index.js. Core code programs against /shared/dweb-interface.js + loadDweb()
+// (whose gated dynamic import this rule can't see — check-dweb-boundary.ts covers
+// that). The store package prunes it; a static import would break the store SW.
+const DWEB_IMPORT = {
+  regex: '(^|/)peerd-distributed/.*',
+  message: 'Dweb is channel-gated. Import /shared/dweb-interface.js types + loadDweb() from /shared/dweb-loader.js — never peerd-distributed directly. See PACKAGING.md.',
+};
+// tests/ is PRUNE_ALWAYS (pruned from every package). A shipped file that
+// statically imports it 404s + blanks the page in a real install. Tests import
+// each other (extension/tests/** is exempt below); runtime code must not.
+const TESTS_IMPORT = {
+  regex: '(^|/)tests/.*',
+  message: 'tests/ is pruned from every package — a shipped file importing it would 404 in a real install. Runtime code must not import test files.',
+};
+// eval/ (the Lab) is pruned from the STORE build. A shipped page that STATICALLY
+// imports it black-screens the store install — this is the v0.2.0 bug. Lazy-load
+// it via a guarded dynamic import (home/home.js → home/eval-section.js). The eval
+// module + that one sanctioned bridge are exempt below; check:imports + check:pages
+// enforce the same invariant against the real artifact.
+const EVAL_IMPORT = {
+  regex: '(^|/)eval/.*',
+  message: 'The Lab (eval/) is pruned from the store build — never STATICALLY import it from a shipped page (the v0.2.0 black-screen). Lazy-load it via a guarded dynamic import; see home/home.js.',
+};
+
 export default [
   // --- global ignores (was: `ignorePatterns`) ---------------------------
   // A config object with ONLY `ignores` sets global ignores.
@@ -112,26 +145,7 @@ export default [
       // own top-level `index.js`.
       'no-restricted-imports': [
         'error',
-        {
-          patterns: [
-            {
-              regex: '(^|/)peerd-[a-z]+/(?!index\\.js$).+',
-              message: 'Cross-module imports must go through /peerd-<name>/index.js. See docs/architecture.md §4.',
-            },
-            // The dweb module is stricter still: NOTHING outside it
-            // may import it — not even its index.js. Core code programs
-            // against /shared/dweb-interface.js and obtains the live
-            // client via loadDweb() in /shared/dweb-loader.js
-            // (whose gated dynamic import this rule can't see — the CI
-            // gate packaging/check-dweb-boundary.ts covers that). The
-            // store package prunes the module entirely; a static import here
-            // would break the store service worker outright.
-            {
-              regex: '(^|/)peerd-distributed/.*',
-              message: 'Dweb is channel-gated. Import /shared/dweb-interface.js types + loadDweb() from /shared/dweb-loader.js — never peerd-distributed directly. See PACKAGING.md.',
-            },
-          ],
-        },
+        { patterns: [CROSS_MODULE_IMPORT, DWEB_IMPORT, TESTS_IMPORT, EVAL_IMPORT] },
       ],
 
       // --- shadow / TDZ class (new — warnings) -------------------------
@@ -274,16 +288,12 @@ export default [
   {
     files: ['extension/peerd-*/**'],
     rules: {
+      // Drop the cross-module rule (deep imports inside a module are fine) but
+      // KEEP the dweb + prune-only-dir guards: a peerd-* file must not import
+      // peerd-distributed, eval/, or tests/ either (all pruned in some channel).
       'no-restricted-imports': [
         'error',
-        {
-          patterns: [
-            {
-              regex: '(^|/)peerd-distributed/.*',
-              message: 'Dweb is channel-gated. Import /shared/dweb-interface.js types + loadDweb() from /shared/dweb-loader.js — never peerd-distributed directly. See PACKAGING.md.',
-            },
-          ],
-        },
+        { patterns: [DWEB_IMPORT, TESTS_IMPORT, EVAL_IMPORT] },
       ],
     },
   },
@@ -303,6 +313,19 @@ export default [
   {
     files: ['extension/tests/**'],
     rules: { 'no-restricted-imports': 'off' },
+  },
+  // The eval module imports itself, and home/eval-section.js is the SANCTIONED
+  // bridge — it ships only where eval/ ships (preview; both pruned together from
+  // store) and is itself only ever LAZILY imported (home/home.js guarded dynamic
+  // import). So these may statically import eval/; every OTHER rule still applies.
+  {
+    files: ['extension/eval/**', 'extension/home/eval-section.js'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        { patterns: [CROSS_MODULE_IMPORT, DWEB_IMPORT, TESTS_IMPORT] },
+      ],
+    },
   },
 
   // --- injected classic-script bodies: keep them ES5 --------------------

--- a/packaging/check-packaged-imports.ts
+++ b/packaging/check-packaged-imports.ts
@@ -86,31 +86,77 @@ const entryPoints = (root: string): string[] => {
     }
   }
   try {
-    const sw = JSON.parse(readFileSync(join(root, 'manifest.json'), 'utf8'))?.background?.service_worker;
-    if (typeof sw === 'string') entries.add(join(root, sw));
+    const bg = JSON.parse(readFileSync(join(root, 'manifest.json'), 'utf8'))?.background;
+    // Chrome: background.service_worker (string). Firefox: gen-manifest rewrites
+    // it to background.scripts (array) — so the Firefox SW import graph would be
+    // silently never walked if we only read service_worker. Handle both shapes.
+    if (typeof bg?.service_worker === 'string') entries.add(join(root, bg.service_worker));
+    if (Array.isArray(bg?.scripts)) {
+      for (const s of bg.scripts) if (typeof s === 'string') entries.add(join(root, s));
+    }
   } catch { /* no manifest — staging always writes one */ }
   return [...entries];
 };
 
-let failed = false;
-for (const channel of ['preview', 'store'] as const) {
-  await packageArtifact({ channel, browser: 'chrome', version, sign: false, verify: false });
-  const root = join(REPO_ROOT, 'artifacts', 'staging', `${channel}-chrome`);
-  const entries = entryPoints(root);
-  let chMiss = 0;
-  for (const entry of entries) {
-    const miss = unresolved(entry, root);
-    if (!miss.length) continue;
-    failed = true;
-    chMiss += miss.length;
-    console.error(`✗ [${channel}] ${relative(root, entry)} — ${miss.length} pruned-but-imported:`);
-    for (const m of miss) console.error(`    ${m.spec}  (from ${m.from})`);
+/**
+ * Manifest-declared asset paths that must ship in the pruned tree: icons,
+ * action.default_icon, and web_accessible_resources. A channel patch pointing any
+ * of these at a pruned/missing file ships a broken icon or a 404'd resource that
+ * neither the import walk nor a page boot would catch. Returns the missing paths.
+ */
+const missingManifestAssets = (root: string): string[] => {
+  let manifest: { icons?: Record<string, string>; action?: { default_icon?: string | Record<string, string> }; web_accessible_resources?: Array<{ resources?: string[] }> };
+  try { manifest = JSON.parse(readFileSync(join(root, 'manifest.json'), 'utf8')); }
+  catch { return []; }
+  const miss: string[] = [];
+  const check = (p: unknown, where: string): void => {
+    if (typeof p !== 'string' || /^(https?:|data:)/.test(p)) return;
+    if (!existsSync(join(root, p.replace(/^\//, '')))) miss.push(`${p}  (${where})`);
+  };
+  for (const p of Object.values(manifest.icons ?? {})) check(p, 'icons');
+  const di = manifest.action?.default_icon;
+  if (typeof di === 'string') check(di, 'action.default_icon');
+  else for (const p of Object.values(di ?? {})) check(p, 'action.default_icon');
+  for (const war of manifest.web_accessible_resources ?? []) {
+    for (const r of war?.resources ?? []) {
+      if (typeof r !== 'string') continue;
+      // Literal path → check directly; glob → check its base dir still ships (a
+      // glob into a fully-pruned dir, e.g. tests/**, then matches nothing).
+      if (r.includes('*')) {
+        const base = r.split('*')[0].replace(/\/$/, '').replace(/^\//, '');
+        if (base && !existsSync(join(root, base))) miss.push(`${r}  (web_accessible_resources — base '${base}' pruned)`);
+      } else check(r, 'web_accessible_resources');
+    }
   }
-  console.log(`[${channel}/chrome] ${entries.length} entry points · ${chMiss} unresolved static import(s)`);
+  return miss;
+};
+
+let failed = false;
+// The full 2×2 release matrix. Firefox diverges most (manifest transform strips
+// sidePanel/offscreen/debugger and rewrites the SW shape), so its import graph
+// needs its own walk — the static resolver needs no browser to run.
+for (const channel of ['preview', 'store'] as const) {
+  for (const browser of ['chrome', 'firefox'] as const) {
+    await packageArtifact({ channel, browser, version, sign: false, verify: false });
+    const root = join(REPO_ROOT, 'artifacts', 'staging', `${channel}-${browser}`);
+    const entries = entryPoints(root);
+    let chMiss = 0;
+    for (const entry of entries) {
+      const miss = unresolved(entry, root);
+      if (!miss.length) continue;
+      failed = true;
+      chMiss += miss.length;
+      console.error(`✗ [${channel}/${browser}] ${relative(root, entry)} — ${miss.length} pruned-but-imported:`);
+      for (const m of miss) console.error(`    ${m.spec}  (from ${m.from})`);
+    }
+    const assetMiss = missingManifestAssets(root);
+    for (const a of assetMiss) { failed = true; console.error(`✗ [${channel}/${browser}] manifest asset missing — ${a}`); }
+    console.log(`[${channel}/${browser}] ${entries.length} entry points · ${chMiss} unresolved import(s) · ${assetMiss.length} missing manifest asset(s)`);
+  }
 }
 
 if (failed) {
   console.error('\nPACKAGED IMPORT CHECK FAILED — a pruned file is still statically imported; that page will 404 + blank in the packaged build. Lazy-import it (guarded) or stop pruning it for that channel.');
   process.exit(1);
 }
-console.log('packaged import check OK — every page\'s static import graph resolves in both channels.');
+console.log('packaged import check OK — every page\'s static import graph resolves in all channel×browser builds.');

--- a/packaging/check-packaged-imports.ts
+++ b/packaging/check-packaged-imports.ts
@@ -105,7 +105,15 @@ const entryPoints = (root: string): string[] => {
  * neither the import walk nor a page boot would catch. Returns the missing paths.
  */
 const missingManifestAssets = (root: string): string[] => {
-  let manifest: { icons?: Record<string, string>; action?: { default_icon?: string | Record<string, string> }; web_accessible_resources?: Array<{ resources?: string[] }> };
+  let manifest: {
+    icons?: Record<string, string>;
+    action?: { default_icon?: string | Record<string, string>; default_popup?: string };
+    web_accessible_resources?: Array<{ resources?: string[] }>;
+    side_panel?: { default_path?: string };
+    options_ui?: { page?: string };
+    sidebar_action?: { default_panel?: string };
+    sandbox?: { pages?: string[] };
+  };
   try { manifest = JSON.parse(readFileSync(join(root, 'manifest.json'), 'utf8')); }
   catch { return []; }
   const miss: string[] = [];
@@ -117,6 +125,14 @@ const missingManifestAssets = (root: string): string[] => {
   const di = manifest.action?.default_icon;
   if (typeof di === 'string') check(di, 'action.default_icon');
   else for (const p of Object.values(di ?? {})) check(p, 'action.default_icon');
+  // HTML ENTRY POINTERS — a manifest field aiming at a page that doesn't ship is a
+  // blank surface when the browser opens it (the entryPoints walk only finds pages
+  // that EXIST, so it can't see a pointer at a pruned one).
+  check(manifest.action?.default_popup, 'action.default_popup');
+  check(manifest.side_panel?.default_path, 'side_panel.default_path');
+  check(manifest.options_ui?.page, 'options_ui.page');
+  check(manifest.sidebar_action?.default_panel, 'sidebar_action.default_panel');
+  for (const p of manifest.sandbox?.pages ?? []) check(p, 'sandbox.pages');
   for (const war of manifest.web_accessible_resources ?? []) {
     for (const r of war?.resources ?? []) {
       if (typeof r !== 'string') continue;

--- a/packaging/preflight.ts
+++ b/packaging/preflight.ts
@@ -61,6 +61,10 @@ const main = () => {
   run('bun tests', 'bun', ['test', './tests']);
   if (args.matrix === true) {
     run('artifact matrix (store artifacts verified)', 'bun', ['packaging/package.ts', '--all', '--no-sign']);
+    // Chrome-cost gate: boots every page of the real pruned build (both channels)
+    // and fails on a blank page / missing same-origin resource. Needs Chrome for
+    // Testing (bun run e2e:chrome); mirrors the CI `packaged page boot` job.
+    run('packaged page boot (every page loads clean in the pruned build)', 'bun', ['run', 'check:pages']);
   }
 
   console.log('\npreflight OK');

--- a/scripts/cdp/check-packaged-pages.mjs
+++ b/scripts/cdp/check-packaged-pages.mjs
@@ -55,7 +55,11 @@ const isAppPage = (root, page) => readFileSync(join(root, page), 'utf8').include
 // references but didn't ship. Ignore favicon (Chrome auto-requests it; extensions
 // ship none) and cross-origin misses (test-env noise, not our artifact).
 const sameOriginNetFails = (events) => (events || [])
-  .filter((e) => e.startsWith('NETFAIL') && e.includes('chrome-extension://') && !e.includes('/favicon.ico'));
+  .filter((e) => e.startsWith('NETFAIL') && e.includes('chrome-extension://')
+    && !e.includes('/favicon.ico')
+    // .map sourcemaps aren't shipped + are only fetched under the Debugger domain
+    // (we don't enable it) — exclude them so adding Debugger later can't red the gate.
+    && !/\.map(\?|#|$)/.test(e));
 const exceptions = (events) => (events || []).filter((e) => /^EXC |^ERR /.test(e));
 
 let failed = false;

--- a/scripts/cdp/check-packaged-pages.mjs
+++ b/scripts/cdp/check-packaged-pages.mjs
@@ -1,13 +1,27 @@
 #!/usr/bin/env bun
 // Behavioral packaged-page BOOT check — the runtime backstop to the static
-// check:imports. It loads the PRUNED/packaged tree headless (launchPeerd with a
-// staging dir, not extension/) and asserts every Mithril #app page actually
-// mounts. This catches packaged-build-only RUNTIME breaks the static check can't
-// see — a 404'd dynamic import of a pruned module, a regressed graceful-degrade
-// path, a pruned CSS/asset — and the whole class e2e misses (it loads the
-// UNPACKED source and only ever opens the side panel). This is the test that
-// would have caught the v0.2.0 home black-screen directly: home/home.html's #app
-// would never have gained children in the packaged build.
+// check:imports, and the broad net that catches the WHOLE "works in dev, blank
+// in a packaged install" class. It packages each channel, loads the PRUNED tree
+// headless via launchPeerd(extensionDir) (not extension/), and boots EVERY
+// shipped page, asserting it referenced nothing it didn't ship.
+//
+// The class-killer signal is a failed SAME-ORIGIN (chrome-extension://) resource
+// load: Chrome emits NO console error for a missing subresource (CSS/font/wasm/
+// img/dynamic-import), so a pruned asset would otherwise ship silently with every
+// other guard green. We capture Network.loadingFailed/4xx in the harness and fail
+// on any same-origin miss — one assertion covers JS, CSS, fonts, wasm, and
+// at-load dynamic imports, on every page, with no per-asset parser to maintain.
+//
+//   - #app pages (home/options/sidepanel): ALSO assert Mithril mounts + zero
+//     uncaught exceptions (clean UI pages — strict).
+//   - other pages (engine tabs, offscreen, mic, dwapps): assert load + zero
+//     missing same-origin resource; exceptions are NOTED, not failed (booting a
+//     page out of its normal context — e.g. the offscreen doc — can throw on a
+//     healthy build, so the reliable signal there is the resource miss).
+//
+// Per-channel page sets fall out for free: walk() lists only files present in the
+// staged tree, so a page pruned for a channel (commons in store) is simply not
+// booted there.
 //
 // Run: bun run check:pages   (needs Chrome for Testing: bun run e2e:chrome)
 
@@ -19,6 +33,8 @@ import { launchPeerd, openExtPage, evalIn, waitFor, log } from './e2e-harness.mj
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const version = String(JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8')).version);
+const SETTLE_MS = 2000;   // let late dynamic-import / asset loadingFailed events land
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 const walk = (dir, out = []) => {
   for (const name of readdirSync(dir)) {
@@ -29,40 +45,60 @@ const walk = (dir, out = []) => {
   return out;
 };
 
-// Pages that mount Mithril at #app — these must never render blank. Auto-
-// discovered from the staged tree, so a future #app page is covered for free.
-const appPages = (root) =>
-  walk(root)
-    .filter((f) => f.endsWith('.html') && readFileSync(f, 'utf8').includes('id="app"'))
-    .map((f) => relative(root, f))
-    .sort();
+// Every shipped page in the staged tree.
+const htmlPages = (root) =>
+  walk(root).filter((f) => f.endsWith('.html')).map((f) => relative(root, f)).sort();
+// Mithril mount pages get the strict treatment.
+const isAppPage = (root, page) => readFileSync(join(root, page), 'utf8').includes('id="app"');
+
+// A same-origin (chrome-extension://) load failure = a file the packaged build
+// references but didn't ship. Ignore favicon (Chrome auto-requests it; extensions
+// ship none) and cross-origin misses (test-env noise, not our artifact).
+const sameOriginNetFails = (events) => (events || [])
+  .filter((e) => e.startsWith('NETFAIL') && e.includes('chrome-extension://') && !e.includes('/favicon.ico'));
+const exceptions = (events) => (events || []).filter((e) => /^EXC |^ERR /.test(e));
 
 let failed = false;
 for (const channel of ['preview', 'store']) {
   await packageArtifact({ channel, browser: 'chrome', version, sign: false, verify: false });
   const root = join(REPO_ROOT, 'artifacts', 'staging', `${channel}-chrome`);
-  const pages = appPages(root);
+  const pages = htmlPages(root);
   let ctx = null;
   try {
-    // Loads the PACKAGED tree (not extension/). launchPeerd already opens +
-    // mounts the side panel as part of setup, so a packaged side-panel break
-    // throws here and is caught below.
+    // Loads the PACKAGED tree (not extension/). launchPeerd opens + mounts the
+    // side panel as part of setup, so a packaged side-panel break throws here.
     ctx = await launchPeerd({ extensionDir: root });
     for (const page of pages) {
-      const p = await openExtPage(ctx, page);
-      const mounted = await waitFor(
-        () => evalIn(p, `(document.getElementById('app')?.childElementCount || 0) > 0`),
-        { budgetMs: 12_000, pollMs: 200 });
-      const errs = (p.events || []).filter((e) => /^EXC|^ERR/.test(e)).slice(0, 6);
-      if (mounted && errs.length === 0) {
-        log(`  ✓ [${channel}] ${page} mounted`);
-      } else {
+      const app = isAppPage(root, page);
+      let p = null; let mounted = true; let openErr = null;
+      try {
+        p = await openExtPage(ctx, page);
+        const ready = app
+          ? `(document.getElementById('app')?.childElementCount || 0) > 0`
+          : `document.readyState === 'complete'`;
+        mounted = await waitFor(() => evalIn(p, ready), { budgetMs: 12_000, pollMs: 200 });
+        await sleep(SETTLE_MS);
+      } catch (e) { openErr = e?.message ?? String(e); }
+      const netFails = p ? sameOriginNetFails(p.events) : [];
+      const excs = p ? exceptions(p.events) : [];
+      try { p?.close(); } catch { /* */ }
+      // Hard fail: an open failure, a missing same-origin resource (ANY page), a
+      // non-mounting #app page, or an uncaught exception on an #app page.
+      const hardFail = !!openErr || netFails.length > 0 || (app && (!mounted || excs.length > 0));
+      if (hardFail) {
         failed = true;
-        log(`  ✗ [${channel}] ${page} — ${mounted ? 'mounted but console errors' : 'NEVER MOUNTED (blank page)'}`);
-        for (const e of errs) log(`      ${e}`);
+        const why = openErr ? `open failed: ${openErr}`
+          : netFails.length ? 'missing same-origin resource(s)'
+          : !mounted ? 'NEVER MOUNTED (blank page)'
+          : 'uncaught exception';
+        log(`  ✗ [${channel}] ${page} — ${why}`);
+        for (const e of [...netFails, ...(app ? excs : [])].slice(0, 6)) log(`      ${e}`);
+      } else {
+        const note = !app && excs.length ? ` (${excs.length} non-fatal exception(s) — out-of-context boot)` : '';
+        log(`  ✓ [${channel}] ${page}${app ? ' mounted' : ' loaded'}${note}`);
       }
     }
-    log(`[${channel}/chrome] booted ${pages.length} #app page(s)`);
+    log(`[${channel}/chrome] booted ${pages.length} page(s)`);
   } catch (e) {
     failed = true;
     log(`✗ [${channel}] launch/boot failed: ${e?.message ?? e}`);
@@ -72,8 +108,8 @@ for (const channel of ['preview', 'store']) {
 }
 
 if (failed) {
-  console.error('\nPACKAGED PAGE BOOT CHECK FAILED — a page rendered blank or errored in the packaged build (the v0.2.0 home black-screen class).');
+  console.error('\nPACKAGED PAGE BOOT CHECK FAILED — a page rendered blank, threw, or referenced a missing file in the packaged build (the v0.2.0 black-screen class).');
   process.exit(1);
 }
-log('packaged page boot check OK — every #app page mounts in both channels.');
+log('packaged page boot check OK — every shipped page boots with no missing same-origin resource, both channels.');
 process.exit(0);

--- a/scripts/cdp/e2e-harness.mjs
+++ b/scripts/cdp/e2e-harness.mjs
@@ -407,14 +407,20 @@ export async function unlockAndReady(page, { provider = 'ollama', model = 'qwen3
  */
 export async function openExtPage(ctx, path) {
   const url = `chrome-extension://${ctx.sw.id}/${String(path).replace(/^\//, '')}`;
-  const created = await (await fetch(`http://127.0.0.1:${ctx.port}/json/new?${encodeURI(url)}`, { method: 'PUT' })).json();
+  // Create the tab at about:blank FIRST, enable Network, THEN navigate. why: if we
+  // open straight at the page URL, the document and its synchronous HEAD resources
+  // (the page's primary <link> stylesheet, <script src>) have already committed by
+  // the time we attach + Network.enable — so a pruned HEAD asset would emit no
+  // captured loadingFailed and slip the packaged-page boot check. Enabling Network
+  // before navigation captures the FULL load. (Same pattern as run-inbrowser-tests.)
+  const created = await (await fetch(`http://127.0.0.1:${ctx.port}/json/new?about:blank`, { method: 'PUT' })).json();
   const page = await attach(created.webSocketDebuggerUrl);
   await page.send('Runtime.enable');
   await page.send('Page.enable');
-  // why: the packaged-page boot check (check-packaged-pages.mjs) needs to see
-  // failed subresource loads (a pruned CSS/font/wasm/dynamic-import 404), which
-  // surface only as Network events — never as console errors.
+  // The packaged-page boot check needs failed subresource loads (a pruned CSS/font/
+  // wasm/dynamic-import 404), which surface only as Network events, never console.
   await page.send('Network.enable');
+  await page.send('Page.navigate', { url });
   return page;
 }
 

--- a/scripts/cdp/e2e-harness.mjs
+++ b/scripts/cdp/e2e-harness.mjs
@@ -90,6 +90,7 @@ async function attach(wsUrl, onEvent) {
   let id = 0;
   const pending = new Map();
   const events = [];
+  const reqUrl = new Map();   // requestId → url; loadingFailed carries no url of its own
   ws.onmessage = (e) => {
     const m = JSON.parse(e.data);
     if (m.id && pending.has(m.id)) { pending.get(m.id)(m); pending.delete(m.id); return; }
@@ -98,6 +99,20 @@ async function attach(wsUrl, onEvent) {
     }
     if (m.method === 'Runtime.consoleAPICalled' && m.params?.type === 'error') {
       events.push('ERR ' + (m.params.args || []).map((a) => a.value || a.description || a.type).join(' '));
+    }
+    // Failed / 4xx-5xx subresource loads. Only populated when Network.enable was
+    // sent on this connection (openExtPage does, for the packaged-page boot check).
+    // why: Chrome emits NO console error for a failed subresource (CSS/font/wasm/
+    // img/dynamic-import), so this is the ONLY signal that a packaged build is
+    // missing a file it references — the silent half of the black-screen class.
+    if (m.method === 'Network.requestWillBeSent') {
+      reqUrl.set(m.params?.requestId, m.params?.request?.url);
+    }
+    if (m.method === 'Network.responseReceived' && (m.params?.response?.status ?? 0) >= 400) {
+      events.push(`NETFAIL ${m.params.response.status} ${m.params.response.url}`);
+    }
+    if (m.method === 'Network.loadingFailed' && !m.params?.canceled) {
+      events.push(`NETFAIL ${m.params?.errorText || 'failed'} ${reqUrl.get(m.params?.requestId) || '(unknown url)'}`);
     }
     if (onEvent) onEvent(m.method, m.params);
   };
@@ -396,6 +411,10 @@ export async function openExtPage(ctx, path) {
   const page = await attach(created.webSocketDebuggerUrl);
   await page.send('Runtime.enable');
   await page.send('Page.enable');
+  // why: the packaged-page boot check (check-packaged-pages.mjs) needs to see
+  // failed subresource loads (a pruned CSS/font/wasm/dynamic-import 404), which
+  // surface only as Network events — never as console errors.
+  await page.send('Network.enable');
   return page;
 }
 


### PR DESCRIPTION
Prevents the **whole class** of the v0.2.0 home black-screen (#113), not just that one instance. Root cause is structural: dev and CI test the *unpacked source* (nothing pruned, dev manifest), but users run the *packaged artifact*. A guard that only runs the source is blind to this class by construction. This closes the gap at three layers, derived from a failure-mode sweep + an adversarial review.

### The class-killer (behavioral)
`check:pages` now boots **every** shipped page (not just the 3 `#app` SPAs) in **both channels**, against the real pruned tree, and fails on **any missing same-origin (`chrome-extension://`) resource** — JS, CSS, font, wasm, or at-load dynamic import. Chrome emits *no console error* for a failed subresource, so this is the only signal that catches a pruned asset.
- The harness now captures `Network.loadingFailed`/4xx; `openExtPage` opens `about:blank`, enables Network, **then** navigates — so the page's **head** resources are captured (an earlier draft missed them; caught in review).
- **Revert-proven:** pruning `shared/fonts.css` *or* the head `sidepanel/styles.css` reddens the affected pages in both channels.

### Static (`check:imports`)
- Now walks the full **2×2 matrix** (channel × browser). Firefox diverged most — `gen-manifest` rewrites `background.service_worker` → `background.scripts`, so its **entire SW import graph was never walked**. Revert-proven (Firefox drops 12→11 entries without the fix).
- Validates **manifest asset + HTML-entry paths** (icons, `default_icon`, `web_accessible_resources`, `side_panel.default_path`, `options_ui.page`, `sandbox.pages`, …) against the pruned tree. Revert-proven (pruning an icon flags it).

### Author-time (ESLint)
`no-restricted-imports` now forbids shipped code from **statically** importing `eval/` or `tests/` (pruned dirs) — a red squiggle before CI. The eval module + the sanctioned lazy bridge (`home/eval-section.js`) are exempt. Revert-proven.

### Process
`check:pages` moved out of the non-required, flaky e2e job into its **own required-capable `packaged page boot` job** (add to branch protection once green), and added to `preflight --matrix`.

### Verification
typecheck · lint · check:tscheck · check:boundary · check:imports (2×2) · no drift · bun **2345** · in-browser **584** · e2e smoke 5/5 · **check:pages** (11 preview / 9 store). Every guard revert-proven. An adversarial review (false-positives-first, since these are gates) confirmed **no live false positive** and surfaced the head-resource hole, which this PR fixes; remaining items are documented coverage-scope notes (e.g. interaction-gated dynamic imports), not safety issues.
