### PR TITLE
proposal(subagent): subagents as async actors — spec + trusted-lineage scaffold

### DIFF
--- a/extension/peerd-runtime/subagent/delegation-lineage.js
+++ b/extension/peerd-runtime/subagent/delegation-lineage.js
@@ -108,3 +108,54 @@ export const mayMessageActor = ({ inbound, senderSessionId, activeSessionId, anc
   // Ran out of chain without reaching the active chat: not a descendant. Refuse.
   return false;
 };
+
+// ── mailbox provenance — the choke-point judgement ──────────────────────────
+//
+// An actor is a serialized CHOKE POINT: one tab (or one origin), one mailbox,
+// one turn at a time. While only the foreground chat messages it, "who sent
+// this" is trivial. Once actors are SHARED — a web actor on a tab that several
+// orchestrators or subagents all message — the actor (and the mailbox in front
+// of it) must arbitrate: coalesce an accidental duplicate, order competing
+// requests, cancel one a newer message supersedes, or keep unrelated senders
+// fair. To make that call it needs each message's PROVENANCE: who sent it, and
+// on whose behalf.
+//
+// The trusted-lineage chain already carries exactly that, so provenance is free
+// once the gate has it. The shell stamps it onto the message ENVELOPE
+// (denormalized) so the actor never has to walk the store mid-turn.
+//
+// why the envelope, not a structured session id: session ids are uuidv7
+// (time-sortable, globally-unique store keys); overloading them with a parent
+// path is brittle to parse and length-bound. The envelope carries the full
+// reference instead — same capability (the actor can name the parent), no id
+// overloading. Encoding it into the id is an owner call; the shape is the same.
+
+/**
+ * The provenance an actor's mailbox stamps on each incoming message, derived
+ * from the sender's trusted-lineage chain.
+ *
+ * @param {Object} req
+ * @param {string} req.senderSessionId
+ * @param {ReadonlyArray<LineageHop>} [req.ancestry]  sender-first chain toward the root
+ * @returns {{ senderSessionId: string, rootSessionId: string, lineagePath: string[] }}
+ *   rootSessionId — the chat at the base of the lineage (who ULTIMATELY asked);
+ *   equals senderSessionId for a top-level chat or a missing chain.
+ *   lineagePath — root → … → sender ids: the "reference to the parent" an actor
+ *   uses to group by root (fairness), match a supersede (same sender), or flag a
+ *   likely duplicate (same lineagePath + same intent, close in time).
+ */
+export const messageProvenance = ({ senderSessionId, ancestry = [] }) => {
+  const byId = new Map(ancestry.map((h) => [h.sessionId, h]));
+  const path = [senderSessionId];
+  const seen = new Set([senderSessionId]);
+  let cursor = /** @type {LineageHop | undefined} */ (byId.get(senderSessionId));
+  // Walk parentSessionId up to the root; the cycle guard keeps a corrupt chain
+  // from hanging us (a self-referential parent just stops the walk).
+  while (cursor?.parentSessionId && !seen.has(cursor.parentSessionId)) {
+    path.push(cursor.parentSessionId);
+    seen.add(cursor.parentSessionId);
+    cursor = byId.get(cursor.parentSessionId);
+  }
+  path.reverse();                 // root → … → sender
+  return { senderSessionId, rootSessionId: path[0], lineagePath: path };
+};

--- a/extension/peerd-runtime/subagent/delegation-lineage.js
+++ b/extension/peerd-runtime/subagent/delegation-lineage.js
@@ -1,0 +1,110 @@
+// @ts-check
+// delegation-lineage — the PURE trust decision for the "subagents as async
+// actors" refactor (PROPOSAL, inert until wired). See PR body for the full spec.
+//
+// PROBLEM. Today a subagent and a message_actor actor are two different async
+// lifecycles. The one that matters here: a subagent CANNOT message an actor, so
+// a subagent can't drive a tab / VM / notebook the way the orchestrator can.
+// What blocks it is the sender gate's IDENTITY check
+// (subagent/actor-messaging.js — `senderSessionId !== active` refuses), which
+// uses "are you the foreground chat" as a stand-in for "are you trusted." A
+// subagent runs under a child session id that is never `currentSessionId`, so it
+// is refused even though it is a first-party descendant of the active chat.
+//
+// THE FIX (this file is its crux). Replace the `=== active` identity check with
+// a trusted-LINEAGE check: a session may message an actor when it is the active
+// chat OR a descendant of it reached ENTIRELY through trusted SPAWN edges. Two
+// walls stay exactly as they are:
+//   1. the inbound wall — `inbound === true` still refuses. `inbound` is the
+//      turn's untrusted-origin flag (synthetic && !trusted, service-worker.js).
+//      It is what keeps an injected/synthetic re-entry from delegating, and it is
+//      ALSO what keeps an async-subagent's RESULT-wake from delegating (that wake
+//      re-enters the parent trusted:false → inbound:true), preserving the explicit
+//      "a parent reacting to a child result is not trusted to delegate" decision.
+//      So the RESULT edge needs no handling here: the inbound wall already covers it.
+//   2. the capability strip — message_actor's ctx closure survives only for a ctx
+//      whose toolset grants message_actor (spawn.js CAPABILITY_CONSUMERS). A
+//      tools:[] fan-out child still can't delegate. Unchanged.
+//
+// THE HOLE THIS CLOSES (why lineage alone is not enough). An INBOUND turn on the
+// active chat is refused message_actor directly — but it can still call
+// spawn_subagent, and the child it spawns runs non-inbound turns. Without care,
+// that child would be a "descendant of the active chat" and could message actors
+// on the injected turn's behalf — laundering delegation around the inbound wall.
+// So a spawn edge is trusted ONLY when the spawning turn was itself trusted
+// (not inbound). The shell stamps that verdict onto the child at spawn time
+// (`spawnedTrusted`), and one untrusted spawn taints its whole subtree. Because
+// parentSessionId is set server-side at sessions.create (never model-supplied),
+// the ancestry chain itself is not attacker-forgeable; the only thing that can
+// downgrade trust is an inbound spawning turn, which is exactly what we taint on.
+//
+// PURE (no IO) → Bun-testable. The imperative shell (actor-messaging.js, once
+// wired) builds `ancestry` by walking parentSessionId up from the sender via the
+// session store, then asks this function yes/no. This function reads values only.
+
+// Feature flag for the refactor. OFF here: nothing imports this yet, so the live
+// sender gate keeps its `=== active` behavior and runtime is unchanged. The
+// follow-up implementation flips this and routes the gate through
+// mayMessageActor() (plus the abortable/timeout-bounded ephemeral-actor
+// lifecycle described in the PR body).
+export const ASYNC_SUBAGENT_ACTORS = false;
+
+/**
+ * One hop of a sender's ancestry: a session record reduced to the fields the
+ * trust decision needs. Nearest-first (the sender itself is index 0).
+ * @typedef {Object} LineageHop
+ * @property {string} sessionId              this session's id
+ * @property {string | null} parentSessionId who spawned it (server-set; null for a root chat)
+ * @property {boolean} spawnedTrusted        was the SPAWNING turn trusted (non-inbound)?
+ *   true for a root chat (nothing spawned it) and for a child spawned by a
+ *   trusted turn; false when an INBOUND turn spawned this session — that taints
+ *   the whole subtree beneath it.
+ */
+
+/**
+ * May `senderSessionId` send a message to an actor? The trusted-lineage rule
+ * that replaces the sender gate's `senderSessionId === active` identity check.
+ *
+ * Accept iff, in order:
+ *   1. the current turn is NOT inbound (untrusted-origin wall, unchanged), AND
+ *   2. the sender IS the active chat, OR it is a descendant of the active chat
+ *      whose entire ancestry up to the active chat was spawned by trusted turns.
+ *
+ * @param {Object} req
+ * @param {boolean} req.inbound           the CURRENT turn's untrusted-origin flag
+ * @param {string | null | undefined} req.senderSessionId  the calling session
+ * @param {string | null | undefined} req.activeSessionId  currentSessionId (foreground chat)
+ * @param {ReadonlyArray<LineageHop>} [req.ancestry]  sender-first chain toward the
+ *   root, built by the shell from the store. Omitted/empty → only the direct
+ *   foreground-identity path can pass (fail-closed for a missing chain).
+ * @returns {boolean}
+ */
+export const mayMessageActor = ({ inbound, senderSessionId, activeSessionId, ancestry = [] }) => {
+  // Wall 1 — inbound origin. An injected/synthetic turn (and the async result-
+  // wake) never delegates, no matter whose lineage it runs under. Fail-closed.
+  if (inbound === true) return false;
+  if (!senderSessionId || !activeSessionId) return false;
+
+  // The foreground chat itself — today's sole accepted sender. Kept as a fast path.
+  if (senderSessionId === activeSessionId) return true;
+
+  // Trusted-lineage: walk the sender's ancestry toward the root. The sender is
+  // admitted only if it reaches the active chat AND every hop from the sender up
+  // to (and including) the active chat was spawned by a trusted turn. A single
+  // untrusted (inbound-spawned) hop taints the subtree and refuses.
+  //
+  // why require the sender itself to be spawnedTrusted: the sender is the child
+  // an inbound turn would have spawned to launder access — so its own spawn
+  // verdict is the first thing that must be trusted.
+  const byId = new Map(ancestry.map((h) => [h.sessionId, h]));
+  let cursor = /** @type {LineageHop | undefined} */ (byId.get(senderSessionId));
+  const seen = new Set();                       // cycle guard (a corrupt chain can't hang us)
+  while (cursor && !seen.has(cursor.sessionId)) {
+    if (!cursor.spawnedTrusted) return false;    // an untrusted spawn anywhere → refuse
+    if (cursor.parentSessionId === activeSessionId) return true; // reached the active root cleanly
+    seen.add(cursor.sessionId);
+    cursor = cursor.parentSessionId ? byId.get(cursor.parentSessionId) : undefined;
+  }
+  // Ran out of chain without reaching the active chat: not a descendant. Refuse.
+  return false;
+};

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -42,7 +42,9 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // 475 → 471: the do/get/check cull removed four // @ts-check'd files (the do/
 // get/check tool defs + runner/index.js — the web actor holds the DOM tools
 // directly now). A legitimate decrease (files deleted, not directives dropped).
-const COVERED_FLOOR = 471;
+// 471 → 473: main added one // @ts-check'd file post-cull, and the async-actor
+// proposal adds delegation-lineage.js (the pure trusted-lineage predicate).
+const COVERED_FLOOR = 473;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/tests/peerd-runtime/delegation-lineage.test.ts
+++ b/tests/peerd-runtime/delegation-lineage.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { mayMessageActor, ASYNC_SUBAGENT_ACTORS } from '../../extension/peerd-runtime/subagent/delegation-lineage.js';
+import { mayMessageActor, messageProvenance, ASYNC_SUBAGENT_ACTORS } from '../../extension/peerd-runtime/subagent/delegation-lineage.js';
 
 // The PURE trust decision for the "subagents as async actors" refactor: may a
 // sender session message an actor? It replaces the sender gate's `=== active`
@@ -76,6 +76,43 @@ describe('mayMessageActor — non-descendants and malformed chains fail closed',
   test('a cyclic chain terminates and refuses (never hangs)', () => {
     const ancestry = [hop('a', 'b', true), hop('b', 'a', true)]; // a→b→a, never reaches active
     expect(mayMessageActor({ inbound: false, senderSessionId: 'a', activeSessionId: ACTIVE, ancestry })).toBe(false);
+  });
+});
+
+describe('messageProvenance — the parent reference the choke-point actor arbitrates on', () => {
+  test('a top-level chat is its own root, path is just itself', () => {
+    expect(messageProvenance({ senderSessionId: ACTIVE, ancestry: [] }))
+      .toEqual({ senderSessionId: ACTIVE, rootSessionId: ACTIVE, lineagePath: [ACTIVE] });
+  });
+
+  test('a subagent resolves to its root chat with a root->sender path', () => {
+    const ancestry = [hop('sub-1', ACTIVE, true)];
+    expect(messageProvenance({ senderSessionId: 'sub-1', ancestry }))
+      .toEqual({ senderSessionId: 'sub-1', rootSessionId: ACTIVE, lineagePath: [ACTIVE, 'sub-1'] });
+  });
+
+  test('a grandchild carries the full root->...->sender path', () => {
+    const ancestry = [hop('sub-2', 'sub-1', true), hop('sub-1', ACTIVE, true)];
+    expect(messageProvenance({ senderSessionId: 'sub-2', ancestry }))
+      .toEqual({ senderSessionId: 'sub-2', rootSessionId: ACTIVE, lineagePath: [ACTIVE, 'sub-1', 'sub-2'] });
+  });
+
+  test('two subagents under one chat share a rootSessionId (so the actor can group + be fair)', () => {
+    const a = messageProvenance({ senderSessionId: 'sub-a', ancestry: [hop('sub-a', ACTIVE, true)] });
+    const b = messageProvenance({ senderSessionId: 'sub-b', ancestry: [hop('sub-b', ACTIVE, true)] });
+    expect(a.rootSessionId).toBe(b.rootSessionId);
+    expect(a.senderSessionId).not.toBe(b.senderSessionId);
+  });
+
+  test('a missing chain fails safe: the sender is treated as its own root', () => {
+    expect(messageProvenance({ senderSessionId: 'sub-orphan' }))
+      .toEqual({ senderSessionId: 'sub-orphan', rootSessionId: 'sub-orphan', lineagePath: ['sub-orphan'] });
+  });
+
+  test('a cyclic chain terminates (never hangs)', () => {
+    const ancestry = [hop('a', 'b', true), hop('b', 'a', true)];
+    const p = messageProvenance({ senderSessionId: 'a', ancestry });
+    expect(p.lineagePath[p.lineagePath.length - 1]).toBe('a'); // sender is last, walk stopped
   });
 });
 

