### PR TITLE
refactor(sw): slim the service worker — extract model catalog, tab affordances, actor kernels

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -251,9 +251,14 @@ export default [
   },
   // system-prompt loader fetches a chrome-extension:// static asset (NOT a
   // network egress). The egress allowlist intentionally wouldn't admit our
-  // own extension origin, so safeFetch isn't the right tool here.
+  // own extension origin, so safeFetch isn't the right tool here. Same for
+  // tab-affordances (the pull-in hint reads our own bundled icon32.png via
+  // runtime.getURL) — extracted from service-worker.js, which had this off.
   {
-    files: ['extension/peerd-runtime/loop/system-prompt.js'],
+    files: [
+      'extension/peerd-runtime/loop/system-prompt.js',
+      'extension/background/tab-affordances.js',
+    ],
     rules: { 'no-restricted-globals': 'off' },
   },
   // voice/model-store loads Moonshine ONNX bytes from CDN URLs (Hugging

--- a/extension/background/dweb-inbound-rate-cap.js
+++ b/extension/background/dweb-inbound-rate-cap.js
@@ -1,0 +1,46 @@
+// @ts-check
+// background/dweb-inbound-rate-cap.js — the dweb agent's inbound wake rate cap.
+//
+// Inbound mesh DMs wake the dweb agent, and every wake can spend money (a model
+// call). The cap MUST bind before that call — a spamming or Sybil peer can mint
+// did:keys for free, so the limit is BOTH per-did (a single peer can't flood) and
+// global (the whole inbox can't drain the user's budget). why extracted from the
+// SW: it's a pure stateful limiter (timestamps + a counter), so the sliding-window
+// + eviction behavior is Bun-testable with an injected clock instead of Date.now.
+//
+// The per-did map is swept on each admit: dids are free/Sybil, so without eviction
+// it would grow monotonically over the keepalive-pinned SW. Bounded by the admit
+// rate, so at most a few dozen live keys ever.
+
+/**
+ * @param {Object} [opts]
+ * @param {() => number} [opts.now]           injectable clock (default Date.now)
+ * @param {number} [opts.perDidPerMinute]     max wakes per did in a sliding minute (default 3)
+ * @param {number} [opts.perHourGlobal]       max wakes across all dids per hour (default 30)
+ */
+export const makeDwebInboundRateCap = ({ now = Date.now, perDidPerMinute = 3, perHourGlobal = 30 } = {}) => {
+  /** @type {Map<string, number[]>} per-did wake timestamps (sliding minute) */
+  const byDid = new Map();
+  let hour = { windowStart: 0, count: 0 };
+
+  /** Admit an inbound wake from `did`? Records the wake when it returns true.
+   *  @param {string} did @returns {boolean} */
+  const allow = (did) => {
+    const nowMs = now();
+    const times = (byDid.get(did) ?? []).filter((t) => nowMs - t < 60_000);
+    if (times.length >= perDidPerMinute) return false;             // per-did minute cap
+    if (nowMs - hour.windowStart > 3_600_000) hour = { windowStart: nowMs, count: 0 };
+    if (hour.count >= perHourGlobal) return false;                 // global hour cap
+    times.push(nowMs);
+    byDid.set(did, times);
+    hour.count += 1;
+    // Sweep dids whose timestamps have all aged out, so the map can't grow
+    // without limit on the long-lived SW.
+    for (const [k, ts] of byDid) {
+      if (k !== did && !ts.some((t) => nowMs - t < 60_000)) byDid.delete(k);
+    }
+    return true;
+  };
+
+  return { allow, _liveDids: () => byDid.size };
+};

--- a/extension/background/mint-once.js
+++ b/extension/background/mint-once.js
@@ -1,0 +1,26 @@
+// @ts-check
+// background/mint-once.js — single-flight dedup for lazy actor minting.
+//
+// Minting an actor session is async (sessions.create + registry writes). Two
+// message_actor calls that race to the SAME instance before either finishes
+// would each mint a session — a duplicate actor. mintOnce collapses concurrent
+// mints of one key onto a SINGLE in-flight promise; the entry clears when it
+// settles, so a later mint (after the first completed) starts fresh.
+//
+// Keys never collide across kinds: engine ids carry a prefix and web keys are
+// `web:<tabId>`. Extracted from the SW as a pure unit — a Map and a promise, no
+// IO — so the single-flight invariant is Bun-testable without a live session store.
+
+export const makeMintOnce = () => {
+  /** @type {Map<string, Promise<string>>} */
+  const inFlight = new Map();
+  /** @param {string} key @param {() => Promise<string>} fn @returns {Promise<string>} */
+  const mintOnce = (key, fn) => {
+    const existing = inFlight.get(key);
+    if (existing) return existing;
+    const p = (async () => { try { return await fn(); } finally { inFlight.delete(key); } })();
+    inFlight.set(key, p);
+    return p;
+  };
+  return { mintOnce, _inFlightCount: () => inFlight.size };
+};

