### PR TITLE
feat(ci): fail on dead path references in the top-level docs

### DIFF
--- a/.github/workflows/package-and-release.yml
+++ b/.github/workflows/package-and-release.yml
@@ -67,6 +67,8 @@ jobs:
         run: bun run check:boundary
       - name: Packaged import graph (no pruned-but-imported file black-screens a page)
         run: bun run check:imports
+      - name: Doc path references (top-level docs point at real files)
+        run: bun run check:docpaths
       - name: Generated-file drift (dev manifest + channel-config + tscheck badge)
         run: |
           bun run gen:dev

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "check:tscheck": "bun packaging/check-tscheck.ts",
     "check:imports": "bun packaging/check-packaged-imports.ts",
     "check:pages": "bun scripts/cdp/check-packaged-pages.mjs",
+    "check:docpaths": "bun packaging/check-doc-paths.ts",
     "verify:store": "bun packaging/verify-store-artifact.ts",
     "feeds": "bun packaging/gen-update-feeds.ts",
     "vendor:codemirror": "bun run scripts/vendor-codemirror.ts"

--- a/packaging/check-doc-paths.ts
+++ b/packaging/check-doc-paths.ts
@@ -1,0 +1,113 @@
+// Top-level docs must not point at files that don't exist. The 0.2.1 doc
+// cut deleted the per-module READMEs and README/CLAUDE/SECURITY kept
+// referencing them for days; this gate makes that class of drift fail CI.
+//
+//   bun packaging/check-doc-paths.ts
+//
+// Checks README.md, CLAUDE.md, SECURITY.md, CONTRIBUTING.md. CHANGELOG.md
+// is deliberately excluded: it is a historical record and may reference
+// files that were later deleted.
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { REPO_ROOT } from './lib.ts';
+
+export const CHECKED_DOCS = ['README.md', 'CLAUDE.md', 'SECURITY.md', 'CONTRIBUTING.md'];
+
+// A backticked token or link target is treated as a repo-path claim only
+// when it looks like one: has a slash, no spaces, no glob/placeholder
+// characters, no URL scheme. Everything else (commands, npm names,
+// hostnames, patterns) is ignored.
+const GLOBBY = /[*?<>{}()|\s…]/;
+const SCHEME = /^[a-z][a-z0-9+.-]*:/i;
+
+/** Strip fenced code blocks; their contents are prose/diagrams, not claims. */
+const stripFences = (md: string): string => md.replace(/^```[\s\S]*?^```/gm, '');
+
+/** Pull every repo-path claim out of one markdown document. */
+export const extractPathRefs = (md: string): string[] => {
+  const body = stripFences(md);
+  const refs = new Set<string>();
+
+  // Markdown link targets: [text](target) — skip anchors and external URLs.
+  for (const m of body.matchAll(/\]\(([^)\s]+)\)/g)) {
+    const t = m[1].split('#')[0];
+    if (t === '' || SCHEME.test(t)) continue;
+    refs.add(t);
+  }
+  // HTML img/src targets.
+  for (const m of body.matchAll(/src="([^"]+)"/g)) {
+    if (!SCHEME.test(m[1])) refs.add(m[1]);
+  }
+  // Backticked tokens that look like paths.
+  for (const m of body.matchAll(/`([^`\n]+)`/g)) {
+    const t = m[1];
+    if (!t.includes('/') || GLOBBY.test(t) || SCHEME.test(t) || t.startsWith('@')) continue;
+    refs.add(t.replace(/[.,;:]+$/, ''));
+  }
+  return [...refs];
+};
+
+/** The roots a doc path claim may be relative to. Docs use module-relative
+ *  shorthand constantly: `peerd-egress/vault/` means extension/peerd-egress/
+ *  vault/, and `tools/exposure.js` or `dom/walk-injected.js` are relative to
+ *  a peerd-* module. */
+export const resolutionRoots = (root: string = REPO_ROOT): string[] => {
+  const modules = existsSync(join(root, 'extension'))
+    ? readdirSync(join(root, 'extension')).filter((d) => d.startsWith('peerd-'))
+      .map((d) => join(root, 'extension', d))
+    : [];
+  return [root, join(root, 'extension'), ...modules];
+};
+
+export const resolvesInRepo = (ref: string, roots: string[]): boolean =>
+  roots.some((r) => existsSync(join(r, ref)));
+
+/** Only flag refs whose first segment is a real directory under one of the
+ *  resolution roots: a missing peerd-runtime/x is drift; UsefulSensors/x is
+ *  a Hugging Face id and none of our business. Leading-slash refs are URL
+ *  paths (`/api/tags`), never repo paths. */
+export const isCheckableRef = (ref: string, roots: string[]): boolean => {
+  if (ref.startsWith('/')) return false;
+  const first = ref.split('/')[0];
+  if (first === '.' || first === '..') return true; // relative link: always checkable
+  return roots.some((r) => existsSync(join(r, first)));
+};
+
+/** Gitignored paths (run artifacts like scripts/cdp/artifacts/) are output
+ *  locations, not repo files; docs may legitimately name them. */
+export const isGitignored = (ref: string, root: string = REPO_ROOT): boolean => {
+  // Try both forms: a "dir/" ignore rule only matches when the queried path
+  // keeps its trailing slash (git can't stat a nonexistent path to learn it
+  // is a directory).
+  for (const form of new Set([ref, ref.replace(/\/$/, '')])) {
+    try {
+      execFileSync('git', ['check-ignore', '-q', form], { cwd: root });
+      return true;
+    } catch { /* not ignored in this form */ }
+  }
+  return false;
+};
+
+const main = () => {
+  let bad = 0;
+  const roots = resolutionRoots();
+  for (const doc of CHECKED_DOCS) {
+    const p = join(REPO_ROOT, doc);
+    if (!existsSync(p)) continue; // a checked doc may legitimately not exist
+    for (const ref of extractPathRefs(readFileSync(p, 'utf8'))) {
+      if (!isCheckableRef(ref, roots)) continue;
+      if (resolvesInRepo(ref, roots) || isGitignored(ref)) continue;
+      console.error(`${doc}: dead path reference: ${ref}`);
+      bad++;
+    }
+  }
+  if (bad > 0) {
+    console.error(`\ncheck-doc-paths FAILED: ${bad} dead reference(s). Fix the doc or the path.`);
+    process.exit(1);
+  }
+  console.log(`doc paths OK (${CHECKED_DOCS.join(', ')})`);
+};
+
+if (import.meta.main) main();

--- a/packaging/preflight.ts
+++ b/packaging/preflight.ts
@@ -58,6 +58,7 @@ const main = () => {
   run('typecheck coverage floor', 'bun', ['run', 'check:tscheck']);
   run('dweb boundary', 'bun', ['run', 'check:boundary']);
   run('packaged import graph (no pruned-but-imported file)', 'bun', ['run', 'check:imports']);
+  run('doc path references (top-level docs point at real files)', 'bun', ['run', 'check:docpaths']);
   run('bun tests', 'bun', ['test', './tests']);
   if (args.matrix === true) {
     run('artifact matrix (store artifacts verified)', 'bun', ['packaging/package.ts', '--all', '--no-sign']);

--- a/tests/packaging/check-doc-paths.test.ts
+++ b/tests/packaging/check-doc-paths.test.ts
@@ -1,0 +1,87 @@
+// The doc-path gate (packaging/check-doc-paths.ts) fails CI when a
+// top-level doc references a repo path that no longer exists (the class of
+// drift the 0.2.1 doc cut left behind). These tests pin the extraction
+// heuristics and the resolution rules.
+
+import { describe, test, expect } from 'bun:test';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  extractPathRefs, resolutionRoots, resolvesInRepo, isCheckableRef,
+  isGitignored, CHECKED_DOCS,
+} from '../../packaging/check-doc-paths.ts';
+import { REPO_ROOT } from '../../packaging/lib.ts';
+
+describe('extractPathRefs', () => {
+  test('markdown links, minus anchors and external URLs', () => {
+    const refs = extractPathRefs(
+      'See [a](docs/A.md), [b](CONTRIBUTING.md#setup), [c](#install), [d](https://x.test/y).',
+    );
+    expect(refs).toContain('docs/A.md');
+    expect(refs).toContain('CONTRIBUTING.md');
+    expect(refs).not.toContain('');
+    expect(refs.some((r) => r.startsWith('http'))).toBe(false);
+  });
+
+  test('img src attributes', () => {
+    expect(extractPathRefs('<img src="docs/store/assets/x.svg" width="1">'))
+      .toContain('docs/store/assets/x.svg');
+  });
+
+  test('backticked paths, minus commands, globs, schemes, npm names', () => {
+    const refs = extractPathRefs([
+      'Read `peerd-egress/vault/` and `tools/exposure.js`.',
+      'Run `bun run gen:dev` with `manifests/*.json` and `@xterm/xterm`.',
+      'Open `chrome://extensions` and `wss://x.test/y`; see `<kind>-tab/`.',
+    ].join('\n'));
+    expect(refs).toContain('peerd-egress/vault/');
+    expect(refs).toContain('tools/exposure.js');
+    expect(refs.some((r) => r.includes('*') || r.includes('<'))).toBe(false);
+    expect(refs.some((r) => r.startsWith('@') || r.includes('://'))).toBe(false);
+    expect(refs).not.toContain('bun run gen:dev');
+  });
+
+  test('fenced code blocks are ignored', () => {
+    const refs = extractPathRefs('```\n`docs/NOT-A-CLAIM.md`\n```\nand `docs/A.md`.');
+    expect(refs).toContain('docs/A.md');
+    expect(refs).not.toContain('docs/NOT-A-CLAIM.md');
+  });
+});
+
+describe('resolution against the real repo', () => {
+  const roots = resolutionRoots();
+
+  test('repo-root, extension/ shorthand, and module shorthand all resolve', () => {
+    expect(resolvesInRepo('packaging/lib.ts', roots)).toBe(true);
+    expect(resolvesInRepo('peerd-egress/vault', roots)).toBe(true);      // extension/
+    expect(resolvesInRepo('tools/exposure.js', roots)).toBe(true);       // peerd-runtime/
+    expect(resolvesInRepo('docs/DOES-NOT-EXIST.md', roots)).toBe(false);
+  });
+
+  test('only plausible repo paths are checkable', () => {
+    expect(isCheckableRef('peerd-runtime/nope.js', roots)).toBe(true);   // real module, drift if missing
+    expect(isCheckableRef('UsefulSensors/moonshine', roots)).toBe(false); // HF id
+    expect(isCheckableRef('/api/tags', roots)).toBe(false);              // URL path
+  });
+
+  test('gitignored output paths get a pass, trailing slash included', () => {
+    expect(isGitignored('scripts/cdp/artifacts/')).toBe(true);
+    expect(isGitignored('packaging/lib.ts')).toBe(false);
+  });
+});
+
+describe('the real top-level docs', () => {
+  // The live gate: every checked doc's path claims must resolve. This is
+  // the same walk main() does, run at PR time via bun test as well.
+  const roots = resolutionRoots();
+  for (const doc of CHECKED_DOCS) {
+    test(`${doc} has no dead path references`, () => {
+      const p = join(REPO_ROOT, doc);
+      if (!existsSync(p)) return;
+      const dead = extractPathRefs(readFileSync(p, 'utf8'))
+        .filter((r) => isCheckableRef(r, roots))
+        .filter((r) => !resolvesInRepo(r, roots) && !isGitignored(r));
+      expect(dead).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
Adds `bun run check:docpaths` (packaging/check-doc-paths.ts): fails when README.md, CLAUDE.md, SECURITY.md, or CONTRIBUTING.md references a repo path that doesn't exist. This is the gate that would have caught the dangling per-module-README pointers left by the 0.2.1 doc cut.

Heuristics keep it quiet: only tokens that look like repo paths are checked (slash, no globs or schemes or placeholders, first segment is a real top-level dir at the repo root, under `extension/`, or under a `peerd-*` module). Gitignored output paths pass (`scripts/cdp/artifacts/`). CHANGELOG.md is excluded as a historical record.

Wired into preflight and the checks job. 11 new Bun tests; full suite 2515 pass; the gate passes on current docs and was negative-tested against planted dead refs.