--- a/tests/peerd-runtime/delegation-lineage.test.ts
+++ b/tests/peerd-runtime/delegation-lineage.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect } from 'bun:test';
+import { mayMessageActor, ASYNC_SUBAGENT_ACTORS } from '../../extension/peerd-runtime/subagent/delegation-lineage.js';
+
+// The PURE trust decision for the "subagents as async actors" refactor: may a
+// sender session message an actor? It replaces the sender gate's `=== active`
+// identity check with a trusted-LINEAGE check. These tests pin the security
+// invariants the refactor rests on — above all that an inbound (injected) turn
+// cannot launder message_actor access through a subagent it spawns.
+
+const ACTIVE = 'chat-active';
+
+// hop helpers — nearest-first ancestry the shell would build from the store.
+const hop = (sessionId: string, parentSessionId: string | null, spawnedTrusted = true) =>
+  ({ sessionId, parentSessionId, spawnedTrusted });
+
+describe('mayMessageActor — the two unchanged walls', () => {
+  test('inbound turn is ALWAYS refused, even for the active chat itself', () => {
+    // the inbound wall is what blocks an injected/synthetic turn AND the async
+    // result-wake (which re-enters trusted:false → inbound:true) from delegating.
+    expect(mayMessageActor({ inbound: true, senderSessionId: ACTIVE, activeSessionId: ACTIVE })).toBe(false);
+  });
+
+  test('a missing sender or active id fails closed', () => {
+    expect(mayMessageActor({ inbound: false, senderSessionId: null, activeSessionId: ACTIVE })).toBe(false);
+    expect(mayMessageActor({ inbound: false, senderSessionId: ACTIVE, activeSessionId: null })).toBe(false);
+  });
+});
+
+describe('mayMessageActor — the foreground chat (today\'s only accepted sender)', () => {
+  test('the active chat on a real (non-inbound) turn is admitted', () => {
+    expect(mayMessageActor({ inbound: false, senderSessionId: ACTIVE, activeSessionId: ACTIVE })).toBe(true);
+  });
+});
+
+describe('mayMessageActor — trusted-lineage descendants (the new capability)', () => {
+  test('a subagent spawned by the active chat on a trusted turn is admitted', () => {
+    const sender = 'sub-1';
+    const ancestry = [hop(sender, ACTIVE, true)];
+    expect(mayMessageActor({ inbound: false, senderSessionId: sender, activeSessionId: ACTIVE, ancestry })).toBe(true);
+  });
+
+  test('a grandchild reached through all-trusted spawn edges is admitted', () => {
+    const ancestry = [hop('sub-2', 'sub-1', true), hop('sub-1', ACTIVE, true)];
+    expect(mayMessageActor({ inbound: false, senderSessionId: 'sub-2', activeSessionId: ACTIVE, ancestry })).toBe(true);
+  });
+});
+
+describe('mayMessageActor — the laundering hole is closed', () => {
+  test('a subagent spawned by an INBOUND turn is refused (cannot launder access)', () => {
+    // THE THREAT: an injected turn on the active chat is refused message_actor
+    // directly, but calls spawn_subagent; the child runs non-inbound turns. Its
+    // spawn edge is marked untrusted, so it is refused despite rooting at active.
+    const ancestry = [hop('sub-inj', ACTIVE, false)];
+    expect(mayMessageActor({ inbound: false, senderSessionId: 'sub-inj', activeSessionId: ACTIVE, ancestry })).toBe(false);
+  });
+
+  test('taint propagates: a trusted grandchild under an inbound-spawned parent is refused', () => {
+    // sub-1 was spawned by an inbound turn (untrusted); sub-2 under it is clean on
+    // its own edge but the subtree is tainted, so it is still refused.
+    const ancestry = [hop('sub-2', 'sub-1', true), hop('sub-1', ACTIVE, false)];
+    expect(mayMessageActor({ inbound: false, senderSessionId: 'sub-2', activeSessionId: ACTIVE, ancestry })).toBe(false);
+  });
+});
+
+describe('mayMessageActor — non-descendants and malformed chains fail closed', () => {
+  test('a descendant of a DIFFERENT chat (not the active one) is refused', () => {
+    const ancestry = [hop('sub-x', 'chat-other', true), hop('chat-other', null, true)];
+    expect(mayMessageActor({ inbound: false, senderSessionId: 'sub-x', activeSessionId: ACTIVE, ancestry })).toBe(false);
+  });
+
+  test('a non-foreground sender with no ancestry supplied is refused (fail-closed)', () => {
+    expect(mayMessageActor({ inbound: false, senderSessionId: 'sub-orphan', activeSessionId: ACTIVE, ancestry: [] })).toBe(false);
+    expect(mayMessageActor({ inbound: false, senderSessionId: 'sub-orphan', activeSessionId: ACTIVE })).toBe(false);
+  });
+
+  test('a cyclic chain terminates and refuses (never hangs)', () => {
+    const ancestry = [hop('a', 'b', true), hop('b', 'a', true)]; // a→b→a, never reaches active
+    expect(mayMessageActor({ inbound: false, senderSessionId: 'a', activeSessionId: ACTIVE, ancestry })).toBe(false);
+  });
+});
+
+describe('the refactor ships behind a flag, default OFF', () => {
+  test('ASYNC_SUBAGENT_ACTORS is off so nothing is wired yet', () => {
+    expect(ASYNC_SUBAGENT_ACTORS).toBe(false);
+  });
+});