--- a/extension/background/model-catalog.js
+++ b/extension/background/model-catalog.js
@@ -1,0 +1,236 @@
+// @ts-check
+// background/model-catalog.js — the per-chat model picker's catalog assembly.
+//
+// Extracted from the SW (which is wiring, not logic — its own header rule):
+// the static curated catalog, the live-inventory cache (Ollama /api/tags), the
+// OpenRouter curated-selection mapping, the live per-model context window, and
+// buildModelOptions, which folds all of it into the picker's options list.
+//
+// Import-free, deps-injected factory (same shape as background/routes/*): every
+// collaborator arrives via `deps`, so the assembly is Bun-unit-testable with
+// fakes and the SW keeps its role as the one place concrete instances meet.
+//
+// why `localModelAvailable` is a thunk: localModelState is created later in the
+// SW's assembly order than this factory is convenient to call; a thunk defers
+// the read to call time without forcing a wiring reorder.
+
+/**
+ * @param {Object} deps
+ * @param {() => Array<any>} deps.listProviders
+ * @param {(name: string, opts: any) => Promise<Array<{model:string,label:string}> | null>} deps.listProviderModels
+ * @param {(provider: string, model: string, opts: any) => Promise<number | null | undefined>} deps.providerModelContextWindow
+ * @param {string} deps.localModelId              LOCAL_MODEL_ID (the WebGPU model's id)
+ * @param {() => boolean} deps.localModelAvailable  is the local WebGPU model downloaded + resident?
+ * @param {{ get: () => any }} deps.settingsStore
+ * @param {{ getSecret: (name: string) => Promise<string | null> }} deps.vault
+ * @param {{ get: (id: string) => Promise<any> }} deps.sessions
+ * @param {() => { name: string, model: string }} deps.resolveActiveProvider
+ * @param {(name: string) => Promise<string | null>} deps.getSecret
+ * @param {any} deps.safeFetch
+ */
+export const makeModelCatalog = (deps) => {
+  const {
+    listProviders, listProviderModels, providerModelContextWindow,
+    localModelId, localModelAvailable, settingsStore, vault, sessions,
+    resolveActiveProvider, getSecret, safeFetch,
+  } = deps;
+
+  // Curated model options per provider, for the per-chat model picker.
+  // Conservative on purpose — only ids we're confident resolve, so the
+  // picker never offers a 404. Exotic models go through the free-form
+  // model field in Settings. The picker also appends whatever model the
+  // user has configured in Settings if it isn't already listed here.
+  const MODEL_CATALOG = Object.freeze({
+    anthropic: [
+      { model: 'claude-opus-4-8',            label: 'Claude Opus 4.8' },
+      { model: 'claude-sonnet-4-6',          label: 'Claude Sonnet 4.6' },
+      { model: 'claude-haiku-4-5-20251001',  label: 'Claude Haiku 4.5' },
+    ],
+    // The fallback set shown until the user curates their own (openrouterChatCatalog).
+    // Led by the current best open-weights tool-calling models (mid-2026), so a
+    // fresh OpenRouter user gets a strong default without curating first.
+    openrouter: [
+      { model: 'z-ai/glm-5.1',          label: 'GLM-5.1 (open · tool-calling)' },
+      { model: 'moonshotai/kimi-k2.6',  label: 'Kimi K2.6 (open)' },
+      { model: 'minimax/minimax-m2',    label: 'MiniMax M2 (open · cheap)' },
+      { model: 'openai/gpt-4o',         label: 'GPT-4o' },
+    ],
+    // Local WebGPU — only surfaced once downloaded/resident (gated in buildModelOptions).
+    'local-webgpu': [
+      { model: localModelId, label: 'Gemma 4 E2B' },
+    ],
+  });
+
+  // Live model inventory cache (providers with `liveModels`, i.e. Ollama
+  // /api/tags). Short TTL: chat-view mounts call models/options freely, and
+  // hammering the local daemon buys nothing. A FAILED probe (daemon down)
+  // is cached as null for the same TTL so the picker degrades quietly
+  // instead of retry-storming localhost.
+  const LIVE_MODELS_TTL_MS = 30_000;
+  /** @type {Map<string, { at: number, list: Array<{model:string,label:string}> | null }>} */
+  const liveModelsCache = new Map();
+  const liveProviderModels = async (/** @type {string} */ name) => {
+    const hit = liveModelsCache.get(name);
+    if (hit && Date.now() - hit.at < LIVE_MODELS_TTL_MS) return hit.list;
+    let list = null;
+    // ollamaHost (issue #104) lets the live inventory fetch a remote daemon's
+    // /api/tags; non-ollama adapters ignore it.
+    try { list = await listProviderModels(name, { safeFetch, ollamaHost: settingsStore.get().ollamaHost }); }
+    catch { list = null; }
+    liveModelsCache.set(name, { at: Date.now(), list });
+    return list;
+  };
+
+  // OpenRouter's chat catalog = the user's CURATED selection (Settings →
+  // Providers), each id mapped to a picker option. why curated and not the live
+  // ~300-model list: the gateway has too many models to dump into a chat
+  // dropdown. Until the user curates, fall back to the small static set we KNOW
+  // resolves, so a fresh OpenRouter user still gets a working picker (no 404).
+  const openrouterChatCatalog = () => {
+    const picked = Array.isArray(settingsStore.get().openrouterModels) ? settingsStore.get().openrouterModels : [];
+    const ids = picked.filter((/** @type {any} */ id) => typeof id === 'string' && id.trim()).map((/** @type {any} */ id) => id.trim());
+    if (ids.length === 0) return MODEL_CATALOG.openrouter;
+    return ids.map((/** @type {any} */ id) => ({ model: id, label: id }));
+  };
+
+  // Live per-model context window, for the dynamic trim trigger. A model's
+  // window is effectively constant for its id, so once we learn it we keep it
+  // for the LIFETIME of this service worker — no timer, no TTL. The cache is a
+  // plain Map checked lazily when a turn needs the value; the MV3 SW's own
+  // frequent teardown (idle reclaim wipes module state) is what eventually
+  // re-fetches, so a time-based expiry would be redundant theater on top of it.
+  //
+  // why NON-BLOCKING: the lookup is a network round-trip and the trigger has a
+  // correct static-table fallback, so blocking the turn on it would add latency
+  // for no correctness gain. A cache MISS returns undefined (the turn uses the
+  // table) and kicks off a one-shot background fetch; the live value refines
+  // LATER turns — the mechanical-fallback-then-async-refine shape used
+  // elsewhere (trim enrichment). We cache only SUCCESSES; a failed/null lookup
+  // is left UNCACHED so a transient failure (locked vault, daemon briefly down)
+  // is retried next turn instead of sticking.
+  /** @type {Map<string, any>} */ const contextWindowCache = new Map();
+  const liveContextWindow = (/** @type {string} */ provider, /** @type {string} */ model) => {
+    if (!provider || !model) return undefined;
+    const key = `${provider}::${model}`;
+    const hit = contextWindowCache.get(key);
+    if (hit && typeof hit.window === 'number') return hit.window; // learned → keep for SW lifetime
+    if (hit && hit.fetching) return undefined;                    // in-flight → don't fire a second
+    contextWindowCache.set(key, { fetching: true });
+    // ollamaHost (issue #104): the live per-model window comes from the daemon's
+    // /api/show, so a remote Ollama needs its host or it would query localhost and
+    // silently fall back to the static table; other adapters ignore it.
+    providerModelContextWindow(provider, model, { getSecret, safeFetch, ollamaHost: settingsStore.get().ollamaHost })
+      .then((w) => {
+        if (typeof w === 'number') contextWindowCache.set(key, { window: w });
+        else contextWindowCache.delete(key); // miss → drop so the next turn retries
+      })
+      .catch(() => contextWindowCache.delete(key));
+    return undefined;
+  };
+
+  /**
+   * Build the per-chat model options + the currently-selected value
+   * (`provider::model`). The side panel shows a picker above the composer when
+   * there are 2+ options.
+   *
+   * Two modes:
+   *   - FRESH chat (no sessionId, or the session doesn't exist): every
+   *     key-configured provider's catalog + the Settings-configured model;
+   *     `selected` follows the active provider; `sessionProvider` is null.
+   *   - MID-SESSION (sessionId resolves to a session): scoped to THAT session's
+   *     provider only (model-only switching — the provider is fixed once a chat
+   *     starts); `selected` is the session's current model and is always present
+   *     even if it's a custom id; `sessionProvider` names the locked provider.
+   *
+   * Keyless/live providers (Ollama): the "has a key" gate becomes "the daemon
+   * answered" — its real pulled-model inventory is the catalog. OpenRouter uses
+   * the curated catalog above.
+   *
+   * @param {{ sessionId?: string | null }} [opts]
+   */
+  const buildModelOptions = async ({ sessionId = null } = {}) => {
+    const sess = sessionId ? await sessions.get(sessionId).catch(() => null) : null;
+    const lockProvider = sess?.provider ?? null;
+
+    const options = [];
+    for (const p of listProviders()) {
+      // Mid-session is model-only within the session's provider.
+      if (lockProvider && p.name !== lockProvider) continue;
+      let hasKey = false;
+      if (p.keyless) {
+        hasKey = true;
+      } else {
+        try { hasKey = !!(await vault.getSecret(/** @type {string} */ (p.vaultSecretName))); }
+        catch { hasKey = false; }
+      }
+      // why: when locked to a session whose provider key was since removed we
+      // still surface that provider's models (and the current one) rather than
+      // render an empty picker; the missing-key skip applies to fresh chats only.
+      if (!hasKey && !lockProvider) continue;
+      // The local WebGPU model only appears once downloaded + resident (the
+      // offscreen engine reports `available`); otherwise selecting it would error
+      // on the first turn ("local model not loaded"). Hardware capability is gated
+      // earlier, at download time (Settings → WebGPU models).
+      if (p.name === 'local-webgpu' && !localModelAvailable()) continue;
+      let catalog = (/** @type {any} */ (MODEL_CATALOG))[p.name] ?? [{ model: p.defaultModel, label: p.defaultModel }];
+      if (p.name === 'openrouter') catalog = openrouterChatCatalog();
+      if (p.liveModels) {
+        const live = await liveProviderModels(p.name);
+        if (live) catalog = live;
+        else if (!lockProvider) continue; // unreachable → offer nothing, not a guess
+      }
+      for (const c of catalog) {
+        options.push({
+          provider: p.name,
+          providerLabel: p.label,
+          model: c.model,
+          label: c.label,
+          value: `${p.name}::${c.model}`,
+        });
+      }
+      // Append the user's Settings-configured model for this provider if
+      // it's a custom id not already in the catalog.
+      if (settingsStore.get().providerName === p.name && settingsStore.get().providerModel
+          && !options.some((o) => o.value === `${p.name}::${settingsStore.get().providerModel}`)) {
+        options.push({
+          provider: p.name,
+          providerLabel: p.label,
+          model: settingsStore.get().providerModel,
+          label: `${settingsStore.get().providerModel} (custom)`,
+          value: `${p.name}::${settingsStore.get().providerModel}`,
+        });
+      }
+    }
+
+    /** @type {any} */ let selected;
+    let sessionProvider = null;
+    if (sess?.provider) {
+      sessionProvider = sess.provider;
+      selected = `${sess.provider}::${sess.model}`;
+      // Always keep the session's CURRENT model selectable, even if it's a
+      // custom id outside the catalog — otherwise the dropdown would show the
+      // wrong value as selected.
+      if (!options.some((o) => o.value === selected)) {
+        options.push({
+          provider: sess.provider,
+          providerLabel: listProviders().find((p) => p.name === sess.provider)?.label ?? sess.provider,
+          model: sess.model,
+          label: `${sess.model} (current)`,
+          value: selected,
+        });
+      }
+    } else {
+      const active = resolveActiveProvider();
+      selected = `${active.name}::${active.model}`;
+      // If the active selection isn't a usable option (e.g. its provider has
+      // no key), fall back to the first option so the picker shows something
+      // valid.
+      if (!options.some((o) => o.value === selected)) {
+        selected = options[0]?.value ?? selected;
+      }
+    }
+    return { options, selected, sessionProvider };
+  };
+
+  return { liveProviderModels, openrouterChatCatalog, liveContextWindow, buildModelOptions };
+};

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -284,6 +284,7 @@ import { makeDenylistStore } from './denylist-store.js';
 import { makeSessionState } from './session-state.js';
 import { makeLocalModelState } from './local-model-state.js';
 import { makeProfileState } from './profile-state.js';
+import { makeModelCatalog } from './model-catalog.js';
 import { makeVaultRoutes } from './routes/vault.js';
 import { makeProviderRoutes } from './routes/providers.js';
 import { makeHooksRoutes } from './routes/hooks.js';
@@ -498,203 +499,10 @@ const maskKey = (/** @type {string} */ k) => {
   return `${s.slice(0, 7)}…${s.slice(-3)} · ${s.length} chars`;
 };
 
