### PR TITLE
feat(subagent): subagents as async actors (#134) + walkId cardinality guard (#36) + CLAUDE.md refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,7 +286,15 @@ gotchas to know going in:
   `background/debugger-pool.js`.
 - Subagents — depth-bounded recursion (default `MAX_DEPTH=5`), tool
   narrowing, output cap. Real implementation at
-  `peerd-runtime/subagent/spawn.js` — not a stub.
+  `peerd-runtime/subagent/spawn.js` — not a stub. Since the async-actor
+  unification (PR #134): a child runs under its own turn slot with an
+  abort signal and a wall-clock timeout (Stop and `subagent_cancel`
+  actually end its work, transitively down the subtree), and a
+  trusted-lineage subagent may `message_actor` — the sender gate walks
+  server-stamped `spawnedTrusted` hops (`subagent/delegation-lineage.js`;
+  an inbound spawn taints its whole subtree), delegation budgets are
+  keyed by the lineage root, and a subagent's actor reply resolves into
+  its tool result (an ephemeral child has no later turn to wake).
 - Voice — local transcription via Moonshine (WASM, SRI-pinned model
   download, OPFS-cached) with a Web Speech API fallback. Hosted in the
   offscreen doc (`peerd-runtime/voice/`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Each maps to one letter and color in the brand wordmark:
 | `p` | cyan    | `peerd-provider/`     | Model adapters (Anthropic + OpenRouter + Ollama shipped; OpenAI later; local WebGPU deferred) |
 | `e` | red     | `peerd-egress/`       | Security: vault, allowlist (`safeFetch`), denylist, audit |
 | `e` | amber   | `peerd-engine/`       | Execution instances — Sandboxes. Three kinds run in their own visible tab: WebVMs (CheerpX Linux), Notebooks (sealed JS worker + OPFS), Apps (opaque-origin iframe). A fourth, the **headless worker** (`js_run`), runs the Notebook's sealed worker offscreen with no tab — the agent's own quick compute. The sandbox is the isolate; a tab is one way to host it (taxonomy in the `peerd-engine/` code). |
-| `r` | green   | `peerd-runtime/`      | Agent loop, tools + do/get/check runner, sessions, profiles, skills, memory, permissions (Plan/Act), review, goal mode (autonomous loop), composer, cost, transfer, voice, clock, web tool policy |
+| `r` | green   | `peerd-runtime/`      | Agent loop, tools + per-environment actors (`message_actor`), sessions, profiles, skills, memory, permissions (Plan/Act), review, goal mode (autonomous loop), composer, cost, transfer, voice, clock, web tool policy |
 | `d` | magenta | `peerd-distributed/` | The dweb. An always-on P2P base network (offscreen mesh + DHT + gossip), did:key identity, signed content addressing, the dwapp bridge, and a peer-to-peer app store that **users AND the agent** build, share, and run dwapps on. Preview channel only |
 
 The extension *chassis* lives outside these modules: `background/`,
@@ -191,8 +191,9 @@ prose orientation is this file, and the rest is the source itself.
   for byte/codec work, reverse iteration, retry loops, or early-exit).
   Name things in full so identifiers read like the docs. **Exception: the
   injected-into-page classic-script bodies** (`dom/walk-injected.js`,
-  `dom/framework-state.js`, `background/debugger-pool.js`,
-  `tools/defs/watch-changes.js`) are deliberately ES5 — `var`, `function`
+  `dom/framework-state.js`, `dom/pull-in-hint-injected.js`,
+  `background/debugger-pool.js`, `tools/defs/watch-changes.js`) are
+  deliberately ES5 — `var`, `function`
   bound to a caller `this` — and are exempted in the config. Don't
   "modernize" them. The same one-paragraph reminder rides the `js_create`
   / `app_create` tool results (`tools/defs/code-style-note.js`) so the
@@ -224,11 +225,18 @@ exists today:
 5. **`peerd-runtime`** — agent loop, tool dispatcher, and the tool
    inventory. Registered tools are assembled from `BUILTIN_TOOLS`, clock,
    web tools, and service-worker wiring; do not pin the live counts in
-   prose. Exposure is decided in `tools/exposure.js`: low-level DOM/page
-   tools are runner-only, the main agent reaches the page through
-   `do`/`get`/`check`, and dweb tools are invisible where `DWEB_ENABLED`
-   is false. Plus sessions, clock (temporal grounding), subagent
-   orchestrator, voice (Moonshine WASM + Web Speech fallback).
+   prose. Exposure is decided in `tools/exposure.js`: the low-level
+   DOM/page tools are actor-only, never on the main agent — the
+   orchestrator delegates plain-language goals to per-environment
+   actors (web / webvm / notebook / app) via `message_actor`
+   (`subagent/actor-messaging.js`; `actor_list` enumerates every
+   addressable handle), and replies re-enter it fenced on a later
+   turn — it never blocks. The web actor (`subagent/web-actor.js`) is
+   the single entry point for web work: it picks between a sessionless,
+   denylist-gated `fetch_url` and opening + driving a tab. Dweb tools
+   are invisible where `DWEB_ENABLED` is false. Plus sessions, clock
+   (temporal grounding), subagent orchestrator, voice (Moonshine WASM
+   + Web Speech fallback).
 6. **Wire it together** in `background/service-worker.js` — message
    routing, dependency injection, lifecycle wiring. The SW is wiring
    plus per-route message handlers (one per RPC the side panel /
@@ -263,7 +271,7 @@ gotchas to know going in:
   package and from every Firefox package (`packaging/gen-manifest.ts`
   `STORE_STRIPPED_PERMISSIONS`; re-added to a store update post-approval —
   a one-line flip; `docs/store/OPEN-DECISIONS.md` §1). The DEFAULT
-  browser-subagent path on store-Chrome AND Firefox is
+  path for the web actor's DOM tools on store-Chrome AND Firefox is
   `chrome.scripting`: a DOM-walk pseudo-a11y snapshot
   (`peerd-runtime/dom/walk-injected.js`) feeding the SAME serializer as
   CDP, with selector/`walkId` click/type and a `world:'MAIN'` `read_state`
@@ -292,15 +300,20 @@ gotchas to know going in:
 - Policy-gated dispatcher with full lineage attached to every tool
   result. The live stack is defined in `gates.js` plus the default
   pre/post tool-use hooks; keep prose at the invariant level so it does
-  not drift. Current posture in code: Plan/Act enforcement, main-vs-runner
-  exposure checks, sensitive-origin blocking, async confirmation, egress
+  not drift. Current posture in code: Plan/Act enforcement, main-vs-actor
+  exposure enforcement (the exposure + actor-capability-tier gates:
+  actor-only tools refused for the main turn, each actor positively
+  pinned to its own kind's toolset and instance), sensitive-origin
+  blocking, async confirmation, egress
   enforcement in the allowlist hook and fetch wrappers, and append-only
   audit. The legacy permission-mode axis was REMOVED
   2026-06-12 — Plan/Act + the denylist carry the safety weight; Plan
   permits pure URL loads only, never clicks (enforced in `gates.js`).
 - The ten-feature buildout — memory, edit + checkpoints, Plan/Act,
   composer (slash commands + @-refs), goal mode (autonomous loop), cost telemetry, skills,
-  review subagent, hooks, and do/get/check — all integrated. Per-feature
+  review subagent, and hooks — all integrated. (The tenth, do/get/check,
+  was CULLED 2026-07-01: the web actor drives pages directly, so one
+  delegation reaches the page instead of two.) Per-feature
   detail lives in the code, under `peerd-runtime/` and its README.
 - Dual distribution: store (no dweb) + preview channels, generated
   `manifest.json` / `channel-config.js` (`bun run gen:dev`). `package.json`,
@@ -329,10 +342,10 @@ land with deliberate design work):
   (the `/tools` presets + `session.toolManifest`; `tools/manifests.js`,
   `tools/manifest-command.js`, enforced in `gates.js`), on top of the
   registration/exposure split. What's still ahead is binding a manifest to
-  a *profile* (rides the Profiles item above). Note: the do/get/check
-  browser-runner is already trimmed to a tight allow-list by
-  construction (`runner/index.js` READ_TOOLSET / DO_TOOLSET) — it never
-  sees the full surface.
+  a *profile* (rides the Profiles item above). Note: the per-environment
+  actors are already trimmed to tight per-kind allow-lists by
+  construction (`tools/exposure.js` `actorAllowedTools`, enforced at
+  dispatch in `gates.js`) — an actor never sees the full surface.
 - OpenAI provider adapter — the file doesn't exist yet (OpenRouter
   covers most vendors meanwhile; Ollama shipped 2026-06-12 with its
   `http://localhost:11434` CSP connect-src entry restored in

--- a/extension/background/routes/sessions.js
+++ b/extension/background/routes/sessions.js
@@ -21,6 +21,7 @@ export const makeSessionRoutes = (deps) => {
     postChatNote, spawnSubagent, requestReview, appClient,
     browser, originOfTabUrl, matchesDenylist, denylistStore,
     startGoalRun, haltGoalRun, ensureSession, actorMessaging,
+    subagentLifecycle,
   } = deps;
 
   return {
@@ -55,6 +56,19 @@ export const makeSessionRoutes = (deps) => {
           if (turnSlots.stop(actorSessionId)) {
             auditLog.append({ type: 'actor_stopped', details: { actorSessionId, reason: 'user_stop_cascade' } }).catch(() => {});
           }
+        }
+      }
+      // PR #134 phase 5 — cascade the Stop through the SUBAGENT subtree too.
+      // Children run under their own turn slots now (spawn.js claims one per
+      // child), so the line above never reached them; without this, spawned
+      // work — including grandchildren, since one Stop must end the whole
+      // delegation graph — kept running after the user hit Stop. stopSubtree
+      // walks the live-children registry transitively and aborts each slot.
+      // (Actor turns those children had in flight are already covered: the
+      // actor bookkeeping is keyed by the lineage ROOT, i.e. this chat.)
+      if (sessionId && subagentLifecycle?.stopSubtree) {
+        for (const childSessionId of subagentLifecycle.stopSubtree(/** @type {any} */ (sessionId))) {
+          auditLog.append({ type: 'subagent_stopped', details: { childSessionId, reason: 'user_stop_cascade' } }).catch(() => {});
         }
       }
       return { ok: true };

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -1095,6 +1095,11 @@ const buildToolContext = async (/** @type {any} */ { sessionId: overrideSessionI
       // the child's depth (parent + 1) and enforce maxDepth. Defaults to
       // 0 for legacy sessions written before the field existed.
       depth: activeSession?.depth ?? 0,
+      // why: message_actor reads ctx.session.kind to pick its reply mode
+      // (PR #134): a 'subagent' sender is an EPHEMERAL call-site with no
+      // later turn to wake, so its actor reply is awaited into the tool
+      // result instead of delivered as a re-entry wake.
+      kind: activeSession?.kind ?? 'chat',
     },
     // Plan/Act permission policy input. The persona gate reads
     // permission.mode to enforce Plan's read-only block; the dispatcher
@@ -1425,11 +1430,24 @@ const spawnSubagentCore = makeSpawnSubagent({
   // boot — settings load async and can change over the SW's life. This
   renderSystemPrompt: (opts) => renderSystemPrompt(opts),
   getToolDescriptors: () => listTools().map((t) => ({ name: t.name, description: t.description, schema: t.schema })),
+  // PR #134 phase 1: children run UNDER turn slots so Stop / cancel / the
+  // wall-clock timeout can abort them. Lazy arrows — turnSlots is defined
+  // later in this module (after the agent loop); only called at spawn time.
+  turnSlots: {
+    claim: (/** @type {string} */ sessionId) => turnSlots.claim(sessionId),
+    stop: (/** @type {string} */ sessionId) => turnSlots.stop(sessionId),
+  },
 });
 
 // SW-bound spawn. Defaults the live forwarder so neither surface has to
 // wire streaming; an explicit onEvent in `req` still wins.
 const spawnSubagent = (/** @type {any} */ req) => spawnSubagentCore({ onEvent: forwardSubagentEvent, ...req });
+// PR #134 phase 5: the live-children registry riding on the spawn orchestrator —
+// agent/stop and subagent_cancel walk it to end whole delegation subtrees.
+const subagentLifecycle = {
+  stopSubtree: (/** @type {string} */ sessionId) => spawnSubagentCore.stopSubtree(sessionId),
+  liveChildrenOf: (/** @type {string} */ sessionId) => spawnSubagentCore.liveChildrenOf(sessionId),
+};
 
 // ---------------------------------------------------------------------------
 // Async subagents (DESIGN-11) — orchestration in peerd-runtime/subagent.
@@ -1480,7 +1498,12 @@ const asyncSubagentsOrchestrator = makeAsyncSubagents({
   turnSlots: {
     runWhenIdle: (sessionId, fn) => turnSlots.runWhenIdle(sessionId, fn),
     isBusy: (sessionId) => turnSlots.isBusy(sessionId),
+    // PR #134: subagent_cancel aborts the child's live slot (children run
+    // under slots now), instead of only dropping the result.
+    stop: (sessionId) => turnSlots.stop(sessionId),
   },
+  // PR #134: a cancel ends the child's own descendants too.
+  stopSubtree: (sessionId) => spawnSubagentCore.stopSubtree(sessionId),
   // async-subagent wakes are NOT trusted to delegate (a parent reacting to a
   // subagent result stays attended-gated for message_actor, like today) —
   // so this reenter deliberately does not forward trusted.
@@ -2895,6 +2918,32 @@ const actorMessaging = makeActorMessaging({
   reenter: ({ userText, sessionId, synthetic, trusted }) => runAgentTurn({ userText, sessionId, synthetic, trusted }),
   turnSlots,
   getActiveSessionId: () => /** @type {Promise<any>} */ (sessionCache.sessionGet('currentSessionId')),
+  // PR #134 phase 3 — the shell walk behind the trusted-lineage gate. Builds
+  // the sender-first LineageHop chain by following parentSessionId up the
+  // session store. spawnedTrusted per hop: a ROOT (no parent) is trusted by
+  // construction (nothing spawned it); a PARENTED record must carry an
+  // explicit true — records written before the field existed read as
+  // untrusted (fail-closed; those children never had delegation anyway).
+  // Hop cap far above MAX_DEPTH: purely an anti-hang bound on corrupt data.
+  getAncestry: async (/** @type {string} */ sessionId) => {
+    /** @type {Array<{ sessionId: string, parentSessionId: string | null, spawnedTrusted: boolean }>} */
+    const hops = [];
+    let cursor = /** @type {string | null} */ (sessionId);
+    const seen = new Set();
+    for (let i = 0; i < 32 && cursor && !seen.has(cursor); i++) {
+      seen.add(cursor);
+      const record = await sessions.get(cursor);
+      if (!record) break; // unknown session → chain ends; the gate fails closed
+      const parentSessionId = record.parentSessionId ?? null;
+      hops.push({
+        sessionId: cursor,
+        parentSessionId,
+        spawnedTrusted: parentSessionId ? record.spawnedTrusted === true : true,
+      });
+      cursor = parentSessionId;
+    }
+    return hops;
+  },
   isVaultLocked: () => vault.isLocked(),
   wrapUntrusted,
   appendAudit: (/** @type {any} */ e) => auditLog.append(e),
@@ -3263,6 +3312,9 @@ browser.runtime.onMessage.addListener(/** @type {any} */ (makeDispatcher({
     startGoalRun, haltGoalRun, ensureSession,
     // DESIGN-17 P1: agent/stop cascades to this chat's in-flight actors.
     actorMessaging,
+    // PR #134 phase 5: agent/stop also cascades through the live subagent
+    // subtree (children run under their own turn slots now).
+    subagentLifecycle,
   }),
   ...makeEngineRoutes({
     vault, auditLog, pushState, browser, vmHttpFetch, appRegistry, vmRegistry, jsRegistry,

--- a/extension/peerd-provider/system-prompt.txt
+++ b/extension/peerd-provider/system-prompt.txt
@@ -163,15 +163,17 @@ per subagent, the verdict, what's next. Their cards are a live view, NOT your
 reply; do not end the turn silent just because the transcripts are on screen. A subagent
 inherits your tools minus spawn_subagent (tools:[...] to scope, [] for
 pure reasoning), runs under your permissions (never escalates), transcript
-inline. A subagent is a PURE FUNCTION: task text in → result text out — for
-DECOMPOSING non-instance work (research, multi-source gathering, parallel
-analysis, reasoning over text). A subagent CANNOT drive a sandbox: the
-instance-mutating tools are actor-only, and message_actor is refused
-from a child (only the active chat may delegate). So never hand a vm/notebook/
-app to a subagent — delegate it to the instance's ACTOR. Instance
-PARALLELISM is many message_actor calls in ONE turn (one per instance): the
-actors run concurrently, each serialising its own work, and each reply comes
-back as its own later fenced note.
+inline. A subagent is best for DECOMPOSING work: research, multi-source
+gathering, parallel analysis, reasoning over text. It can ALSO drive a
+sandbox — a subagent granted message_actor may delegate to an instance's
+actor, and (unlike you) it gets that actor's reply back RIGHT IN its
+message_actor tool result, so it can do a full "drive this VM, then report"
+task end-to-end in one child. (Its whole delegation tree shares one runaway
+budget with you, and Stop ends the tree at once.) The instance-mutating
+tools stay actor-only either way, so it's still message_actor, never a direct
+mutate. Instance PARALLELISM is many message_actor calls in ONE turn (one per
+instance): the actors run concurrently, each serialising its own work, and
+each reply comes back as its own later fenced note.
 
 peerd.runAgent is for a different job — an app or Notebook you BUILD for the
 user embedding its own agent (e.g. a chat box that calls a model). Your own

--- a/extension/peerd-runtime/sessions/store.js
+++ b/extension/peerd-runtime/sessions/store.js
@@ -147,6 +147,7 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
    *   model?: string,
    *   kind?: import('./types.js').SessionKind,
    *   parentSessionId?: string,
+   *   spawnedTrusted?: boolean,
    *   task?: string,
    *   depth?: number,
    *   permissionMode?: string,
@@ -164,6 +165,7 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
     model = 'claude-sonnet-4-6',
     kind = 'chat',
     parentSessionId,
+    spawnedTrusted,
     task,
     depth = 0,
     permissionMode,
@@ -192,6 +194,11 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
         : {}),
       ...(normalizedManifest ? { toolManifest: normalizedManifest } : {}),
       ...(parentSessionId ? { parentSessionId } : {}),
+      // Trusted-lineage hop verdict (subagent/delegation-lineage.js): stamped by
+      // spawn.js from the SPAWNING turn's inbound flag, server-side — the model
+      // never supplies it. Persisted only when explicitly passed, so roots stay
+      // absent (getAncestry treats an unparented record as trusted).
+      ...(spawnedTrusted !== undefined ? { spawnedTrusted } : {}),
       ...(task ? { task } : {}),
       // DESIGN-17: an actor self-describes the instance it owns + its kind.
       ...(instanceId ? { instanceId } : {}),

--- a/extension/peerd-runtime/sessions/types.js
+++ b/extension/peerd-runtime/sessions/types.js
@@ -38,6 +38,12 @@
  * @property {string} [parentSessionId]       who spawned this; absent for top-level
  * @property {string} [task]                  the spawning prompt (subagents only)
  * @property {number} depth                   0 for top-level; parent.depth + 1 otherwise
+ * @property {boolean} [spawnedTrusted]       was the SPAWNING turn trusted (non-inbound)?
+ *   The per-hop verdict the trusted-lineage gate (subagent/delegation-lineage.js)
+ *   walks: stamped server-side at create() by spawn.js, never model-supplied.
+ *   Absent on roots (nothing spawned them — treated as trusted) and on records
+ *   written before the async-actor refactor (a PARENTED record missing it reads
+ *   as untrusted — fail-closed; see the SW's getAncestry).
  *
  * Actor binding (DESIGN-17). A `kind:'actor'` session self-describes
  * which instance it owns: `instanceId` (the WebVM/Notebook/App id it drives, or

--- a/extension/peerd-runtime/subagent/actor-messaging.js
+++ b/extension/peerd-runtime/subagent/actor-messaging.js
@@ -184,6 +184,19 @@ export const makeActorMessaging = (deps) => {
     return actorsFor(root);
   };
 
+  // Stop the ONE actor turn a subagent's awaitReply was waiting on, when that
+  // subagent aborts (#1/#3). Bump the lineage's Stop generation so a still-
+  // QUEUED actor turn skips when its slot frees, and abort a RUNNING one via
+  // turnSlots.stop (optional — the pure-heap test harness injects no stop; the
+  // await resolves either way). Scoped to the single actorSessionId the child
+  // delegated to, not the whole lineage, so a sibling's in-flight actor is
+  // untouched.
+  /** @param {string} root @param {string} actorSessionId */
+  const stopActorForAwait = (root, actorSessionId) => {
+    stopGen.set(root, (stopGen.get(root) ?? 0) + 1);
+    /** @type {{ stop?: (id: string) => boolean }} */ (turnSlots).stop?.(actorSessionId);
+  };
+
   /** @param {string} root */
   const decInFlight = (root) => {
     const c = (inFlight.get(root) ?? 1) - 1;
@@ -311,14 +324,17 @@ export const makeActorMessaging = (deps) => {
   };
 
   /**
-   * @param {{ to?: string, message?: string, senderSessionId?: string|null, inbound?: boolean, toolUseId?: string, oneShot?: boolean, awaitReply?: boolean }} req
+   * @param {{ to?: string, message?: string, senderSessionId?: string|null, inbound?: boolean, toolUseId?: string, oneShot?: boolean, awaitReply?: boolean, awaitSignal?: { aborted: boolean, addEventListener: (t: string, fn: () => void, opts?: object) => void } }} req
    *   awaitReply — the SUBAGENT reply mode (PR #134): resolve the fenced reply
    *   into this call's result instead of a later-turn wake. Set by the
    *   message_actor tool for a `kind:'subagent'` sender.
+   *   awaitSignal — the awaiting subagent's AbortSignal (its wall-clock timeout
+   *   / cancel). Only meaningful with awaitReply: the await races the reply
+   *   against it so an aborted child unblocks instead of parking on a hung actor.
    * @returns {Promise<{ ok: boolean, content?: string, error?: string }>}
    */
   const messageActor = async (req) => {
-    const { to, message, senderSessionId, inbound, toolUseId, oneShot, awaitReply } = req;
+    const { to, message, senderSessionId, inbound, toolUseId, oneShot, awaitReply, awaitSignal } = req;
     if (typeof to !== 'string' || !to.trim()) {
       return { ok: false, error: 'message_actor: `to` (a tab-hosted instance id) is required' };
     }
@@ -400,7 +416,14 @@ export const makeActorMessaging = (deps) => {
     const intentK = intentKey(instanceId, message);
     if ((inFlightIntents.get(rootSessionId)?.get(intentK) ?? 0) > 0) {
       log('REFUSED', { reason: 'duplicate_intent', senderSessionId, rootSessionId, to: instanceId });
-      return { ok: false, error: `message_actor: an identical request to '${to}' is already in flight for this chat — await its reply instead of re-sending.` };
+      // why this wording: the in-flight twin may have been sent by a DIFFERENT
+      // session in this delegation tree (a sibling subagent, or the parent),
+      // and its reply routes to THAT sender — never to this one. Telling this
+      // caller to "await its reply" would be unactionable (a subagent has no
+      // channel to observe another's reply). So the honest guidance is: this
+      // work is already happening elsewhere in the tree — don't re-send; report
+      // that and proceed / synthesize from what you have.
+      return { ok: false, error: `message_actor: an identical request to '${to}' is already in flight elsewhere in this chat's delegation tree — do NOT re-send. That work is already happening; proceed with what you have or report that it's underway.` };
     }
 
     recent.push(nowMs);
@@ -438,11 +461,36 @@ export const makeActorMessaging = (deps) => {
     // like the async path; only the completion routing differs.
     if (awaitReply === true) {
       const settled = await new Promise((resolve) => {
+        // Race the actor reply against the CALLING SUBAGENT's abort signal.
+        // why: the subagent is suspended here in tool dispatch, and its loop
+        // only observes the signal at wave boundaries — so its wall-clock
+        // timeout / subagent_cancel (which fire this signal) cannot unwind this
+        // await on their own. Without the race, a hung/queued actor turn parks
+        // the child, its slot, and its parent's await indefinitely — the exact
+        // "parked forever" failure the timeout exists to prevent. On abort we
+        // ALSO stop the actor turn this child was waiting on (stopActorForAwait):
+        // it is the child's delegate, so it should die with the child, not run
+        // on orphaned. onReply and onAbort guard each other (first wins; the loser
+        // is a no-op). runEngineDelivery is ALWAYS called so its trackActor/clear
+        // bookkeeping stays symmetric and the mailbox entry is cleaned up even on
+        // abort (its onReply is just a no-op by then).
+        let done = false;
+        const finish = (/** @type {{ text: string, failed: boolean }} */ v) => { if (!done) { done = true; resolve(v); } };
+        // Queue the actor turn FIRST — so it captures the current Stop generation
+        // BEFORE onAbort bumps it, letting the gen-skip actually cancel a queued turn.
         runEngineDelivery({
           correlationId, senderSessionId: sender, rootSessionId, actor, message,
           parentToolUseId: toolUseId, oneShot: oneShot === true,
-          onReply: (text, failed) => resolve({ text, failed }),
+          onReply: (text, failed) => finish({ text, failed }),
         });
+        const onAbort = () => {
+          stopActorForAwait(rootSessionId, actor.actorSessionId);
+          finish({ text: replyText(instanceId, kind, name, 'the request was aborted (timeout or cancel) before the actor replied.', true), failed: true });
+        };
+        if (awaitSignal) {
+          if (awaitSignal.aborted) onAbort();               // already aborted → resolve now
+          else awaitSignal.addEventListener('abort', onAbort, { once: true });
+        }
       });
       return settled.failed
         ? { ok: false, error: settled.text }
@@ -512,6 +560,12 @@ export const makeActorMessaging = (deps) => {
         continue;
       }
       inFlight.set(wakeTarget, (inFlight.get(wakeTarget) ?? 0) + 1);
+      // Track the intent too (#4): runEngineDelivery's clear() unconditionally
+      // untrackIntent()s on settle, so a redrained turn that never tracked would
+      // decrement — and delete — a DIFFERENT live send's refcount, silently
+      // defeating the dedupe guard. Mirror the live path's trackIntent here so
+      // the ref is symmetric. Keyed on the resolved instanceId, as the live path.
+      trackIntent(wakeTarget, intentKey(actor.instanceId, e.message));
       // senderSessionId here is the DELIVERY address (deliver() wakes it) and the
       // bookkeeping root on a redrain — for a rerouted entry both are the root.
       runEngineDelivery({ correlationId: e.id, senderSessionId: wakeTarget, rootSessionId: wakeTarget, actor, message: e.message, oneShot: e.oneShot === true });

--- a/extension/peerd-runtime/subagent/actor-messaging.js
+++ b/extension/peerd-runtime/subagent/actor-messaging.js
@@ -24,17 +24,38 @@
 // every pending message on boot (mirrors goalRunner.resume). The default no-op
 // mailbox keeps the pure-heap behavior in tests.
 //
-// Posture: a message is accepted from the active foreground chat (`senderSessionId
-// === getActiveSessionId()`) when it is NOT `inbound`. `inbound` is the
-// untrusted-ORIGIN signal the turn driver folds from synthetic + trusted:
-// `inbound = synthetic && !trusted`. So a real user turn (non-synthetic) and an
-// explicit first-party continuation (a goal turn, or the orchestrator reacting to
-// an actor's reply — both set trusted:true) MAY delegate; an untrusted/external
-// synthetic turn (future peer messages / scheduled tasks — never trusted) is
-// refused. Fail-CLOSED (default deny for synthetic) + the `=== active` second
-// wall. The per-sender runaway guard bounds an autonomous parent↔actor loop.
+// Posture (PR #134 — subagents as async actors): a message is accepted when the
+// turn is NOT `inbound` AND the sender passes the TRUSTED-LINEAGE gate
+// (delegation-lineage.js mayMessageActor): the active foreground chat, or a
+// descendant of it reached entirely through trusted spawn edges (spawn.js
+// stamps `spawnedTrusted` per hop; one inbound spawn taints its subtree).
+// `inbound` is the untrusted-ORIGIN signal the turn driver folds from
+// synthetic + trusted: `inbound = synthetic && !trusted`. So a real user turn,
+// an explicit first-party continuation (a goal turn, or the orchestrator
+// reacting to an actor's reply — both set trusted:true), and a trusted-lineage
+// subagent MAY delegate; an untrusted/external synthetic turn (future peer
+// messages / scheduled tasks — never trusted) is refused. Fail-CLOSED: a
+// missing/unwalkable ancestry admits only the foreground chat itself.
+//
+// The runaway guard + Stop bookkeeping are keyed by the lineage ROOT
+// (messageProvenance) rather than the raw sender, so a parent↔child↔actor
+// cycle shares ONE budget (phase 4) and a user Stop on the chat cascades to
+// actor turns its descendants started (phase 5). Envelopes (durable mailbox
+// entries) carry the provenance so a boot redrain can arbitrate: a reply whose
+// awaiting sender was an EPHEMERAL subagent (dead after restart) is rerouted
+// to the root instead of waking a headless child (phase 7).
+//
+// Reply modes: the ORCHESTRATOR (and any long-lived chat session) gets the
+// async wake — deliver() re-enters it on a later turn. A SUBAGENT sender sets
+// `awaitReply`: it is a fire-once call-site with no later turn, so its reply
+// resolves INTO the message_actor tool result (still wrapUntrusted-fenced).
+// why not wake a subagent like a chat: the reenter path runs sessions under
+// the SW's main turn driver — waking a finished child would both run an
+// orphan turn nobody consumes AND rebuild its context on the MAIN exposure
+// surface, escalating past the child's narrowed toolset.
 
 import { escapeAttr } from '/shared/util.js';
+import { ASYNC_SUBAGENT_ACTORS, mayMessageActor, messageProvenance } from './delegation-lineage.js';
 
 /**
  * @param {Object} deps
@@ -55,13 +76,18 @@ import { escapeAttr } from '/shared/util.js';
  *   marks a first-party continuation allowed to message actors (the reply-wake).
  * @param {{ runWhenIdle: (sessionId: string, fn: () => void) => void }} deps.turnSlots
  * @param {() => Promise<string | null>} deps.getActiveSessionId
+ * @param {(sessionId: string) => Promise<Array<import('./delegation-lineage.js').LineageHop>>} [deps.getAncestry]
+ *   Build the sender's lineage chain (sender-first toward the root) from the
+ *   session store — the shell walk mayMessageActor/messageProvenance read.
+ *   Default returns [] — FAIL-CLOSED: without a chain only the foreground chat
+ *   itself passes the gate, and provenance collapses to the sender.
  * @param {() => boolean} deps.isVaultLocked
  * @param {(opts: { origin: string, tool: string, body: string, retrievedAt?: string }) => string} deps.wrapUntrusted
  * @param {(entry: object) => Promise<unknown>} [deps.appendAudit]
  * @param {() => number} [deps.now]
  * @param {{ outstanding?: number, rateCap?: number, rateWindowMs?: number, resultChars?: number }} [deps.caps]
  * @param {(...args: unknown[]) => void} [deps.log]
- * @param {{ append: (e: { id: string, senderSessionId: string, to: string, message: string, createdAt: number }) => Promise<unknown>, remove: (id: string) => Promise<unknown>, load: () => Promise<any[]> }} [deps.mailbox]
+ * @param {{ append: (e: { id: string, senderSessionId: string, to: string, message: string, createdAt: number, provenance?: { rootSessionId: string, lineagePath: string[] }, oneShot?: boolean }) => Promise<unknown>, remove: (id: string) => Promise<unknown>, load: () => Promise<any[]> }} [deps.mailbox]
  *   DURABLE MAILBOX (DESIGN-17 P1). Persists EVERY actor's in-flight
  *   message→reply correlation — web included — so an SW death between accept and
  *   deliver() doesn't silently drop the reply-wake. append() on accept, remove()
@@ -72,6 +98,7 @@ export const makeActorMessaging = (deps) => {
   const {
     resolveActor, runActorTurn, reenter, turnSlots,
     getActiveSessionId, isVaultLocked, wrapUntrusted,
+    getAncestry = async () => [],
     appendAudit = async () => {}, now = Date.now, caps = {}, log = () => {},
     mailbox = { append: async () => {}, remove: async () => {}, load: async () => [] },
   } = deps;
@@ -81,62 +108,93 @@ export const makeActorMessaging = (deps) => {
   const RATE_WINDOW_MS = caps.rateWindowMs ?? 60_000;
   const RESULT_CHARS = caps.resultChars ?? 16 * 1024;
 
-  /** @type {Map<string, number>} senderSessionId → actor messages currently in flight */
+  // PR #134 phase 4: ALL of the bookkeeping below is keyed by the lineage ROOT
+  // (messageProvenance.rootSessionId — the chat at the base of the sender's
+  // lineage), not the raw sender. One budget bounds a whole delegation graph
+  // (a parent↔child↔actor cycle can't multiply its caps by fanning out), and
+  // stopActorsFor(chatId) — the user's Stop, which only knows the CHAT id —
+  // reaches actor turns that a descendant subagent started. For a plain chat
+  // sender, root === sender, so the pre-#134 behavior is unchanged.
+  /** @type {Map<string, number>} rootSessionId → actor messages currently in flight */
   const inFlight = new Map();
-  /** @type {Map<string, number[]>} senderSessionId → recent dispatch timestamps (the burst guard) */
+  /** @type {Map<string, number[]>} rootSessionId → recent dispatch timestamps (the burst guard) */
   const recentSends = new Map();
-  // senderSessionId → (actorSessionId → REFCOUNT). A set can't represent two
+  // rootSessionId → (actorSessionId → REFCOUNT). A set can't represent two
   // messages in flight to the SAME actor, so a Stop cascade would miss the
   // second once the first settled and cleared the entry. Refcount keeps the
   // actorSessionId visible to actorsFor() for the whole span ANY message to
   // it is in flight. @type {Map<string, Map<string, number>>}
   const inFlightActors = new Map();
-  // senderSessionId → Stop generation. Bumped by stopActorsFor(); a queued
+  // rootSessionId → Stop generation. Bumped by stopActorsFor(); a queued
   // (not-yet-started) engine turn whose captured generation no longer matches skips
   // — so Stop reaches not just the RUNNING actor slot (turnSlots.stop) but also
   // actor turns still queued behind it on the same slot. @type {Map<string, number>}
   const stopGen = new Map();
+  // Phase 7 (mechanical dedupe): rootSessionId → the (to + message) intents
+  // currently in flight for that lineage. An IDENTICAL request while its twin is
+  // still running is almost always a double-fire (a parent and its child both
+  // asking, or a wake-loop re-asking) — refuse it loudly with an "await the
+  // first" pointer instead of running the actor turn twice. Deliberately NOT a
+  // supersede (auto-cancelling the older one is a policy call the mailbox has
+  // provenance for, but nobody has asked for yet). @type {Map<string, Map<string, number>>}
+  const inFlightIntents = new Map();
+  /** @param {string} to @param {string} message */
+  const intentKey = (to, message) => `${to}\u0000${message}`;
+  /** @param {string} root @param {string} key */
+  const trackIntent = (root, key) => {
+    const m = inFlightIntents.get(root) ?? new Map();
+    m.set(key, (m.get(key) ?? 0) + 1);
+    inFlightIntents.set(root, m);
+  };
+  /** @param {string} root @param {string} key */
+  const untrackIntent = (root, key) => {
+    const m = inFlightIntents.get(root);
+    if (!m) return;
+    const c = (m.get(key) ?? 1) - 1;
+    if (c <= 0) m.delete(key); else m.set(key, c);
+    if (m.size === 0) inFlightIntents.delete(root);
+  };
   // Monotonic correlation id — durable-mailbox key + de-dupe. Process-unique
   // (not now()-derived, which is fixed in tests and collides on same-ms sends).
   let seq = 0;
 
-  /** @param {string} sender @param {string} actorSessionId */
-  const trackActor = (sender, actorSessionId) => {
-    const m = inFlightActors.get(sender) ?? new Map();
+  /** @param {string} root @param {string} actorSessionId */
+  const trackActor = (root, actorSessionId) => {
+    const m = inFlightActors.get(root) ?? new Map();
     m.set(actorSessionId, (m.get(actorSessionId) ?? 0) + 1);
-    inFlightActors.set(sender, m);
+    inFlightActors.set(root, m);
   };
-  /** @param {string} sender @param {string} actorSessionId */
-  const untrackActor = (sender, actorSessionId) => {
-    const m = inFlightActors.get(sender);
+  /** @param {string} root @param {string} actorSessionId */
+  const untrackActor = (root, actorSessionId) => {
+    const m = inFlightActors.get(root);
     if (!m) return;
     const c = (m.get(actorSessionId) ?? 1) - 1;
     if (c <= 0) m.delete(actorSessionId); else m.set(actorSessionId, c);
-    if (m.size === 0) inFlightActors.delete(sender);
+    if (m.size === 0) inFlightActors.delete(root);
   };
-  /** @param {string} sender @returns {string[]} the actor sessions this sender has in flight */
-  const actorsFor = (sender) => [...(inFlightActors.get(sender)?.keys() ?? [])];
-  // Stop every actor this sender has in flight: bump the generation (so QUEUED
+  // `root` is the lineage root (a chat id) — for a plain chat sender it IS the
+  // sender, so agent/stop's call with the current chat id covers the whole tree.
+  /** @param {string} root @returns {string[]} the actor sessions this lineage has in flight */
+  const actorsFor = (root) => [...(inFlightActors.get(root)?.keys() ?? [])];
+  // Stop every actor this lineage has in flight: bump the generation (so QUEUED
   // turns skip) and return the RUNNING ones (so the caller aborts their slots).
-  /** @param {string} sender @returns {string[]} */
-  const stopActorsFor = (sender) => {
-    stopGen.set(sender, (stopGen.get(sender) ?? 0) + 1);
-    return actorsFor(sender);
+  /** @param {string} root @returns {string[]} */
+  const stopActorsFor = (root) => {
+    stopGen.set(root, (stopGen.get(root) ?? 0) + 1);
+    return actorsFor(root);
   };
 
-  /** @param {string} sender */
-  const decInFlight = (sender) => {
-    const c = (inFlight.get(sender) ?? 1) - 1;
-    if (c <= 0) inFlight.delete(sender); else inFlight.set(sender, c);
+  /** @param {string} root */
+  const decInFlight = (root) => {
+    const c = (inFlight.get(root) ?? 1) - 1;
+    if (c <= 0) inFlight.delete(root); else inFlight.set(root, c);
   };
 
-  // Re-enter the SENDER with the actor's reply as a synthetic, wrapUntrusted-
-  // fenced wake — via runWhenIdle(senderSessionId) so it NEVER steer-aborts the
-  // user's live turn (the focus/work-theft bug, DECISIONS #20). Only the one-line
-  // lead is trusted; the actor's body is fenced (mandatory for App actors,
-  // which render attacker content).
-  /** @param {string} senderSessionId @param {string} instanceId @param {string} kind @param {string|undefined} name @param {string} body @param {boolean} [failed] */
-  const deliver = (senderSessionId, instanceId, kind, name, body, failed = false) => {
+  // Build the ONE reply text shape (trusted lead + fenced body) both reply
+  // modes share: deliver() re-enters a long-lived sender with it; the
+  // awaitReply path (a subagent's call) resolves it into the tool result.
+  /** @param {string} instanceId @param {string} kind @param {string|undefined} name @param {string} body @param {boolean} [failed] */
+  const replyText = (instanceId, kind, name, body, failed = false) => {
     const wrapped = wrapUntrusted({
       origin: instanceId, tool: 'message_actor', body,
       retrievedAt: new Date(now()).toISOString(),
@@ -164,43 +222,77 @@ export const makeActorMessaging = (deps) => {
     const lead = failed
       ? `${subject} could not complete your request:`
       : `${subject} you messaged has replied:`;
+    return `${lead}\n\n${wrapped}`;
+  };
+
+  // Re-enter the SENDER with the actor's reply as a synthetic, wrapUntrusted-
+  // fenced wake — via runWhenIdle(senderSessionId) so it NEVER steer-aborts the
+  // user's live turn (the focus/work-theft bug, DECISIONS #20). Only the one-line
+  // lead is trusted; the actor's body is fenced (mandatory for App actors,
+  // which render attacker content).
+  /** @param {string} senderSessionId @param {string} instanceId @param {string} kind @param {string|undefined} name @param {string} body @param {boolean} [failed] */
+  const deliver = (senderSessionId, instanceId, kind, name, body, failed = false) => {
+    const text = replyText(instanceId, kind, name, body, failed);
     turnSlots.runWhenIdle(senderSessionId, () => {
       // trusted:true — the reply-wake is a FIRST-PARTY continuation (the sender's
       // own actor replied), so the sender's turn that reads it MAY fire a
       // follow-up message_actor. The reply BODY is still wrapUntrusted-fenced:
       // trusted is about the turn's ORIGIN (peerd's own loop), not its content.
-      Promise.resolve(reenter({ userText: `${lead}\n\n${wrapped}`, sessionId: senderSessionId, synthetic: true, trusted: true }))
+      Promise.resolve(reenter({ userText: text, sessionId: senderSessionId, synthetic: true, trusted: true }))
         .catch((e) => log('reenter failed', e));
     });
   };
 
-  // Queue ONE engine actor turn on its slot, deliver the fenced reply to the
+  // Queue ONE engine actor turn on its slot, route the fenced reply to the
   // sender, and clear the mailbox entry on settle. Shared by a fresh message and a
   // boot redrain() so the in-flight bookkeeping (count, Stop-cascade tracking,
   // durable entry) stays identical on both paths. parentToolUseId (absent on a
   // redrain — the orchestrator card is gone) keys the actor's display stream.
-  /** @param {{ correlationId: string, senderSessionId: string, actor: { instanceId: string, kind: string, actorSessionId: string, name?: string, tabId?: number }, message: string, parentToolUseId?: string, oneShot?: boolean }} o */
-  const runEngineDelivery = ({ correlationId, senderSessionId, actor, message, parentToolUseId, oneShot }) => {
+  //
+  // Reply routing: `onReply` (the awaitReply path — a subagent's call) receives
+  // the composed reply text and its failed flag INSTEAD of the deliver() wake;
+  // the caller resolves it into the tool result. Every settle path — success,
+  // thrown turn, Stop-skip — routes through exactly one of onReply/deliver, so
+  // an awaiting caller is never left hanging.
+  //
+  // Bookkeeping is keyed by rootSessionId (phase 4/5): the lineage root shares
+  // one budget and one Stop generation, whoever in the tree actually sent.
+  /** @param {{ correlationId: string, senderSessionId: string, rootSessionId: string, actor: { instanceId: string, kind: string, actorSessionId: string, name?: string, tabId?: number }, message: string, parentToolUseId?: string, oneShot?: boolean, onReply?: (text: string, failed: boolean) => void }} o */
+  const runEngineDelivery = ({ correlationId, senderSessionId, rootSessionId, actor, message, parentToolUseId, oneShot, onReply }) => {
     const { instanceId, kind, actorSessionId, name, tabId } = actor;
-    trackActor(senderSessionId, actorSessionId);
-    // Capture the sender's Stop generation NOW — if the user Stops while this turn is
+    trackActor(rootSessionId, actorSessionId);
+    const intentK = intentKey(instanceId, message);
+    // Capture the root's Stop generation NOW — if the user Stops while this turn is
     // queued behind another on the same actor slot, the generation advances and we
     // skip it when the slot finally frees (so Stop reaches queued work, not just the
     // running slot turnSlots.stop aborts). The bookkeeping is cleared either way.
-    const genAtQueue = stopGen.get(senderSessionId) ?? 0;
+    const genAtQueue = stopGen.get(rootSessionId) ?? 0;
     const clear = () => {
-      decInFlight(senderSessionId);
-      untrackActor(senderSessionId, actorSessionId);
+      decInFlight(rootSessionId);
+      untrackActor(rootSessionId, actorSessionId);
+      untrackIntent(rootSessionId, intentK);
       mailbox.remove(correlationId).catch(() => {});
+    };
+    // ONE reply seam for both modes (see routing note above).
+    /** @param {string} body @param {boolean} failed */
+    const settle = (body, failed) => {
+      if (onReply) { onReply(replyText(instanceId, kind, name, body, failed), failed); return; }
+      deliver(senderSessionId, instanceId, kind, name, body, failed);
     };
     // Serialize on the ACTOR's slot — runWhenIdle runs the turn the moment the
     // actor is idle (never interrupting an in-flight actor turn). A thrown/
     // failed actor turn STILL wakes the sender (with an error notice) so the
     // caller is never left hanging.
     turnSlots.runWhenIdle(actorSessionId, () => {
-      // Stopped after we queued → don't start the turn; just clean up silently (the
-      // sender was stopped, so a wake would re-start unwanted post-Stop activity).
-      if ((stopGen.get(senderSessionId) ?? 0) !== genAtQueue) { clear(); return; }
+      // Stopped after we queued → don't start the turn. A woken sender would
+      // re-start unwanted post-Stop activity, so the wake path stays silent —
+      // but an AWAITING caller (onReply) must still resolve, or its tool call
+      // would hang past the Stop that was meant to end it.
+      if ((stopGen.get(rootSessionId) ?? 0) !== genAtQueue) {
+        if (onReply) onReply(replyText(instanceId, kind, name, 'the request was stopped before the actor ran it.', true), true);
+        clear();
+        return;
+      }
       // Instrumentation (temporary): the actor turn's wall-clock. It spans the
       // tool work (e.g. a VM command — logged separately as [vm.timing]) PLUS the
       // model inference to compose the reply. (actorTurnMs − the tool's own ms) is
@@ -211,19 +303,22 @@ export const makeActorMessaging = (deps) => {
       Promise.resolve(runActorTurn({ actorSessionId, message, actorTabId: tabId, instanceId, kind, parentToolUseId, name, oneShot }))
         .then((res) => {
           log('actor.timing', { kind, instanceId, actorTurnMs: now() - turnStartedAt });
-          return deliver(senderSessionId, instanceId, kind, name, (res?.result || '(the actor produced no text reply)').slice(0, RESULT_CHARS), res?.stopped === true);
+          return settle((res?.result || '(the actor produced no text reply)').slice(0, RESULT_CHARS), res?.stopped === true);
         })
-        .catch((e) => deliver(senderSessionId, instanceId, kind, name, `the actor turn failed: ${/** @type {{ message?: string }} */ (e)?.message ?? String(e)}`, true))
+        .catch((e) => settle(`the actor turn failed: ${/** @type {{ message?: string }} */ (e)?.message ?? String(e)}`, true))
         .finally(clear);
     });
   };
 
   /**
-   * @param {{ to?: string, message?: string, senderSessionId?: string|null, inbound?: boolean, toolUseId?: string, oneShot?: boolean }} req
+   * @param {{ to?: string, message?: string, senderSessionId?: string|null, inbound?: boolean, toolUseId?: string, oneShot?: boolean, awaitReply?: boolean }} req
+   *   awaitReply — the SUBAGENT reply mode (PR #134): resolve the fenced reply
+   *   into this call's result instead of a later-turn wake. Set by the
+   *   message_actor tool for a `kind:'subagent'` sender.
    * @returns {Promise<{ ok: boolean, content?: string, error?: string }>}
    */
   const messageActor = async (req) => {
-    const { to, message, senderSessionId, inbound, toolUseId, oneShot } = req;
+    const { to, message, senderSessionId, inbound, toolUseId, oneShot, awaitReply } = req;
     if (typeof to !== 'string' || !to.trim()) {
       return { ok: false, error: 'message_actor: `to` (a tab-hosted instance id) is required' };
     }
@@ -238,23 +333,49 @@ export const makeActorMessaging = (deps) => {
     // Fail-closed sender gate: the foreground chat, and not an untrusted-origin
     // (inbound) turn. A real user turn and an explicit first-party continuation
     // (goal turn / actor reply-wake — both non-inbound) pass; an untrusted or
-    // background synthetic turn, or any non-active sender, is refused.
+    // background synthetic turn is refused. PR #134 phase 3: the second wall is
+    // the TRUSTED-LINEAGE check (delegation-lineage.js) — the active chat OR a
+    // descendant reached entirely through trusted spawn edges. The ancestry is
+    // walked from the store ONLY for a non-active sender (the foreground fast
+    // path costs nothing new); a walk failure yields [] — fail-closed, only the
+    // foreground identity can then pass. The flag reverts to the strict
+    // `=== active` identity gate if turned off.
     const active = await getActiveSessionId();
-    if (inbound === true || !senderSessionId || senderSessionId !== active) {
+    /** @type {Array<import('./delegation-lineage.js').LineageHop>} */
+    let ancestry = [];
+    if (ASYNC_SUBAGENT_ACTORS && senderSessionId && senderSessionId !== active) {
+      try { ancestry = await getAncestry(senderSessionId); }
+      catch (e) { log('getAncestry failed (fail-closed)', e); ancestry = []; }
+    }
+    const senderAllowed = ASYNC_SUBAGENT_ACTORS
+      ? mayMessageActor({ inbound: inbound === true, senderSessionId, activeSessionId: active, ancestry })
+      : (inbound !== true && !!senderSessionId && senderSessionId === active);
+    if (!senderAllowed) {
       log('REFUSED', { reason: 'sender_gate', senderSessionId, inbound });
-      return { ok: false, error: 'message_actor: only the active foreground chat (or its first-party autonomous continuation — a goal turn, or reacting to an actor reply) may message an actor; untrusted/background senders and non-active chats are blocked' };
+      return { ok: false, error: 'message_actor: only the active foreground chat, its first-party autonomous continuation (a goal turn, or reacting to an actor reply), or a trusted-lineage subagent it spawned may message an actor; untrusted/background senders are blocked' };
     }
 
-    // Runaway guard (per sender) — a burst means a likely loop, so refuse past
-    // the rate cap within the window; a long, legit session spreads out.
+    // The gate refused every falsy sender above; bind the narrowed string once
+    // so the sites below don't each re-assert it.
+    const sender = /** @type {string} */ (senderSessionId);
+
+    // Phase 4/7 — the lineage ROOT keys every budget below (one bound for the
+    // whole delegation graph), and the provenance rides the durable envelope so
+    // the mailbox can arbitrate (dedupe here; reroute on redrain).
+    const provenance = messageProvenance({ senderSessionId: sender, ancestry });
+    const rootSessionId = provenance.rootSessionId;
+
+    // Runaway guard (per lineage ROOT) — a burst means a likely loop, so refuse
+    // past the rate cap within the window; a long, legit session spreads out.
+    // Root-keyed so a parent can't multiply its budget by fanning out children.
     const nowMs = now();
-    const recent = (recentSends.get(senderSessionId) ?? []).filter((t) => nowMs - t < RATE_WINDOW_MS);
+    const recent = (recentSends.get(rootSessionId) ?? []).filter((t) => nowMs - t < RATE_WINDOW_MS);
     if (recent.length >= RATE_CAP) {
-      log('REFUSED', { reason: 'rate_cap', senderSessionId, recent: recent.length });
-      return { ok: false, error: `message_actor: ${recent.length} actor messages in ${Math.round(RATE_WINDOW_MS / 1000)}s — refusing to prevent a runaway loop. Synthesize what you have, or wait a moment.` };
+      log('REFUSED', { reason: 'rate_cap', senderSessionId, rootSessionId, recent: recent.length });
+      return { ok: false, error: `message_actor: ${recent.length} actor messages in ${Math.round(RATE_WINDOW_MS / 1000)}s across this chat's delegation tree — refusing to prevent a runaway loop. Synthesize what you have, or wait a moment.` };
     }
-    if ((inFlight.get(senderSessionId) ?? 0) >= OUTSTANDING_CAP) {
-      return { ok: false, error: `message_actor: ${OUTSTANDING_CAP} actor messages already in flight for this chat — await their replies before sending more.` };
+    if ((inFlight.get(rootSessionId) ?? 0) >= OUTSTANDING_CAP) {
+      return { ok: false, error: `message_actor: ${OUTSTANDING_CAP} actor messages already in flight across this chat's delegation tree — await their replies before sending more.` };
     }
 
     // Resolve (+ lazy-mint) the actor for this instance. Thread the sender so the
@@ -269,28 +390,66 @@ export const makeActorMessaging = (deps) => {
     if (!actor) {
       return { ok: false, error: `message_actor: no tab-hosted instance found for id '${to}' (use the create/list tools to find one)` };
     }
-    const { instanceId, kind, actorSessionId, name, tabId } = actor;
+    const { instanceId, kind, name } = actor;
+
+    // Phase 7 — mechanical dedupe. An IDENTICAL (instance, message) intent
+    // already in flight for this lineage is a double-fire (a parent and its
+    // child both asking, or a loop re-asking): refuse loudly, point at the
+    // in-flight twin. Keyed on the RESOLVED instanceId so two aliases of the
+    // same actor ('web' vs its tabId) can't slip a duplicate through.
+    const intentK = intentKey(instanceId, message);
+    if ((inFlightIntents.get(rootSessionId)?.get(intentK) ?? 0) > 0) {
+      log('REFUSED', { reason: 'duplicate_intent', senderSessionId, rootSessionId, to: instanceId });
+      return { ok: false, error: `message_actor: an identical request to '${to}' is already in flight for this chat — await its reply instead of re-sending.` };
+    }
 
     recent.push(nowMs);
-    recentSends.set(senderSessionId, recent);
-    inFlight.set(senderSessionId, (inFlight.get(senderSessionId) ?? 0) + 1);
-    appendAudit({ type: 'actor_message', details: { to: instanceId, kind, senderSessionId } }).catch(() => {});
+    recentSends.set(rootSessionId, recent);
+    inFlight.set(rootSessionId, (inFlight.get(rootSessionId) ?? 0) + 1);
+    trackIntent(rootSessionId, intentK);
+    appendAudit({ type: 'actor_message', details: { to: instanceId, kind, senderSessionId, rootSessionId, lineagePath: provenance.lineagePath } }).catch(() => {});
 
-    // ASYNC for EVERY kind — web included. The orchestrator never blocks: it hands a
-    // task to the actor and gets woken with the reply on a later turn (the actor
-    // model, uniformly). Persist the correlation to the durable mailbox FIRST (await
-    // the write so the record is on disk before any actor side effect begins —
-    // closing the accept→persist window an SW death could otherwise drop), then queue
-    // the wake. The actor's slot serializes its turns (one actor per tab/
-    // instance), and deliver() wrapUntrusted-fences the reply — so a web actor's
-    // page-derived reply is fenced like any other untrusted content. A storage
-    // failure degrades to heap-only rather than throwing.
+    // ASYNC for EVERY long-lived sender — web included. The orchestrator never
+    // blocks: it hands a task to the actor and gets woken with the reply on a
+    // later turn (the actor model, uniformly). Persist the correlation to the
+    // durable mailbox FIRST (await the write so the record is on disk before any
+    // actor side effect begins — closing the accept→persist window an SW death
+    // could otherwise drop), then queue the wake. The actor's slot serializes its
+    // turns (one actor per tab/instance), and deliver() wrapUntrusted-fences the
+    // reply — so a web actor's page-derived reply is fenced like any other
+    // untrusted content. A storage failure degrades to heap-only rather than
+    // throwing.
     const correlationId = `${instanceId}:${++seq}:${nowMs}`;
     // Persist oneShot too, so a redrain after an SW restart re-runs the turn in the
     // same mode (a dropped flag would just fall back to a full summarize turn — safe,
     // but inconsistent). Older entries without the field redrain as full turns.
-    await Promise.resolve(mailbox.append({ id: correlationId, senderSessionId, to: instanceId, message, createdAt: nowMs, ...(oneShot === true ? { oneShot: true } : {}) })).catch(() => {});
-    runEngineDelivery({ correlationId, senderSessionId, actor, message, parentToolUseId: toolUseId, oneShot: oneShot === true });
+    // The provenance rides the envelope (phase 7) so a redrain can arbitrate —
+    // notably rerouting a reply whose awaiting sender was an ephemeral subagent.
+    await Promise.resolve(mailbox.append({
+      id: correlationId, senderSessionId: sender, to: instanceId, message, createdAt: nowMs,
+      provenance: { rootSessionId, lineagePath: provenance.lineagePath },
+      ...(oneShot === true ? { oneShot: true } : {}),
+    })).catch(() => {});
+
+    // PR #134 — the SUBAGENT reply mode. An ephemeral child has no later turn
+    // to wake (and waking its session would re-run it on the wrong exposure
+    // surface — see the module header), so its reply resolves INTO this call.
+    // The actor turn still queues/serializes on the actor's own slot exactly
+    // like the async path; only the completion routing differs.
+    if (awaitReply === true) {
+      const settled = await new Promise((resolve) => {
+        runEngineDelivery({
+          correlationId, senderSessionId: sender, rootSessionId, actor, message,
+          parentToolUseId: toolUseId, oneShot: oneShot === true,
+          onReply: (text, failed) => resolve({ text, failed }),
+        });
+      });
+      return settled.failed
+        ? { ok: false, error: settled.text }
+        : { ok: true, content: settled.text };
+    }
+
+    runEngineDelivery({ correlationId, senderSessionId: sender, rootSessionId, actor, message, parentToolUseId: toolUseId, oneShot: oneShot === true });
 
     const recipient = (kind === 'web' && instanceId === 'web')
       ? 'the web actor'
@@ -327,18 +486,35 @@ export const makeActorMessaging = (deps) => {
       // sender's actor, not whatever chat is focused at boot.
       try { actor = await resolveActor(e.to, { senderSessionId: e.senderSessionId }); }
       catch { actor = null; }
+      // Phase 7 (envelope arbitration) — a redrained reply must reach a session
+      // that can actually receive a wake. When the envelope's provenance says
+      // the sender was NOT its own lineage root, the sender was an EPHEMERAL
+      // subagent awaiting the reply in a tool call; that await died with the SW,
+      // and waking the child's session would run an orphan turn on the wrong
+      // exposure surface. Reroute to the ROOT — the chat that ultimately asked —
+      // which handles it like any other fenced actor note. Entries without
+      // provenance (pre-#134) keep the old sender-addressed behavior.
+      const wakeTarget = (typeof e.provenance?.rootSessionId === 'string'
+        && e.provenance.rootSessionId !== e.senderSessionId)
+        ? e.provenance.rootSessionId
+        : e.senderSessionId;
+      if (wakeTarget !== e.senderSessionId) {
+        appendAudit({ type: 'actor_reply_rerouted', details: { to: e.to, senderSessionId: e.senderSessionId, rootSessionId: wakeTarget } }).catch(() => {});
+      }
       // The instance is gone (engine instance deleted, or a web actor's tab
-      // closed) → abandon it; wake the sender so it isn't left waiting on a reply
+      // closed) → abandon it; wake the target so it isn't left waiting on a reply
       // that can never come. A live instance (any kind, web included) re-runs.
       if (!actor) {
-        deliver(e.senderSessionId, e.to, 'tab-hosted', undefined,
+        deliver(wakeTarget, e.to, 'tab-hosted', undefined,
           'could not be reached after a restart (its instance may have been closed). Re-issue the request if it still matters.', true);
         mailbox.remove(e.id).catch(() => {});
         appendAudit({ type: 'actor_message_abandoned', details: { to: e.to, senderSessionId: e.senderSessionId } }).catch(() => {});
         continue;
       }
-      inFlight.set(e.senderSessionId, (inFlight.get(e.senderSessionId) ?? 0) + 1);
-      runEngineDelivery({ correlationId: e.id, senderSessionId: e.senderSessionId, actor, message: e.message, oneShot: e.oneShot === true });
+      inFlight.set(wakeTarget, (inFlight.get(wakeTarget) ?? 0) + 1);
+      // senderSessionId here is the DELIVERY address (deliver() wakes it) and the
+      // bookkeeping root on a redrain — for a rerouted entry both are the root.
+      runEngineDelivery({ correlationId: e.id, senderSessionId: wakeTarget, rootSessionId: wakeTarget, actor, message: e.message, oneShot: e.oneShot === true });
       redrained += 1;
     }
     log('redrained', redrained);

--- a/extension/peerd-runtime/subagent/async-subagents.js
+++ b/extension/peerd-runtime/subagent/async-subagents.js
@@ -220,7 +220,18 @@ export const makeAsyncSubagents = (deps) => {
 
     /** @param {{ type: string, sessionId?: string, text?: string, [k: string]: unknown }} ev */
     const onEvent = (ev) => {
-      if (ev.type === 'subagent-start') entry.childSessionId = ev.sessionId ?? null;
+      if (ev.type === 'subagent-start') {
+        entry.childSessionId = ev.sessionId ?? null;
+        // #9 race: a cancel that landed BEFORE this start event couldn't stop a
+        // child whose id it didn't yet know (childSessionId was null), so it
+        // only flipped status. Now that the id has arrived, honor that pending
+        // cancel — abort the child (and its subtree) so the copy "its work is
+        // being stopped" is true instead of leaving it running its full budget.
+        if (entry.status === 'cancelled' && entry.childSessionId) {
+          stopSubtree?.(entry.childSessionId);
+          turnSlots.stop?.(entry.childSessionId);
+        }
+      }
       if (ev.type === 'delta' && typeof ev.text === 'string' && ev.text) {
         entry.ring.push(ev.text);
         while (entry.ring.length > RING_LINES) entry.ring.shift();
@@ -233,6 +244,22 @@ export const makeAsyncSubagents = (deps) => {
     /** @param {Partial<ChildEntry>} patch */
     const settle = (patch) => {
       if (entry.status === 'cancelled') return; // cancelled mid-run → drop, no wake
+      // A user Stop cascades to the child (routes/sessions.js stopSubtree aborts
+      // its slot); the child unwinds and comes back `stopped:true`. Do NOT drain
+      // a Stop-aborted child: the parent's OWN turn was just stopped too, so a
+      // reintegration wake would re-enter it with a synthetic turn and the model
+      // would immediately start a fresh full-tool turn — seconds after the user
+      // pressed Stop (the actor-messaging path already guards this via its
+      // stop-generation skip; the spawn path needs the same guard). Drop it like
+      // a cancel: mark terminal, surface on the bar, no wake. A TIMEOUT is
+      // different — the parent is still working and wants the partial — so
+      // timedOut still drains. (A goal/auto continuation isn't a user Stop; those
+      // don't cascade stopSubtree, so they never reach here as `stopped`.)
+      if (patch.stopped === true) {
+        Object.assign(entry, patch, { status: 'cancelled' });
+        onTasksChanged(parentSessionId);
+        return;
+      }
       Object.assign(entry, patch, { status: 'done' });
       onTasksChanged(parentSessionId); // running → done (still on the bar until delivered)
       turnSlots.runWhenIdle(parentSessionId, () => {

--- a/extension/peerd-runtime/subagent/async-subagents.js
+++ b/extension/peerd-runtime/subagent/async-subagents.js
@@ -22,9 +22,16 @@
 
 /**
  * @param {Object} deps
- * @param {(req: object) => Promise<{ result?: string, sessionId?: string|null, exceeded?: boolean, refused?: boolean }>} deps.spawnSubagent
+ * @param {(req: object) => Promise<{ result?: string, sessionId?: string|null, exceeded?: boolean, refused?: boolean, timedOut?: boolean, stopped?: boolean }>} deps.spawnSubagent
  *   The bound child runner (resolves when the child's whole loop finishes).
- * @param {{ runWhenIdle: (sessionId: string, fn: () => void) => void, isBusy: (sessionId: string) => boolean }} deps.turnSlots
+ * @param {{ runWhenIdle: (sessionId: string, fn: () => void) => void, isBusy: (sessionId: string) => boolean, stop?: (sessionId: string) => boolean }} deps.turnSlots
+ *   stop (optional — PR #134): abort a child session's live turn slot, so
+ *   subagent_cancel actually ENDS the child's work instead of only dropping
+ *   its result. Absent (older harnesses/tests) → cancel keeps the drop-only
+ *   behavior.
+ * @param {(sessionId: string) => string[]} [deps.stopSubtree]
+ *   Transitively stop a cancelled child's OWN descendants (spawn.js
+ *   stopSubtree) — a cancel must end the whole subtree, like Stop does.
  * @param {(opts: { userText: string, sessionId: string, synthetic: boolean }) => Promise<unknown>} deps.reenter
  *   Re-enter a session with a (synthetic) turn — the SW's runAgentTurn.
  * @param {() => Promise<string|null>} deps.getActiveSessionId
@@ -42,7 +49,7 @@
 export const makeAsyncSubagents = (deps) => {
   const {
     spawnSubagent, turnSlots, reenter, getActiveSessionId, isVaultLocked,
-    wrapUntrusted, forwardEvent, notify, now = Date.now, caps = {},
+    wrapUntrusted, forwardEvent, notify, stopSubtree, now = Date.now, caps = {},
     // Mirror the live task list to a UI on each status transition. No-op in
     // tests / headless contexts that don't render it.
     onTasksChanged = () => {},
@@ -68,6 +75,8 @@ export const makeAsyncSubagents = (deps) => {
    * @property {string} result
    * @property {boolean} exceeded
    * @property {boolean} interrupted
+   * @property {boolean} timedOut     the child hit its wall-clock budget (PR #134)
+   * @property {boolean} stopped      the child's slot was aborted (Stop cascade)
    * @property {string | null} childSessionId
    * @property {boolean} reintegrated
    * @property {string[]} ring
@@ -99,18 +108,26 @@ export const makeAsyncSubagents = (deps) => {
     }));
   };
 
-  // Cancel: stop the result from coming back and free the cap slot. The child
-  // loop settles on its own; a cancelled entry is dropped on settle (no wake).
-  // taskId may arrive undefined (callers read it off a possibly-error spawn
-  // handle); Map.get tolerates it and the !entry guard below catches it.
+  // Cancel: ABORT the child's live turn (PR #134 — its loop runs under a turn
+  // slot now, so cancel actually ends the work, not just the result), stop the
+  // result from coming back, and free the cap slot. The aborted loop settles
+  // through spawnSubagent's normal path; a cancelled entry is dropped on settle
+  // (no wake). The child's own descendants are stopped too — a cancel ends the
+  // whole subtree, exactly like Stop. taskId may arrive undefined (callers read
+  // it off a possibly-error spawn handle); Map.get tolerates it and the !entry
+  // guard below catches it.
   /** @param {string} parentSessionId @param {string | undefined} taskId */
   const subagentCancel = (parentSessionId, taskId) => {
     const entry = children.get(parentSessionId)?.get(taskId ?? '');
     if (!entry) return { ok: false, error: 'no_such_task' };
     if (entry.status !== 'running') return { ok: false, error: `task already ${entry.reintegrated ? 'delivered' : entry.status}` };
     entry.status = 'cancelled';
+    if (entry.childSessionId) {
+      stopSubtree?.(entry.childSessionId);
+      turnSlots.stop?.(entry.childSessionId);
+    }
     onTasksChanged(parentSessionId);
-    return { ok: true, content: `subagent ${taskId} cancelled — its result will not come back` };
+    return { ok: true, content: `subagent ${taskId} cancelled — its work is being stopped and its result will not come back` };
   };
 
   // Coalesce all of a parent's finished-but-unreintegrated children into ONE
@@ -144,6 +161,8 @@ export const makeAsyncSubagents = (deps) => {
       // determinism, formatted correctly.
       const wrapped = wrapUntrusted({ origin: 'subagent', tool: 'spawn_subagent', body, retrievedAt: new Date(now()).toISOString() });
       const flag = c.interrupted ? ' (interrupted before finishing — partial)'
+        : c.timedOut ? ' (hit its wall-clock timeout — partial)'
+        : c.stopped ? ' (stopped before finishing — partial)'
         : c.exceeded ? ' (hit its step cap — may be incomplete)' : '';
       return `Subagent "${c.task.slice(0, 80)}"${flag}:\n${wrapped}`;
     });
@@ -193,7 +212,8 @@ export const makeAsyncSubagents = (deps) => {
     /** @type {ChildEntry} */
     const entry = {
       taskId, task: String(req.task ?? ''), status: 'running', result: '',
-      exceeded: false, interrupted: false, childSessionId: null, reintegrated: false, ring: [],
+      exceeded: false, interrupted: false, timedOut: false, stopped: false,
+      childSessionId: null, reintegrated: false, ring: [],
     };
     kids.set(taskId, entry);
     onTasksChanged(parentSessionId); // new task → appears on the live bar
@@ -223,6 +243,8 @@ export const makeAsyncSubagents = (deps) => {
       .then((out) => settle({
         result: out.refused ? out.result : (out.result ?? ''),
         exceeded: out.exceeded === true || out.refused === true,
+        timedOut: out.timedOut === true,
+        stopped: out.stopped === true,
         childSessionId: out.sessionId ?? entry.childSessionId,
       }))
       .catch((e) => settle({ result: `subagent errored: ${/** @type {{ message?: string }} */ (e)?.message ?? String(e)}`, interrupted: true }));

--- a/extension/peerd-runtime/subagent/delegation-lineage.js
+++ b/extension/peerd-runtime/subagent/delegation-lineage.js
@@ -1,6 +1,7 @@
 // @ts-check
 // delegation-lineage — the PURE trust decision for the "subagents as async
-// actors" refactor (PROPOSAL, inert until wired). See PR body for the full spec.
+// actors" refactor (PR #134, WIRED — the sender gate in actor-messaging.js
+// routes through mayMessageActor and stamps messageProvenance on envelopes).
 //
 // PROBLEM. Today a subagent and a message_actor actor are two different async
 // lifecycles. The one that matters here: a subagent CANNOT message an actor, so
@@ -42,12 +43,13 @@
 // wired) builds `ancestry` by walking parentSessionId up from the sender via the
 // session store, then asks this function yes/no. This function reads values only.
 
-// Feature flag for the refactor. OFF here: nothing imports this yet, so the live
-// sender gate keeps its `=== active` behavior and runtime is unchanged. The
-// follow-up implementation flips this and routes the gate through
-// mayMessageActor() (plus the abortable/timeout-bounded ephemeral-actor
-// lifecycle described in the PR body).
-export const ASYNC_SUBAGENT_ACTORS = false;
+// Feature flag for the refactor — ON: the sender gate (actor-messaging.js)
+// routes through mayMessageActor(), subagents run under abortable,
+// timeout-bounded turn slots (spawn.js), and envelopes carry provenance.
+// Kept (not deleted) so the gate can revert to the strict `=== active`
+// identity check with a one-line flip if a field problem surfaces; OFF
+// restores the pre-#134 sender gate, everything else stands.
+export const ASYNC_SUBAGENT_ACTORS = true;
 
 /**
  * One hop of a sender's ancestry: a session record reduced to the fields the

--- a/extension/peerd-runtime/subagent/delegation-lineage.js
+++ b/extension/peerd-runtime/subagent/delegation-lineage.js
@@ -108,3 +108,54 @@ export const mayMessageActor = ({ inbound, senderSessionId, activeSessionId, anc
   // Ran out of chain without reaching the active chat: not a descendant. Refuse.
   return false;
 };
+
+// ── mailbox provenance — the choke-point judgement ──────────────────────────
+//
+// An actor is a serialized CHOKE POINT: one tab (or one origin), one mailbox,
+// one turn at a time. While only the foreground chat messages it, "who sent
+// this" is trivial. Once actors are SHARED — a web actor on a tab that several
+// orchestrators or subagents all message — the actor (and the mailbox in front
+// of it) must arbitrate: coalesce an accidental duplicate, order competing
+// requests, cancel one a newer message supersedes, or keep unrelated senders
+// fair. To make that call it needs each message's PROVENANCE: who sent it, and
+// on whose behalf.
+//
+// The trusted-lineage chain already carries exactly that, so provenance is free
+// once the gate has it. The shell stamps it onto the message ENVELOPE
+// (denormalized) so the actor never has to walk the store mid-turn.
+//
+// why the envelope, not a structured session id: session ids are uuidv7
+// (time-sortable, globally-unique store keys); overloading them with a parent
+// path is brittle to parse and length-bound. The envelope carries the full
+// reference instead — same capability (the actor can name the parent), no id
+// overloading. Encoding it into the id is an owner call; the shape is the same.
+
+/**
+ * The provenance an actor's mailbox stamps on each incoming message, derived
+ * from the sender's trusted-lineage chain.
+ *
+ * @param {Object} req
+ * @param {string} req.senderSessionId
+ * @param {ReadonlyArray<LineageHop>} [req.ancestry]  sender-first chain toward the root
+ * @returns {{ senderSessionId: string, rootSessionId: string, lineagePath: string[] }}
+ *   rootSessionId — the chat at the base of the lineage (who ULTIMATELY asked);
+ *   equals senderSessionId for a top-level chat or a missing chain.
+ *   lineagePath — root → … → sender ids: the "reference to the parent" an actor
+ *   uses to group by root (fairness), match a supersede (same sender), or flag a
+ *   likely duplicate (same lineagePath + same intent, close in time).
+ */
+export const messageProvenance = ({ senderSessionId, ancestry = [] }) => {
+  const byId = new Map(ancestry.map((h) => [h.sessionId, h]));
+  const path = [senderSessionId];
+  const seen = new Set([senderSessionId]);
+  let cursor = /** @type {LineageHop | undefined} */ (byId.get(senderSessionId));
+  // Walk parentSessionId up to the root; the cycle guard keeps a corrupt chain
+  // from hanging us (a self-referential parent just stops the walk).
+  while (cursor?.parentSessionId && !seen.has(cursor.parentSessionId)) {
+    path.push(cursor.parentSessionId);
+    seen.add(cursor.parentSessionId);
+    cursor = byId.get(cursor.parentSessionId);
+  }
+  path.reverse();                 // root → … → sender
+  return { senderSessionId, rootSessionId: path[0], lineagePath: path };
+};

--- a/extension/peerd-runtime/subagent/delegation-lineage.js
+++ b/extension/peerd-runtime/subagent/delegation-lineage.js
@@ -1,0 +1,110 @@
+// @ts-check
+// delegation-lineage — the PURE trust decision for the "subagents as async
+// actors" refactor (PROPOSAL, inert until wired). See PR body for the full spec.
+//
+// PROBLEM. Today a subagent and a message_actor actor are two different async
+// lifecycles. The one that matters here: a subagent CANNOT message an actor, so
+// a subagent can't drive a tab / VM / notebook the way the orchestrator can.
+// What blocks it is the sender gate's IDENTITY check
+// (subagent/actor-messaging.js — `senderSessionId !== active` refuses), which
+// uses "are you the foreground chat" as a stand-in for "are you trusted." A
+// subagent runs under a child session id that is never `currentSessionId`, so it
+// is refused even though it is a first-party descendant of the active chat.
+//
+// THE FIX (this file is its crux). Replace the `=== active` identity check with
+// a trusted-LINEAGE check: a session may message an actor when it is the active
+// chat OR a descendant of it reached ENTIRELY through trusted SPAWN edges. Two
+// walls stay exactly as they are:
+//   1. the inbound wall — `inbound === true` still refuses. `inbound` is the
+//      turn's untrusted-origin flag (synthetic && !trusted, service-worker.js).
+//      It is what keeps an injected/synthetic re-entry from delegating, and it is
+//      ALSO what keeps an async-subagent's RESULT-wake from delegating (that wake
+//      re-enters the parent trusted:false → inbound:true), preserving the explicit
+//      "a parent reacting to a child result is not trusted to delegate" decision.
+//      So the RESULT edge needs no handling here: the inbound wall already covers it.
+//   2. the capability strip — message_actor's ctx closure survives only for a ctx
+//      whose toolset grants message_actor (spawn.js CAPABILITY_CONSUMERS). A
+//      tools:[] fan-out child still can't delegate. Unchanged.
+//
+// THE HOLE THIS CLOSES (why lineage alone is not enough). An INBOUND turn on the
+// active chat is refused message_actor directly — but it can still call
+// spawn_subagent, and the child it spawns runs non-inbound turns. Without care,
+// that child would be a "descendant of the active chat" and could message actors
+// on the injected turn's behalf — laundering delegation around the inbound wall.
+// So a spawn edge is trusted ONLY when the spawning turn was itself trusted
+// (not inbound). The shell stamps that verdict onto the child at spawn time
+// (`spawnedTrusted`), and one untrusted spawn taints its whole subtree. Because
+// parentSessionId is set server-side at sessions.create (never model-supplied),
+// the ancestry chain itself is not attacker-forgeable; the only thing that can
+// downgrade trust is an inbound spawning turn, which is exactly what we taint on.
+//
+// PURE (no IO) → Bun-testable. The imperative shell (actor-messaging.js, once
+// wired) builds `ancestry` by walking parentSessionId up from the sender via the
+// session store, then asks this function yes/no. This function reads values only.
+
+// Feature flag for the refactor. OFF here: nothing imports this yet, so the live
+// sender gate keeps its `=== active` behavior and runtime is unchanged. The
+// follow-up implementation flips this and routes the gate through
+// mayMessageActor() (plus the abortable/timeout-bounded ephemeral-actor
+// lifecycle described in the PR body).
+export const ASYNC_SUBAGENT_ACTORS = false;
+
+/**
+ * One hop of a sender's ancestry: a session record reduced to the fields the
+ * trust decision needs. Nearest-first (the sender itself is index 0).
+ * @typedef {Object} LineageHop
+ * @property {string} sessionId              this session's id
+ * @property {string | null} parentSessionId who spawned it (server-set; null for a root chat)
+ * @property {boolean} spawnedTrusted        was the SPAWNING turn trusted (non-inbound)?
+ *   true for a root chat (nothing spawned it) and for a child spawned by a
+ *   trusted turn; false when an INBOUND turn spawned this session — that taints
+ *   the whole subtree beneath it.
+ */
+
+/**
+ * May `senderSessionId` send a message to an actor? The trusted-lineage rule
+ * that replaces the sender gate's `senderSessionId === active` identity check.
+ *
+ * Accept iff, in order:
+ *   1. the current turn is NOT inbound (untrusted-origin wall, unchanged), AND
+ *   2. the sender IS the active chat, OR it is a descendant of the active chat
+ *      whose entire ancestry up to the active chat was spawned by trusted turns.
+ *
+ * @param {Object} req
+ * @param {boolean} req.inbound           the CURRENT turn's untrusted-origin flag
+ * @param {string | null | undefined} req.senderSessionId  the calling session
+ * @param {string | null | undefined} req.activeSessionId  currentSessionId (foreground chat)
+ * @param {ReadonlyArray<LineageHop>} [req.ancestry]  sender-first chain toward the
+ *   root, built by the shell from the store. Omitted/empty → only the direct
+ *   foreground-identity path can pass (fail-closed for a missing chain).
+ * @returns {boolean}
+ */
+export const mayMessageActor = ({ inbound, senderSessionId, activeSessionId, ancestry = [] }) => {
+  // Wall 1 — inbound origin. An injected/synthetic turn (and the async result-
+  // wake) never delegates, no matter whose lineage it runs under. Fail-closed.
+  if (inbound === true) return false;
+  if (!senderSessionId || !activeSessionId) return false;
+
+  // The foreground chat itself — today's sole accepted sender. Kept as a fast path.
+  if (senderSessionId === activeSessionId) return true;
+
+  // Trusted-lineage: walk the sender's ancestry toward the root. The sender is
+  // admitted only if it reaches the active chat AND every hop from the sender up
+  // to (and including) the active chat was spawned by a trusted turn. A single
+  // untrusted (inbound-spawned) hop taints the subtree and refuses.
+  //
+  // why require the sender itself to be spawnedTrusted: the sender is the child
+  // an inbound turn would have spawned to launder access — so its own spawn
+  // verdict is the first thing that must be trusted.
+  const byId = new Map(ancestry.map((h) => [h.sessionId, h]));
+  let cursor = /** @type {LineageHop | undefined} */ (byId.get(senderSessionId));
+  const seen = new Set();                       // cycle guard (a corrupt chain can't hang us)
+  while (cursor && !seen.has(cursor.sessionId)) {
+    if (!cursor.spawnedTrusted) return false;    // an untrusted spawn anywhere → refuse
+    if (cursor.parentSessionId === activeSessionId) return true; // reached the active root cleanly
+    seen.add(cursor.sessionId);
+    cursor = cursor.parentSessionId ? byId.get(cursor.parentSessionId) : undefined;
+  }
+  // Ran out of chain without reaching the active chat: not a descendant. Refuse.
+  return false;
+};

--- a/extension/peerd-runtime/subagent/spawn.js
+++ b/extension/peerd-runtime/subagent/spawn.js
@@ -37,6 +37,18 @@ export const DEFAULT_MAX_DEPTH = 5;
 export const DEFAULT_MAX_STEPS = 20;
 export const DEFAULT_MAX_OUTPUT_TOKENS = 4096;
 
+// Wall-clock ceiling for a child's WHOLE run (subagents-as-async-actors,
+// PR #134 phase 2). Before this, a subagent had only step/depth caps — a
+// single hung tool call or provider stall could park it forever, with no
+// abort path (no signal was threaded) and nothing to wake the parent. The
+// timer aborts the child's turn-slot controller, so the loop unwinds
+// through its normal abort branch (persists the partial, stopReason
+// 'aborted') and the parent is woken with a timeout-flagged result.
+// Callers may pass timeoutMs lower or higher, clamped to MAX — the same
+// "can't be raised past the backstop" posture as maxSteps.
+export const DEFAULT_TIMEOUT_MS = 10 * 60_000;
+export const MAX_TIMEOUT_MS = 30 * 60_000;
+
 /**
  * Compute the tool subset a subagent may use.
  *
@@ -206,6 +218,16 @@ export const finalAssistantText = (session) => {
  * @param {() => Array<{ name: string, description: string, schema: object }>} deps.getToolDescriptors
  *   Returns the full registered tool descriptor set (parent's tools).
  * @param {() => number} [deps.now]
+ * @param {{ claim: (sessionId: string) => { controller: AbortController, release: () => void }, stop: (sessionId: string) => boolean }} [deps.turnSlots]
+ *   The per-session turn-slot system (loop/turn-slots.js). PR #134 phase 1: a
+ *   child runs UNDER a slot so it is abortable — Stop, the wall-clock timeout,
+ *   and subagentCancel all reach it via the slot's controller. The default is a
+ *   standalone stub (a fresh controller per spawn, stop() a no-op) so orchestrators
+ *   that never stop children (tests, cheap-call harnesses) need no wiring.
+ * @param {(fn: () => void, ms: number) => unknown} [deps.setTimer]
+ * @param {(handle: unknown) => void} [deps.clearTimer]
+ *   Injected timer pair (setTimeout/clearTimeout in the SW) so the timeout is
+ *   Bun-testable without real waiting.
  */
 export const makeSpawnSubagent = (deps) => {
   const {
@@ -213,7 +235,56 @@ export const makeSpawnSubagent = (deps) => {
     appendAudit, buildToolContext, dispatchToolCall,
     renderSystemPrompt, getToolDescriptors,
     now = Date.now,
+    turnSlots = {
+      claim: () => ({ controller: new AbortController(), release: () => {} }),
+      stop: () => false,
+    },
+    setTimer = (/** @type {() => void} */ fn, /** @type {number} */ ms) => setTimeout(fn, ms),
+    clearTimer = (/** @type {unknown} */ handle) => clearTimeout(/** @type {any} */ (handle)),
   } = deps;
+
+  // Live-children registry (phase 5, multi-hop Stop): parent → the child
+  // sessions whose loops are CURRENTLY running under this orchestrator.
+  // In-memory, in-session only — same durability posture as async-subagents'
+  // task map (a child lost to SW death is reported interrupted, never resumed).
+  /** @type {Map<string, Set<string>>} */
+  const liveChildren = new Map();
+  /** @param {string} parentSessionId @param {string} childSessionId */
+  const registerChild = (parentSessionId, childSessionId) => {
+    const set = liveChildren.get(parentSessionId) ?? new Set();
+    set.add(childSessionId);
+    liveChildren.set(parentSessionId, set);
+  };
+  /** @param {string} parentSessionId @param {string} childSessionId */
+  const unregisterChild = (parentSessionId, childSessionId) => {
+    const set = liveChildren.get(parentSessionId);
+    if (!set) return;
+    set.delete(childSessionId);
+    if (set.size === 0) liveChildren.delete(parentSessionId);
+  };
+
+  /** The DIRECT live children of a session. @param {string} parentSessionId @returns {string[]} */
+  const liveChildrenOf = (parentSessionId) => [...(liveChildren.get(parentSessionId) ?? [])];
+
+  // Phase 5 — transitive Stop. Abort every live descendant's turn slot,
+  // depth-first from the given root (the root itself is the caller's to stop —
+  // agent/stop already does). Returns the descendants whose slot actually
+  // aborted, for the caller's audit trail. The cycle guard is defensive: the
+  // registry is built from fresh child ids, but a corrupt map must not hang us.
+  /** @param {string} rootSessionId @returns {string[]} */
+  const stopSubtree = (rootSessionId) => {
+    const stopped = [];
+    const seen = new Set([rootSessionId]);
+    const queue = liveChildrenOf(rootSessionId);
+    while (queue.length > 0) {
+      const id = queue.shift();
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      if (turnSlots.stop(id)) stopped.push(id);
+      queue.push(...liveChildrenOf(id));
+    }
+    return stopped;
+  };
 
   /**
    * @param {Object} req
@@ -226,6 +297,15 @@ export const makeSpawnSubagent = (deps) => {
    * @param {boolean} [req.allowRecursion]         keep spawn_subagent in the subset
    * @param {string} req.parentSessionId           who is spawning this
    * @param {number} [req.parentDepth]             spawner's depth (child = +1)
+   * @param {boolean} [req.parentInbound]          was the SPAWNING turn inbound
+   *   (untrusted-origin)? Stamped onto the child as `spawnedTrusted` — the
+   *   per-hop verdict the trusted-lineage gate walks (delegation-lineage.js).
+   *   FAIL-CLOSED: only an explicit `false` (the spawn_subagent tool passes
+   *   ctx.inbound) yields a trusted hop; undefined (the Notebook route, review,
+   *   cheap-call, any legacy caller) taints the child — those children never
+   *   had delegation, so nothing regresses.
+   * @param {number} [req.timeoutMs]               wall-clock budget for the whole
+   *   run (default DEFAULT_TIMEOUT_MS, clamped to MAX_TIMEOUT_MS)
    * @param {(ev: object) => void} [req.onEvent]   live forwarder for the side panel
    * @param {string} [req.parentToolUseId]         links the parent's card → child session
    * @param {boolean} [req.persistDeltas=true]      set false for ephemeral
@@ -233,7 +313,7 @@ export const makeSpawnSubagent = (deps) => {
    *   IDB rewrite. Finalization writes still happen — the result extraction
    *   below reads the COMPLETED session, which is the only persistence an
    *   ephemeral child needs (a mid-run SW death orphans the await anyway).
-   * @returns {Promise<{ result: string, sessionId: string | null, toolCalls: number, durationMs: number, depth: number, usage?: { inputTokens: number, outputTokens: number, cacheReadTokens: number, cacheWriteTokens: number }, exceeded?: true, refused?: true }>}
+   * @returns {Promise<{ result: string, sessionId: string | null, toolCalls: number, durationMs: number, depth: number, usage?: { inputTokens: number, outputTokens: number, cacheReadTokens: number, cacheWriteTokens: number }, exceeded?: true, refused?: true, timedOut?: true, stopped?: true }>}
    */
   const spawnSubagent = async (req) => {
     const {
@@ -246,6 +326,8 @@ export const makeSpawnSubagent = (deps) => {
       allowRecursion = false,
       parentSessionId,
       parentDepth = 0,
+      parentInbound,
+      timeoutMs,
       onEvent,
       parentToolUseId,
       persistDeltas = true,
@@ -316,6 +398,14 @@ export const makeSpawnSubagent = (deps) => {
       // intersects against it again — no depth at which the narrowing
       // evaporates.
       ...(parent?.toolManifest !== undefined ? { toolManifest: parent.toolManifest } : {}),
+      // PR #134 phase 3 — the trusted-lineage hop verdict, stamped SERVER-SIDE
+      // at create so the chain is never model-supplied. Trusted ONLY when the
+      // spawning turn explicitly proved itself non-inbound; an inbound spawn
+      // (or a caller that doesn't know) taints this child and — because the
+      // gate requires every hop trusted — its whole subtree. This is what
+      // closes the laundering hole: an injected turn refused message_actor
+      // can't spawn a child to delegate on its behalf.
+      spawnedTrusted: parentInbound === false,
     });
 
     // why: tag EVERY audit entry this subagent produces with its
@@ -389,6 +479,31 @@ export const makeSpawnSubagent = (deps) => {
     // tool card → this session id and render live, before any loop event.
     onEvent?.({ type: 'subagent-start', parentToolUseId, parentSessionId, sessionId: child.sessionId, depth, task });
 
+    // PR #134 phases 1+2 — the child runs UNDER a turn slot with an abort
+    // signal and a wall-clock budget. Before this it was un-abortable (no
+    // signal threaded) and un-bounded in time (only step/depth caps): a hung
+    // tool call parked it forever, invisible to Stop. Claiming the CHILD's own
+    // slot (a fresh id — nothing contends it) gives Stop/cancel/timeout one
+    // uniform lever: abort the controller, and the loop unwinds through its
+    // normal abort branch exactly like a steered main turn.
+    const { controller, release } = turnSlots.claim(child.sessionId);
+    registerChild(parentSessionId, child.sessionId);
+    let timedOut = false;
+    // Clamp to the backstop either way: a caller may lower the budget freely,
+    // but can't park a child past MAX (same posture as maxSteps).
+    const budgetMs = Math.min(
+      Number.isFinite(timeoutMs) && /** @type {number} */ (timeoutMs) > 0 ? /** @type {number} */ (timeoutMs) : DEFAULT_TIMEOUT_MS,
+      MAX_TIMEOUT_MS,
+    );
+    const timer = setTimer(() => {
+      timedOut = true;
+      appendAudit({
+        type: 'subagent_timeout',
+        details: { parentSessionId, subagentSessionId: child.sessionId, depth, budgetMs },
+      }).catch(() => {});
+      controller.abort();
+    }, budgetMs);
+
     let toolCalls = 0;
     let lastStopReason;
     // why: the child's model usage is yielded as 'usage' events but is NOT
@@ -414,6 +529,9 @@ export const makeSpawnSubagent = (deps) => {
         maxSteps,
         persistDeltas,
         now,
+        // Phase 1: the child is abortable — Stop cascades, subagentCancel, and
+        // the wall-clock timer all fire this controller.
+        signal: controller.signal,
       })) {
         if (ev.type === 'tool-use') toolCalls++;
         if (ev.type === 'stop') lastStopReason = ev.stopReason;
@@ -426,6 +544,11 @@ export const makeSpawnSubagent = (deps) => {
         onEvent?.(ev);
       }
     } finally {
+      clearTimer(timer);
+      unregisterChild(parentSessionId, child.sessionId);
+      // Release AFTER unregistering, so a Stop racing this settle can't abort a
+      // slot the registry no longer owns up to.
+      release();
       onEvent?.({ type: 'subagent-stop', parentToolUseId, sessionId: child.sessionId, depth });
     }
 
@@ -436,10 +559,14 @@ export const makeSpawnSubagent = (deps) => {
     // of room before finishing. Surface it so the caller (and the model)
     // knows the result may be partial.
     const exceeded = lastStopReason === 'max_steps';
+    // Phase 2: distinguish WHY an abort unwound the loop. timedOut is stamped
+    // by the timer before it fires the controller; any other abort (Stop
+    // cascade, subagentCancel) reports `stopped`. Both mean a partial result.
+    const stopped = !timedOut && lastStopReason === 'aborted';
 
     taggedAudit({
       type: 'subagent_completed',
-      details: { toolCalls, durationMs, exceeded, resultChars: result.length },
+      details: { toolCalls, durationMs, exceeded, timedOut, stopped, resultChars: result.length },
     }).catch(() => {});
 
     return {
@@ -450,8 +577,13 @@ export const makeSpawnSubagent = (deps) => {
       depth,
       usage,
       ...(exceeded ? { exceeded: true } : {}),
+      ...(timedOut ? { timedOut: true } : {}),
+      ...(stopped ? { stopped: true } : {}),
     };
   };
 
-  return spawnSubagent;
+  // The registry accessors ride ON the spawn function (not a wrapper object) so
+  // the ~25 existing construction sites — `const spawn = makeSpawnSubagent(d)` —
+  // keep working unchanged; the SW picks the extras off the same value.
+  return Object.assign(spawnSubagent, { liveChildrenOf, stopSubtree });
 };

--- a/extension/peerd-runtime/subagent/spawn.js
+++ b/extension/peerd-runtime/subagent/spawn.js
@@ -420,6 +420,46 @@ export const makeSpawnSubagent = (deps) => {
 
     taggedAudit({ type: 'subagent_spawned', details: { task: task.slice(0, 200), maxSteps, maxDepth } }).catch(() => {});
 
+    // PR #134 phases 1+2 — claim the child's turn slot and arm the wall-clock
+    // timer NOW, immediately after the session exists, BEFORE the tool-context
+    // build below. why here and not later: a Stop cascade enumerates the
+    // live-children registry, so a child not yet registered when Stop fires
+    // would escape it and run its full budget post-Stop (the tighter the window
+    // between create and register, the smaller that hole). Claiming the CHILD's
+    // own slot (a fresh id — nothing contends it) gives Stop/cancel/timeout one
+    // uniform lever: abort the controller, and the loop unwinds through its
+    // normal abort branch exactly like a steered main turn.
+    const { controller, release } = turnSlots.claim(child.sessionId);
+    registerChild(parentSessionId, child.sessionId);
+    let timerFired = false;
+    // Clamp to the backstop either way: a caller may lower the budget freely,
+    // but can't park a child past MAX (same posture as maxSteps).
+    const budgetMs = Math.min(
+      Number.isFinite(timeoutMs) && /** @type {number} */ (timeoutMs) > 0 ? /** @type {number} */ (timeoutMs) : DEFAULT_TIMEOUT_MS,
+      MAX_TIMEOUT_MS,
+    );
+    const timer = setTimer(() => {
+      timerFired = true;
+      appendAudit({
+        type: 'subagent_timeout',
+        details: { parentSessionId, subagentSessionId: child.sessionId, depth, budgetMs },
+      }).catch(() => {});
+      // why turnSlots.stop AND controller.abort: stop() fires the slot's onAbort
+      // hook (confirmCoordinator.declineSession) so a child parked on a confirm
+      // is declined at once instead of overshooting the budget by the confirm
+      // protocol's own 120s timeout — the same path user Stop / cancel take.
+      // The direct abort() is the guaranteed backstop (the injected stub stop()
+      // is a no-op in tests); abort() is idempotent, so calling both is safe.
+      turnSlots.stop(child.sessionId);
+      controller.abort();
+    }, budgetMs);
+    // Reclaim the child on ITS OWN abort too (#1/#3): a subagent blocked in an
+    // awaitReply message_actor call is suspended in tool dispatch — the loop
+    // only checks the signal at wave boundaries, so aborting the controller
+    // doesn't unwind that await by itself. message_actor reads this signal off
+    // ctx and races the actor reply against it, so the timeout / cancel that
+    // fires this controller also unblocks the awaiting child.
+
     // ---- Guardrail 2: tool narrowing -------------------------------------
     // The parent session's tool manifest caps the child's set whatever the
     // caller asked for — intersection, never escalation (fail-closed: a
@@ -442,7 +482,11 @@ export const makeSpawnSubagent = (deps) => {
       // the full capability surface (secrets/egress/spawn closures); we remove the
       // ones no granted tool needs so a narrowed child has no closure path to them
       // even if a granted tool were confused into reaching for one.
-      const childCtx = restrictCtxCapabilities({ ...baseCtx, audit: taggedAudit }, allowedNames);
+      // abortSignal (#1/#3): the child's own abort signal, so a blocking tool
+      // (message_actor awaitReply) can race its wait against it and unwind when
+      // the wall-clock timeout / cancel fires — restrictCtxCapabilities passes
+      // through any key not in CAPABILITY_CONSUMERS, so this survives the strip.
+      const childCtx = restrictCtxCapabilities({ ...baseCtx, audit: taggedAudit, abortSignal: controller.signal }, allowedNames);
       toolDispatch = (call) => {
         // Defense in depth: even if the model hallucinates a tool name
         // outside its granted subset, the dispatch refuses it. The
@@ -478,31 +522,6 @@ export const makeSpawnSubagent = (deps) => {
     // Announce the child up-front so the side panel can map the parent's
     // tool card → this session id and render live, before any loop event.
     onEvent?.({ type: 'subagent-start', parentToolUseId, parentSessionId, sessionId: child.sessionId, depth, task });
-
-    // PR #134 phases 1+2 — the child runs UNDER a turn slot with an abort
-    // signal and a wall-clock budget. Before this it was un-abortable (no
-    // signal threaded) and un-bounded in time (only step/depth caps): a hung
-    // tool call parked it forever, invisible to Stop. Claiming the CHILD's own
-    // slot (a fresh id — nothing contends it) gives Stop/cancel/timeout one
-    // uniform lever: abort the controller, and the loop unwinds through its
-    // normal abort branch exactly like a steered main turn.
-    const { controller, release } = turnSlots.claim(child.sessionId);
-    registerChild(parentSessionId, child.sessionId);
-    let timedOut = false;
-    // Clamp to the backstop either way: a caller may lower the budget freely,
-    // but can't park a child past MAX (same posture as maxSteps).
-    const budgetMs = Math.min(
-      Number.isFinite(timeoutMs) && /** @type {number} */ (timeoutMs) > 0 ? /** @type {number} */ (timeoutMs) : DEFAULT_TIMEOUT_MS,
-      MAX_TIMEOUT_MS,
-    );
-    const timer = setTimer(() => {
-      timedOut = true;
-      appendAudit({
-        type: 'subagent_timeout',
-        details: { parentSessionId, subagentSessionId: child.sessionId, depth, budgetMs },
-      }).catch(() => {});
-      controller.abort();
-    }, budgetMs);
 
     let toolCalls = 0;
     let lastStopReason;
@@ -559,10 +578,16 @@ export const makeSpawnSubagent = (deps) => {
     // of room before finishing. Surface it so the caller (and the model)
     // knows the result may be partial.
     const exceeded = lastStopReason === 'max_steps';
-    // Phase 2: distinguish WHY an abort unwound the loop. timedOut is stamped
-    // by the timer before it fires the controller; any other abort (Stop
-    // cascade, subagentCancel) reports `stopped`. Both mean a partial result.
-    const stopped = !timedOut && lastStopReason === 'aborted';
+    // Phase 2: distinguish WHY an abort unwound the loop — but ONLY when the
+    // loop actually aborted. timerFired alone doesn't imply a timeout: the timer
+    // can fire in the race window between a clean 'end_turn' finish and this
+    // finally's clearTimer, which must NOT relabel a complete result as partial.
+    // Gate both flags on lastStopReason==='aborted' (a real abort unwind), then
+    // split by cause: timer → timedOut, anything else (Stop cascade, cancel) →
+    // stopped. A non-aborted finish is neither.
+    const aborted = lastStopReason === 'aborted';
+    const timedOut = aborted && timerFired;
+    const stopped = aborted && !timerFired;
 
     taggedAudit({
       type: 'subagent_completed',

--- a/extension/peerd-runtime/tools/defs/click.js
+++ b/extension/peerd-runtime/tools/defs/click.js
@@ -108,13 +108,20 @@ export const clickTool = {
       if (!entry) return { ok: false, error: `stale_ref: ${ref} — re-run snapshot on this tab first` };
 
       if (entry.backendDOMNodeId != null && typeof debuggerPool?.clickBackendNode === 'function') {
+        // Cardinality guard on the CDP channel too (#36 consistency): a resolved
+        // backendDOMNodeId ref IS exactly one node, so any expectedCount other
+        // than 1 is a mismatch — same shape the walk-ref/selector paths return,
+        // so the guard the schema promises holds identically across channels.
+        if (expectedCount != null && expectedCount !== 1) {
+          return { ok: false, error: 'matched_count_mismatch', matchedCount: 1, expectedCount };
+        }
         try {
           const r = await debuggerPool.clickBackendNode(tab.id, entry.backendDOMNodeId);
           if (!r.ok) return { ok: false, error: r.error ?? 'ref_click_failed' };
           return {
             ok: true,
             content: JSON.stringify({
-              clicked: true, ref, role: entry.role, name: entry.name, tag: r.tag, text: r.text,
+              clicked: true, ref, role: entry.role, name: entry.name, tag: r.tag, text: r.text, matchedCount: 1,
               ...(r.navigated ? { navigated: true } : {}),
               // Action-result attribution: what the click changed on the page.
               result: r.navigated ? 'page navigated' : summarizeMutations(r.mutations),

--- a/extension/peerd-runtime/tools/defs/click.js
+++ b/extension/peerd-runtime/tools/defs/click.js
@@ -69,7 +69,7 @@ export const clickTool = {
       expectedCount: {
         type: 'integer',
         minimum: 1,
-        description: 'Optional deterministic guard for selector actions: fail before clicking unless the selector resolves to exactly this many elements.',
+        description: 'Optional deterministic guard: fail before clicking unless the target resolves to exactly this many elements (the selector match count; a walk ref resolves to 0 or 1).',
       },
       tabId: {
         type: 'integer',
@@ -88,6 +88,13 @@ export const clickTool = {
     // ToolContext typedef; scripting is typed opaquely — narrow all three.
     const { domRefs, debuggerPool } = /** @type {DomCtxExtras} */ (ctx);
     const scripting = /** @type {typeof chrome.scripting} */ (ctx.scripting);
+
+    // why: hoisted above the ref branch — the cardinality guard applies to
+    // BOTH resolution channels the injected body serves (selector match count,
+    // walk-ref 0/1), not just selector calls (issue #36).
+    const expectedCount = Number.isInteger(args?.expectedCount) && args.expectedCount > 0
+      ? args.expectedCount
+      : null;
 
     // Ref path (a11y snapshot): the harness owns the ref→node mapping, so
     // there's no ambiguity and no "selector not found". Two resolutions,
@@ -124,7 +131,7 @@ export const clickTool = {
           const results = await scripting.executeScript({
             target: { tabId: tab.id },
             func: clickInjected,
-            args: [null, 0, entry.walkId],
+            args: [null, 0, entry.walkId, expectedCount],
           });
           scriptResult = results[0]?.result;
         } catch (e) {
@@ -137,6 +144,10 @@ export const clickTool = {
           content: JSON.stringify({
             clicked: true, ref, role: entry.role, name: entry.name,
             tag: scriptResult.tag, text: scriptResult.text,
+            // why: keep matchedCount present on every success shape (selector
+            // AND walk ref) so the agent reads one consistent contract; a
+            // resolved walk ref is always exactly 1 (issue #36).
+            matchedCount: scriptResult.matchedCount,
             // Honest about the channel: a scripting click is synthetic
             // (isTrusted=false) — sites that gate on trusted input may
             // ignore it, and there is no fallback channel here.
@@ -160,9 +171,6 @@ export const clickTool = {
       return { ok: false, error: 'selector_or_ref_required' };
     }
     const nth = Number.isInteger(args.nth) && args.nth >= 0 ? args.nth : 0;
-    const expectedCount = Number.isInteger(args.expectedCount) && args.expectedCount > 0
-      ? args.expectedCount
-      : null;
 
     let scriptResult;
     try {
@@ -201,7 +209,12 @@ export const clickTool = {
  * @param {number | null} [walkId]
  * @param {number | null} [expectedCount]
  */
-function clickInjected(selector, nth, walkId, expectedCount) {
+// why: exported for the Bun tests to exercise the REAL body's walk-ref
+// cardinality guard (mocked scriptResults would hide an omission — #103
+// review lesson). Same precedent as domWalkInjected; `export` is not part
+// of Function.prototype.toString, so executeScript serialization is
+// unchanged.
+export function clickInjected(selector, nth, walkId, expectedCount) {
   'use strict';
   /** @type {HTMLElement | null} */
   let el;
@@ -214,6 +227,21 @@ function clickInjected(selector, nth, walkId, expectedCount) {
     // a standard global, so reach it through an erased cast.
     const reg = /** @type {{ __peerdWalkEls?: Map<number, HTMLElement> }} */ (globalThis).__peerdWalkEls;
     el = reg && typeof reg.get === 'function' ? (reg.get(walkId) ?? null) : null;
+    // why: a walkId names exactly one registered element, so the real match
+    // cardinality is 0 (stale/unregistered) or 1 (found). Enforce the guard
+    // against that count — same code + fields as the selector path — instead
+    // of silently ignoring expectedCount on ref calls (issue #36). Checked
+    // BEFORE the stale return so the 0 case reports the mismatch the caller
+    // asked to be told about, with the re-snapshot hint kept in the text.
+    matchedCount = el && el.isConnected ? 1 : 0;
+    if (expectedCount != null && matchedCount !== expectedCount) {
+      return {
+        ok: false,
+        error: `matched_count_mismatch: walk ref matched ${matchedCount} element(s), expected ${expectedCount}${matchedCount === 0 ? ' — element no longer in the page; re-run snapshot on this tab first' : ''}`,
+        matchedCount,
+        expectedCount,
+      };
+    }
     if (!el || !el.isConnected) {
       return { ok: false, error: 'stale_ref: element no longer in the page — re-run snapshot on this tab first' };
     }

--- a/extension/peerd-runtime/tools/defs/message-actor.js
+++ b/extension/peerd-runtime/tools/defs/message-actor.js
@@ -14,8 +14,8 @@
  * The ctx slot message_actor reads (an SW-injected extra, not on the base
  * ToolContext contract).
  * @typedef {Object} MessageActorCtx
- * @property {(req: { to: string, message: string, senderSessionId?: string|null, inbound?: boolean, toolUseId?: string, oneShot?: boolean }) => Promise<{ ok: boolean, content?: string, error?: string }>} [messageActor]
- * @property {{ sessionId?: string }} [session]
+ * @property {(req: { to: string, message: string, senderSessionId?: string|null, inbound?: boolean, toolUseId?: string, oneShot?: boolean, awaitReply?: boolean }) => Promise<{ ok: boolean, content?: string, error?: string }>} [messageActor]
+ * @property {{ sessionId?: string, kind?: string }} [session]
  * @property {boolean} [inbound]
  * @property {string} [toolUseId]
  */
@@ -40,6 +40,8 @@ export const messageActorTool = {
     'message at a time (its mailbox): reuse the same `to` for follow-up (no',
     're-orientation); message a DIFFERENT tab/instance for independent work — separate',
     'actors run in parallel. Your ONLY path to act on a page or mutate an instance.',
+    '(When you are a SUBAGENT, the reply comes back directly in THIS tool result',
+    'instead of a later turn — use it and continue.)',
   ].join(' '),
   schema: {
     type: 'object',
@@ -85,6 +87,11 @@ export const messageActorTool = {
       // same thread spawn_subagent uses) keys the actor's live display stream
       // to this card, so its work renders inline like a subagent transcript.
       toolUseId: c.toolUseId,
+      // PR #134 — the subagent reply mode. An ephemeral child has no later turn
+      // for the reply-wake to re-enter (and waking its session would rebuild it
+      // on the main exposure surface), so its reply resolves INTO this tool
+      // result — still wrapUntrusted-fenced. Long-lived senders keep the wake.
+      awaitReply: c.session?.kind === 'subagent',
     });
     // Narrow the orchestrator's {ok, content?, error?} into the ToolResult union.
     return res.ok

--- a/extension/peerd-runtime/tools/defs/message-actor.js
+++ b/extension/peerd-runtime/tools/defs/message-actor.js
@@ -14,10 +14,11 @@
  * The ctx slot message_actor reads (an SW-injected extra, not on the base
  * ToolContext contract).
  * @typedef {Object} MessageActorCtx
- * @property {(req: { to: string, message: string, senderSessionId?: string|null, inbound?: boolean, toolUseId?: string, oneShot?: boolean, awaitReply?: boolean }) => Promise<{ ok: boolean, content?: string, error?: string }>} [messageActor]
+ * @property {(req: { to: string, message: string, senderSessionId?: string|null, inbound?: boolean, toolUseId?: string, oneShot?: boolean, awaitReply?: boolean, awaitSignal?: any }) => Promise<{ ok: boolean, content?: string, error?: string }>} [messageActor]
  * @property {{ sessionId?: string, kind?: string }} [session]
  * @property {boolean} [inbound]
  * @property {string} [toolUseId]
+ * @property {{ aborted: boolean, addEventListener: Function }} [abortSignal]
  */
 
 /** @type {import('/shared/tool-types.js').Tool} */
@@ -92,6 +93,10 @@ export const messageActorTool = {
       // on the main exposure surface), so its reply resolves INTO this tool
       // result — still wrapUntrusted-fenced. Long-lived senders keep the wake.
       awaitReply: c.session?.kind === 'subagent',
+      // The child's own abort signal (spawn.js threads it onto ctx). Lets the
+      // awaited reply race the child's wall-clock timeout / cancel, so a hung
+      // actor turn doesn't park the subagent past its budget (#1/#3).
+      awaitSignal: c.abortSignal,
     });
     // Narrow the orchestrator's {ok, content?, error?} into the ToolResult union.
     return res.ok

--- a/extension/peerd-runtime/tools/defs/spawn-subagent.js
+++ b/extension/peerd-runtime/tools/defs/spawn-subagent.js
@@ -24,13 +24,14 @@ const MAX_RESULT_CHARS = 200 * 1024;
  * @typedef {{
  *   result: string, sessionId: string | null, toolCalls: number,
  *   durationMs: number, depth: number, exceeded?: true, refused?: true,
+ *   timedOut?: true, stopped?: true,
  * }} SpawnSubagentResult
  */
 /**
  * @typedef {{
  *   task: string, tools?: string[], maxSteps?: number, maxDepth?: number,
  *   allowRecursion: boolean, parentSessionId: string, parentDepth: number,
- *   parentToolUseId?: string,
+ *   parentInbound: boolean, parentToolUseId?: string,
  * }} SpawnRequest
  */
 /**
@@ -39,6 +40,7 @@ const MAX_RESULT_CHARS = 200 * 1024;
  *   spawnSubagentAsync?: (req: SpawnRequest) => Promise<{ ok: true, content: string } | { ok: false, error: string }>,
  *   toolUseId?: string,
  *   session?: { sessionId?: string, depth?: number },
+ *   inbound?: boolean,
  * }} SubagentCtx
  */
 
@@ -122,6 +124,12 @@ export const spawnSubagentTool = {
       // why: ctx.session.depth is the spawner's depth; the child is +1.
       // buildToolContext defaults it to 0 for legacy sessions.
       parentDepth: sctx.session?.depth ?? 0,
+      // Trusted-lineage stamping (delegation-lineage.js): the SPAWNING turn's
+      // untrusted-origin flag, folded by buildToolContext (synthetic && !trusted,
+      // always set on a real ctx). FAIL-CLOSED coercion: spawn.js trusts the
+      // child ONLY on an explicit `parentInbound === false`, so an ABSENT flag
+      // (a ctx that never folded it) must read as inbound — taint, never pass.
+      parentInbound: sctx.inbound === false ? false : true,
       // why: the dispatcher threads the tool_use_id into ctx so the live
       // event stream can be mapped to THIS card in the side panel.
       parentToolUseId: sctx.toolUseId,
@@ -158,9 +166,12 @@ const formatSubagentResult = (out) => {
     const head = result.slice(0, MAX_RESULT_CHARS);
     result = `${head}\n\n…[result truncated at ${MAX_RESULT_CHARS} chars — expand the card in the side panel for the full transcript]`;
   }
+  const flag = out.timedOut ? ' — HIT WALL-CLOCK TIMEOUT, result is partial'
+    : out.stopped ? ' — STOPPED before finishing, result is partial'
+    : out.exceeded ? ' — HIT STEP CAP, result may be incomplete' : '';
   const lines = [
     `subagent (session ${out.sessionId}, depth ${out.depth}) — `
-      + `${out.toolCalls} tool call${out.toolCalls === 1 ? '' : 's'}, ${out.durationMs}ms${out.exceeded ? ' — HIT STEP CAP, result may be incomplete' : ''}`,
+      + `${out.toolCalls} tool call${out.toolCalls === 1 ? '' : 's'}, ${out.durationMs}ms${flag}`,
     '',
     result || '(subagent returned no text)',
   ];

--- a/extension/peerd-runtime/tools/defs/type.js
+++ b/extension/peerd-runtime/tools/defs/type.js
@@ -107,6 +107,12 @@ export const typeTool = {
       if (!entry) return { ok: false, error: `stale_ref: ${ref} — re-run snapshot on this tab first` };
 
       if (entry.backendDOMNodeId != null && typeof debuggerPool?.setValueBackendNode === 'function') {
+        // Cardinality guard on the CDP channel too (#36 consistency): a resolved
+        // backendDOMNodeId ref IS exactly one node, so any expectedCount other
+        // than 1 is a mismatch — same shape the walk-ref/selector paths return.
+        if (expectedCount != null && expectedCount !== 1) {
+          return { ok: false, error: 'matched_count_mismatch', matchedCount: 1, expectedCount };
+        }
         try {
           const r = await debuggerPool.setValueBackendNode(tab.id, entry.backendDOMNodeId, args.text, !!args.submit);
           if (!r.ok) return { ok: false, error: r.error ?? 'ref_type_failed' };
@@ -114,7 +120,7 @@ export const typeTool = {
             ok: true,
             content: JSON.stringify({
               typed: args.text.slice(0, 200), submitted: !!args.submit,
-              ref, role: entry.role, name: entry.name, tag: r.tag,
+              ref, role: entry.role, name: entry.name, tag: r.tag, matchedCount: 1,
               ...(r.navigated ? { navigated: true } : {}),
               // Action-result attribution: what typing changed on the page.
               result: r.navigated ? 'page navigated' : summarizeMutations(r.mutations),

--- a/extension/peerd-runtime/tools/defs/type.js
+++ b/extension/peerd-runtime/tools/defs/type.js
@@ -65,7 +65,7 @@ export const typeTool = {
       expectedCount: {
         type: 'integer',
         minimum: 1,
-        description: 'Optional deterministic guard for selector actions: fail before typing unless the selector resolves to exactly this many elements.',
+        description: 'Optional deterministic guard: fail before typing unless the target resolves to exactly this many elements (the selector match count; a walk ref resolves to 0 or 1).',
       },
       tabId: {
         type: 'integer',
@@ -88,6 +88,13 @@ export const typeTool = {
     // ToolContext typedef; scripting is typed opaquely — narrow all three.
     const { domRefs, debuggerPool } = /** @type {DomCtxExtras} */ (ctx);
     const scripting = /** @type {typeof chrome.scripting} */ (ctx.scripting);
+
+    // why: hoisted above the ref branch — the cardinality guard applies to
+    // BOTH resolution channels the injected body serves (selector match count,
+    // walk-ref 0/1), not just selector calls (issue #36).
+    const expectedCount = Number.isInteger(args?.expectedCount) && args.expectedCount > 0
+      ? args.expectedCount
+      : null;
 
     // Ref path (a11y snapshot): exact node, no selector ambiguity. Two
     // resolutions, matching the snapshot's two capture channels
@@ -124,7 +131,7 @@ export const typeTool = {
           const results = await scripting.executeScript({
             target: { tabId: tab.id },
             func: typeInjected,
-            args: [null, args.text, !!args.submit, entry.walkId],
+            args: [null, args.text, !!args.submit, entry.walkId, expectedCount],
           });
           scriptResult = results[0]?.result;
         } catch (e) {
@@ -137,6 +144,10 @@ export const typeTool = {
           content: JSON.stringify({
             typed: scriptResult.typed, submitted: scriptResult.submitted,
             ref, role: entry.role, name: entry.name, tag: scriptResult.tag,
+            // why: keep matchedCount present on every success shape (selector
+            // AND walk ref) so the agent reads one consistent contract; a
+            // resolved walk ref is always exactly 1 (issue #36).
+            matchedCount: scriptResult.matchedCount,
             // Honest about the channel: scripting input is synthetic
             // (isTrusted=false); sites that gate on trusted keystrokes
             // may ignore it, and there is no fallback channel here.
@@ -162,9 +173,6 @@ export const typeTool = {
 
     let scriptResult;
     try {
-      const expectedCount = Number.isInteger(args.expectedCount) && args.expectedCount > 0
-        ? args.expectedCount
-        : null;
       const results = await scripting.executeScript({
         target: { tabId: tab.id },
         func: typeInjected,
@@ -196,7 +204,12 @@ export const typeTool = {
  * @param {number | null} [walkId]
  * @param {number | null} [expectedCount]
  */
-function typeInjected(selector, text, submit, walkId, expectedCount) {
+// why: exported for the Bun tests to exercise the REAL body's walk-ref
+// cardinality guard (mocked scriptResults would hide an omission — #103
+// review lesson). Same precedent as domWalkInjected; `export` is not part
+// of Function.prototype.toString, so executeScript serialization is
+// unchanged.
+export function typeInjected(selector, text, submit, walkId, expectedCount) {
   // why: serialized by chrome.scripting.executeScript and re-evaluated
   // in the page's classic-script world; the calling module's strict
   // mode doesn't carry across. Opt in here.
@@ -212,6 +225,21 @@ function typeInjected(selector, text, submit, walkId, expectedCount) {
     // a standard global, so reach it through an erased cast.
     const reg = /** @type {{ __peerdWalkEls?: Map<number, HTMLElement> }} */ (globalThis).__peerdWalkEls;
     el = reg && typeof reg.get === 'function' ? (reg.get(walkId) ?? null) : null;
+    // why: a walkId names exactly one registered element, so the real match
+    // cardinality is 0 (stale/unregistered) or 1 (found). Enforce the guard
+    // against that count — same code + fields as the selector path — instead
+    // of silently ignoring expectedCount on ref calls (issue #36). Checked
+    // BEFORE the stale return so the 0 case reports the mismatch the caller
+    // asked to be told about, with the re-snapshot hint kept in the text.
+    matchedCount = el && el.isConnected ? 1 : 0;
+    if (expectedCount != null && matchedCount !== expectedCount) {
+      return {
+        ok: false,
+        error: `matched_count_mismatch: walk ref matched ${matchedCount} element(s), expected ${expectedCount}${matchedCount === 0 ? ' — element no longer in the page; re-run snapshot on this tab first' : ''}`,
+        matchedCount,
+        expectedCount,
+      };
+    }
     if (!el || !el.isConnected) {
       return { ok: false, error: 'stale_ref: element no longer in the page — re-run snapshot on this tab first' };
     }

--- a/extension/tests/unit/peerd-runtime/dom-walk.test.js
+++ b/extension/tests/unit/peerd-runtime/dom-walk.test.js
@@ -166,7 +166,29 @@ describe('snapshot → click/type over walk refs — full chain', () => {
       const r = await clickTool.execute({ ref }, ctx);
       expect(r.ok).toBe(true);
       expect(contentOf(r)).toContain('"via": "dom-walk"');
+      // matchedCount rides the walk-ref success shape too — a resolved walk
+      // ref is exactly one element (issue #36 contract consistency).
+      expect(contentOf(r)).toContain('"matchedCount": 1');
       expect(clicks > 0).toBe(true);
+    });
+  });
+
+  it('click {ref, expectedCount≠1} fails matched_count_mismatch BEFORE clicking', async () => {
+    await withFixture(async (host) => {
+      const ctx = makeCtx();
+      let clicks = 0;
+      const btn = /** @type {HTMLButtonElement} */ (host.querySelector('#dw-send'));
+      btn.disabled = false;
+      btn.addEventListener('click', () => { clicks += 1; });
+      const snap = await snapshotTool.execute({ budget: 30000 }, ctx);
+      const ref = /(@e\d+) button "Send order"/.exec(contentOf(snap))?.[1];
+      // A walk ref names exactly one element — expecting 2 is a planning
+      // contradiction the guard must catch deterministically, pre-action.
+      const r = await clickTool.execute({ ref, expectedCount: 2 }, ctx);
+      expect(r.ok).toBe(false);
+      expect(errorOf(r)).toContain('matched_count_mismatch');
+      expect(errorOf(r)).toContain('matched 1 element(s), expected 2');
+      expect(clicks).toBe(0);
     });
   });
 
@@ -202,6 +224,8 @@ describe('snapshot → click/type over walk refs — full chain', () => {
       expect(typeof ref).toBe('string');
       const r = await typeTool.execute({ ref, text: 'Ada Lovelace' }, ctx);
       expect(r.ok).toBe(true);
+      // matchedCount rides the walk-ref success shape too (issue #36).
+      expect(contentOf(r)).toContain('"matchedCount": 1');
       expect(field.value).toBe('Ada Lovelace');
       expect(inputs).toBe(1);
     });

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -42,7 +42,9 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // 475 → 471: the do/get/check cull removed four // @ts-check'd files (the do/
 // get/check tool defs + runner/index.js — the web actor holds the DOM tools
 // directly now). A legitimate decrease (files deleted, not directives dropped).
-const COVERED_FLOOR = 471;
+// 471 → 473: main added one // @ts-check'd file post-cull, and the async-actor
+// proposal adds delegation-lineage.js (the pure trusted-lineage predicate).
+const COVERED_FLOOR = 473;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/tests/peerd-runtime/actor-prompt.test.ts
+++ b/tests/peerd-runtime/actor-prompt.test.ts
@@ -58,11 +58,14 @@ describe('the baked orchestrator prompt (system-prompt.txt)', () => {
     expect(base.includes('do                       — perform an action')).toBe(false); // runner listing gone
   });
 
-  test('the subagents section no longer routes instance work to a child', () => {
-    // A subagent can't mutate (actor-only) nor message_actor (sender-gated),
-    // so the old "pass a child the ids it should act on" guidance is a dead end.
-    expect(base.includes('the ids it should act on')).toBe(false);
-    expect(base.includes('never hand a vm/notebook/')).toBe(true);
+  test('the subagents section reflects the PR #134 trusted-lineage capability', () => {
+    // A subagent still can't MUTATE an instance directly (actor-only), but a
+    // trusted-lineage child MAY now message_actor and gets the reply in its own
+    // tool result — so the prompt no longer tells the model to never delegate to
+    // a child, and no longer claims message_actor is refused from one.
+    expect(base.includes('never hand a vm/notebook/')).toBe(false);
+    expect(base.includes('message_actor is refused')).toBe(false);
+    expect(base.includes('RIGHT IN its')).toBe(true);            // reply-in-tool-result guidance
     expect(base.includes('PARALLELISM is many message_actor')).toBe(true);
   });
 

--- a/tests/peerd-runtime/delegation-lineage.test.ts
+++ b/tests/peerd-runtime/delegation-lineage.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { mayMessageActor, ASYNC_SUBAGENT_ACTORS } from '../../extension/peerd-runtime/subagent/delegation-lineage.js';
+import { mayMessageActor, messageProvenance, ASYNC_SUBAGENT_ACTORS } from '../../extension/peerd-runtime/subagent/delegation-lineage.js';
 
 // The PURE trust decision for the "subagents as async actors" refactor: may a
 // sender session message an actor? It replaces the sender gate's `=== active`
@@ -76,6 +76,43 @@ describe('mayMessageActor — non-descendants and malformed chains fail closed',
   test('a cyclic chain terminates and refuses (never hangs)', () => {
     const ancestry = [hop('a', 'b', true), hop('b', 'a', true)]; // a→b→a, never reaches active
     expect(mayMessageActor({ inbound: false, senderSessionId: 'a', activeSessionId: ACTIVE, ancestry })).toBe(false);
+  });
+});
+
+describe('messageProvenance — the parent reference the choke-point actor arbitrates on', () => {
+  test('a top-level chat is its own root, path is just itself', () => {
+    expect(messageProvenance({ senderSessionId: ACTIVE, ancestry: [] }))
+      .toEqual({ senderSessionId: ACTIVE, rootSessionId: ACTIVE, lineagePath: [ACTIVE] });
+  });
+
+  test('a subagent resolves to its root chat with a root->sender path', () => {
+    const ancestry = [hop('sub-1', ACTIVE, true)];
+    expect(messageProvenance({ senderSessionId: 'sub-1', ancestry }))
+      .toEqual({ senderSessionId: 'sub-1', rootSessionId: ACTIVE, lineagePath: [ACTIVE, 'sub-1'] });
+  });
+
+  test('a grandchild carries the full root->...->sender path', () => {
+    const ancestry = [hop('sub-2', 'sub-1', true), hop('sub-1', ACTIVE, true)];
+    expect(messageProvenance({ senderSessionId: 'sub-2', ancestry }))
+      .toEqual({ senderSessionId: 'sub-2', rootSessionId: ACTIVE, lineagePath: [ACTIVE, 'sub-1', 'sub-2'] });
+  });
+
+  test('two subagents under one chat share a rootSessionId (so the actor can group + be fair)', () => {
+    const a = messageProvenance({ senderSessionId: 'sub-a', ancestry: [hop('sub-a', ACTIVE, true)] });
+    const b = messageProvenance({ senderSessionId: 'sub-b', ancestry: [hop('sub-b', ACTIVE, true)] });
+    expect(a.rootSessionId).toBe(b.rootSessionId);
+    expect(a.senderSessionId).not.toBe(b.senderSessionId);
+  });
+
+  test('a missing chain fails safe: the sender is treated as its own root', () => {
+    expect(messageProvenance({ senderSessionId: 'sub-orphan' }))
+      .toEqual({ senderSessionId: 'sub-orphan', rootSessionId: 'sub-orphan', lineagePath: ['sub-orphan'] });
+  });
+
+  test('a cyclic chain terminates (never hangs)', () => {
+    const ancestry = [hop('a', 'b', true), hop('b', 'a', true)];
+    const p = messageProvenance({ senderSessionId: 'a', ancestry });
+    expect(p.lineagePath[p.lineagePath.length - 1]).toBe('a'); // sender is last, walk stopped
   });
 });
 

--- a/tests/peerd-runtime/delegation-lineage.test.ts
+++ b/tests/peerd-runtime/delegation-lineage.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect } from 'bun:test';
+import { mayMessageActor, ASYNC_SUBAGENT_ACTORS } from '../../extension/peerd-runtime/subagent/delegation-lineage.js';
+
+// The PURE trust decision for the "subagents as async actors" refactor: may a
+// sender session message an actor? It replaces the sender gate's `=== active`
+// identity check with a trusted-LINEAGE check. These tests pin the security
+// invariants the refactor rests on — above all that an inbound (injected) turn
+// cannot launder message_actor access through a subagent it spawns.
+
+const ACTIVE = 'chat-active';
+
+// hop helpers — nearest-first ancestry the shell would build from the store.
+const hop = (sessionId: string, parentSessionId: string | null, spawnedTrusted = true) =>
+  ({ sessionId, parentSessionId, spawnedTrusted });
+
+describe('mayMessageActor — the two unchanged walls', () => {
+  test('inbound turn is ALWAYS refused, even for the active chat itself', () => {
+    // the inbound wall is what blocks an injected/synthetic turn AND the async
+    // result-wake (which re-enters trusted:false → inbound:true) from delegating.
+    expect(mayMessageActor({ inbound: true, senderSessionId: ACTIVE, activeSessionId: ACTIVE })).toBe(false);
+  });
+
+  test('a missing sender or active id fails closed', () => {
+    expect(mayMessageActor({ inbound: false, senderSessionId: null, activeSessionId: ACTIVE })).toBe(false);
+    expect(mayMessageActor({ inbound: false, senderSessionId: ACTIVE, activeSessionId: null })).toBe(false);
+  });
+});
+
+describe('mayMessageActor — the foreground chat (today\'s only accepted sender)', () => {
+  test('the active chat on a real (non-inbound) turn is admitted', () => {
+    expect(mayMessageActor({ inbound: false, senderSessionId: ACTIVE, activeSessionId: ACTIVE })).toBe(true);
+  });
+});
+
+describe('mayMessageActor — trusted-lineage descendants (the new capability)', () => {
+  test('a subagent spawned by the active chat on a trusted turn is admitted', () => {
+    const sender = 'sub-1';
+    const ancestry = [hop(sender, ACTIVE, true)];
+    expect(mayMessageActor({ inbound: false, senderSessionId: sender, activeSessionId: ACTIVE, ancestry })).toBe(true);
+  });
+
+  test('a grandchild reached through all-trusted spawn edges is admitted', () => {
+    const ancestry = [hop('sub-2', 'sub-1', true), hop('sub-1', ACTIVE, true)];
+    expect(mayMessageActor({ inbound: false, senderSessionId: 'sub-2', activeSessionId: ACTIVE, ancestry })).toBe(true);
+  });
+});
+
+describe('mayMessageActor — the laundering hole is closed', () => {
+  test('a subagent spawned by an INBOUND turn is refused (cannot launder access)', () => {
+    // THE THREAT: an injected turn on the active chat is refused message_actor
+    // directly, but calls spawn_subagent; the child runs non-inbound turns. Its
+    // spawn edge is marked untrusted, so it is refused despite rooting at active.
+    const ancestry = [hop('sub-inj', ACTIVE, false)];
+    expect(mayMessageActor({ inbound: false, senderSessionId: 'sub-inj', activeSessionId: ACTIVE, ancestry })).toBe(false);
+  });
+
+  test('taint propagates: a trusted grandchild under an inbound-spawned parent is refused', () => {
+    // sub-1 was spawned by an inbound turn (untrusted); sub-2 under it is clean on
+    // its own edge but the subtree is tainted, so it is still refused.
+    const ancestry = [hop('sub-2', 'sub-1', true), hop('sub-1', ACTIVE, false)];
+    expect(mayMessageActor({ inbound: false, senderSessionId: 'sub-2', activeSessionId: ACTIVE, ancestry })).toBe(false);
+  });
+});
+
+describe('mayMessageActor — non-descendants and malformed chains fail closed', () => {
+  test('a descendant of a DIFFERENT chat (not the active one) is refused', () => {
+    const ancestry = [hop('sub-x', 'chat-other', true), hop('chat-other', null, true)];
+    expect(mayMessageActor({ inbound: false, senderSessionId: 'sub-x', activeSessionId: ACTIVE, ancestry })).toBe(false);
+  });
+
+  test('a non-foreground sender with no ancestry supplied is refused (fail-closed)', () => {
+    expect(mayMessageActor({ inbound: false, senderSessionId: 'sub-orphan', activeSessionId: ACTIVE, ancestry: [] })).toBe(false);
+    expect(mayMessageActor({ inbound: false, senderSessionId: 'sub-orphan', activeSessionId: ACTIVE })).toBe(false);
+  });
+
+  test('a cyclic chain terminates and refuses (never hangs)', () => {
+    const ancestry = [hop('a', 'b', true), hop('b', 'a', true)]; // a→b→a, never reaches active
+    expect(mayMessageActor({ inbound: false, senderSessionId: 'a', activeSessionId: ACTIVE, ancestry })).toBe(false);
+  });
+});
+
+describe('the refactor ships behind a flag, default OFF', () => {
+  test('ASYNC_SUBAGENT_ACTORS is off so nothing is wired yet', () => {
+    expect(ASYNC_SUBAGENT_ACTORS).toBe(false);
+  });
+});

--- a/tests/peerd-runtime/delegation-lineage.test.ts
+++ b/tests/peerd-runtime/delegation-lineage.test.ts
@@ -116,8 +116,8 @@ describe('messageProvenance — the parent reference the choke-point actor arbit
   });
 });
 
-describe('the refactor ships behind a flag, default OFF', () => {
-  test('ASYNC_SUBAGENT_ACTORS is off so nothing is wired yet', () => {
-    expect(ASYNC_SUBAGENT_ACTORS).toBe(false);
+describe('the refactor ships behind a flag, now ON', () => {
+  test('ASYNC_SUBAGENT_ACTORS is on — the sender gate routes through mayMessageActor', () => {
+    expect(ASYNC_SUBAGENT_ACTORS).toBe(true);
   });
 });

--- a/tests/peerd-runtime/dom/walk-ref-actions.test.ts
+++ b/tests/peerd-runtime/dom/walk-ref-actions.test.ts
@@ -129,6 +129,28 @@ describe('click/type — walk-ref dispatch', () => {
     expect(r.content).toContain('"matchedCount": 3');
   });
 
+  test('CDP ref {expectedCount:2} is a mismatch (a resolved backend node is exactly one)', async () => {
+    const { ctx } = makeCtx(() => [{ result: WALK_RESULT }]);
+    ctx.debuggerPool = { clickBackendNode: async () => ({ ok: true, tag: 'button', text: 'Send' }) };
+    ctx.domRefs.setSnapshot(7, [{ ref: '@e1', backendDOMNodeId: 99, role: 'button', name: 'Send' }]);
+    const r = await clickTool.execute({ ref: '@e1', expectedCount: 2 }, ctx);
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected error result');
+    expect(r.error).toBe('matched_count_mismatch');
+    expect((r as any).matchedCount).toBe(1);
+    expect((r as any).expectedCount).toBe(2);
+  });
+
+  test('CDP ref {expectedCount:1} passes and reports matchedCount:1', async () => {
+    const { ctx } = makeCtx(() => [{ result: WALK_RESULT }]);
+    ctx.debuggerPool = { clickBackendNode: async () => ({ ok: true, tag: 'button', text: 'Send' }) };
+    ctx.domRefs.setSnapshot(7, [{ ref: '@e1', backendDOMNodeId: 99, role: 'button', name: 'Send' }]);
+    const r = await clickTool.execute({ ref: '@e1', expectedCount: 1 }, ctx);
+    expect(r.ok).toBe(true);
+    if (!r.ok) throw new Error('expected ok result');
+    expect(r.content).toContain('"matchedCount": 1');
+  });
+
   test('type {selector, expectedCount} forwards a pre-action cardinality guard', async () => {
     const { ctx, injections } = makeCtx((req: any) => [{ result: { ok: true, typed: 'Ada', submitted: false, tag: 'input', matchedCount: 1 } }]);
     const r = await typeTool.execute({ selector: 'input[name="assignee"]', text: 'Ada', expectedCount: 1 }, ctx);

--- a/tests/peerd-runtime/dom/walk-ref-actions.test.ts
+++ b/tests/peerd-runtime/dom/walk-ref-actions.test.ts
@@ -7,8 +7,8 @@
 
 import { describe, test, expect } from 'bun:test';
 import { snapshotTool } from '../../../extension/peerd-runtime/tools/defs/snapshot.js';
-import { clickTool } from '../../../extension/peerd-runtime/tools/defs/click.js';
-import { typeTool } from '../../../extension/peerd-runtime/tools/defs/type.js';
+import { clickTool, clickInjected } from '../../../extension/peerd-runtime/tools/defs/click.js';
+import { typeTool, typeInjected } from '../../../extension/peerd-runtime/tools/defs/type.js';
 import { createRefRegistry } from '../../../extension/peerd-runtime/dom/ref-registry.js';
 
 const WALK_RESULT = {
@@ -72,22 +72,28 @@ describe('click/type — walk-ref dispatch', () => {
     expect(r.ok).toBe(true);
     if (!r.ok) throw new Error('expected ok result');
     expect(r.content).toContain('"via": "dom-walk"');
-    // The click injection carried [selector=null, nth=0, walkId=1].
-    expect(injections[1].args).toEqual([null, 0, 1]);
+    // matchedCount is part of the walk-ref success contract too (issue #36).
+    expect(r.content).toContain('"matchedCount": 1');
+    // The click injection carried [selector=null, nth=0, walkId=1,
+    // expectedCount=null] — the guard slot is always forwarded.
+    expect(injections[1].args).toEqual([null, 0, 1, null]);
   });
 
   test('type {ref} resolves a walk ref via scripting with the walkId', async () => {
     const { ctx, injections } = makeCtx((req: any) =>
       req.args && req.args[3] != null
-        ? [{ result: { ok: true, typed: 'hi', submitted: false, tag: 'input' } }]
+        ? [{ result: { ok: true, typed: 'hi', submitted: false, tag: 'input', matchedCount: 1 } }]
         : [{ result: WALK_RESULT }]);
     await snapshotTool.execute({}, ctx);
     const r = await typeTool.execute({ ref: '@e2', text: 'hi' }, ctx);
     expect(r.ok).toBe(true);
     if (!r.ok) throw new Error('expected ok result');
     expect(r.content).toContain('"via": "dom-walk"');
-    // [selector=null, text, submit, walkId=2]
-    expect(injections[1].args).toEqual([null, 'hi', false, 2]);
+    // matchedCount is part of the walk-ref success contract too (issue #36).
+    expect(r.content).toContain('"matchedCount": 1');
+    // [selector=null, text, submit, walkId=2, expectedCount=null] — the
+    // guard slot is always forwarded.
+    expect(injections[1].args).toEqual([null, 'hi', false, 2, null]);
   });
 
   test('page-side stale walk ref surfaces as stale_ref', async () => {
@@ -131,5 +137,124 @@ describe('click/type — walk-ref dispatch', () => {
     // [selector, text, submit, walkId=null, expectedCount]
     expect(injections[0].args).toEqual(['input[name="assignee"]', 'Ada', false, null, 1]);
     expect(r.content).toContain('"matchedCount": 1');
+  });
+
+  test('click {ref, expectedCount} forwards the guard on the walk-ref injection', async () => {
+    const { ctx, injections } = makeCtx((req: any) =>
+      req.args && req.args[2] != null
+        ? [{ result: { ok: true, clicked: 'walk:1', nth: 0, matchedCount: 1, tag: 'button', text: 'Send' } }]
+        : [{ result: WALK_RESULT }]);
+    await snapshotTool.execute({}, ctx);
+    const r = await clickTool.execute({ ref: '@e1', expectedCount: 1 }, ctx);
+    expect(r.ok).toBe(true);
+    if (!r.ok) throw new Error('expected ok result');
+    expect(r.content).toContain('"matchedCount": 1');
+    // [selector=null, nth=0, walkId=1, expectedCount=1]
+    expect(injections[1].args).toEqual([null, 0, 1, 1]);
+  });
+
+  test('type {ref, expectedCount} forwards the guard on the walk-ref injection', async () => {
+    const { ctx, injections } = makeCtx((req: any) =>
+      req.args && req.args[3] != null
+        ? [{ result: { ok: true, typed: 'hi', submitted: false, tag: 'input', matchedCount: 1 } }]
+        : [{ result: WALK_RESULT }]);
+    await snapshotTool.execute({}, ctx);
+    const r = await typeTool.execute({ ref: '@e2', text: 'hi', expectedCount: 1 }, ctx);
+    expect(r.ok).toBe(true);
+    if (!r.ok) throw new Error('expected ok result');
+    expect(r.content).toContain('"matchedCount": 1');
+    // [selector=null, text, submit, walkId=2, expectedCount=1]
+    expect(injections[1].args).toEqual([null, 'hi', false, 2, 1]);
+  });
+
+  test('page-side walk-ref count mismatch surfaces through the tool', async () => {
+    // The mocked scriptResult mirrors EXACTLY what the real injected body
+    // returns for this case (pinned by the real-body tests below).
+    const { ctx } = makeCtx((req: any) =>
+      req.args && req.args[2] != null
+        ? [{ result: { ok: false, error: 'matched_count_mismatch: walk ref matched 1 element(s), expected 2', matchedCount: 1, expectedCount: 2 } }]
+        : [{ result: WALK_RESULT }]);
+    await snapshotTool.execute({}, ctx);
+    const r = await clickTool.execute({ ref: '@e1', expectedCount: 2 }, ctx);
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected error result');
+    expect(r.error).toContain('matched_count_mismatch');
+  });
+});
+
+// The injected bodies themselves — the walk-ref cardinality guard runs
+// BEFORE any DOM interaction, so it is exercisable here against the real
+// functions (no mocked scriptResult that could hide an omission — the
+// #103 review lesson). Success paths need real event dispatch and stay in
+// the in-browser suite (extension/tests/unit/peerd-runtime/dom-walk.test.js).
+describe('injected bodies — walk-ref cardinality guard (real functions)', () => {
+  const walkGlobal = globalThis as any;
+  const withRegistry = (entries: Array<[number, any]>, fn: () => void) => {
+    const prior = walkGlobal.__peerdWalkEls;
+    walkGlobal.__peerdWalkEls = new Map(entries);
+    try { fn(); }
+    finally { walkGlobal.__peerdWalkEls = prior; }
+  };
+  // A registered element the guard can see; the guard only reads isConnected.
+  const liveEl = { isConnected: true };
+
+  test('clickInjected: found walk ref vs expectedCount>1 → matched_count_mismatch with counts', () => {
+    withRegistry([[1, liveEl]], () => {
+      const r: any = clickInjected(null, 0, 1, 2);
+      expect(r.ok).toBe(false);
+      expect(r.error).toContain('matched_count_mismatch');
+      expect(r.error).toContain('matched 1 element(s), expected 2');
+      expect(r.matchedCount).toBe(1);
+      expect(r.expectedCount).toBe(2);
+    });
+  });
+
+  test('clickInjected: stale walk ref with expectedCount → mismatch with matchedCount 0 and re-snapshot hint', () => {
+    withRegistry([], () => {
+      const r: any = clickInjected(null, 0, 99, 1);
+      expect(r.ok).toBe(false);
+      expect(r.error).toContain('matched_count_mismatch');
+      expect(r.error).toContain('re-run snapshot');
+      expect(r.matchedCount).toBe(0);
+      expect(r.expectedCount).toBe(1);
+    });
+  });
+
+  test('clickInjected: stale walk ref WITHOUT expectedCount still fails as stale_ref', () => {
+    withRegistry([], () => {
+      const r: any = clickInjected(null, 0, 99, null);
+      expect(r.ok).toBe(false);
+      expect(r.error).toContain('stale_ref');
+    });
+  });
+
+  test('typeInjected: found walk ref vs expectedCount>1 → matched_count_mismatch with counts', () => {
+    withRegistry([[2, liveEl]], () => {
+      const r: any = typeInjected(null, 'hi', false, 2, 3);
+      expect(r.ok).toBe(false);
+      expect(r.error).toContain('matched_count_mismatch');
+      expect(r.error).toContain('matched 1 element(s), expected 3');
+      expect(r.matchedCount).toBe(1);
+      expect(r.expectedCount).toBe(3);
+    });
+  });
+
+  test('typeInjected: stale walk ref with expectedCount → mismatch with matchedCount 0 and re-snapshot hint', () => {
+    withRegistry([], () => {
+      const r: any = typeInjected(null, 'hi', false, 99, 1);
+      expect(r.ok).toBe(false);
+      expect(r.error).toContain('matched_count_mismatch');
+      expect(r.error).toContain('re-run snapshot');
+      expect(r.matchedCount).toBe(0);
+      expect(r.expectedCount).toBe(1);
+    });
+  });
+
+  test('typeInjected: stale walk ref WITHOUT expectedCount still fails as stale_ref', () => {
+    withRegistry([], () => {
+      const r: any = typeInjected(null, 'hi', false, 99, null);
+      expect(r.ok).toBe(false);
+      expect(r.error).toContain('stale_ref');
+    });
   });
 });

--- a/tests/peerd-runtime/subagent-async-actors.test.ts
+++ b/tests/peerd-runtime/subagent-async-actors.test.ts
@@ -195,6 +195,24 @@ describe('spawn lifecycle — wall-clock timeout (phase 2)', () => {
     expect(out.stopped).toBeUndefined();
     expect(cleared).toEqual([42]);
   });
+
+  test('a timer that fires AFTER a clean finish does not mislabel the result timedOut (#5)', async () => {
+    // The child finishes cleanly (end_turn); we fire the captured timer callback
+    // AFTER the run resolved. timedOut is gated on lastStopReason==='aborted', so
+    // a post-finish timer tick must not flip a complete result to partial.
+    const store = makeStore();
+    const parent = await store.create({});
+    let timerCb: (() => void) | null = null;
+    const spawn = makeSpawnSubagent(spawnDeps(store, makeFastLoop('complete'), {
+      setTimer: (fn: () => void) => { timerCb = fn; return 1; },
+      clearTimer: () => {},
+    }) as any);
+    const out = await spawn({ task: 't', tools: [], parentSessionId: parent.sessionId });
+    (timerCb as null | (() => void))?.(); // the stray macrotask fires late
+    expect(out.result).toBe('complete');
+    expect(out.timedOut).toBeUndefined();
+    expect(out.stopped).toBeUndefined();
+  });
 });
 
 // ---- actor-messaging: the lineage gate + arbitration ------------------------
@@ -332,6 +350,51 @@ describe('message_actor — the subagent awaitReply mode', () => {
     await tick();
     expect(reentries.length).toBe(0); // the child is never woken
   });
+  test('an aborted subagent unblocks even if the actor turn never settles (#1/#3)', async () => {
+    // The actor turn is held in the queue (never run), so onReply never fires.
+    // The child's abort signal must still unwind the await — and stop the
+    // actor slot it was waiting on.
+    const stopped: string[] = [];
+    const controller = new AbortController();
+    const { messageActor } = gateHarness({
+      getAncestry: ancestryOf(trustedChild),
+      turnSlots: {
+        runWhenIdle: (_sid: string, _fn: () => void) => { /* hold: never run the actor turn */ },
+        stop: (id: string) => { stopped.push(id); return true; },
+      } as any,
+    });
+    const pending = messageActor({
+      to: 'app-1', message: 'hang', senderSessionId: 'sub-1', inbound: false,
+      awaitReply: true, awaitSignal: controller.signal,
+    });
+    await tick();
+    controller.abort(); // the child's wall-clock timeout / cancel fires
+    const r = await pending;
+    expect(r.ok).toBe(false);
+    expect(String(r.error)).toContain('aborted');
+    // the delegated actor turn was stopped, not left running orphaned
+    expect(stopped).toContain('res-1');
+  });
+
+  test('an already-aborted signal resolves immediately and stops the actor', async () => {
+    const stopped: string[] = [];
+    const controller = new AbortController();
+    controller.abort();
+    const { messageActor } = gateHarness({
+      getAncestry: ancestryOf(trustedChild),
+      turnSlots: {
+        runWhenIdle: (_sid: string, _fn: () => void) => { /* hold */ },
+        stop: (id: string) => { stopped.push(id); return true; },
+      } as any,
+    });
+    const r = await messageActor({
+      to: 'app-1', message: 'x', senderSessionId: 'sub-1', inbound: false,
+      awaitReply: true, awaitSignal: controller.signal,
+    });
+    expect(r.ok).toBe(false);
+    expect(stopped).toContain('res-1');
+  });
+
   test('a failed actor turn resolves ok:false with the fenced error', async () => {
     const { messageActor, reentries } = gateHarness({
       getAncestry: ancestryOf(trustedChild),
@@ -384,6 +447,26 @@ describe('message_actor — envelope provenance + redrain reroute (phase 7)', ()
     expect(reentries.length).toBe(1);
     expect(reentries[0].sessionId).toBe('chat-1');
     expect(audits.some((a) => a.type === 'actor_reply_rerouted')).toBe(true);
+  });
+
+  test('a redrained in-flight twin still counts against dedupe (#4 symmetry)', async () => {
+    // Hold every queued turn so the redrained turn stays in flight; its intent
+    // must be tracked so an identical fresh send is refused and — critically —
+    // the redrained turn's settle doesn't decrement a DIFFERENT send's refcount.
+    const queued: Array<() => void> = [];
+    const { messageActor, redrain } = gateHarness({
+      turnSlots: { runWhenIdle: (_sid: string, fn: () => void) => { queued.push(fn); } },
+      mailbox: {
+        append: async () => {},
+        remove: async () => {},
+        load: async () => [{ id: 'c-1', senderSessionId: 'chat-1', to: 'app-1', message: 'reprice', createdAt: 1 }],
+      },
+    });
+    await redrain(); // re-queues (chat-1 → app-1, 'reprice'); intent now tracked
+    // An identical fresh send from the same chat is refused as a duplicate.
+    const dup = await messageActor({ to: 'app-1', message: 'reprice', senderSessionId: 'chat-1' });
+    expect(dup.ok).toBe(false);
+    expect(dup.error).toContain('already in flight');
   });
 
   test('a pre-#134 envelope (no provenance) keeps the sender-addressed wake', async () => {

--- a/tests/peerd-runtime/subagent-async-actors.test.ts
+++ b/tests/peerd-runtime/subagent-async-actors.test.ts
@@ -1,0 +1,402 @@
+// PR #134 — subagents as async actors: the lifecycle (turn slots, abort,
+// wall-clock timeout, transitive Stop), the trusted-lineage sender gate wiring,
+// root-keyed budgets, mechanical dedupe, the subagent awaitReply mode, and the
+// redrain reroute. Complements delegation-lineage.test.ts (the pure predicate)
+// and actor-messaging.test.ts / spawn.test.ts (the pre-#134 behaviors, which
+// must all still hold).
+import { describe, test, expect } from 'bun:test';
+import { makeSpawnSubagent, DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS } from '../../extension/peerd-runtime/subagent/spawn.js';
+import { makeActorMessaging } from '../../extension/peerd-runtime/subagent/actor-messaging.js';
+import { makeTurnSlots } from '../../extension/peerd-runtime/loop/turn-slots.js';
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+// ---- spawn lifecycle harness ----------------------------------------------
+
+const makeStore = () => {
+  const map = new Map<string, any>();
+  const createOpts: any[] = [];
+  let n = 0;
+  return {
+    map,
+    createOpts,
+    create: async (opts: any = {}) => {
+      createOpts.push(opts);
+      const s = {
+        sessionId: `s-${++n}`,
+        createdAt: n,
+        messages: [] as any[],
+        provider: opts.provider ?? 'anthropic',
+        model: opts.model ?? 'inherited-model',
+        kind: opts.kind ?? 'chat',
+        depth: opts.depth ?? 0,
+        ...(opts.parentSessionId ? { parentSessionId: opts.parentSessionId } : {}),
+        ...(opts.spawnedTrusted !== undefined ? { spawnedTrusted: opts.spawnedTrusted } : {}),
+        ...(opts.task ? { task: opts.task } : {}),
+      };
+      map.set(s.sessionId, s);
+      return s;
+    },
+    get: async (id: string) => map.get(id),
+    appendMessage: async (id: string, msg: any) => {
+      const s = map.get(id);
+      s.messages.push(msg);
+      return s;
+    },
+  };
+};
+
+// A loop that finishes only when its signal aborts — the shape a hung tool
+// call / stalled provider takes from the orchestrator's point of view.
+const makeAbortableLoop = () => {
+  async function* loop(ctx: any) {
+    await ctx.sessions.appendMessage(ctx.sessionId, { role: 'assistant', content: 'partial work' });
+    if (!ctx.signal) throw new Error('no signal threaded into the loop');
+    await new Promise<void>((resolve) => {
+      if (ctx.signal.aborted) { resolve(); return; }
+      ctx.signal.addEventListener('abort', () => resolve(), { once: true });
+    });
+    yield { type: 'stop', sessionId: ctx.sessionId, stopReason: 'aborted' };
+  }
+  return loop;
+};
+
+const makeFastLoop = (finalText = 'done') => {
+  async function* loop(ctx: any) {
+    await ctx.sessions.appendMessage(ctx.sessionId, { role: 'assistant', content: finalText });
+    yield { type: 'stop', sessionId: ctx.sessionId, stopReason: 'end_turn' };
+  }
+  return loop;
+};
+
+const spawnDeps = (store: any, loop: any, extra: any = {}) => ({
+  sessions: store,
+  runUserTurn: loop,
+  callModel: async function* () { yield { type: 'message-stop', stopReason: 'end_turn' }; },
+  getSecret: async () => 'sk-test',
+  safeFetch: async () => new Response('ok'),
+  appendAudit: async () => {},
+  buildToolContext: async ({ sessionId }: any) => ({ session: { sessionId }, audit: async () => {} }),
+  dispatchToolCall: async () => ({ ok: true, content: 'tool ran' }),
+  renderSystemPrompt: async ({ taskOverride }: any) => `sys task=${taskOverride}`,
+  getToolDescriptors: () => [{ name: 'a', description: 'A', schema: {} }],
+  now: (() => { let t = 1000; return () => (t += 25); })(),
+  ...extra,
+});
+
+describe('spawn lifecycle — spawnedTrusted stamping (phase 3, fail-closed)', () => {
+  const stampFor = async (parentInbound: boolean | undefined) => {
+    const store = makeStore();
+    const parent = await store.create({});
+    const spawn = makeSpawnSubagent(spawnDeps(store, makeFastLoop()) as any);
+    await spawn({ task: 't', tools: [], parentSessionId: parent.sessionId, ...(parentInbound === undefined ? {} : { parentInbound }) });
+    // createOpts[0] is the parent; [1] the child.
+    return store.createOpts[1].spawnedTrusted;
+  };
+  test('an explicitly non-inbound spawning turn yields a TRUSTED hop', async () => {
+    expect(await stampFor(false)).toBe(true);
+  });
+  test('an inbound spawning turn taints the child', async () => {
+    expect(await stampFor(true)).toBe(false);
+  });
+  test('an ABSENT verdict taints the child (fail-closed default)', async () => {
+    expect(await stampFor(undefined)).toBe(false);
+  });
+});
+
+describe('spawn lifecycle — abort + registry (phases 1 & 5)', () => {
+  test('a child runs under a turn slot: turnSlots.stop() aborts it and the result is flagged stopped', async () => {
+    const store = makeStore();
+    const parent = await store.create({});
+    const turnSlots = makeTurnSlots();
+    const spawn = makeSpawnSubagent(spawnDeps(store, makeAbortableLoop(), { turnSlots }) as any);
+    const running = spawn({ task: 'long job', tools: [], parentSessionId: parent.sessionId });
+    await tick();
+    const [childId] = spawn.liveChildrenOf(parent.sessionId);
+    expect(childId).toBeDefined();
+    expect(turnSlots.isBusy(childId)).toBe(true);
+    turnSlots.stop(childId);
+    const out = await running;
+    expect(out.stopped).toBe(true);
+    expect(out.timedOut).toBeUndefined();
+    expect(out.result).toBe('partial work');
+    expect(spawn.liveChildrenOf(parent.sessionId)).toEqual([]);
+  });
+
+  test('stopSubtree() aborts transitive descendants (grandchildren included)', async () => {
+    const store = makeStore();
+    const root = await store.create({});
+    const turnSlots = makeTurnSlots();
+    const spawn = makeSpawnSubagent(spawnDeps(store, makeAbortableLoop(), { turnSlots }) as any);
+    const child = spawn({ task: 'c1', tools: [], parentSessionId: root.sessionId });
+    await tick();
+    const [childId] = spawn.liveChildrenOf(root.sessionId);
+    const grandchild = spawn({ task: 'c2', tools: [], parentSessionId: childId, parentDepth: 1 });
+    await tick();
+    const [grandchildId] = spawn.liveChildrenOf(childId);
+    expect(grandchildId).toBeDefined();
+
+    const stopped = spawn.stopSubtree(root.sessionId);
+    expect(new Set(stopped)).toEqual(new Set([childId, grandchildId]));
+    const [c, g] = await Promise.all([child, grandchild]);
+    expect(c.stopped).toBe(true);
+    expect(g.stopped).toBe(true);
+    expect(spawn.liveChildrenOf(root.sessionId)).toEqual([]);
+  });
+});
+
+describe('spawn lifecycle — wall-clock timeout (phase 2)', () => {
+  test('the timer aborts a parked child and flags timedOut', async () => {
+    const store = makeStore();
+    const parent = await store.create({});
+    const timers: Array<{ fn: () => void; ms: number }> = [];
+    const cleared: unknown[] = [];
+    const spawn = makeSpawnSubagent(spawnDeps(store, makeAbortableLoop(), {
+      turnSlots: makeTurnSlots(),
+      setTimer: (fn: () => void, ms: number) => { timers.push({ fn, ms }); return timers.length; },
+      clearTimer: (h: unknown) => { cleared.push(h); },
+    }) as any);
+    const running = spawn({ task: 'will park', tools: [], parentSessionId: parent.sessionId });
+    await tick();
+    expect(timers.length).toBe(1);
+    expect(timers[0].ms).toBe(DEFAULT_TIMEOUT_MS);
+    timers[0].fn(); // the budget elapses
+    const out = await running;
+    expect(out.timedOut).toBe(true);
+    expect(out.stopped).toBeUndefined();
+    expect(cleared.length).toBe(1); // the timer is always cleared on settle
+  });
+
+  test('timeoutMs is caller-lowerable but clamped to MAX_TIMEOUT_MS', async () => {
+    const store = makeStore();
+    const parent = await store.create({});
+    const budgets: number[] = [];
+    const spawn = makeSpawnSubagent(spawnDeps(store, makeFastLoop(), {
+      setTimer: (_fn: () => void, ms: number) => { budgets.push(ms); return 1; },
+      clearTimer: () => {},
+    }) as any);
+    await spawn({ task: 'a', tools: [], parentSessionId: parent.sessionId, timeoutMs: 5_000 });
+    await spawn({ task: 'b', tools: [], parentSessionId: parent.sessionId, timeoutMs: MAX_TIMEOUT_MS * 10 });
+    await spawn({ task: 'c', tools: [], parentSessionId: parent.sessionId });
+    expect(budgets).toEqual([5_000, MAX_TIMEOUT_MS, DEFAULT_TIMEOUT_MS]);
+  });
+
+  test('a clean finish clears the timer and sets no flag', async () => {
+    const store = makeStore();
+    const parent = await store.create({});
+    const cleared: unknown[] = [];
+    const spawn = makeSpawnSubagent(spawnDeps(store, makeFastLoop('all good'), {
+      setTimer: () => 42,
+      clearTimer: (h: unknown) => { cleared.push(h); },
+    }) as any);
+    const out = await spawn({ task: 't', tools: [], parentSessionId: parent.sessionId });
+    expect(out.result).toBe('all good');
+    expect(out.timedOut).toBeUndefined();
+    expect(out.stopped).toBeUndefined();
+    expect(cleared).toEqual([42]);
+  });
+});
+
+// ---- actor-messaging: the lineage gate + arbitration ------------------------
+
+type Reenter = { userText: string; sessionId: string; synthetic: boolean };
+type Hop = { sessionId: string; parentSessionId: string | null; spawnedTrusted: boolean };
+
+const gateHarness = (over: Partial<Parameters<typeof makeActorMessaging>[0]> = {}) => {
+  const reentries: Reenter[] = [];
+  const turnsRun: Array<{ actorSessionId: string; message: string }> = [];
+  const appended: any[] = [];
+  const deps = {
+    resolveActor: async (to: string) =>
+      to === 'app-1'
+        ? { instanceId: 'app-1', kind: 'app', actorSessionId: 'res-1', name: 'todo', tabId: 7 }
+        : null,
+    runActorTurn: async (o: { actorSessionId: string; message: string }) => {
+      turnsRun.push({ actorSessionId: o.actorSessionId, message: o.message });
+      return { result: 'built the thing' };
+    },
+    reenter: async (r: Reenter) => { reentries.push(r); },
+    turnSlots: { runWhenIdle: (_sid: string, fn: () => void) => fn() },
+    getActiveSessionId: async () => 'chat-1',
+    isVaultLocked: () => false,
+    wrapUntrusted: ({ origin, body }: { origin: string; body: string }) => `<u origin="${origin}">${body}</u>`,
+    appendAudit: async () => {},
+    mailbox: { append: async (e: any) => { appended.push(e); }, remove: async () => {}, load: async () => [] },
+    now: () => 1000,
+    log: () => {},
+    ...over,
+  } as Parameters<typeof makeActorMessaging>[0];
+  return { ...makeActorMessaging(deps), reentries, turnsRun, appended };
+};
+
+// A trusted direct child of the active chat.
+const trustedChild: Hop[] = [
+  { sessionId: 'sub-1', parentSessionId: 'chat-1', spawnedTrusted: true },
+];
+const ancestryOf = (hops: Hop[]) => async (_sessionId: string) => hops;
+
+describe('message_actor — the trusted-lineage sender gate (phase 3)', () => {
+  test('ACCEPTS a trusted-lineage subagent (non-active sender with a clean chain)', async () => {
+    const { messageActor, turnsRun } = gateHarness({ getAncestry: ancestryOf(trustedChild) });
+    const r = await messageActor({ to: 'app-1', message: 'do it', senderSessionId: 'sub-1', inbound: false });
+    expect(r.ok).toBe(true);
+    await tick();
+    expect(turnsRun.length).toBe(1);
+  });
+  test('refuses a TAINTED chain (the child was spawned by an inbound turn)', async () => {
+    const tainted: Hop[] = [{ sessionId: 'sub-1', parentSessionId: 'chat-1', spawnedTrusted: false }];
+    const { messageActor } = gateHarness({ getAncestry: ancestryOf(tainted) });
+    const r = await messageActor({ to: 'app-1', message: 'do it', senderSessionId: 'sub-1', inbound: false });
+    expect(r.ok).toBe(false);
+  });
+  test('refuses a non-active sender with NO ancestry (fail-closed default walk)', async () => {
+    const { messageActor } = gateHarness(); // default getAncestry → []
+    const r = await messageActor({ to: 'app-1', message: 'do it', senderSessionId: 'sub-1', inbound: false });
+    expect(r.ok).toBe(false);
+  });
+  test('refuses an INBOUND turn even on a trusted-lineage sender', async () => {
+    const { messageActor } = gateHarness({ getAncestry: ancestryOf(trustedChild) });
+    const r = await messageActor({ to: 'app-1', message: 'do it', senderSessionId: 'sub-1', inbound: true });
+    expect(r.ok).toBe(false);
+  });
+  test('a throwing ancestry walk fails closed (refuse, not crash)', async () => {
+    const { messageActor } = gateHarness({ getAncestry: async () => { throw new Error('store down'); } });
+    const r = await messageActor({ to: 'app-1', message: 'do it', senderSessionId: 'sub-1', inbound: false });
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('message_actor — root-keyed budgets (phase 4)', () => {
+  test('a subagent\'s sends draw from its ROOT\'s rate budget (one bound per delegation tree)', async () => {
+    const { messageActor } = gateHarness({
+      getAncestry: ancestryOf(trustedChild),
+      caps: { rateCap: 2 },
+    });
+    // Two sends from the root chat itself…
+    expect((await messageActor({ to: 'app-1', message: 'a', senderSessionId: 'chat-1' })).ok).toBe(true);
+    await tick();
+    expect((await messageActor({ to: 'app-1', message: 'b', senderSessionId: 'chat-1' })).ok).toBe(true);
+    await tick();
+    // …exhaust the budget for the subagent too — it shares the root's window.
+    const r = await messageActor({ to: 'app-1', message: 'c', senderSessionId: 'sub-1', inbound: false });
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('delegation tree');
+  });
+
+  test('stopActorsFor(root chat) covers an actor turn a SUBAGENT started', async () => {
+    // Hold the actor turn in the queue so it stays in flight.
+    const queued: Array<() => void> = [];
+    const { messageActor, stopActorsFor } = gateHarness({
+      getAncestry: ancestryOf(trustedChild),
+      turnSlots: { runWhenIdle: (_sid: string, fn: () => void) => { queued.push(fn); } },
+    });
+    // Fire-and-forget: awaitReply resolves only after the queued turn runs.
+    const pending = messageActor({ to: 'app-1', message: 'go', senderSessionId: 'sub-1', inbound: false, awaitReply: true });
+    await tick();
+    // The user hits Stop on the CHAT — the root — and the subagent's in-flight
+    // actor session is returned for the slot-abort cascade.
+    expect(stopActorsFor('chat-1')).toEqual(['res-1']);
+    queued.forEach((fn) => fn()); // drain: the stopped-generation path settles the await
+    const r = await pending;
+    expect(r.ok).toBe(false);
+    expect(String(r.error)).toContain('stopped');
+  });
+});
+
+describe('message_actor — mechanical dedupe (phase 7)', () => {
+  test('an identical (instance, message) intent already in flight for the tree is refused', async () => {
+    const queued: Array<() => void> = [];
+    const { messageActor } = gateHarness({
+      turnSlots: { runWhenIdle: (_sid: string, fn: () => void) => { queued.push(fn); } },
+    });
+    expect((await messageActor({ to: 'app-1', message: 'same ask', senderSessionId: 'chat-1' })).ok).toBe(true);
+    const dup = await messageActor({ to: 'app-1', message: 'same ask', senderSessionId: 'chat-1' });
+    expect(dup.ok).toBe(false);
+    expect(dup.error).toContain('identical request');
+    // A DIFFERENT message to the same actor is not a duplicate.
+    expect((await messageActor({ to: 'app-1', message: 'other ask', senderSessionId: 'chat-1' })).ok).toBe(true);
+    queued.forEach((fn) => fn());
+    await tick();
+    // Settled → the same intent may be sent again.
+    expect((await messageActor({ to: 'app-1', message: 'same ask', senderSessionId: 'chat-1' })).ok).toBe(true);
+  });
+});
+
+describe('message_actor — the subagent awaitReply mode', () => {
+  test('resolves the fenced reply INTO the tool result (no reentry wake)', async () => {
+    const { messageActor, reentries } = gateHarness({ getAncestry: ancestryOf(trustedChild) });
+    const r = await messageActor({ to: 'app-1', message: 'build', senderSessionId: 'sub-1', inbound: false, awaitReply: true });
+    expect(r.ok).toBe(true);
+    expect(r.content).toContain('<u origin="app-1">built the thing</u>');
+    expect(r.content).toContain('has replied');
+    await tick();
+    expect(reentries.length).toBe(0); // the child is never woken
+  });
+  test('a failed actor turn resolves ok:false with the fenced error', async () => {
+    const { messageActor, reentries } = gateHarness({
+      getAncestry: ancestryOf(trustedChild),
+      runActorTurn: async () => { throw new Error('exploded'); },
+    });
+    const r = await messageActor({ to: 'app-1', message: 'build', senderSessionId: 'sub-1', inbound: false, awaitReply: true });
+    expect(r.ok).toBe(false);
+    expect(String(r.error)).toContain('exploded');
+    await tick();
+    expect(reentries.length).toBe(0);
+  });
+  test('the ORCHESTRATOR default (no awaitReply) still gets the later-turn wake', async () => {
+    const { messageActor, reentries } = gateHarness();
+    const r = await messageActor({ to: 'app-1', message: 'build', senderSessionId: 'chat-1' });
+    expect(r.ok).toBe(true);
+    expect(r.content).toContain('LATER turn');
+    await tick();
+    expect(reentries.length).toBe(1);
+    expect(reentries[0].sessionId).toBe('chat-1');
+  });
+});
+
+describe('message_actor — envelope provenance + redrain reroute (phase 7)', () => {
+  test('the durable envelope carries { rootSessionId, lineagePath }', async () => {
+    const { messageActor, appended } = gateHarness({ getAncestry: ancestryOf(trustedChild) });
+    await messageActor({ to: 'app-1', message: 'go', senderSessionId: 'sub-1', inbound: false });
+    await tick();
+    expect(appended.length).toBe(1);
+    expect(appended[0].provenance).toEqual({ rootSessionId: 'chat-1', lineagePath: ['chat-1', 'sub-1'] });
+    expect(appended[0].senderSessionId).toBe('sub-1');
+  });
+
+  test('a redrained reply whose sender was an ephemeral subagent is rerouted to the ROOT', async () => {
+    const audits: any[] = [];
+    const { redrain, reentries } = gateHarness({
+      appendAudit: async (e: any) => { audits.push(e); },
+      mailbox: {
+        append: async () => {},
+        remove: async () => {},
+        load: async () => [{
+          id: 'c-1', senderSessionId: 'sub-9', to: 'app-1', message: 'finish it',
+          createdAt: 1, provenance: { rootSessionId: 'chat-1', lineagePath: ['chat-1', 'sub-9'] },
+        }],
+      },
+    });
+    const r = await redrain();
+    expect(r.redrained).toBe(1);
+    await tick();
+    // The wake reached the CHAT, not the dead child.
+    expect(reentries.length).toBe(1);
+    expect(reentries[0].sessionId).toBe('chat-1');
+    expect(audits.some((a) => a.type === 'actor_reply_rerouted')).toBe(true);
+  });
+
+  test('a pre-#134 envelope (no provenance) keeps the sender-addressed wake', async () => {
+    const { redrain, reentries } = gateHarness({
+      mailbox: {
+        append: async () => {},
+        remove: async () => {},
+        load: async () => [{ id: 'c-2', senderSessionId: 'chat-1', to: 'app-1', message: 'redo', createdAt: 1 }],
+      },
+    });
+    await redrain();
+    await tick();
+    expect(reentries.length).toBe(1);
+    expect(reentries[0].sessionId).toBe('chat-1');
+  });
+});

--- a/tests/peerd-runtime/subagent/async-subagents.test.ts
+++ b/tests/peerd-runtime/subagent/async-subagents.test.ts
@@ -43,6 +43,34 @@ describe('makeAsyncSubagents', () => {
     expect(reenters[0].userText).toContain('[UNTRUSTED]'); // child result is wrapped
   });
 
+  // PR #134 #2 (regression guard): a child that came back STOPPED (a user Stop
+  // cascaded to it) must NOT re-enter the parent — the parent's own turn was
+  // just stopped, so a reintegration wake would restart it seconds after Stop.
+  test('a Stop-aborted child does not wake the parent (dropped like a cancel)', async () => {
+    const reenters: any[] = [];
+    const as = makeAsyncSubagents(baseDeps({
+      spawnSubagent: async () => ({ result: 'partial', sessionId: 'c1', stopped: true }),
+      reenter: async (o: any) => { reenters.push(o); },
+    }));
+    await as.spawnSubagentAsync({ task: 'long', parentSessionId: 'parent' });
+    await flush();
+    expect(reenters).toHaveLength(0); // no synthetic wake after a user Stop
+  });
+
+  // A TIMEOUT is different from a user Stop — the parent is still working and
+  // wants the partial, so a timed-out child DOES reintegrate.
+  test('a timed-out child still wakes the parent with its partial', async () => {
+    const reenters: any[] = [];
+    const as = makeAsyncSubagents(baseDeps({
+      spawnSubagent: async () => ({ result: 'partial', sessionId: 'c1', timedOut: true }),
+      reenter: async (o: any) => { reenters.push(o); },
+    }));
+    await as.spawnSubagentAsync({ task: 'slow', parentSessionId: 'parent' });
+    await flush();
+    expect(reenters).toHaveLength(1);
+    expect(reenters[0].userText).toContain('wall-clock timeout');
+  });
+
   // The status-bar feed (DESIGN-11 UI): every transition must push so the bar
   // never goes stale. Spawn makes the task appear; settle flips it done.
   test('onTasksChanged fires on spawn and on settle (feeds the live status bar)', async () => {


### PR DESCRIPTION
## What & why

Three units, landed together after an adversarial review swarm:

**1. Subagents as async actors (#134, ratified).** Unifies the two async-delegation lifecycles. A subagent now runs under its own abortable turn slot with a wall-clock timeout, a trusted-lineage subagent may `message_actor`, and the delegation graph is bounded and stoppable as a whole:
- **Lifecycle** — children run under a turn slot with an `AbortSignal` and a whole-run wall-clock budget (10min default, 30min clamp). Stop, `subagent_cancel`, and the timeout all reach a child through one lever; results carry explicit `timedOut`/`stopped` flags. A hung tool call can no longer park a child forever.
- **Trusted-lineage sender gate** — `actor-messaging` routes through `mayMessageActor` (`delegation-lineage.js`, flag ON): the active chat, or a descendant reached entirely through trusted spawn edges, may message actors. `spawnedTrusted` is stamped server-side at `sessions.create` from the spawning turn's inbound flag (fail-closed); one inbound spawn taints its whole subtree, closing the spawn-laundering path. The inbound wall and capability strip are unchanged.
- **Graph bound + transitive Stop** — runaway/rate/outstanding budgets and Stop bookkeeping are keyed by the lineage root, so a parent↔child↔actor cycle shares one budget; `agent/stop` and `subagent_cancel` cascade through the live-children registry.
- **Envelope provenance** — durable mailbox entries carry `{ rootSessionId, lineagePath }`; identical in-flight intents are deduped; a boot redrain reroutes a reply whose awaiting sender was an ephemeral subagent to the root instead of waking a dead child.
- **Subagent reply mode** — a subagent's actor reply is awaited into its `message_actor` tool result rather than delivered as a later-turn wake (waking a finished child would rebuild it on the main exposure surface — an escalation).

**2. `expectedCount` cardinality guard on the walkId path (#36).** #103 enforced the guard on the CSS-selector path only; the walkId (and now CDP `backendDOMNodeId`) ref branch of `click`/`type` ignored `expectedCount` and hardcoded a count of 1. Threaded the guard into every resolution channel with a consistent `matchedCount` on success, so list/repeating actions fail loud on over/under-match instead of acting silently.

**3. CLAUDE.md refresh.** Rewrote the stale do/get/check references (culled in #133) to the actor architecture.

Closes #36. Implements #134.

## Checklist

- [x] `bun run preflight` passes (tests 2401 pass, typecheck, lint, ts-check floor 473, no manifest drift)
- [x] Commits are signed off
- [x] Only original or permissively-licensed code — no GPL / AGPL / copyleft
- [x] Tests added or updated
- [x] No hand-edited generated files (`manifest.json`, `shared/channel-config.js`)
- [x] Touches a **danger zone** — the `message_actor` sender gate and the subagent lifecycle. See below.

## Notes for reviewers

**Danger zone: the `message_actor` sender gate.** This replaces the gate's `senderSessionId === active` identity check with a trusted-lineage predicate. Two walls are deliberately unchanged: the inbound wall (`inbound === true` still refuses, covering injected turns and result-wakes) and the capability strip (a `tools:[]` child still can't delegate). The only trust downgrade is an inbound spawning turn, which taints its subtree; `parentSessionId`/`spawnedTrusted` are set server-side, so the chain isn't model-forgeable.

**Review process.** After implementation, a review swarm (4 dimension finders × 3 adversarial verifiers per finding) surfaced 11 confirmed findings — including one HIGH regression (an async Stop cascade re-entered the just-stopped parent) and a medium where the new `awaitReply` await wasn't abort-aware (a hung actor could park a child past its own timeout). All 11 are fixed in the final commit with regression tests; the 4 rejected findings were left as-is.

**Scaffold commits.** The two `proposal(subagent):` commits are the ratified `delegation-lineage.js` predicate + provenance (cherry-picked from the #134 design branch); the feature commit wires them in and flips the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018scDZ7G3pkkAxKjmQkWY2q

---
_Generated by [Claude Code](https://claude.ai/code/session_018scDZ7G3pkkAxKjmQkWY2q)_