### PR DESCRIPTION
## What & why

**This is a design proposal, not the finished refactor.** It recommends unifying two async-delegation lifecycles that have drifted apart, and lands the load-bearing primitives as reviewable, tested code so you can approve the approach before the risky lifecycle work is built. Nothing here changes runtime behavior — the flag is off and nothing imports the new module.

The follow-up to the do/get/check cull (#133): make **subagents behave like the async actors the orchestrator already delegates to** via `message_actor` — ephemeral actors that eventually complete or time out, and that can themselves message actors.

### The problem: two lifecycles for the same shape

A subagent and a `message_actor` actor both mean "fire work, let it run async, wake the parent with the result." But they are built differently, and the subagent side is the weaker one:

| | subagent (today) | actor (today) |
|---|---|---|
| runs under a turn slot | **no** (`runUserTurn` called directly, `spawn.js`) | yes (`turnSlots.claim`, `turn-driver.js`) |
| abortable mid-flight | **no** — no `AbortSignal` threaded in | yes (Stop cascades via `turnSlots.stop`) |
| wall-clock timeout | **no** (only `maxSteps`/`maxDepth`) | n/a (but re-driveable) |
| can message actors | **no** — sender gate refuses | no (same gate; also not in tool set) |
| result re-enters parent | async wake, `trusted:false` | async wake, `trusted:true` |

Consequences: a subagent can **hang forever** (no timeout, no abort), and it **can't drive a tab / VM / notebook** because it can't call `message_actor`. Two code paths maintain the same async pattern.

### The recommendation

Make a subagent an **ephemeral actor**: the same async machinery as an actor (turn slot, abort signal, durable-style completion, trusted wake), minus the persistence and addressing (no `actor_list` entry, not re-messageable by handle — fire once, complete or time out). The difference between a subagent and an actor becomes *addressing/persistence*, not *lifecycle*.

Seven moving parts, phased so each is independently reviewable:

1. **Run subagents through the turn-slot system with an `AbortSignal`.** Today `spawnSubagent` drives `runUserTurn` directly and threads no signal (`spawn.js`), so a child can't be aborted. Route it through the slot system so Stop reaches it.
2. **Wall-clock timeout** — the "eventually complete or **time out**" you asked for. Abort the child loop past a budget, deliver a timeout note. There is no timeout anywhere today.
3. **Let subagents (and actors) message actors** by replacing the sender gate's `senderSessionId === active` identity check (`actor-messaging.js:243`) with the trusted-lineage predicate in this PR.
4. **Bound the delegation graph.** Runaway caps are per-sender, so a parent↔child↔actor cycle isn't bounded overall. Carry a lineage-total depth/budget (extend the existing `MAX_DEPTH=5` across the whole graph, not just spawn depth).
5. **Multi-hop Stop.** Stop cascades one level today (`routes/sessions.js` → direct in-flight actors). Make it cascade transitively down the lineage.
6. **Keep subagents ephemeral** — no `actor_list` entry, no re-addressing. Persistence is what still separates them from actors.
7. **Provenance-aware mailbox arbitration** for shared actors — see the section below (added from review).

### The security decision (in this PR)

The gate uses "are you the foreground chat" as a proxy for "are you trusted." A subagent runs under a child session id that is never `currentSessionId`, so it's refused even though it's a first-party descendant. `delegation-lineage.js`'s `mayMessageActor` replaces that with a **trusted-lineage** check, keeping two walls exactly as they are:

- **The inbound wall stays.** `inbound === true` (a `synthetic && !trusted` turn) still refuses. That is what blocks an injected/synthetic re-entry — and it is *also* what blocks an async subagent's **result-wake** from delegating (the wake re-enters the parent `trusted:false → inbound:true`), preserving the deliberate "a parent reacting to a child result is not trusted to delegate" decision (`service-worker.js:1487`). So the result edge needs no new handling.
- **The capability strip stays.** `message_actor`'s ctx closure survives only for a context whose toolset grants it (`spawn.js` `CAPABILITY_CONSUMERS`). A `tools:[]` fan-out child still can't delegate.

**The hole it closes.** An inbound turn is refused `message_actor` directly, but it can call `spawn_subagent`, and the child runs non-inbound turns. Without care, that child would be a "descendant of the active chat" and could message actors on the injected turn's behalf. So a spawn edge is trusted **only when the spawning turn was itself trusted (not inbound)**; the shell stamps that verdict onto the child at spawn time (`spawnedTrusted`), and one untrusted spawn taints its whole subtree. `parentSessionId` is set server-side at `sessions.create`, so the chain itself isn't forgeable — the only thing that can downgrade trust is an inbound spawning turn, which is exactly what we taint on.

### Shared actors: mailbox provenance and the choke-point judgement (from review)

An actor is a serialized **choke point**: one tab (or one origin), one mailbox, one turn at a time. While only the foreground chat messages it, "who sent this" is trivial. Once actors are **shared** — a web actor on a tab that several orchestrators or subagents all message — the actor (and the mailbox in front of it) has to arbitrate: coalesce an accidental duplicate, order competing requests, cancel one a newer message supersedes, or keep unrelated senders fair. To do that it needs each message's **provenance**: who sent it, and on whose behalf.

The trusted-lineage chain already carries exactly that, so provenance is **free** once the gate has it. `delegation-lineage.js`'s `messageProvenance` (also in this PR) derives `{ senderSessionId, rootSessionId, lineagePath }` from the same chain — `rootSessionId` is who ultimately asked, `lineagePath` is the full `root → … → sender` reference. The shell stamps it onto the message **envelope** (denormalized) so the actor never walks the store mid-turn. With that in hand the mailbox can: **dedupe** (same `lineagePath` + same intent, close in time → likely a double-fire, coalesce or cancel-and-replace), **order/fair-share** (group by `rootSessionId` so one busy lineage can't starve another), and **supersede** (a newer request from the same sender cancels its in-flight one).