-// Curated model options per provider, for the per-chat model picker.
-// Conservative on purpose — only ids we're confident resolve, so the
-// picker never offers a 404. Exotic models go through the free-form
-// model field in Settings. The picker also appends whatever model the
-// user has configured in Settings if it isn't already listed here.
-const MODEL_CATALOG = Object.freeze({
-  anthropic: [
-    { model: 'claude-opus-4-8',            label: 'Claude Opus 4.8' },
-    { model: 'claude-sonnet-4-6',          label: 'Claude Sonnet 4.6' },
-    { model: 'claude-haiku-4-5-20251001',  label: 'Claude Haiku 4.5' },
-  ],
-  // The fallback set shown until the user curates their own (openrouterChatCatalog).
-  // Led by the current best open-weights tool-calling models (mid-2026), so a
-  // fresh OpenRouter user gets a strong default without curating first.
-  openrouter: [
-    { model: 'z-ai/glm-5.1',          label: 'GLM-5.1 (open · tool-calling)' },
-    { model: 'moonshotai/kimi-k2.6',  label: 'Kimi K2.6 (open)' },
-    { model: 'minimax/minimax-m2',    label: 'MiniMax M2 (open · cheap)' },
-    { model: 'openai/gpt-4o',         label: 'GPT-4o' },
-  ],
-  // Local WebGPU — only surfaced once downloaded/resident (gated in buildModelOptions).
-  'local-webgpu': [
-    { model: LOCAL_MODEL_ID, label: 'Gemma 4 E2B' },
-  ],
-});
-
-// Live model inventory cache (providers with `liveModels`, i.e. Ollama
-// /api/tags). Short TTL: chat-view mounts call models/options freely, and
-// hammering the local daemon buys nothing. A FAILED probe (daemon down)
-// is cached as null for the same TTL so the picker degrades quietly
-// instead of retry-storming localhost.
-const LIVE_MODELS_TTL_MS = 30_000;
-/** @type {Map<string, { at: number, list: Array<{model:string,label:string}> | null }>} */
-const liveModelsCache = new Map();
-const liveProviderModels = async (/** @type {string} */ name) => {
-  const hit = liveModelsCache.get(name);
-  if (hit && Date.now() - hit.at < LIVE_MODELS_TTL_MS) return hit.list;
-  let list = null;
-  // ollamaHost (issue #104) lets the live inventory fetch a remote daemon's
-  // /api/tags; non-ollama adapters ignore it.
-  try { list = await listProviderModels(name, { safeFetch, ollamaHost: settingsStore.get().ollamaHost }); }
-  catch { list = null; }
-  liveModelsCache.set(name, { at: Date.now(), list });
-  return list;
-};
-
-// OpenRouter's chat catalog = the user's CURATED selection (Settings →
-// Providers), each id mapped to a picker option. why curated and not the live
-// ~300-model list: the gateway has too many models to dump into a chat
-// dropdown. Until the user curates, fall back to the small static set we KNOW
-// resolves, so a fresh OpenRouter user still gets a working picker (no 404).
-const openrouterChatCatalog = () => {
-  const picked = Array.isArray(settingsStore.get().openrouterModels) ? settingsStore.get().openrouterModels : [];
-  const ids = picked.filter((/** @type {any} */ id) => typeof id === 'string' && id.trim()).map((/** @type {any} */ id) => id.trim());
-  if (ids.length === 0) return MODEL_CATALOG.openrouter;
-  return ids.map((/** @type {any} */ id) => ({ model: id, label: id }));
-};
-
-// Live per-model context window, for the dynamic trim trigger. A model's
-// window is effectively constant for its id, so once we learn it we keep it
-// for the LIFETIME of this service worker — no timer, no TTL. The cache is a
-// plain Map checked lazily when a turn needs the value; the MV3 SW's own
-// frequent teardown (idle reclaim wipes module state) is what eventually
-// re-fetches, so a time-based expiry would be redundant theater on top of it.
-//
-// why NON-BLOCKING: the lookup is a network round-trip and the trigger has a
-// correct static-table fallback, so blocking the turn on it would add latency
-// for no correctness gain. A cache MISS returns undefined (the turn uses the
-// table) and kicks off a one-shot background fetch; the live value refines
-// LATER turns — the mechanical-fallback-then-async-refine shape used
-// elsewhere (trim enrichment). We cache only SUCCESSES; a failed/null lookup
-// is left UNCACHED so a transient failure (locked vault, daemon briefly down)
-// is retried next turn instead of sticking.
-/** @type {Map<string, { window: number } | { fetching: true }>} */
-/** @type {Map<string, any>} */ const contextWindowCache = new Map();
-const liveContextWindow = (/** @type {string} */ provider, /** @type {string} */ model) => {
-  if (!provider || !model) return undefined;
-  const key = `${provider}::${model}`;
-  const hit = contextWindowCache.get(key);
-  if (hit && typeof hit.window === 'number') return hit.window; // learned → keep for SW lifetime
-  if (hit && hit.fetching) return undefined;                    // in-flight → don't fire a second
-  contextWindowCache.set(key, { fetching: true });
-  // ollamaHost (issue #104): the live per-model window comes from the daemon's
-  // /api/show, so a remote Ollama needs its host or it would query localhost and
-  // silently fall back to the static table; other adapters ignore it.
-  providerModelContextWindow(provider, model, { getSecret, safeFetch, ollamaHost: settingsStore.get().ollamaHost })
-    .then((w) => {
-      if (typeof w === 'number') contextWindowCache.set(key, { window: w });
-      else contextWindowCache.delete(key); // miss → drop so the next turn retries
-    })
-    .catch(() => contextWindowCache.delete(key));
-  return undefined;
-};
-
-/**
- * Build the per-chat model options + the currently-selected value
- * (`provider::model`). The side panel shows a picker above the composer when
- * there are 2+ options.
- *
- * Two modes:
- *   - FRESH chat (no sessionId, or the session doesn't exist): every
- *     key-configured provider's catalog + the Settings-configured model;
- *     `selected` follows the active provider; `sessionProvider` is null.
- *   - MID-SESSION (sessionId resolves to a session): scoped to THAT session's
- *     provider only (model-only switching — the provider is fixed once a chat
- *     starts); `selected` is the session's current model and is always present
- *     even if it's a custom id; `sessionProvider` names the locked provider.
- *
- * Keyless/live providers (Ollama): the "has a key" gate becomes "the daemon
- * answered" — its real pulled-model inventory is the catalog. OpenRouter uses
- * the curated catalog above.
- *
- * @param {{ sessionId?: string | null }} [opts]
- */
-const buildModelOptions = async ({ sessionId = null } = {}) => {
-  const sess = sessionId ? await sessions.get(sessionId).catch(() => null) : null;
-  const lockProvider = sess?.provider ?? null;
-
-  const options = [];
-  for (const p of listProviders()) {
-    // Mid-session is model-only within the session's provider.
-    if (lockProvider && p.name !== lockProvider) continue;
-    let hasKey = false;
-    if (p.keyless) {
-      hasKey = true;
-    } else {
-      try { hasKey = !!(await vault.getSecret(/** @type {string} */ (p.vaultSecretName))); }
-      catch { hasKey = false; }
-    }
-    // why: when locked to a session whose provider key was since removed we
-    // still surface that provider's models (and the current one) rather than
-    // render an empty picker; the missing-key skip applies to fresh chats only.
-    if (!hasKey && !lockProvider) continue;
-    // The local WebGPU model only appears once downloaded + resident (the
-    // offscreen engine reports `available`); otherwise selecting it would error
-    // on the first turn ("local model not loaded"). Hardware capability is gated
-    // earlier, at download time (Settings → WebGPU models).
-    if (p.name === 'local-webgpu' && !localModelState.available()) continue;
-    let catalog = (/** @type {any} */ (MODEL_CATALOG))[p.name] ?? [{ model: p.defaultModel, label: p.defaultModel }];
-    if (p.name === 'openrouter') catalog = openrouterChatCatalog();
-    if (p.liveModels) {
-      const live = await liveProviderModels(p.name);
-      if (live) catalog = live;
-      else if (!lockProvider) continue; // unreachable → offer nothing, not a guess
-    }
-    for (const c of catalog) {
-      options.push({
-        provider: p.name,
-        providerLabel: p.label,
-        model: c.model,
-        label: c.label,
-        value: `${p.name}::${c.model}`,
-      });
-    }
-    // Append the user's Settings-configured model for this provider if
-    // it's a custom id not already in the catalog.
-    if (settingsStore.get().providerName === p.name && settingsStore.get().providerModel
-        && !options.some((o) => o.value === `${p.name}::${settingsStore.get().providerModel}`)) {
-      options.push({
-        provider: p.name,
-        providerLabel: p.label,
-        model: settingsStore.get().providerModel,
-        label: `${settingsStore.get().providerModel} (custom)`,
-        value: `${p.name}::${settingsStore.get().providerModel}`,
-      });
-    }
-  }
-
-  /** @type {any} */ let selected;
-  let sessionProvider = null;
-  if (sess?.provider) {
-    sessionProvider = sess.provider;
-    selected = `${sess.provider}::${sess.model}`;
-    // Always keep the session's CURRENT model selectable, even if it's a
-    // custom id outside the catalog — otherwise the dropdown would show the
-    // wrong value as selected.
-    if (!options.some((o) => o.value === selected)) {
-      options.push({
-        provider: sess.provider,
-        providerLabel: listProviders().find((p) => p.name === sess.provider)?.label ?? sess.provider,
-        model: sess.model,
-        label: `${sess.model} (current)`,
-        value: selected,
-      });
-    }
-  } else {
-    const active = resolveActiveProvider();
-    selected = `${active.name}::${active.model}`;
-    // If the active selection isn't a usable option (e.g. its provider has
-    // no key), fall back to the first option so the picker shows something
-    // valid.
-    if (!options.some((o) => o.value === selected)) {
-      selected = options[0]?.value ?? selected;
-    }
-  }
-  return { options, selected, sessionProvider };
-};
+// The per-chat model picker's catalog assembly lives in background/model-catalog.js
+// (curated catalog, live Ollama inventory, OpenRouter curated mapping, live
+// context window, buildModelOptions). The factory is invoked further down, after
+// its collaborators (safeFetch, getSecret, sessions) are created.
 
 // The user-configured Ollama host (issue #104). Its exact origin joins the
 // allowlist so safeFetch permits a remote daemon — the loopback default is
@@ -817,6 +625,14 @@ const contacts = createContactsStore({ idb });
 // pushState doesn't re-read IDB on every push and onboarding/complete can reach
 // it via deps. profileState.get() ensures+caches; completeOnboarding refreshes.
 const profileState = makeProfileState({ profiles });
+
+// The per-chat model picker's catalog assembly (background/model-catalog.js).
+// localModelAvailable is a thunk because localModelState is created later.
+const { liveProviderModels, liveContextWindow, buildModelOptions } = makeModelCatalog({
+  listProviders, listProviderModels, providerModelContextWindow,
+  localModelId: LOCAL_MODEL_ID, localModelAvailable: () => localModelState.available(),
+  settingsStore, vault, sessions, resolveActiveProvider, getSecret, safeFetch,
+});
 
 // ---------------------------------------------------------------------------
 // Tool layer

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -282,6 +282,8 @@ import { makeLocalModelState } from './local-model-state.js';
 import { makeProfileState } from './profile-state.js';
 import { makeModelCatalog } from './model-catalog.js';
 import { makeTabAffordances } from './tab-affordances.js';
+import { makeMintOnce } from './mint-once.js';
+import { makeDwebInboundRateCap } from './dweb-inbound-rate-cap.js';
 import { makeVaultRoutes } from './routes/vault.js';
 import { makeProviderRoutes } from './routes/providers.js';
 import { makeHooksRoutes } from './routes/hooks.js';
