### PR TITLE
release: v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ storage formats may move until the surface stabilizes.
 
 ## [Unreleased]
 
+## [0.2.2] — 2026-07-04
+
 ### Added
 - **The dweb actor — a dedicated, opt-in mesh operator** (preview only). When
   the network is on, a second toggle spins up a persistent, keyless agent in

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "peerd (dev)",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "An AI assistant that automates tasks in your browser. Local-first: your own API key, no account, no servers, no tracking.",
   "side_panel": {
     "default_path": "sidepanel/sidepanel.html"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "peerd",
   "private": true,
   "type": "module",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Browser-native AI agent harness. Solo dev — Bun is for tests + one-shot vendor scripts only; the extension itself runs no build step.",
   "license": "Apache-2.0",
   "homepage": "https://peerd.ai",


### PR DESCRIPTION
Cuts v0.2.2 from current main. Promotes the maintained `[Unreleased]` changelog to `[0.2.2]` and bumps package.json.

Headlines since v0.2.1: the **heap split** (#138), the **dweb actor** (#141), **culling do/get/check + the browser-runner** so the web actor drives pages directly (#133), **subagents as async actors** (#134/#135), configurable remote Ollama host (#128), and the dweb "Start the network" error-surfacing fix (#118).