### PR TITLE
feat(provider): configurable remote Ollama host (fixes #104)

### DIFF
--- a/extension/background/routes/providers.js
+++ b/extension/background/routes/providers.js
@@ -31,7 +31,8 @@ export const makeProviderRoutes = (deps) => {
       // and doesn't load a multi-GB model into memory just for a ping.
       if (adapter?.keyless && adapter.liveModels) {
         try {
-          const models = await listProviderModels(provider, { safeFetch });
+          // ollamaHost (issue #104): test the daemon the user actually configured.
+          const models = await listProviderModels(provider, { safeFetch, ollamaHost: settingsStore.get().ollamaHost });
           auditLog.append({ type: 'provider_validated', details: { provider } }).catch(() => {});
           return { ok: true, models: models?.length ?? 0 };
         } catch (e) {

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -577,7 +577,10 @@ const liveContextWindow = (/** @type {string} */ provider, /** @type {string} */
   if (hit && typeof hit.window === 'number') return hit.window; // learned → keep for SW lifetime
   if (hit && hit.fetching) return undefined;                    // in-flight → don't fire a second
   contextWindowCache.set(key, { fetching: true });
-  providerModelContextWindow(provider, model, { getSecret, safeFetch })
+  // ollamaHost (issue #104): the live per-model window comes from the daemon's
+  // /api/show, so a remote Ollama needs its host or it would query localhost and
+  // silently fall back to the static table; other adapters ignore it.
+  providerModelContextWindow(provider, model, { getSecret, safeFetch, ollamaHost: settingsStore.get().ollamaHost })
     .then((w) => {
       if (typeof w === 'number') contextWindowCache.set(key, { window: w });
       else contextWindowCache.delete(key); // miss → drop so the next turn retries

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -533,7 +533,9 @@ const liveProviderModels = async (/** @type {string} */ name) => {
   const hit = liveModelsCache.get(name);
   if (hit && Date.now() - hit.at < LIVE_MODELS_TTL_MS) return hit.list;
   let list = null;
-  try { list = await listProviderModels(name, { safeFetch }); }
+  // ollamaHost (issue #104) lets the live inventory fetch a remote daemon's
+  // /api/tags; non-ollama adapters ignore it.
+  try { list = await listProviderModels(name, { safeFetch, ollamaHost: settingsStore.get().ollamaHost }); }
   catch { list = null; }
   liveModelsCache.set(name, { at: Date.now(), list });
   return list;
@@ -688,8 +690,26 @@ const buildModelOptions = async ({ sessionId = null } = {}) => {
   return { options, selected, sessionProvider };
 };
 
+// The user-configured Ollama host (issue #104). Its exact origin joins the
+// allowlist so safeFetch permits a remote daemon — the loopback default is
+// already hardcoded, so this only ever adds a custom host. why origin-only +
+// try/catch: settings-patch already stores it as a validated origin, but the
+// allowlist is the security boundary, so read it defensively and contribute
+// nothing on a bad/missing value. (The SSRF/private-network guard is on the
+// open-web path, not this credentialed provider path — so a LAN host is fine
+// here, and exact-origin matching keeps it to the one host the user set.)
+const ollamaAllowedOrigin = () => {
+  try { return new URL(settingsStore.get().ollamaHost || '').origin; }
+  catch { return null; }
+};
+
 export const safeFetch = makeSafeFetch({
-  getAllowlist: () => [...HARDCODED_ALLOWLIST, ...userEndpoints],
+  getAllowlist: () => {
+    const ollama = ollamaAllowedOrigin();
+    return ollama
+      ? [...HARDCODED_ALLOWLIST, ...userEndpoints, ollama]
+      : [...HARDCODED_ALLOWLIST, ...userEndpoints];
+  },
   audit: /** @type {any} */ (auditLog.append),
 });
 

--- a/extension/background/settings-patch.js
+++ b/extension/background/settings-patch.js
@@ -184,5 +184,17 @@ export const normalizeSettingsPatch = (patch, {
   if (dwebEnabled && typeof patch.dwebEnabled === 'boolean') {
     next.dwebEnabled = patch.dwebEnabled;
   }
+  // Ollama host (issue #104). Accept ONLY a well-formed http(s) ORIGIN, stored
+  // normalized (origin-only — scheme + host + port, no path/query). why strict:
+  // this value is added to the egress allowlist and fetched with no key, so a
+  // malformed or non-http(s) value must never persist. `new URL(...).origin`
+  // both validates and canonicalizes (drops any path, lowercases the host). A
+  // garbage/non-string/non-http value drops the key, leaving the prior host.
+  if (typeof patch.ollamaHost === 'string') {
+    try {
+      const u = new URL(patch.ollamaHost.trim());
+      if (u.protocol === 'http:' || u.protocol === 'https:') next.ollamaHost = u.origin;
+    } catch { /* not a valid URL — drop the key */ }
+  }
   return next;
 };

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -31,7 +31,7 @@
     "<all_urls>"
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' blob: https: wss: http://localhost:11434",
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' blob: https: wss: http://*:11434",
     "sandbox": "sandbox allow-scripts allow-forms allow-popups allow-modals allow-popups-to-escape-sandbox allow-pointer-lock allow-downloads; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; worker-src 'self' blob:; child-src 'self' blob:;"
   },
   "sandbox": {

--- a/extension/options/sections/providers.js
+++ b/extension/options/sections/providers.js
@@ -426,7 +426,31 @@ export const ProvidersSection = {
         // "Which local model fits this machine?" — only meaningful when
         // local inference is the selected provider.
         effectiveProvider === 'ollama'
-          ? [m('.settings-divider'), m(OllamaRecommendation, { send })]
+          ? [
+              m('.settings-divider'),
+              // Remote Ollama host (issue #104). Empty/default = local loopback.
+              m('.input-row', [
+                m('label', { for: 'ollama-host' }, 'Ollama host'),
+                m('input', {
+                  id: 'ollama-host',
+                  type: 'text',
+                  spellcheck: false,
+                  placeholder: 'http://localhost:11434',
+                  value: state.settings?.ollamaHost ?? '',
+                  onchange: async (/** @type {{ target: HTMLInputElement }} */ e) => {
+                    await send({ type: 'settings/update', patch: { ollamaHost: e.target.value } });
+                    m.redraw();
+                  },
+                }),
+              ]),
+              m('p.hint', [
+                'The Ollama daemon URL — default ', m('code', 'http://localhost:11434'),
+                '. For a daemon on another machine, enter its address (e.g. ',
+                m('code', 'http://192.168.1.4:11434'), '). Over plain HTTP only the standard ',
+                m('code', '11434'), ' port is reachable; an HTTPS-fronted host works on any port.',
+              ]),
+              m(OllamaRecommendation, { send }),
+            ]
           : null,
         m('.input-row', [
           m('label', { for: 'runner-model' }, 'Page-reader model'),

--- a/extension/peerd-provider/adapters/ollama.js
+++ b/extension/peerd-provider/adapters/ollama.js
@@ -31,10 +31,26 @@ import {
   OllamaNotRunningError,
 } from '../errors.js';
 
-const ORIGIN = 'http://localhost:11434';
-const ENDPOINT = `${ORIGIN}/v1/chat/completions`;
-const TAGS_ENDPOINT = `${ORIGIN}/api/tags`;
-const SHOW_ENDPOINT = `${ORIGIN}/api/show`;
+// The default daemon origin (local loopback). A user with a remote/LAN Ollama
+// box overrides it via the `ollamaHost` setting (issue #104), threaded into each
+// call below. localhost:11434 + 127.0.0.1:11434 are on the hardcoded egress
+// allowlist; a custom host is added to the allowlist from its setting.
+const DEFAULT_ORIGIN = 'http://localhost:11434';
+
+/**
+ * Build the three Ollama endpoints from a host. `host` is a normalized origin
+ * (settings-patch validates it to `new URL(...).origin`); we still strip a
+ * trailing slash and fall back to the loopback default defensively.
+ * @param {string} [host]
+ */
+const endpointsFor = (host) => {
+  const origin = String(host || DEFAULT_ORIGIN).replace(/\/+$/, '');
+  return {
+    completions: `${origin}/v1/chat/completions`,
+    tags: `${origin}/api/tags`,
+    show: `${origin}/api/show`,
+  };
+};
 
 // why 120s (vs the 45s the cloud adapters use): Ollama sends response
 // headers only after the model is LOADED into memory — a cold start on a
@@ -66,6 +82,10 @@ export const DEFAULT_MODEL = 'qwen3:8b';
  * @param {ReadonlyArray<{ name: string, description: string, schema: object }>} [args.tools]
  * @param {(resource: string | URL | Request, init?: RequestInit) => Promise<Response>} args.safeFetch
  * @param {AbortSignal} [args.signal]
+ * @param {string} [args.ollamaHost]
+ *   Daemon base URL (issue #104). Defaults to the local loopback; a remote/LAN
+ *   host is threaded in from the `ollamaHost` setting. Must already be on the
+ *   egress allowlist (the SW adds the configured host).
  * @param {(ms: number, signal?: AbortSignal) => Promise<void>} [args._sleep]
  *   Test seam for the connection-drop retry backoff — same contract as the
  *   other adapters' _sleep. Production callers leave it undefined.
@@ -79,9 +99,11 @@ export async function* callOllama(args) {
     tools,
     safeFetch,
     signal,
+    ollamaHost,
     _sleep = abortableSleep,
   } = args;
 
+  const { completions: ENDPOINT } = endpointsFor(ollamaHost);
   const body = toOpenAiBody({ model, system, messages, tools, maxTokens });
   const requestInit = {
     method: 'POST',
@@ -138,9 +160,11 @@ export async function* callOllama(args) {
  * @param {Object} deps
  * @param {(resource: string | URL | Request, init?: RequestInit) => Promise<Response>} deps.safeFetch
  * @param {AbortSignal} [deps.signal]
+ * @param {string} [deps.ollamaHost] daemon base URL (issue #104); defaults to loopback.
  * @returns {Promise<Array<{ model: string, label: string, sizeBytes: number }>>}
  */
-export const listOllamaModels = async ({ safeFetch, signal }) => {
+export const listOllamaModels = async ({ safeFetch, signal, ollamaHost }) => {
+  const { tags: TAGS_ENDPOINT } = endpointsFor(ollamaHost);
   let res;
   try {
     res = await safeFetch(TAGS_ENDPOINT, { method: 'GET', signal });
@@ -189,10 +213,12 @@ export const listOllamaModels = async ({ safeFetch, signal }) => {
  * @param {string} args.model
  * @param {(resource: string | URL | Request, init?: RequestInit) => Promise<Response>} args.safeFetch
  * @param {AbortSignal} [args.signal]
+ * @param {string} [args.ollamaHost] daemon base URL (issue #104); defaults to loopback.
  * @returns {Promise<number | null>}
  */
-export const fetchOllamaContextWindow = async ({ model, safeFetch, signal }) => {
+export const fetchOllamaContextWindow = async ({ model, safeFetch, signal, ollamaHost }) => {
   if (typeof model !== 'string' || !model) return null;
+  const { show: SHOW_ENDPOINT } = endpointsFor(ollamaHost);
   return fetchModelWindow({
     safeFetch,
     url: SHOW_ENDPOINT,
@@ -233,7 +259,9 @@ export const fetchOllamaContextWindow = async ({ model, safeFetch, signal }) => 
 export const ollamaAdapter = Object.freeze({
   name: 'ollama',
   label: 'Ollama (local)',
-  endpoint: ENDPOINT,
+  // Informational default; the live endpoint is built per-call from the
+  // `ollamaHost` setting (endpointsFor) so a remote daemon works (issue #104).
+  endpoint: `${DEFAULT_ORIGIN}/v1/chat/completions`,
   defaultModel: DEFAULT_MODEL,
   // why: Ollama has no separate fast/cheap tier the way the cloud gateways
   // do — the runner rides the same local model as chat. Set it explicitly

--- a/extension/peerd-provider/registry.js
+++ b/extension/peerd-provider/registry.js
@@ -116,7 +116,9 @@ export const listProviders = () =>
  * callers can surface the legible message.
  *
  * @param {string} name
- * @param {{ safeFetch: Function, signal?: AbortSignal }} deps
+ * @param {{ safeFetch: Function, signal?: AbortSignal, ollamaHost?: string }} deps
+ *   ollamaHost (issue #104) routes the live inventory to a remote daemon; other
+ *   adapters ignore it.
  * @returns {Promise<Array<{ model: string, label: string }> | null>}
  */
 export const listProviderModels = async (name, deps) => {

--- a/extension/peerd-provider/registry.js
+++ b/extension/peerd-provider/registry.js
@@ -137,7 +137,8 @@ export const listProviderModels = async (name, deps) => {
  *
  * @param {string} name
  * @param {string} model
- * @param {{ getSecret: Function, safeFetch: Function, signal?: AbortSignal }} deps
+ * @param {{ getSecret: Function, safeFetch: Function, signal?: AbortSignal, ollamaHost?: string }} deps
+ *   ollamaHost (issue #104) routes the live /api/show window to a remote daemon.
  * @returns {Promise<number | null>}
  */
 export const providerModelContextWindow = async (name, model, deps) => {

--- a/extension/peerd-runtime/loop/turn-driver.js
+++ b/extension/peerd-runtime/loop/turn-driver.js
@@ -432,12 +432,16 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
   const callModelWithFailover = async function* (/** @type {any} */ modelArgs) {
     const start = failoverLastGood ?? { provider: modelArgs.provider, model: modelArgs.model };
     const chain = resolveFailoverChain(start);
+    // why: the Ollama adapter reads `ollamaHost` to reach a remote daemon (issue
+    // #104). Thread it from settings for every candidate; non-ollama adapters
+    // ignore the extra arg. (The configured host is also on the egress allowlist.)
+    const ollamaHost = settingsStore.get().ollamaHost;
     let lastErr;
     for (let i = 0; i < chain.length; i++) {
       const cand = chain[i];
       let streamedContent = false;
       try {
-        for await (const ev of callModel({ ...modelArgs, provider: cand.provider, model: cand.model })) {
+        for await (const ev of callModel({ ...modelArgs, ollamaHost, provider: cand.provider, model: cand.model })) {
           // rate-limit-pause is the adapter's pre-stream backoff signal, not
           // model output — failover stays safe while only those have flowed.
           if (ev.type !== 'rate-limit-pause') streamedContent = true;

--- a/extension/shared/channel-config.js
+++ b/extension/shared/channel-config.js
@@ -27,6 +27,7 @@ export const CHANNEL_DEFAULTS = Object.freeze({
   reasoningEffort: "medium",
   providerName: "",
   providerModel: "",
+  ollamaHost: "http://localhost:11434",
   openrouterModels: [],
   advancedAutomationEnabled: true,
   runnerModel: "",

--- a/manifests/base.json
+++ b/manifests/base.json
@@ -37,7 +37,7 @@
   ],
 
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' blob: https: wss://disks.webvm.io http://localhost:11434",
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' blob: https: wss://disks.webvm.io http://*:11434",
     "sandbox": "sandbox allow-scripts allow-forms allow-popups allow-modals allow-popups-to-escape-sandbox allow-pointer-lock allow-downloads; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; worker-src 'self' blob:; child-src 'self' blob:;"
   },
 

--- a/manifests/dev.patch.json
+++ b/manifests/dev.patch.json
@@ -10,7 +10,7 @@
     "default_title": "peerd (dev)"
   },
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' blob: https: wss: http://localhost:11434"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' blob: https: wss: http://*:11434"
   },
   "web_accessible_resources": [
     {

--- a/manifests/preview.patch.json
+++ b/manifests/preview.patch.json
@@ -13,6 +13,6 @@
     "default_title": "peerd preview"
   },
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' blob: https: wss://disks.webvm.io wss://bootstrap.peerd.ai http://localhost:11434"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' blob: https: wss://disks.webvm.io wss://bootstrap.peerd.ai http://*:11434"
   }
 }

--- a/packaging/default-settings.mjs
+++ b/packaging/default-settings.mjs
@@ -86,6 +86,13 @@ export const defaults = {
   providerName: { store: '', preview: '' },
   providerModel: { store: '', preview: '' },
 
+  // Ollama daemon base URL (issue #104). Default is the local loopback; a user
+  // running Ollama on a separate box (a dedicated Mac mini, a LAN server) points
+  // this at it (e.g. http://192.168.1.4:11434). Validated to an http(s) origin
+  // at write (settings-patch), added to the egress allowlist, and reached by the
+  // adapter for /v1/chat/completions, /api/tags, and /api/show.
+  ollamaHost: { store: 'http://localhost:11434', preview: 'http://localhost:11434' },
+
   // Curated OpenRouter model ids the chat model-picker offers (OpenRouter is
   // a gateway to hundreds of models — too many to dump in a dropdown, so the
   // user checks the ones they want in Settings). Empty = fall back to the

--- a/tests/background/settings-patch.test.ts
+++ b/tests/background/settings-patch.test.ts
@@ -123,3 +123,24 @@ describe('normalizeSettingsPatch — dweb gate', () => {
     expect(norm({ dwebEnabled: 'yes' })).toEqual({});
   });
 });
+
+describe('normalizeSettingsPatch — ollamaHost (issue #104)', () => {
+  test('keeps a valid http(s) origin', () => {
+    expect(norm({ ollamaHost: 'http://localhost:11434' })).toEqual({ ollamaHost: 'http://localhost:11434' });
+    expect(norm({ ollamaHost: 'http://192.168.1.4:11434' })).toEqual({ ollamaHost: 'http://192.168.1.4:11434' });
+    expect(norm({ ollamaHost: 'https://ollama.example.com' })).toEqual({ ollamaHost: 'https://ollama.example.com' });
+  });
+  test('canonicalizes to the ORIGIN — strips path/query/trailing slash, trims whitespace', () => {
+    expect(norm({ ollamaHost: 'http://192.168.1.4:11434/' })).toEqual({ ollamaHost: 'http://192.168.1.4:11434' });
+    expect(norm({ ollamaHost: 'http://192.168.1.4:11434/api/tags' })).toEqual({ ollamaHost: 'http://192.168.1.4:11434' });
+    expect(norm({ ollamaHost: '  http://192.168.1.4:11434  ' })).toEqual({ ollamaHost: 'http://192.168.1.4:11434' });
+  });
+  test('drops a non-http(s) scheme, a malformed URL, a bare host, and a non-string', () => {
+    expect(norm({ ollamaHost: 'ftp://192.168.1.4:11434' })).toEqual({});  // only http(s)
+    expect(norm({ ollamaHost: 'file:///etc/passwd' })).toEqual({});
+    expect(norm({ ollamaHost: '192.168.1.4:11434' })).toEqual({});         // missing scheme
+    expect(norm({ ollamaHost: 'not a url' })).toEqual({});
+    expect(norm({ ollamaHost: '' })).toEqual({});
+    expect(norm({ ollamaHost: 123 })).toEqual({});
+  });
+});

--- a/tests/peerd-provider/ollama-adapter.test.ts
+++ b/tests/peerd-provider/ollama-adapter.test.ts
@@ -190,3 +190,53 @@ describe('listOllamaModels', () => {
     expect(err.status).toBe(403);
   });
 });
+
+describe('remote host — ollamaHost (issue #104)', () => {
+  test('callOllama posts to the CONFIGURED host, not localhost', async () => {
+    let url = '';
+    await drain(callOllama({
+      ...baseArgs,
+      ollamaHost: 'http://192.168.1.4:11434',
+      safeFetch: async (u: any) => { url = String(u); return okStreamingResponse([
+        'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n',
+        'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+        'data: [DONE]\n\n',
+      ]); },
+    } as any));
+    expect(url).toBe('http://192.168.1.4:11434/v1/chat/completions');
+  });
+
+  test('listOllamaModels reads /api/tags on the configured host', async () => {
+    let url = '';
+    const models = await listOllamaModels({
+      ollamaHost: 'http://192.168.1.4:11434',
+      safeFetch: async (u: any) => { url = String(u); return /** @type {any} */ ({
+        ok: true, status: 200, headers: new Headers(),
+        json: async () => ({ models: [{ name: 'qwen3:8b', size: 1 }] }),
+      }); },
+    } as any);
+    expect(url).toBe('http://192.168.1.4:11434/api/tags');
+    expect(models[0].model).toBe('qwen3:8b');
+  });
+
+  test('defaults to the local loopback when no host is given (back-compat)', async () => {
+    let url = '';
+    await listOllamaModels({
+      safeFetch: async (u: any) => { url = String(u); return /** @type {any} */ ({
+        ok: true, status: 200, headers: new Headers(), json: async () => ({ models: [] }),
+      }); },
+    } as any);
+    expect(url).toBe('http://localhost:11434/api/tags');
+  });
+
+  test('a trailing slash on the host is stripped, not doubled', async () => {
+    let url = '';
+    await listOllamaModels({
+      ollamaHost: 'http://192.168.1.4:11434/',
+      safeFetch: async (u: any) => { url = String(u); return /** @type {any} */ ({
+        ok: true, status: 200, headers: new Headers(), json: async () => ({ models: [] }),
+      }); },
+    } as any);
+    expect(url).toBe('http://192.168.1.4:11434/api/tags');
+  });
+});

--- a/tests/peerd-provider/ollama-adapter.test.ts
+++ b/tests/peerd-provider/ollama-adapter.test.ts
@@ -11,6 +11,7 @@ import { describe, test, expect } from 'bun:test';
 import {
   callOllama,
   listOllamaModels,
+  fetchOllamaContextWindow,
   ollamaAdapter,
 } from '../../extension/peerd-provider/adapters/ollama.js';
 import {
@@ -238,5 +239,18 @@ describe('remote host — ollamaHost (issue #104)', () => {
       }); },
     } as any);
     expect(url).toBe('http://192.168.1.4:11434/api/tags');
+  });
+
+  test('fetchOllamaContextWindow queries /api/show on the configured host', async () => {
+    let url = '';
+    const w = await fetchOllamaContextWindow({
+      model: 'qwen3:8b',
+      ollamaHost: 'http://192.168.1.4:11434',
+      safeFetch: async (u: any) => { url = String(u); return /** @type {any} */ ({
+        ok: true, status: 200, headers: new Headers(), json: async () => ({ parameters: 'num_ctx 8192' }),
+      }); },
+    } as any);
+    expect(url).toBe('http://192.168.1.4:11434/api/show');
+    expect(w).toBe(8192);
   });
 });

--- a/tests/store/store-posture.test.ts
+++ b/tests/store/store-posture.test.ts
@@ -75,17 +75,25 @@ describe('store manifest posture', () => {
     expect(csp).not.toMatch(/\bwss:(?!\/\/)/);
   });
 
-  test('connect-src admits the local Ollama daemon on every channel', () => {
-    // The native Ollama adapter ships in the box, so the store package now
-    // GENUINELY uses http://localhost:11434 — declaring it no longer
-    // violates the "never request what the shipped version doesn't use"
-    // store posture. Pinned exact-origin (scheme+host+port), not a
-    // scheme wildcard.
+  test('connect-src admits Ollama on the standard port, host-wildcard but PORT-SCOPED (issue #104)', () => {
+    // The native Ollama adapter ships in the box and now supports a REMOTE
+    // daemon (issue #104, e.g. a LAN box at http://192.168.1.4:11434). MV3 CSP
+    // can't be set dynamically, so the host can't be pinned at build time — the
+    // connect-src is a HOST wildcard on the standard Ollama port: http://*:11434.
+    // The real gate stays the exact-origin EGRESS allowlist (the SW adds only the
+    // user's configured host); this CSP entry is the browser-level permission.
+    // The invariant pinned here: the wildcard is PORT-SCOPED (only :11434) — no
+    // blanket http: and no plain-http on any other port (an HTTPS-fronted remote
+    // host rides the existing `https:`).
     for (const mf of [manifest, preview]) {
       const csp = mf.content_security_policy?.extension_pages ?? '';
-      expect(csp).toContain('http://localhost:11434');
-      // No blanket http: — only the pinned loopback origin.
-      expect(csp).not.toMatch(/\bhttp:(?!\/\/localhost:11434)/);
+      expect(csp).toContain('http://*:11434');
+      // Every plain-http source must be on :11434 — nothing wider slipped in.
+      const httpSources = csp.match(/http:\/\/\S+/g) ?? [];
+      expect(httpSources.length).toBeGreaterThan(0);
+      for (const src of httpSources) expect(src).toMatch(/:11434$/);
+      // No scheme-only `http:` (which would admit any http host on any port).
+      expect(csp).not.toMatch(/\bhttp:(?!\/\/)/);
     }
   });
 


### PR DESCRIPTION
Fixes #104 — a configurable **remote Ollama host**, so a user running Ollama on a separate box (a dedicated Mac mini, a LAN server) can point peerd at it instead of being limited to `localhost`.

### What changed
- **Setting** `ollamaHost` (default `http://localhost:11434`), validated in `settings-patch.js` to a clean http(s) **origin** (`new URL(x).origin` — canonicalizes, strips path/query, rejects non-http(s)/garbage).
- **Adapter** (`peerd-provider/adapters/ollama.js`) builds `/v1/chat/completions`, `/api/tags`, and `/api/show` from the host via `endpointsFor()` (defaults to the loopback).
- **Wiring** — `turn-driver` threads it into every model call; both `listProviderModels` sites (SW live inventory + `provider/test`) and the live context-window fetch pass it.
- **Egress** — the SW adds the configured host's exact origin to `getAllowlist()` so `safeFetch` permits the remote daemon.
- **CSP** — `connect-src` broadened `http://localhost:11434` → `http://*:11434` (port-scoped host wildcard) across all channels. MV3 CSP can't be set dynamically, so the host can't be pinned at build time.
- **UI** — an "Ollama host" input under the Ollama provider, with a hint about the HTTP-port vs HTTPS tradeoff.

### Security posture (the thing to review)
The intent: the agent — **including a prompt-injected one** — can reach **only the user-configured Ollama host** over HTTP, plus the existing allowlist. Verified:
- **The agent cannot change `ollamaHost`.** `settings/update` is a UI-only route; no tool writes settings. The host is user-controlled via Settings only.
- **The egress allowlist stays the tight gate** — exact-origin match; the CSP wildcard is just the browser-level permission, and the effective reachable set is `allowlist ∩ CSP`.
- **No leak to the open-web path.** The credentialed allowlist entry isn't used by `web_fetch`, which is allowlist-free and has its own SSRF/private-network block (so the agent can't reach the LAN host via `web_fetch`).
- The SSRF/private-network guard is intentionally on the open-web path, not this credentialed provider path — so a LAN host is fine here, scoped to the one origin the user set.

⚠️ **Reviewer call to make:** the CSP broadening `http://localhost:11434` → `http://*:11434` (port-scoped, any host on `:11434`). This is the explicit cost of remote Ollama over plain HTTP; an HTTPS-fronted host needs no CSP change (rides the existing `https:`). The `store-posture` test was updated to pin the new posture (port-scoped, no blanket `http:`).

### Known limitation
A remote host on a **non-standard HTTP port** (e.g. `:8080`) is accepted by settings + the allowlist but blocked by the port-scoped CSP → the fetch fails. The UI hint surfaces this ("use HTTPS for any port"); a more legible runtime error is a reasonable follow-up.

### Verification
typecheck · lint · check:boundary · check:tscheck · check:imports · no gen drift · bun **2353** · in-browser **584** · e2e smoke 5/5. New tests cover the host validation, the adapter/inventory/context-window threading, and the updated CSP posture. The adapter defaults to the loopback throughout, so existing local setups are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