@@ -2370,15 +2372,9 @@ const ACTOR_REGISTRY_BY_PREFIX = {
 // promise collapses them to ONE mint; the entry clears when it settles. why a
 // shared map: engine ids carry a prefix and web keys are `web:<tabId>`, so they
 // never collide. @type {Map<string, Promise<string>>} */
-const mintInFlight = new Map();
-/** @param {string} key @param {() => Promise<string>} fn @returns {Promise<string>} */
-const mintOnce = (key, fn) => {
-  const existing = mintInFlight.get(key);
-  if (existing) return existing;
-  const p = (async () => { try { return await fn(); } finally { mintInFlight.delete(key); } })();
-  mintInFlight.set(key, p);
-  return p;
-};
+// Single-flight dedup for lazy actor minting (background/mint-once.js): two
+// message_actor calls racing to the same instance collapse onto ONE mint.
+const { mintOnce } = makeMintOnce();
 
 // Start the actor process on demand: lazily mint an actor session for an
 // instance (on the first message_actor). Inherits the spawning chat's RESOLVED
@@ -2426,15 +2422,22 @@ const mintActor = async (/** @type {{ reg: any, kind: string }} */ entry, /** @t
 // session storage (ephemeral by design — on a cold miss we re-mint against the
 // live tab, whose DOM re-derives state). The address the orchestrator uses is the
 // tabId AS A STRING (the actor's instanceId).
+// A registry's chrome.storage.session persistence: the persist thunk + the
+// best-effort boot rehydrate, shared by the three actor registries below (a
+// missing/garbage stored value just starts empty). Ephemeral by design — every
+// one of these is a routing cache whose durable truth lives on the session record.
+const persistRegistry = (/** @type {string} */ key, /** @type {{ entries: () => any }} */ registry) =>
+  () => { sessionCache.sessionSet(key, registry.entries()).catch(() => {}); };
+const hydrateRegistry = (/** @type {string} */ key, /** @type {{ load: (e: any) => void }} */ registry) => {
+  Promise.resolve(sessionCache.sessionGet(key))
+    .then((e) => { if (Array.isArray(e)) registry.load(/** @type {any} */ (e)); })
+    .catch(() => {});
+};
+
 const webActorTabBindings = makeWebActorTabBindings();
 const WEB_BINDINGS_KEY = 'webActorTabBindings';
-const persistWebBindings = () => {
-  sessionCache.sessionSet(WEB_BINDINGS_KEY, webActorTabBindings.entries()).catch(() => {});
-};
-// Rehydrate on SW boot (best-effort; a missing/garbage value just starts empty).
-Promise.resolve(sessionCache.sessionGet(WEB_BINDINGS_KEY))
-  .then((e) => { if (Array.isArray(e)) webActorTabBindings.load(/** @type {any} */ (e)); })
-  .catch(() => {});
+const persistWebBindings = persistRegistry(WEB_BINDINGS_KEY, webActorTabBindings);
+hydrateRegistry(WEB_BINDINGS_KEY, webActorTabBindings);
 
 // The chat→web-actor registry — the 0-or-1-tab web actor (addressed by `to:'web'`,
 // the SINGLE entry point for web work). Separate from webActorTabBindings because
@@ -2443,12 +2446,8 @@ Promise.resolve(sessionCache.sessionGet(WEB_BINDINGS_KEY))
 // the tab bindings — ephemeral is fine (re-mint on loss).
 const webActorRegistry = makeWebActorRegistry();
 const WEB_ACTOR_KEY = 'webActorRegistry';
-const persistWebActors = () => {
-  sessionCache.sessionSet(WEB_ACTOR_KEY, webActorRegistry.entries()).catch(() => {});
-};
-Promise.resolve(sessionCache.sessionGet(WEB_ACTOR_KEY))
-  .then((e) => { if (Array.isArray(e)) webActorRegistry.load(/** @type {any} */ (e)); })
-  .catch(() => {});
+const persistWebActors = persistRegistry(WEB_ACTOR_KEY, webActorRegistry);
+hydrateRegistry(WEB_ACTOR_KEY, webActorRegistry);
 
 // DESIGN-18 — API actors. An API integration is a `web` actor (backing:'api') with NO
 // tab: it owns ONE FIXED origin and reaches it fetch-only. Keyed by (ownerChatId,
@@ -2463,12 +2462,8 @@ Promise.resolve(sessionCache.sessionGet(WEB_ACTOR_KEY))
 // no unbounded growth + no cleanup hook needed) while the durable session is the truth.
 const apiActorBindings = makeApiActorBindings();
 const API_ACTOR_KEY = 'apiActorBindings';
-const persistApiActors = () => {
-  sessionCache.sessionSet(API_ACTOR_KEY, apiActorBindings.entries()).catch(() => {});
-};
-Promise.resolve(sessionCache.sessionGet(API_ACTOR_KEY))
-  .then((e) => { if (Array.isArray(e)) apiActorBindings.load(/** @type {any} */ (e)); })
-  .catch(() => {});
+const persistApiActors = persistRegistry(API_ACTOR_KEY, apiActorBindings);
+hydrateRegistry(API_ACTOR_KEY, apiActorBindings);
 
 // DESIGN-18 P2 — the API-integration discovery surface (injected as ctx.listApiIntegrations,
 // the integration rows of actor_list). The addressable set is the chat's FORMED integrations (origins it
@@ -2742,27 +2737,9 @@ const resolveDwebActor = async () => {
 // spends money; the actor's loop is the thing being protected.
 const DWEB_AGENT_ROOM = 'peerd-agent';
 const DWEB_AGENT_NO_REPORT = 'NO_REPORT';
-/** per-did wake timestamps (sliding minute) + a global hourly counter */
-const dwebInboundByDid = new Map();
-let dwebInboundHour = { windowStart: 0, count: 0 };
-const dwebInboundAllowed = (/** @type {string} */ did) => {
-  const nowMs = Date.now();
-  const times = (dwebInboundByDid.get(did) ?? []).filter((/** @type {number} */ t) => nowMs - t < 60_000);
-  if (times.length >= 3) return false;                      // 3/min per did
-  if (nowMs - dwebInboundHour.windowStart > 3_600_000) dwebInboundHour = { windowStart: nowMs, count: 0 };
-  if (dwebInboundHour.count >= 30) return false;            // 30/hour global
-  times.push(nowMs);
-  dwebInboundByDid.set(did, times);
-  dwebInboundHour.count += 1;
-  // Sweep dead entries: dids are free/Sybil (self-minted did:key), so without
-  // eviction the map grows monotonically over the long-lived (keepalive-pinned)
-  // SW. Drop any entry whose timestamps have all aged out. Cheap — bounded by
-  // the 30/hour ADMIT rate, so at most a few dozen live keys ever.
-  for (const [k, ts] of dwebInboundByDid) {
-    if (k !== did && !ts.some((/** @type {number} */ t) => nowMs - t < 60_000)) dwebInboundByDid.delete(k);
-  }
-  return true;
-};
+// Inbound wake rate cap (background/dweb-inbound-rate-cap.js): 3/min per did +
+// 30/hour global, bound BEFORE any model call so a Sybil peer can't drain budget.
+const { allow: dwebInboundAllowed } = makeDwebInboundRateCap();
 
 // ── A2A: the agent-to-agent mesh dispatch (the a2a_run code surface) ─────────
 // ONE dispatch instance (state: pending asks) wired to real mesh IO on the

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -30,7 +30,6 @@
 import browser from '/vendor/browser-polyfill.js';
 import { makeDispatcher, isTrustedSender } from '/shared/messaging.js';
 import { CHANNEL_DEFAULTS, CHANNEL, DWEB_ENABLED } from '/shared/channel-config.js';
-import { openHome } from '/shared/open-home.js';
 import { REMOTE_SKILL_INSTALL } from '/shared/flags.js';
 
 import {
@@ -237,8 +236,6 @@ import {
   // (addressing + same-origin-lock anchor), and the "what I learned" self-fence.
   makeApiActorBindings, normalizeApiOrigin, fenceApiActorSummary,
   finalAssistantText,
-  // The informational "pull peerd in" reminder injected into peerd-opened web tabs.
-  pullInHintInjected,
 } from '/peerd-runtime/index.js';
 
 import { flattenCategorisedDenylist, normalizeDenylistPattern } from '/peerd-egress/index.js';
@@ -251,7 +248,6 @@ import { makeOffscreenJsClient } from './offscreen-js-client.js';
 import { makeOffscreenActorClient } from './offscreen-actor-client.js';
 import { makeOffscreenPdfClient } from './offscreen-pdf-client.js';
 import { makeUiPorts } from './ui-ports.js';
-import { decidePullIn } from './panel-affordance.js';
 import { createAppClient, APP_TAB_GROUP_TITLE } from './app-client.js';
 import { createAppTabTracker } from './app-tab-tracker.js';
 import {
@@ -285,6 +281,7 @@ import { makeSessionState } from './session-state.js';
 import { makeLocalModelState } from './local-model-state.js';
 import { makeProfileState } from './profile-state.js';
 import { makeModelCatalog } from './model-catalog.js';
+import { makeTabAffordances } from './tab-affordances.js';
 import { makeVaultRoutes } from './routes/vault.js';
 import { makeProviderRoutes } from './routes/providers.js';
 import { makeHooksRoutes } from './routes/hooks.js';
@@ -1886,6 +1883,15 @@ const closeSidePanel = async () => {
   }
 };
 
+// How peerd shows up in the tab strip (background/tab-affordances.js): the
+// agent-tab card, the "pull peerd in" web-tab hint, and the toolbar-icon /
+// Alt+Shift+P front door. It owns all the tab-strip state + listeners; the SW
+// calls noteAgentTab/scheduleWebTabHint/broadcastAgentTab/showWebTabHint from
+// its tool-context + port wiring, and setTabAnchor from the actor-turn start.
+const {
+  noteAgentTab, broadcastAgentTab, scheduleWebTabHint, showWebTabHint, setTabAnchor, isHomeOpen,
+} = makeTabAffordances({ browser, uiPorts, denylistStore, closeSidePanel });
+
 // Confirmation coordinator. The dispatcher's async confirmation step
 // calls ctx.confirm(prompt); this pushes a 'confirm/request' to the side
 // panel and resolves when the panel posts back 'confirm/answer'.
@@ -3120,7 +3126,7 @@ const actorMessaging = makeActorMessaging({
         : kind === 'notebook' ? jsTabTracker.getTabId(instanceId)
         : kind === 'app' ? appTabTracker.getTabId(instanceId)
         : null;
-      if (typeof ownedTab === 'number') tabMsgAnchor.set(ownedTab, parentToolUseId);
+      if (typeof ownedTab === 'number') setTabAnchor(ownedTab, parentToolUseId);
     }
     // DESIGN-17 P1 glass pane: when this turn was triggered by a live message_actor
     // call (parentToolUseId present — absent on a boot redrain), pass a `display`
@@ -3204,147 +3210,6 @@ const postChatNote = (/** @type {string} */ text, /** @type {any} */ action = nu
   try { uiPorts.broadcast({ type: 'turn/system-note', text, ...(action ? { action } : {}) }); }
   catch { /* panel gone */ }
 };
-
-// The CURRENT AGENT TAB — the single tab the loop most recently created OR
-// interacted with (ran a command in, navigated, clicked, …). Agent tabs open in
-// the BACKGROUND now (never steal focus), so the chat shows ONE persistent,
-// sticky "go to the tab peerd is working in" card pointing here; clicking it is
-// the user gesture that focuses the tab AND opens the side panel (Chrome won't
-// let the agent/SW open the panel on its own — DESIGN-12). Updated on every
-// touch, so it always tracks where the agent IS, not just the last tab created.
-// p·cyan e·red e·amber r·green d·magenta — the home agent-tab card's Open button
-// draws a fresh one each time the card is (re)generated.
-const AGENT_TAB_COLORS = ['#00B7EB', '#EF4444', '#F59E0B', '#22C55E', '#D946EF'];
-// DESIGN-17/18 tab-card anchoring: maps an agent tab → the message_actor tool_use that
-// LAST drove it. The inline "peerd opened …" notice anchors to THAT message's turn, not
-// the wall-clock-latest user message — actor work is async, so a physical tab touch
-// (engine ensureTab / web DOM noteTab) often lands during a later turn, which would clump
-// the cards at the chat's end. Set at each actor-turn start (runActorTurn) for the actor's
-// owned tab; never cleared — overwritten only when a NEW message re-drives that tab, which
-// is exactly when the card should resurface to the newer turn. Orchestrator-opened tabs
-// (open_tab) are absent here → they keep the wall-clock anchor (correct; they're synchronous).
-/** @type {Map<number, string>} tabId → parentToolUseId */
-const tabMsgAnchor = new Map();
-/** @type {number | null} */ let agentTabId = null;
-/** @type {any} */ let agentTabInfo = null;   // the last { tabId, windowId, kind, name, label, color } noted
-/** @type {number | null} */ let activeTabId = null;    // the currently-active tab — hide the card when you're ON it
-// Broadcast the current-agent-tab pointer. `noted` is true ONLY when this fires
-// from a real agent touch (noteAgentTab) — the inline notice creates/resurfaces
-// on those; a passive refresh (tab activation, a fresh surface replay) sends
-// noted:false so clicking around tabs never bumps a notice.
-const broadcastAgentTab = (noted = false) => {
-  uiPorts.broadcast({
-    type: 'agent/tab',
-    tab: agentTabInfo ? { ...agentTabInfo, current: agentTabInfo.tabId === activeTabId, noted } : null,
-  });
-};
-const noteAgentTab = async (/** @type {number} */ tabId, /** @type {any} */ info = {}) => {
-  if (typeof tabId !== 'number') return;
-  const { kind = null, name = null, label = null, opened = true, parentToolUseId: ptuArg = null } = (typeof info === 'string' ? { label: info } : info);
-  // The message_actor turn driving this tab (see tabMsgAnchor) — caller-supplied or the
-  // last actor-turn-start mapping. Flows to the agent/tab event so the notice anchors to
-  // that message's turn instead of the wall-clock-latest user message.
-  const parentToolUseId = ptuArg ?? tabMsgAnchor.get(tabId) ?? null;
-  let windowId; let title = null;
-  try { const t = await browser.tabs.get(tabId); windowId = t.windowId; title = t.title || t.url || null; }
-  catch { return; } // tab already gone — don't point the card at a dead tab
-  agentTabId = tabId;
-  // Instance tabs carry a kind + the instance NAME (the card reads like a tab:
-  // "Notebook | my-nb"); a web tab (open_tab / DOM) just shows its page label.
-  const text = (kind && name) ? `${kind} · ${name}` : (label || title || 'a tab');
-  // why a fresh brand color each generation (owner): the home card's Open button
-  // cycles a peerd brand color (p·cyan e·red e·amber r·green d·magenta) so it
-  // stays eye-catching — the sanctioned "peers/actions are the content" accent.
-  const color = AGENT_TAB_COLORS[Math.floor(Math.random() * AGENT_TAB_COLORS.length)];
-  // `opened`: true when peerd OPENED this tab (open_tab / an engine create) — the
-  // only case that mints an inline notice; false when the web actor merely ACTED
-  // on a tab, which resurfaces an existing notice but never invents one for a tab
-  // the USER opened. `noted: true` marks this as a real agent touch (vs. a
-  // passive current-flag refresh on tab activation).
-  agentTabInfo = { tabId, windowId, kind, name, label: text, color, opened, parentToolUseId };
-  broadcastAgentTab(true);
-};
-// Track the active tab so the card hides when you're on the agent tab, and shows
-// again when you move away.
-browser.tabs?.onActivated?.addListener(({ tabId }) => {
-  activeTabId = tabId;
-  if (agentTabInfo) broadcastAgentTab();
-});
-// Clear the card when the agent tab closes (clicking a dead tab does nothing).
-browser.tabs?.onRemoved?.addListener((tabId) => {
-  if (tabId === agentTabId) { agentTabId = null; agentTabInfo = null; broadcastAgentTab(); }
-});
-
-// "Pull peerd in" reminder on the regular web pages peerd opens. A peerd-opened
-// WEB tab gets a brief, auto-dismissing caption (top-right) that types out
-// "Press <shortcut> to pull peerd in" — engine tabs carry the real button, a
-// third-party page can't, so this points you at the shortcut/icon. INFORMATIONAL
-// ONLY (it never messages the SW back), so it crosses no boundary and needs no
-// new permission (docs/PULL-IN-PEERD-WEB-SCOPE.md). One-shot, on first load, via
-// chrome.scripting; never on a denylisted/sensitive origin; the injected script
-// itself waits until the tab is actually visible before it shows.
-// Peerd-opened web tabs (tabId → origin), tracked persistently so we can show
-// the reminder at the RIGHT moment: when the user is ACTIVELY VIEWING one with
-// the SIDEBAR CLOSED — they walked onto it, OR they closed the panel while on it.
-// The page world can't read sidebar state, so the SW gates the inject; the
-// injected script is idempotent + auto-dismissing, so re-injecting is safe.
-/** @type {Map<number, string>} */
-const peerdWebTabs = new Map();
-// The peerd toolbar icon as a data: URL, so the injected hint can show it on a
-// third-party page without a chrome-extension:// fetch (no web_accessible_
-// resources needed). Fetched + cached once; '' if it ever fails (the hint then
-// falls back to the wordmark text).
-/** @type {string | null} */ let pullInIconUrl = null;
-const getPullInIconUrl = async () => {
-  if (pullInIconUrl !== null) return pullInIconUrl;
-  try {
-    const res = await fetch(browser.runtime.getURL('icons/icon32.png'));
-    const bytes = new Uint8Array(await res.arrayBuffer());
-    pullInIconUrl = `data:image/png;base64,${btoa(String.fromCharCode(...bytes))}`;
-  } catch (e) {
-    console.debug('[sw] pull-in icon load failed', (/** @type {{ message?: string }} */ (e))?.message ?? e);
-    pullInIconUrl = '';
-  }
-  return pullInIconUrl;
-};
-const showWebTabHint = async (/** @type {number} */ tabId) => {
-  if (!peerdWebTabs.has(tabId)) return;
-  if (uiPorts.hasNamed('sidepanel')) return;          // sidebar open → the chat's already here
-  let tab;
-  try { tab = await browser.tabs.get(tabId); } catch { return; }
-  if (!tab || tab.status !== 'complete' || tab.active !== true) return; // only when actually being viewed
-  // Still the page peerd opened? (don't graffiti the user's own later navigation.)
-  let origin;
-  try { origin = new URL(/** @type {string} */ (tab.url)).origin; } catch { return; }
-  if (origin !== peerdWebTabs.get(tabId)) { peerdWebTabs.delete(tabId); return; }
-  let shortcut = '';
-  try {
-    const cmds = await browser.commands?.getAll?.();
-    shortcut = (cmds ?? []).find((c) => c.name === 'pull-in-peerd')?.shortcut || '';
-  } catch { /* no commands API in this build */ }
-  const iconUrl = await getPullInIconUrl();
-  try {
-    await browser.scripting.executeScript({ target: { tabId }, func: pullInHintInjected, args: [shortcut, iconUrl] });
-  } catch (e) {
-    // Pages the browser refuses to inject into (chrome:, the stores, a hard CSP)
-    // — harmless; the hint just doesn't show.
-    console.debug('[sw] pull-in hint inject skipped', (/** @type {{ message?: string }} */ (e))?.message ?? e);
-  }
-};
-const scheduleWebTabHint = (/** @type {number} */ tabId, /** @type {string} */ url) => {
-  if (typeof tabId !== 'number' || typeof url !== 'string') return;
-  let u;
-  try { u = new URL(url); } catch { return; } // not a real web URL → no hint
-  if (!u.protocol.startsWith('http')) return;
-  if (matchesDenylist(u.hostname, denylistStore.patterns())) return; // never graffiti a sensitive site
-  peerdWebTabs.set(tabId, u.origin);
-  showWebTabHint(tabId); // if the user is already viewing it with the sidebar closed
-};
-// Show when the user WALKS ONTO a peerd web tab, or it finishes loading while
-// they're on it. (Sidebar-close is handled at the port disconnect, below.)
-browser.tabs?.onActivated?.addListener(({ tabId }) => { showWebTabHint(tabId); });
-browser.tabs?.onUpdated?.addListener((tabId, changeInfo) => { if (changeInfo.status === 'complete') showWebTabHint(tabId); });
-browser.tabs?.onRemoved?.addListener((tabId) => { peerdWebTabs.delete(tabId); });
 
 // /init orchestration lives in peerd-runtime/memory/init-orchestrator.js
 // (scan → draft → confirm → persist); the SW binds the IO. The
@@ -3597,98 +3462,9 @@ browser.runtime.onMessage.addListener(/** @type {any} */ (makeDispatcher({
   ...(/** @type {any} */ (originCredentialRoutes)),
 })));
 
-// ---------------------------------------------------------------------------
-// 7. Toolbar icon + "pull in peerd" shortcut → home, or pull the chat to the side
-// ---------------------------------------------------------------------------
-
-// The toolbar icon is peerd's FRONT DOOR. With no home up yet it opens the
-// full-page home — peerd should feel first-party, not a bolted-on sidebar
-// (DESIGN-12, owner 2026-06-20). Once home IS up, the icon COMPLEMENTS: it pulls
-// the chat into the window-global side panel (Chrome) / sidebar (Firefox) so the
-// chat follows you onto ANY tab — including a plain web page peerd opened, the
-// case the engine-tab "pull in peerd" button couldn't reach without breaching the
-// fail-closed SW boundary (docs/PULL-IN-PEERD-WEB-SCOPE.md). The Alt+Shift+P
-// command is the dedicated twin: it ALWAYS pulls the panel in, from anywhere.
-//
-// Hard constraint: sidePanel.open()/sidebarAction.open() must run SYNCHRONOUSLY
-// inside the click/keystroke gesture — no await before them or the activation is
-// dropped. So every decision input must be available without awaiting: the
-// window id (from the listener's tab arg) and "is home open?" (two sync signals
-// below). We cannot tabs.query() in the gesture; decidePullIn is a pure sync fn.
-
-// Sync "is home open?" — a boot-seeded set of home tab ids OR a live home port.
-// why both: the set survives an SW respawn (the home port may not have
-// reconnected in the instant the icon fires); the port covers a home tab the set
-// hasn't learned yet. A miss is benign — openHome() is focus-or-create, so the
-// worst case is the first post-respawn click focusing home instead of the panel.
-const HOME_URL = browser.runtime.getURL('home/home.html');
-/** @type {Set<number>} */
-const homeTabIds = new Set();
-const trackHomeTab = (/** @type {number} */ tabId, /** @type {string} */ url) => {
-  if (typeof url !== 'string') return;
-  if (url.startsWith(HOME_URL)) homeTabIds.add(tabId);
-  else homeTabIds.delete(tabId);
-};
-browser.tabs?.query?.({}).then((tabs) => {
-  for (const t of tabs) if (t.id != null) trackHomeTab(t.id, t.url ?? '');
-}).catch((e) => console.debug('[sw] home-tab bootstrap failed', e));
-// A second onUpdated/onRemoved pair (the DOM-ref ones live earlier) — keeping the
-// home-tab bookkeeping self-contained here reads cleaner than threading it in.
-browser.tabs?.onUpdated?.addListener((tabId, changeInfo, tab) => {
-  if (changeInfo.url != null || tab?.url != null) trackHomeTab(tabId, /** @type {string} */ (changeInfo.url ?? tab.url));
-});
-browser.tabs?.onRemoved?.addListener((tabId) => { homeTabIds.delete(tabId); });
-const isHomeOpen = () => homeTabIds.size > 0 || uiPorts.hasNamed('home');
-
-// A synchronous current-window id for sidePanel.open({ windowId }). onClicked and
-// (modern) onCommand both supply the tab, so this only backstops engines whose
-// command callback omits it. Seeded at boot, kept warm on focus changes.
-/** @type {number | null} */ let lastFocusedWindowId = null;
-browser.windows?.getLastFocused?.().then((w) => { lastFocusedWindowId = w?.id ?? lastFocusedWindowId; }).catch(() => {});
-browser.windows?.onFocusChanged?.addListener((winId) => {
-  if (winId != null && winId !== browser.windows.WINDOW_ID_NONE) lastFocusedWindowId = winId;
-});
-
-// The pull-in itself — open() runs synchronously (no await before it) to keep the
-// gesture; a failed/declined open falls back to home so the icon never dead-ends.
-const pullInPeerd = (/** @type {number} */ windowId, { fromShortcut = false } = {}) => {
-  const target = decidePullIn({
-    homeOpen: isHomeOpen(),
-    panelOpen: uiPorts.hasNamed('sidepanel'),
-    hasSidePanel: !!(/** @type {any} */ (browser)).sidePanel?.open,
-    hasSidebar: !!browser.sidebarAction?.open,
-    fromShortcut,
-  });
-  // Toggle-closed (shortcut only) — close needs no gesture, so fire and forget.
-  if (target === 'close') { closeSidePanel(); return; }
-  try {
-    if (target === 'panel' && windowId != null) {
-      const p = (/** @type {any} */ (browser)).sidePanel.open({ windowId });
-      if (p?.catch) p.catch((/** @type {any} */ e) => { console.warn('[sw] sidePanel.open failed', e); openHome(); });
-      return;
-    }
-    if (target === 'sidebar') {
-      const p = browser.sidebarAction.open();
-      if (p?.catch) p.catch((e) => { console.warn('[sw] sidebarAction.open failed', e); openHome(); });
-      return;
-    }
-  } catch (e) { console.warn('[sw] pull-in open threw', e); }
-  openHome();
-};
-
-browser.action?.onClicked?.addListener((tab) => {
-  pullInPeerd(/** @type {number} */ (tab?.windowId ?? lastFocusedWindowId), { fromShortcut: false });
-});
-// Alt+Shift+P (user-rebindable at the browser's extension-shortcuts page) —
-// TOGGLES the panel: pulls it in, or closes it if already open. The command
-// handler is a VALID user-gesture context on BOTH Chrome and Firefox, so it needs
-// no content-script relay — and thus no hole in the fail-closed SW boundary the
-// injected-web-page button would have required.
-browser.commands?.onCommand?.addListener((command, tab) => {
-  if (command !== 'pull-in-peerd') return;
-  pullInPeerd(/** @type {number} */ (tab?.windowId ?? lastFocusedWindowId), { fromShortcut: true });
-});
-
+// The toolbar icon + Alt+Shift+P front door (open home, or pull the chat panel
+// in) lives in background/tab-affordances.js alongside the agent-tab card and
+// web-tab hint — it owns the sync-gesture pull-in and its listeners.
 loadUserEndpoints();
 loadSettings();
 

--- a/extension/background/tab-affordances.js
+++ b/extension/background/tab-affordances.js
@@ -1,0 +1,257 @@
+// @ts-check
+// background/tab-affordances.js — how peerd shows up in the browser's tab strip.
+//
+// Extracted from the SW (wiring, not logic). Three cohesive affordances, all
+// pure UI presence with NO security surface, sharing only tab-strip state:
+//   1. the agent-tab CARD — the home/side-panel notice "peerd opened <tab>",
+//      anchored to the message_actor turn that last drove that tab (tabMsgAnchor);
+//   2. the "pull peerd in" HINT — a one-shot, informational, auto-dismissing
+//      caption injected into peerd-opened web tabs (never messages the SW back,
+//      crosses no boundary — docs/PULL-IN-PEERD-WEB-SCOPE.md);
+//   3. the FRONT DOOR — the toolbar icon + Alt+Shift+P command: open home, or
+//      pull the chat panel in.
+//
+// A helper module (like tab-tracker.js), so it imports its stateless
+// collaborators directly and receives the stateful ones (browser, uiPorts,
+// denylist, closeSidePanel) as deps. All the reassigned tab-strip state
+// (agentTab*, activeTabId, peerdWebTabs, homeTabIds, lastFocusedWindowId,
+// tabMsgAnchor) is cluster-internal and lives here; the SW keeps the wiring.
+
+import { openHome } from '/shared/open-home.js';
+import { decidePullIn } from './panel-affordance.js';
+import { pullInHintInjected } from '/peerd-runtime/index.js';
+import { matchesDenylist } from '/peerd-egress/index.js';
+
+// The home agent-tab card's Open button draws a fresh brand color each time the
+// card is (re)generated — the sanctioned "peers/actions are the content" accent
+// (p·cyan e·red e·amber r·green d·magenta).
+const AGENT_TAB_COLORS = ['#00B7EB', '#EF4444', '#F59E0B', '#22C55E', '#D946EF'];
+
+/**
+ * @param {Object} deps
+ * @param {any} deps.browser
+ * @param {{ broadcast: (m: any) => void, hasNamed: (name: string) => boolean }} deps.uiPorts
+ * @param {{ patterns: () => any }} deps.denylistStore
+ * @param {() => Promise<any>} deps.closeSidePanel
+ */
+export const makeTabAffordances = ({ browser, uiPorts, denylistStore, closeSidePanel }) => {
+  const HOME_URL = browser.runtime.getURL('home/home.html');
+
+  // ── 1. the agent-tab card ──────────────────────────────────────────────────
+  // DESIGN-17/18 tab-card anchoring: maps an agent tab → the message_actor tool_use
+  // that LAST drove it. The inline "peerd opened …" notice anchors to THAT message's
+  // turn, not the wall-clock-latest user message — actor work is async, so a physical
+  // tab touch (engine ensureTab / web DOM noteTab) often lands during a later turn,
+  // which would clump the cards at the chat's end. Set at each actor-turn start
+  // (runActorTurn) for the actor's owned tab; never cleared — overwritten only when a
+  // NEW message re-drives that tab, which is exactly when the card should resurface to
+  // the newer turn. Orchestrator-opened tabs (open_tab) are absent here → they keep the
+  // wall-clock anchor (correct; they're synchronous).
+  /** @type {Map<number, string>} tabId → parentToolUseId */
+  const tabMsgAnchor = new Map();
+  const setTabAnchor = (/** @type {number} */ tabId, /** @type {string} */ parentToolUseId) => {
+    if (typeof tabId === 'number') tabMsgAnchor.set(tabId, parentToolUseId);
+  };
+
+  /** @type {number | null} */ let agentTabId = null;
+  /** @type {any} */ let agentTabInfo = null;   // the last { tabId, windowId, kind, name, label, color } noted
+  /** @type {number | null} */ let activeTabId = null;    // the currently-active tab — hide the card when you're ON it
+  // Broadcast the current-agent-tab pointer. `noted` is true ONLY when this fires
+  // from a real agent touch (noteAgentTab) — the inline notice creates/resurfaces
+  // on those; a passive refresh (tab activation, a fresh surface replay) sends
+  // noted:false so clicking around tabs never bumps a notice.
+  const broadcastAgentTab = (noted = false) => {
+    uiPorts.broadcast({
+      type: 'agent/tab',
+      tab: agentTabInfo ? { ...agentTabInfo, current: agentTabInfo.tabId === activeTabId, noted } : null,
+    });
+  };
+  const noteAgentTab = async (/** @type {number} */ tabId, /** @type {any} */ info = {}) => {
+    if (typeof tabId !== 'number') return;
+    const { kind = null, name = null, label = null, opened = true, parentToolUseId: ptuArg = null } = (typeof info === 'string' ? { label: info } : info);
+    // The message_actor turn driving this tab (see tabMsgAnchor) — caller-supplied or the
+    // last actor-turn-start mapping. Flows to the agent/tab event so the notice anchors to
+    // that message's turn instead of the wall-clock-latest user message.
+    const parentToolUseId = ptuArg ?? tabMsgAnchor.get(tabId) ?? null;
+    let windowId; let title = null;
+    try { const t = await browser.tabs.get(tabId); windowId = t.windowId; title = t.title || t.url || null; }
+    catch { return; } // tab already gone — don't point the card at a dead tab
+    agentTabId = tabId;
+    // Instance tabs carry a kind + the instance NAME (the card reads like a tab:
+    // "Notebook | my-nb"); a web tab (open_tab / DOM) just shows its page label.
+    const text = (kind && name) ? `${kind} · ${name}` : (label || title || 'a tab');
+    // why a fresh brand color each generation (owner): the home card's Open button
+    // cycles a peerd brand color so it stays eye-catching.
+    const color = AGENT_TAB_COLORS[Math.floor(Math.random() * AGENT_TAB_COLORS.length)];
+    // `opened`: true when peerd OPENED this tab (open_tab / an engine create) — the
+    // only case that mints an inline notice; false when the web actor merely ACTED
+    // on a tab, which resurfaces an existing notice but never invents one for a tab
+    // the USER opened. `noted: true` marks this as a real agent touch (vs. a
+    // passive current-flag refresh on tab activation).
+    agentTabInfo = { tabId, windowId, kind, name, label: text, color, opened, parentToolUseId };
+    broadcastAgentTab(true);
+  };
+  // Track the active tab so the card hides when you're on the agent tab, and shows
+  // again when you move away.
+  browser.tabs?.onActivated?.addListener((/** @type {{ tabId: number }} */ { tabId }) => {
+    activeTabId = tabId;
+    if (agentTabInfo) broadcastAgentTab();
+  });
+  // Clear the card when the agent tab closes (clicking a dead tab does nothing).
+  browser.tabs?.onRemoved?.addListener((/** @type {number} */ tabId) => {
+    if (tabId === agentTabId) { agentTabId = null; agentTabInfo = null; broadcastAgentTab(); }
+  });
+
+  // ── 2. the "pull peerd in" hint ─────────────────────────────────────────────
+  // A peerd-opened WEB tab gets a brief, auto-dismissing caption (top-right) that
+  // types out "Press <shortcut> to pull peerd in" — engine tabs carry the real
+  // button, a third-party page can't, so this points you at the shortcut/icon.
+  // INFORMATIONAL ONLY (it never messages the SW back), so it crosses no boundary
+  // and needs no new permission. One-shot, on first load, via chrome.scripting;
+  // never on a denylisted/sensitive origin; the injected script itself waits until
+  // the tab is actually visible before it shows. Peerd-opened web tabs (tabId →
+  // origin), tracked so we can show the reminder at the RIGHT moment: when the user
+  // is ACTIVELY VIEWING one with the SIDEBAR CLOSED — they walked onto it, OR they
+  // closed the panel while on it. The page world can't read sidebar state, so the
+  // SW gates the inject; the injected script is idempotent + auto-dismissing.
+  /** @type {Map<number, string>} */
+  const peerdWebTabs = new Map();
+  // The peerd toolbar icon as a data: URL, so the injected hint can show it on a
+  // third-party page without a chrome-extension:// fetch. Fetched + cached once;
+  // '' if it ever fails (the hint then falls back to the wordmark text).
+  /** @type {string | null} */ let pullInIconUrl = null;
+  const getPullInIconUrl = async () => {
+    if (pullInIconUrl !== null) return pullInIconUrl;
+    try {
+      const res = await fetch(browser.runtime.getURL('icons/icon32.png'));
+      const bytes = new Uint8Array(await res.arrayBuffer());
+      pullInIconUrl = `data:image/png;base64,${btoa(String.fromCharCode(...bytes))}`;
+    } catch (e) {
+      console.debug('[sw] pull-in icon load failed', (/** @type {{ message?: string }} */ (e))?.message ?? e);
+      pullInIconUrl = '';
+    }
+    return pullInIconUrl;
+  };
+  const showWebTabHint = async (/** @type {number} */ tabId) => {
+    if (!peerdWebTabs.has(tabId)) return;
+    if (uiPorts.hasNamed('sidepanel')) return;          // sidebar open → the chat's already here
+    let tab;
+    try { tab = await browser.tabs.get(tabId); } catch { return; }
+    if (!tab || tab.status !== 'complete' || tab.active !== true) return; // only when actually being viewed
+    // Still the page peerd opened? (don't graffiti the user's own later navigation.)
+    let origin;
+    try { origin = new URL(/** @type {string} */ (tab.url)).origin; } catch { return; }
+    if (origin !== peerdWebTabs.get(tabId)) { peerdWebTabs.delete(tabId); return; }
+    let shortcut = '';
+    try {
+      const cmds = await browser.commands?.getAll?.();
+      shortcut = (cmds ?? []).find((/** @type {any} */ c) => c.name === 'pull-in-peerd')?.shortcut || '';
+    } catch { /* no commands API in this build */ }
+    const iconUrl = await getPullInIconUrl();
+    try {
+      await browser.scripting.executeScript({ target: { tabId }, func: pullInHintInjected, args: [shortcut, iconUrl] });
+    } catch (e) {
+      // Pages the browser refuses to inject into (chrome:, the stores, a hard CSP)
+      // — harmless; the hint just doesn't show.
+      console.debug('[sw] pull-in hint inject skipped', (/** @type {{ message?: string }} */ (e))?.message ?? e);
+    }
+  };
+  const scheduleWebTabHint = (/** @type {number} */ tabId, /** @type {string} */ url) => {
+    if (typeof tabId !== 'number' || typeof url !== 'string') return;
+    let u;
+    try { u = new URL(url); } catch { return; } // not a real web URL → no hint
+    if (!u.protocol.startsWith('http')) return;
+    if (matchesDenylist(u.hostname, denylistStore.patterns())) return; // never graffiti a sensitive site
+    peerdWebTabs.set(tabId, u.origin);
+    showWebTabHint(tabId); // if the user is already viewing it with the sidebar closed
+  };
+  // Show when the user WALKS ONTO a peerd web tab, or it finishes loading while
+  // they're on it. (Sidebar-close is handled at the port disconnect, in the SW.)
+  browser.tabs?.onActivated?.addListener((/** @type {{ tabId: number }} */ { tabId }) => { showWebTabHint(tabId); });
+  browser.tabs?.onUpdated?.addListener((/** @type {number} */ tabId, /** @type {any} */ changeInfo) => { if (changeInfo.status === 'complete') showWebTabHint(tabId); });
+  browser.tabs?.onRemoved?.addListener((/** @type {number} */ tabId) => { peerdWebTabs.delete(tabId); });
+
+  // ── 3. the front door — toolbar icon + Alt+Shift+P ──────────────────────────
+  // The toolbar icon is peerd's FRONT DOOR. With no home up yet it opens the
+  // full-page home — peerd should feel first-party, not a bolted-on sidebar
+  // (DESIGN-12). Once home IS up, the icon COMPLEMENTS: it pulls the chat into the
+  // window-global side panel (Chrome) / sidebar (Firefox) so the chat follows you
+  // onto ANY tab. The Alt+Shift+P command is the dedicated twin: it ALWAYS pulls
+  // the panel in, from anywhere.
+  //
+  // Hard constraint: sidePanel.open()/sidebarAction.open() must run SYNCHRONOUSLY
+  // inside the click/keystroke gesture — no await before them or the activation is
+  // dropped. So every decision input must be available without awaiting: the window
+  // id (from the listener's tab arg) and "is home open?" (two sync signals below).
+  // We cannot tabs.query() in the gesture; decidePullIn is a pure sync fn.
+
+  // Sync "is home open?" — a boot-seeded set of home tab ids OR a live home port.
+  // why both: the set survives an SW respawn (the home port may not have reconnected
+  // in the instant the icon fires); the port covers a home tab the set hasn't learned
+  // yet. A miss is benign — openHome() is focus-or-create.
+  /** @type {Set<number>} */
+  const homeTabIds = new Set();
+  const trackHomeTab = (/** @type {number} */ tabId, /** @type {string} */ url) => {
+    if (typeof url !== 'string') return;
+    if (url.startsWith(HOME_URL)) homeTabIds.add(tabId);
+    else homeTabIds.delete(tabId);
+  };
+  browser.tabs?.query?.({}).then((/** @type {any[]} */ tabs) => {
+    for (const t of tabs) if (t.id != null) trackHomeTab(t.id, t.url ?? '');
+  }).catch((/** @type {any} */ e) => console.debug('[sw] home-tab bootstrap failed', e));
+  browser.tabs?.onUpdated?.addListener((/** @type {number} */ tabId, /** @type {any} */ changeInfo, /** @type {any} */ tab) => {
+    if (changeInfo.url != null || tab?.url != null) trackHomeTab(tabId, /** @type {string} */ (changeInfo.url ?? tab.url));
+  });
+  browser.tabs?.onRemoved?.addListener((/** @type {number} */ tabId) => { homeTabIds.delete(tabId); });
+  const isHomeOpen = () => homeTabIds.size > 0 || uiPorts.hasNamed('home');
+
+  // A synchronous current-window id for sidePanel.open({ windowId }). onClicked and
+  // (modern) onCommand both supply the tab, so this only backstops engines whose
+  // command callback omits it. Seeded at boot, kept warm on focus changes.
+  /** @type {number | null} */ let lastFocusedWindowId = null;
+  browser.windows?.getLastFocused?.().then((/** @type {any} */ w) => { lastFocusedWindowId = w?.id ?? lastFocusedWindowId; }).catch(() => {});
+  browser.windows?.onFocusChanged?.addListener((/** @type {number} */ winId) => {
+    if (winId != null && winId !== browser.windows.WINDOW_ID_NONE) lastFocusedWindowId = winId;
+  });
+
+  // The pull-in itself — open() runs synchronously (no await before it) to keep the
+  // gesture; a failed/declined open falls back to home so the icon never dead-ends.
+  const pullInPeerd = (/** @type {number} */ windowId, { fromShortcut = false } = {}) => {
+    const target = decidePullIn({
+      homeOpen: isHomeOpen(),
+      panelOpen: uiPorts.hasNamed('sidepanel'),
+      hasSidePanel: !!(/** @type {any} */ (browser)).sidePanel?.open,
+      hasSidebar: !!browser.sidebarAction?.open,
+      fromShortcut,
+    });
+    // Toggle-closed (shortcut only) — close needs no gesture, so fire and forget.
+    if (target === 'close') { closeSidePanel(); return; }
+    try {
+      if (target === 'panel' && windowId != null) {
+        const p = (/** @type {any} */ (browser)).sidePanel.open({ windowId });
+        if (p?.catch) p.catch((/** @type {any} */ e) => { console.warn('[sw] sidePanel.open failed', e); openHome(); });
+        return;
+      }
+      if (target === 'sidebar') {
+        const p = browser.sidebarAction.open();
+        if (p?.catch) p.catch((/** @type {any} */ e) => { console.warn('[sw] sidebarAction.open failed', e); openHome(); });
+        return;
+      }
+    } catch (e) { console.warn('[sw] pull-in open threw', e); }
+    openHome();
+  };
+
+  browser.action?.onClicked?.addListener((/** @type {any} */ tab) => {
+    pullInPeerd(/** @type {number} */ (tab?.windowId ?? lastFocusedWindowId), { fromShortcut: false });
+  });
+  // Alt+Shift+P (user-rebindable) — TOGGLES the panel: pulls it in, or closes it if
+  // already open. The command handler is a VALID user-gesture context on BOTH Chrome
+  // and Firefox, so it needs no content-script relay — and thus no hole in the
+  // fail-closed SW boundary the injected-web-page button would have required.
+  browser.commands?.onCommand?.addListener((/** @type {string} */ command, /** @type {any} */ tab) => {
+    if (command !== 'pull-in-peerd') return;
+    pullInPeerd(/** @type {number} */ (tab?.windowId ?? lastFocusedWindowId), { fromShortcut: true });
+  });
+
+  return { noteAgentTab, broadcastAgentTab, scheduleWebTabHint, showWebTabHint, setTabAnchor, isHomeOpen };
+};

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -52,7 +52,7 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // stack (a reasoning subagent is a tool-less ephemeral actor), deleting those four
 // phase-1 files; their code lives on in the (still // @ts-check'd) actor-* stack.
 // A legitimate decrease (files deleted, not directives dropped).
-const COVERED_FLOOR = 483;
+const COVERED_FLOOR = 484;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -52,7 +52,7 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // stack (a reasoning subagent is a tool-less ephemeral actor), deleting those four
 // phase-1 files; their code lives on in the (still // @ts-check'd) actor-* stack.
 // A legitimate decrease (files deleted, not directives dropped).
-const COVERED_FLOOR = 482;
+const COVERED_FLOOR = 483;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -52,7 +52,7 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // stack (a reasoning subagent is a tool-less ephemeral actor), deleting those four
 // phase-1 files; their code lives on in the (still // @ts-check'd) actor-* stack.
 // A legitimate decrease (files deleted, not directives dropped).
-const COVERED_FLOOR = 484;
+const COVERED_FLOOR = 486;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/tests/background/dweb-inbound-rate-cap.test.ts
+++ b/tests/background/dweb-inbound-rate-cap.test.ts
@@ -1,0 +1,71 @@
+// The dweb agent's inbound wake rate cap: per-did minute cap + global hour cap,
+// sliding windows, and dead-did eviction — all driven by an injected clock.
+
+import { describe, test, expect } from 'bun:test';
+import { makeDwebInboundRateCap } from '../../extension/background/dweb-inbound-rate-cap.js';
+
+const clock = (start = 1_000_000) => {
+  let t = start;
+  return { now: () => t, advance: (ms: number) => { t += ms; } };
+};
+
+describe('makeDwebInboundRateCap — per-did minute cap', () => {
+  test('admits 3 wakes from one did, then blocks the 4th within the minute', () => {
+    const c = clock();
+    const cap = makeDwebInboundRateCap({ now: c.now });
+    expect(cap.allow('did:a')).toBe(true);
+    expect(cap.allow('did:a')).toBe(true);
+    expect(cap.allow('did:a')).toBe(true);
+    expect(cap.allow('did:a')).toBe(false);   // 4th in the same minute
+  });
+
+  test('the per-did window slides — after 60s the did admits again', () => {
+    const c = clock();
+    const cap = makeDwebInboundRateCap({ now: c.now });
+    cap.allow('did:a'); cap.allow('did:a'); cap.allow('did:a');
+    expect(cap.allow('did:a')).toBe(false);
+    c.advance(61_000);
+    expect(cap.allow('did:a')).toBe(true);    // old timestamps aged out
+  });
+
+  test('one did being capped does not block a different did', () => {
+    const c = clock();
+    const cap = makeDwebInboundRateCap({ now: c.now });
+    cap.allow('did:a'); cap.allow('did:a'); cap.allow('did:a');
+    expect(cap.allow('did:a')).toBe(false);
+    expect(cap.allow('did:b')).toBe(true);
+  });
+});
+
+describe('makeDwebInboundRateCap — global hour cap', () => {
+  test('blocks past 30 wakes across many dids within the hour', () => {
+    const c = clock();
+    const cap = makeDwebInboundRateCap({ now: c.now });
+    let admitted = 0;
+    // 30 distinct dids, one wake each (well under the per-did cap) → 30 admits.
+    for (let i = 0; i < 40; i += 1) if (cap.allow(`did:${i}`)) admitted += 1;
+    expect(admitted).toBe(30);
+    expect(cap.allow('did:fresh')).toBe(false);   // global cap hit
+  });
+
+  test('the global window resets after an hour', () => {
+    const c = clock();
+    const cap = makeDwebInboundRateCap({ now: c.now });
+    for (let i = 0; i < 30; i += 1) cap.allow(`did:${i}`);
+    expect(cap.allow('did:x')).toBe(false);
+    c.advance(3_600_001);
+    expect(cap.allow('did:x')).toBe(true);
+  });
+});
+
+describe('makeDwebInboundRateCap — eviction', () => {
+  test('dids whose timestamps all aged out are swept, bounding the map', () => {
+    const c = clock();
+    const cap = makeDwebInboundRateCap({ now: c.now });
+    cap.allow('did:old');
+    expect(cap._liveDids()).toBe(1);
+    c.advance(61_000);
+    cap.allow('did:new');           // admit sweeps the stale did:old
+    expect(cap._liveDids()).toBe(1);
+  });
+});

--- a/tests/background/mint-once.test.ts
+++ b/tests/background/mint-once.test.ts
@@ -1,0 +1,47 @@
+// Single-flight actor minting: concurrent mints of one key collapse onto one
+// promise; a later mint after settlement starts fresh; distinct keys are independent.
+
+import { describe, test, expect } from 'bun:test';
+import { makeMintOnce } from '../../extension/background/mint-once.js';
+
+describe('makeMintOnce', () => {
+  test('concurrent mints of the SAME key run the fn once and share the result', async () => {
+    const { mintOnce, _inFlightCount } = makeMintOnce();
+    let calls = 0;
+    let release: (v: string) => void = () => {};
+    const fn = () => new Promise<string>((r) => { calls += 1; release = r; });
+    const a = mintOnce('web:1', fn);
+    const b = mintOnce('web:1', fn);
+    expect(_inFlightCount()).toBe(1);
+    release('sess-1');
+    expect(await a).toBe('sess-1');
+    expect(await b).toBe('sess-1');
+    expect(calls).toBe(1);            // the racing second call did NOT re-run fn
+    expect(_inFlightCount()).toBe(0); // entry cleared on settle
+  });
+
+  test('a mint AFTER the first settled runs fn again (no stale caching)', async () => {
+    const { mintOnce } = makeMintOnce();
+    let calls = 0;
+    const fn = async () => { calls += 1; return `s${calls}`; };
+    expect(await mintOnce('k', fn)).toBe('s1');
+    expect(await mintOnce('k', fn)).toBe('s2');   // not deduped — the first already settled
+    expect(calls).toBe(2);
+  });
+
+  test('distinct keys never collide', async () => {
+    const { mintOnce } = makeMintOnce();
+    const [a, b] = await Promise.all([
+      mintOnce('web:1', async () => 'A'),
+      mintOnce('web:2', async () => 'B'),
+    ]);
+    expect([a, b]).toEqual(['A', 'B']);
+  });
+
+  test('a rejected mint clears its entry so the next attempt can retry', async () => {
+    const { mintOnce, _inFlightCount } = makeMintOnce();
+    await expect(mintOnce('k', async () => { throw new Error('boom'); })).rejects.toThrow('boom');
+    expect(_inFlightCount()).toBe(0);
+    expect(await mintOnce('k', async () => 'ok')).toBe('ok');
+  });
+});

--- a/tests/peerd-provider/pricing.test.ts
+++ b/tests/peerd-provider/pricing.test.ts
@@ -1,25 +1,25 @@
 // Pricing ↔ catalog parity guard.
 //
-// DEFAULT_PRICING (peerd-provider/pricing.js) and the SW's MODEL_CATALOG
-// drifted once already: catalog models with no rate card silently priced
-// at $0, and a rate card existed for a model that doesn't. The catalog
-// lives in background/service-worker.js, which can't be imported under
-// Bun (chrome.* at module scope) — so this test reads the SW SOURCE and
-// extracts the Anthropic catalog ids textually. If either table changes
-// without the other, this fails in the terminal.
+// DEFAULT_PRICING (peerd-provider/pricing.js) and MODEL_CATALOG drifted once
+// already: catalog models with no rate card silently priced at $0, and a rate
+// card existed for a model that doesn't. The catalog lives in
+// background/model-catalog.js, which can't be imported under Bun (it's assembled
+// against chrome.*-bound collaborators) — so this test reads the SOURCE and
+// extracts the Anthropic catalog ids textually. If either table changes without
+// the other, this fails in the terminal.
 
 import { describe, test, expect } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { DEFAULT_PRICING, costOf, resolvePricing } from '../../extension/peerd-provider/pricing.js';
 
-const swPath = join(import.meta.dir, '../../extension/background/service-worker.js');
+const catalogPath = join(import.meta.dir, '../../extension/background/model-catalog.js');
 
-/** Extract the Anthropic model ids out of the SW's MODEL_CATALOG literal. */
+/** Extract the Anthropic model ids out of the MODEL_CATALOG literal. */
 const anthropicCatalogIds = (): string[] => {
-  const src = readFileSync(swPath, 'utf8');
+  const src = readFileSync(catalogPath, 'utf8');
   const catalog = src.match(/const MODEL_CATALOG = Object\.freeze\(\{([\s\S]*?)\}\);/);
-  if (!catalog) throw new Error('MODEL_CATALOG literal not found in service-worker.js');
+  if (!catalog) throw new Error('MODEL_CATALOG literal not found in model-catalog.js');
   const anthropic = catalog[1].match(/anthropic:\s*\[([\s\S]*?)\]/);
   if (!anthropic) throw new Error('anthropic entry not found in MODEL_CATALOG');
   return [...anthropic[1].matchAll(/model:\s*'([^']+)'/g)].map((m) => m[1]);


### PR DESCRIPTION
## What & why

The SW's own header says it owns "no business logic of its own" and a thing "stays inline only when it closes over reassigned module state." It had drifted to 4043 lines. This pulls out the clusters whose reassigned state is entirely cluster-internal, so the SW reads as what it claims to be — wiring. Three commits, each verified independently, taking it to 3612 lines with the logic redistributed into four small, named, tested modules.

Stacked on `a2a-bridge-refactor` (#149).

**1. `background/model-catalog.js`** — the per-chat model picker's whole catalog assembly (curated `MODEL_CATALOG`, the live Ollama-inventory cache, the OpenRouter curated-selection mapping, the live per-model context window, and `buildModelOptions`). An import-free, deps-injected factory the same shape as `background/routes/*`, so it's Bun-testable with fakes. `localModelAvailable` is passed as a thunk (localModelState is created later in the SW's assembly order).

**2. `background/tab-affordances.js`** — how peerd shows up in the tab strip: the agent-tab card (anchored to the driving `message_actor` turn), the "pull peerd in" web-tab hint, and the toolbar-icon / Alt+Shift+P front door. All pure UI presence, no security surface, sharing only tab-strip state. Owns every reassigned bit of that state and its own listeners; the SW keeps the six methods it still calls. The sync-inside-the-gesture constraint on `pullInPeerd` is preserved verbatim.

**3. `background/mint-once.js` + `background/dweb-inbound-rate-cap.js`** — the two pure kernels from the actor region, extracted where they become testable in isolation: the single-flight mint dedup (concurrent `message_actor` calls collapse onto one session) and the dweb inbound wake rate cap (3/min per did + 30/hour global, sliding windows, dead-did eviction, injected clock). Plus a `persistRegistry`/`hydrateRegistry` dedup of the three near-identical actor-registry persist pairs.

## Checklist

- [x] `bun run preflight` passes (tests, typecheck, lint, in-browser, dweb-boundary, no manifest drift)
- [x] Commits are signed off — `git commit -s` (we use the DCO)
- [x] Only original or permissively-licensed code — **no GPL / AGPL / copyleft**
- [x] Tests added or updated (Bun suites for mint-once + the rate cap; the pricing↔catalog parity test now reads the catalog's new home; existing in-browser + e2e suites guard the relocations)
- [x] No hand-edited generated files (`manifest.json`, `shared/channel-config.js`)
- [x] Touches a **danger zone** — the SW assembly + the dweb inbound path. See below.

## Notes for reviewers

**No behavior change.** Every extraction is a relocation: signatures, call sites, and the wire behavior are identical. The one substantive fix rides commit 2 — the pull-in hint's local-icon `fetch` (a bundled `runtime.getURL` asset, not egress) joins the system-prompt loader's existing `no-restricted-globals` exemption, which `service-worker.js` already had by name.

**What I deliberately did NOT extract, and why.** The web/api/dweb actor-minting and turn-driving orchestration (`mintWebSession`, `runActorTurnOffscreen`, `actorMessaging`, `handleDwebAgentInbound`, `a2aCallRoute`) stays inline. It's ~25-collaborator IO code that gains no isolated unit testability from extraction — the exact "net-negative giant deps object" the codebase's own `buildStateSnapshot` comment warns against — and driving actors IS the SW's Layer-6 job. The testability win from that region is the two pure kernels above (rate cap + mint dedup), delivered surgically with their own tests, not a wholesale relocation of IO orchestration. `buildToolContext` and `buildStateSnapshot` are left untouched for the same reason (the latter's no-key-material invariant is pinned by a stronger live test).

**Verified after each commit**: 2555 Bun tests (10 new), strict typecheck, ESLint, 596 in-browser real-worker tests, and the full 17-state / 94-check `e2e:verify` — `actor-delegate`, `dweb-actor-delegate`, and `a2a-code-surface` exercise the relocated card path, rate cap, and mint dedup. Side-panel render confirmed by screenshot. ts-check floor 482 → 486.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018scDZ7G3pkkAxKjmQkWY2q

---
_Generated by [Claude Code](https://claude.ai/code/session_018scDZ7G3pkkAxKjmQkWY2q)_