### PR TITLE
feat(release): pull release notes from CHANGELOG.md

### DIFF
--- a/.github/workflows/package-and-release.yml
+++ b/.github/workflows/package-and-release.yml
@@ -331,22 +331,17 @@ jobs:
             update-feeds/chrome-preview.xml
             update-feeds/firefox-preview.json
           )
+          # Notes come from the tag's CHANGELOG.md section (same helper the
+          # local release path uses). A missing section fails the job here,
+          # so a release is never published with boilerplate notes.
+          bun packaging/release-notes.ts --version="${GITHUB_REF_NAME#v}" > "$RUNNER_TEMP/release-notes.md"
           if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
             echo "release $GITHUB_REF_NAME exists — re-uploading assets"
             gh release upload "$GITHUB_REF_NAME" --clobber "${ASSETS[@]}"
           else
             gh release create "$GITHUB_REF_NAME" \
               --title "peerd-preview-$GITHUB_REF_NAME" \
-              --notes "peerd preview $GITHUB_REF_NAME — peerd with the decentralized web (dweb) preview enabled.
-
-          The dweb protocol is research-grade and may change. Most users want the store packages (see the README's Install section).
-
-          | artifact | install |
-          |---|---|
-          | peerd-preview-firefox.xpi | Firefox — click to install (recommended path) |
-          | peerd-preview-chrome.crx | Chrome — drag into chrome://extensions (developer mode) |
-
-          Store-channel artifacts for this version are produced by the same CI run and submitted to Chrome Web Store / AMO separately; store review lag is expected." \
+              --notes-file "$RUNNER_TEMP/release-notes.md" \
               "${ASSETS[@]}"
           fi
 

--- a/packaging/release-notes.ts
+++ b/packaging/release-notes.ts
@@ -1,0 +1,60 @@
+// Release notes come from CHANGELOG.md, not a template. This script owns
+// the extraction so packaging/release.ts and the CI release job share one
+// implementation and cannot drift.
+//
+//   bun packaging/release-notes.ts                   notes for package.json's version
+//   bun packaging/release-notes.ts --version=0.2.2   notes for a named version
+//
+// Prints the notes body to stdout. Exits 1 if CHANGELOG.md has no section
+// for the version: a release is never cut with empty or boilerplate notes.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { REPO_ROOT, readVersion, parseArgs } from './lib.ts';
+
+// The short install pointer appended after the changelog section. Plain
+// English, no em dashes (house style).
+export const INSTALL_FOOTER = [
+  '---',
+  '**Install (preview):** Firefox: click the `.xpi` on this page. Chrome: drag',
+  'the `.crx` into `chrome://extensions` with Developer mode on. Most users',
+  'want the store packages (see the README). The auto-update feeds are',
+  'attached here and served at `peerd.ai/updates/`.',
+].join('\n');
+
+// Pure: pull one version's section out of a Keep-a-Changelog document.
+// The section runs from its "## [X.Y.Z]" heading to the next "## [" heading
+// (or end of file), minus the heading itself, trailing "---" separators, and
+// the link-reference block at the bottom of the file.
+export const extractChangelogSection = (changelog: string, version: string): string => {
+  const lines = changelog.split('\n');
+  const start = lines.findIndex((l) => l.startsWith(`## [${version}]`));
+  if (start === -1) throw new Error(`CHANGELOG.md has no "## [${version}]" section`);
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (lines[i].startsWith('## [')) { end = i; break; }
+  }
+  const body = lines.slice(start + 1, end)
+    .filter((l) => !/^\[[^\]]+\]:\s+http/.test(l))   // link-reference lines
+    .join('\n')
+    .replace(/\n---\s*$/g, '')                        // trailing section separator
+    .trim();
+  if (body === '') throw new Error(`the "## [${version}]" changelog section is empty`);
+  return body;
+};
+
+export const buildReleaseNotes = (changelog: string, version: string): string =>
+  `${extractChangelogSection(changelog, version)}\n\n${INSTALL_FOOTER}\n`;
+
+// CLI entry (skipped when imported by release.ts or the tests).
+if (import.meta.main) {
+  const args = parseArgs(process.argv.slice(2));
+  const version = typeof args.version === 'string' ? args.version : readVersion();
+  try {
+    const changelog = readFileSync(join(REPO_ROOT, 'CHANGELOG.md'), 'utf8');
+    process.stdout.write(buildReleaseNotes(changelog, version));
+  } catch (e) {
+    console.error(`release-notes FAILED: ${e instanceof Error ? e.message : String(e)}`);
+    process.exit(1);
+  }
+}

--- a/packaging/release.ts
+++ b/packaging/release.ts
@@ -30,6 +30,7 @@ import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { REPO_ROOT, ARTIFACTS_DIR, readVersion, parseArgs } from './lib.ts';
 import { fetchFeedVersions } from './check-feeds.ts';
+import { buildReleaseNotes } from './release-notes.ts';
 
 const run = (cmd: string, args: string[]) =>
   execFileSync(cmd, args, { cwd: REPO_ROOT, stdio: 'inherit' });
@@ -41,16 +42,11 @@ const die = (msg: string): never => {
   process.exit(1);
 };
 