On where the parent reference lives: I'd keep session ids as opaque uuidv7 (time-sortable, globally-unique store keys) and put the reference on the **envelope** rather than encode it into the id — same capability, no brittle id parsing. Encoding it into the id instead is an owner call; the provenance shape is identical either way.

### Open decisions for you

- **Timeout budget**: wall-clock ceiling for an ephemeral actor, and whether it's per-turn or whole-run.
- **Graph bound**: reuse `MAX_DEPTH=5` as a lineage-total, or a separate delegation budget?
- **Actor→actor too?** The same lineage change unblocks actor→actor messaging (an actor session is also never `active`). Do we want that now, or keep it subagent→actor only?
- **Mailbox arbitration policy**: which of dedupe / ordering / supersede / fairness the actor applies by default, and how much the model gets to decide vs. the mailbox enforcing mechanically.
- **Parent reference location**: envelope provenance (recommended) vs. encoding lineage into the session id.
- **Ephemeral vs listed**: confirm subagents stay out of `actor_list` (fire-once), so the taxonomy stays "actor = addressable/persistent, subagent = ephemeral."

## Checklist

- [x] `bun run preflight` gates pass locally (2362 bun tests, typecheck, eslint, tscheck floor 473, no manifest drift)
- [x] Commits are signed off
- [x] Only original code
- [x] Tests added (the trusted-lineage predicate incl. the laundering-hole + taint cases; the provenance derivation incl. shared-root + cycle-safety)
- [x] No hand-edited generated files
- [x] Touches a **danger zone** — the actor sender gate. See below.

## Notes for reviewers

Danger zone: this proposes a change to the `message_actor` sender gate, the seam that authorizes delegation.

- **Nothing is wired yet.** `ASYNC_SUBAGENT_ACTORS` is `false`, `delegation-lineage.js` has no importers, and the live gate is untouched — runtime behavior is identical to `main`. This PR is the design (body) plus the crux primitives (`mayMessageActor` trust, `messageProvenance` arbitration) as tested code, for approval before the lifecycle work.
- The predicate deliberately does **not** relax the inbound wall; it only replaces the `=== active` *identity* half of the gate with a *lineage* check, and taints the spawn edge by inbound provenance so the injected-turn laundering path is closed.
- Grounded in a code recon of both lifecycles and the gate; file:line references above point at the exact seams the follow-up would change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCcVD9PK3ySvLbKoB1vMhS