-const releaseNotes = (version: string) => `peerd preview v${version} — peerd with the decentralized web (dweb) preview enabled.
-
-The dweb protocol is research-grade and may change. Most users want the store packages (see the README's Install section).
-
-| artifact | install |
-|---|---|
-| peerd-preview-firefox.xpi | Firefox — click to install (recommended path) |
-| peerd-preview-chrome.crx | Chrome — drag into chrome://extensions (developer mode) |
-
-Store-channel artifacts for this version are built and verified by the same pipeline and submitted to Chrome Web Store / AMO separately; store review lag is expected.`;
+// Notes come from CHANGELOG.md (packaging/release-notes.ts). Throws when the
+// version has no changelog section, which aborts the release before the tag
+// step: a release is never cut with boilerplate notes.
+const releaseNotes = (version: string) =>
+  buildReleaseNotes(readFileSync(join(REPO_ROOT, 'CHANGELOG.md'), 'utf8'), version);
 
 const main = async () => {
   const args = parseArgs(process.argv.slice(2));
@@ -59,6 +55,11 @@ const main = async () => {
   const tag = `v${version}`;
 
   step(`preconditions for ${tag}${dryRun ? ' (dry run)' : ''}`);
+  // Notes must exist BEFORE anything irreversible: a missing changelog
+  // section aborts here, not after the tag is pushed.
+  try { releaseNotes(version); } catch (e) {
+    die(e instanceof Error ? e.message : String(e));
+  }
   if (capture('git', ['branch', '--show-current']) !== 'main') die('not on main');
   // A dry run is what you run BEFORE committing — allow a dirty tree
   // there (with a note); a real release must start clean.

--- a/tests/packaging/release-notes.test.ts
+++ b/tests/packaging/release-notes.test.ts
@@ -1,0 +1,89 @@
+// Release notes are extracted from CHANGELOG.md (packaging/release-notes.ts),
+// shared by the local release path and the CI release job. These tests pin
+// the extraction so a refactor can't silently ship boilerplate or empty
+// notes again.
+
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { extractChangelogSection, buildReleaseNotes, INSTALL_FOOTER } from '../../packaging/release-notes.ts';
+import { REPO_ROOT, readVersion } from '../../packaging/lib.ts';
+
+const FIXTURE = `# Changelog
+
+Header prose.
+
+## [Unreleased]
+
+## [0.2.0] - 2026-06-29
+
+Intro line for 0.2.0.
+
+### Added
+- **Thing one.** Does a thing (#12).
+
+---
+
+## [0.1.0] - 2026
+
+### Added
+- **Base.** The first cut.
+
+[Unreleased]: https://example.com/compare/v0.1.0...HEAD
+[0.1.0]: https://example.com/releases/tag/v0.1.0
+`;
+
+describe('extractChangelogSection', () => {
+  test('pulls exactly one version section, without its heading', () => {
+    const s = extractChangelogSection(FIXTURE, '0.2.0');
+    expect(s).toContain('Intro line for 0.2.0.');
+    expect(s).toContain('Thing one');
+    expect(s).toContain('#12');
+    expect(s).not.toContain('## [0.2.0]');
+    // stops at the next version heading
+    expect(s).not.toContain('0.1.0');
+    expect(s).not.toContain('Base');
+  });
+
+  test('strips the trailing --- separator', () => {
+    const s = extractChangelogSection(FIXTURE, '0.2.0');
+    expect(s.endsWith('---')).toBe(false);
+  });
+
+  test('the last section drops the link-reference block', () => {
+    const s = extractChangelogSection(FIXTURE, '0.1.0');
+    expect(s).toContain('The first cut.');
+    expect(s).not.toContain('https://example.com');
+  });
+
+  test('throws on a version with no section', () => {
+    expect(() => extractChangelogSection(FIXTURE, '9.9.9')).toThrow('no "## [9.9.9]" section');
+  });
+
+  test('throws on an empty section', () => {
+    expect(() => extractChangelogSection(FIXTURE, 'Unreleased')).toThrow('empty');
+  });
+});
+
+describe('buildReleaseNotes', () => {
+  test('is the section plus the install footer', () => {
+    const n = buildReleaseNotes(FIXTURE, '0.2.0');
+    expect(n).toContain('Thing one');
+    expect(n).toContain(INSTALL_FOOTER);
+    expect(n.indexOf(INSTALL_FOOTER)).toBeGreaterThan(n.indexOf('Thing one'));
+  });
+
+  test('the footer is plain: no em dashes', () => {
+    expect(INSTALL_FOOTER.includes('—')).toBe(false);
+  });
+});
+
+describe('the real CHANGELOG.md', () => {
+  // Drift guard: package.json's version must always have a changelog
+  // section, so a release PR that bumps the version without writing the
+  // changelog fails CI here, before anything is tagged.
+  test(`has a section for the current version (${readVersion()})`, () => {
+    const changelog = readFileSync(join(REPO_ROOT, 'CHANGELOG.md'), 'utf8');
+    expect(buildReleaseNotes(changelog, readVersion()).length).toBeGreaterThan(100);
+  });
+});


### PR DESCRIPTION
GitHub releases were published with a generic boilerplate body (the historical ones were fixed by hand). This makes the pipeline do it.

- New `packaging/release-notes.ts`: extracts the version's `## [X.Y.Z]` section from CHANGELOG.md, appends a short plain install footer, fails loudly if the section is missing or empty. Runnable as a CLI and importable.
- `packaging/release.ts`: uses it, and validates the section in preconditions so a missing changelog aborts before the tag push.
- CI release job: generates the body with the same script and passes `--notes-file`, so the two paths cannot drift.
- `tests/packaging/release-notes.test.ts`: pins the extraction, plus a drift guard that package.json's current version always has a changelog section (a version bump without notes now fails CI at PR time).

Verified: 8 new tests pass, full Bun suite 2504 pass, typecheck and lint clean, CLI smoke prints the real 0.2.2 notes with zero em dashes and exits 1 on a missing version.