### PR TITLE
A2A hardening: live two-peer round-trip + re-swarm fixes (card caps, one-shot consent)

### DIFF
--- a/.github/workflows/package-and-release.yml
+++ b/.github/workflows/package-and-release.yml
@@ -129,6 +129,19 @@ jobs:
             sleep 5
           done
           exit 1
+      - name: Run the two-peer a2a ask/reply round-trip over CDP
+        env:
+          CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
+        # Same live mesh, plus the production a2a ask/reply correlation between the
+        # two peers (envelope + did-bound resolve over real WebRTC). Same flake
+        # retry as the gossip run above.
+        run: |
+          for attempt in 1 2 3; do
+            bun run test:twopeer:a2a && exit 0
+            echo "::warning::two-peer a2a attempt $attempt failed (headless-WebRTC flake) — retrying"
+            sleep 5
+          done
+          exit 1
 
   # Additive job — the multi-PROCESS dweb node test (PHASE1-TESTING §A.2),
   # previously run only by hand. Spawns a relay + N real node processes that

--- a/extension/background/a2a-consent.js
+++ b/extension/background/a2a-consent.js
@@ -1,0 +1,43 @@
+// @ts-check
+// background/a2a-consent.js — the two PURE consent decisions for a2a first-contact.
+//
+// Extracted from service-worker.js so the security-sensitive rule the swarm
+// flagged — "Allow once" must NOT persist as a standing signing grant — is unit
+// tested in isolation, not left to trace-by-eye through the SW. Values in, values
+// out, no IO.
+//
+// The two decisions work together (the SW wires both):
+//   1. downgradesActorConfirm — the DESIGN-17 actor per-turn rule rewrites an
+//      ephemeral actor's "yes_session" to a one-shot so an actor can't accumulate
+//      a standing grant. a2a_contact is the SANCTIONED exception: it's an explicit
+//      first-contact ALLOWLIST decision (the exact peer did is shown to the user,
+//      like adding a contact), not a steer-able per-action confirm — so its raw
+//      answer survives.
+//   2. a2aConsentOutcome — given that surviving answer, decide whether this call is
+//      allowed and whether the peer is PERSISTED to the allowlist. Only
+//      "yes_session" persists; "yes_once" allows this call ONLY.
+
+/**
+ * Should the actor per-turn rule downgrade this confirm answer to a one-shot?
+ * True only for an ephemeral (actor) session answering "yes_session" on a tool
+ * OTHER than a2a_contact — every other actor confirm keeps the strict downgrade.
+ * @param {string} tool
+ * @param {boolean} ephemeral   is the confirming session an actor (kind:'actor')?
+ * @param {string} answer       the raw confirm answer
+ * @returns {boolean}
+ */
+export const downgradesActorConfirm = (tool, ephemeral, answer) =>
+  ephemeral === true && tool !== 'a2a_contact' && answer === 'yes_session';
+
+/**
+ * Turn a resolved a2a_contact answer into { ok, persist }.
+ *   yes_session → ok, and PERSIST the peer to the revocable allowlist (silent after)
+ *   yes_once    → ok for THIS call only, never persisted
+ *   anything else (no / dismissed) → denied
+ * @param {string} answer
+ * @returns {{ ok: boolean, persist: boolean }}
+ */
+export const a2aConsentOutcome = (answer) => ({
+  ok: answer === 'yes_once' || answer === 'yes_session',
+  persist: answer === 'yes_session',
+});

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -1979,8 +1979,15 @@ const confirmAction = async (prompt) => {
     if (!sessionConfirmGrants.has(sid)) sessionConfirmGrants.set(sid, new Set());
     (/** @type {Set<string>} */ (sessionConfirmGrants.get(sid))).add(grantKey);
   }
+  // a2a_contact is the SANCTIONED exception to the actor per-turn rule: it's an
+  // explicit first-contact ALLOWLIST decision — the exact peer did is shown to the
+  // user (like adding a contact), not a steer-able per-action confirm. So its
+  // "Allow for session" is NOT downgraded (it persists in the a2a allowlist, which
+  // a2aResolveConsent owns + dweb_block revokes), and its "Allow once" stays a
+  // genuine one-shot. Every OTHER actor confirm keeps the strict per-turn downgrade.
+  const standingAllowed = prompt.tool === 'a2a_contact';
   // Ephemeral: an actor's yes_session approves THIS call only (no standing grant).
-  return ephemeral && answer === 'yes_session' ? 'yes_once' : answer;
+  return ephemeral && !standingAllowed && answer === 'yes_session' ? 'yes_once' : answer;
 };
 
 // Per-SW "current active session" cache (background/session-state.js), behind a
@@ -2777,9 +2784,13 @@ const a2aRevoke = (/** @type {string} */ did) => {
 const a2aResolveConsent = async (/** @type {string} */ target, /** @type {string} */ sessionId, /** @type {string} */ op = 'message') => {
   if (a2aApprovedDids.has(target)) return true;
   const answer = await confirmAction({ tool: 'a2a_contact', sessionId, origins: [target] });
+  // "Allow for session" (yes_session) adds the peer to the revocable allowlist —
+  // silent thereafter, the intended contact-add. "Allow once" (yes_once)
+  // authorizes THIS call ONLY and is NOT persisted, so a one-time click can't
+  // silently become a standing signing grant (the swarm's consent finding).
   const ok = answer === 'yes_once' || answer === 'yes_session';
-  if (ok) a2aApprove(target);
-  auditLog.append({ type: 'a2a_consent', details: { target, op, approved: ok } }).catch(() => {});
+  if (answer === 'yes_session') a2aApprove(target);
+  auditLog.append({ type: 'a2a_consent', details: { target, op, approved: ok, standing: answer === 'yes_session' } }).catch(() => {});
   return ok;
 };
 const meshHostRoom = (/** @type {object} */ payload) =>

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -284,6 +284,7 @@ import { makeModelCatalog } from './model-catalog.js';
 import { makeTabAffordances } from './tab-affordances.js';
 import { makeMintOnce } from './mint-once.js';
 import { makeDwebInboundRateCap } from './dweb-inbound-rate-cap.js';
+import { downgradesActorConfirm, a2aConsentOutcome } from './a2a-consent.js';
 import { makeVaultRoutes } from './routes/vault.js';
 import { makeProviderRoutes } from './routes/providers.js';
 import { makeHooksRoutes } from './routes/hooks.js';
@@ -1979,15 +1980,12 @@ const confirmAction = async (prompt) => {
     if (!sessionConfirmGrants.has(sid)) sessionConfirmGrants.set(sid, new Set());
     (/** @type {Set<string>} */ (sessionConfirmGrants.get(sid))).add(grantKey);
   }
-  // a2a_contact is the SANCTIONED exception to the actor per-turn rule: it's an
-  // explicit first-contact ALLOWLIST decision — the exact peer did is shown to the
-  // user (like adding a contact), not a steer-able per-action confirm. So its
-  // "Allow for session" is NOT downgraded (it persists in the a2a allowlist, which
-  // a2aResolveConsent owns + dweb_block revokes), and its "Allow once" stays a
-  // genuine one-shot. Every OTHER actor confirm keeps the strict per-turn downgrade.
-  const standingAllowed = prompt.tool === 'a2a_contact';
-  // Ephemeral: an actor's yes_session approves THIS call only (no standing grant).
-  return ephemeral && !standingAllowed && answer === 'yes_session' ? 'yes_once' : answer;
+  // Ephemeral: an actor's yes_session approves THIS call only (no standing grant),
+  // EXCEPT a2a_contact — the sanctioned exception (an explicit first-contact
+  // allowlist decision, the peer did shown to the user), whose raw answer survives
+  // so a2aResolveConsent can honor "Allow for session" vs "Allow once". Decision is
+  // the pure downgradesActorConfirm (background/a2a-consent.js), unit-tested.
+  return downgradesActorConfirm(prompt.tool, ephemeral, answer) ? 'yes_once' : answer;
 };
 
 // Per-SW "current active session" cache (background/session-state.js), behind a
@@ -2784,13 +2782,13 @@ const a2aRevoke = (/** @type {string} */ did) => {
 const a2aResolveConsent = async (/** @type {string} */ target, /** @type {string} */ sessionId, /** @type {string} */ op = 'message') => {
   if (a2aApprovedDids.has(target)) return true;
   const answer = await confirmAction({ tool: 'a2a_contact', sessionId, origins: [target] });
-  // "Allow for session" (yes_session) adds the peer to the revocable allowlist —
-  // silent thereafter, the intended contact-add. "Allow once" (yes_once)
-  // authorizes THIS call ONLY and is NOT persisted, so a one-time click can't
-  // silently become a standing signing grant (the swarm's consent finding).
-  const ok = answer === 'yes_once' || answer === 'yes_session';
-  if (answer === 'yes_session') a2aApprove(target);
-  auditLog.append({ type: 'a2a_consent', details: { target, op, approved: ok, standing: answer === 'yes_session' } }).catch(() => {});
+  // "Allow for session" adds the peer to the revocable allowlist (silent after —
+  // the intended contact-add); "Allow once" authorizes THIS call only and is NOT
+  // persisted, so a one-time click can't become a standing signing grant. The
+  // { ok, persist } split is the pure a2aConsentOutcome (background/a2a-consent.js).
+  const { ok, persist } = a2aConsentOutcome(answer);
+  if (persist) a2aApprove(target);
+  auditLog.append({ type: 'a2a_consent', details: { target, op, approved: ok, standing: persist } }).catch(() => {});
   return ok;
 };
 const meshHostRoom = (/** @type {object} */ payload) =>

--- a/extension/offscreen/dweb-base.js
+++ b/extension/offscreen/dweb-base.js
@@ -265,7 +265,14 @@ const handleRoomOp = async (msg) => {
     // publishes MY signed card (retained so late joiners backfill), card-get
     // reads a peer's latest card from the retained history by its did.
     case 'card-set': {
-      const card = { ...(msg.card && typeof msg.card === 'object' ? msg.card : {}), did: room.did };
+      // Validate + clamp MY card before it hits the mesh: strips arbitrary extra
+      // fields and REJECTS an oversized one (the agent-card caps — MAX_CARD_BYTES
+      // etc.), so a retained '~card' envelope we emit can't amplify to late-joiners.
+      const client = /** @type {any} */ (await loadDweb());
+      let clean;
+      try { clean = client.validateCard(msg.card).card; }
+      catch (e) { return { ok: false, error: /** @type {{ message?: string }} */ (e)?.message ?? 'agent card rejected' }; }
+      const card = { ...clean, did: room.did };
       room.sync.retain('~card');
       const env = await room.sync.publish('~card', card);
       return { ok: true, did: room.did, id: env.id };
@@ -278,7 +285,11 @@ const handleRoomOp = async (msg) => {
       // newest by envelope ts so a re-advertised card always supersedes.
       const mine = room.sync.history('~card').filter((/** @type {any} */ e) => e.from === msg.did);
       const latest = mine.reduce((/** @type {any} */ best, /** @type {any} */ e) => (!best || (e.ts ?? 0) >= (best.ts ?? 0) ? e : best), null);
-      return { ok: true, card: latest ? latest.body.data : null };
+      // Clamp the UNTRUSTED peer card (parsePeerCard: coerce + cap, null if it
+      // blows the ceiling) before it reaches the actor's a2a_run worker — the caps
+      // exist precisely to bound a malicious multi-MB / unbounded-fields card.
+      const client = /** @type {any} */ (await loadDweb());
+      return { ok: true, card: latest ? client.parsePeerCard(latest.body.data) : null };
     }
     case 'mute': room.gossip.mute(msg.did); return { ok: true };
     case 'publish-app': { const h = await start(); const { uri, hash } = await h.base.publishApp({ name: msg.name, entry: msg.entry, files: msg.files }); return { ok: true, uri, hash }; }

--- a/extension/peerd-distributed/index.js
+++ b/extension/peerd-distributed/index.js
@@ -74,6 +74,12 @@ export { installAppBundle, BundleRejectedError } from './apps/loader.js';
 export { createDwebBridge } from './apps/bridge.js';
 export { loadSeedApp, COMMONS_SEED } from './apps/seed.js';
 
+// A2A Agent Card validation/caps — exposed so the offscreen base host (dweb-base.js,
+// which reaches this module only via loadDweb, never a static import) can enforce
+// them on the card-set (validate my own card, reject/strip before it hits the mesh)
+// and card-get (clamp an untrusted peer card before handing it to the actor) paths.
+export { normalizeCard, validateCard, parsePeerCard, CardRejectedError } from './agent-card.js';
+
 // --- the core-facing client (shared/dweb-interface.js shape) -------
 // The ONLY entry point core code reaches (via shared/dweb-loader.js,
 // preview packages only). PHASE lives in client.js next to the client.

--- a/extension/tests/dweb-twopeer.js
+++ b/extension/tests/dweb-twopeer.js
@@ -18,11 +18,20 @@
 
 import { generateIdentity, joinRoom } from '/peerd-distributed/index.js';
 import { createBaseNetwork } from '/peerd-distributed/base-network.js';
+// The PRODUCTION a2a ask/reply correlation core — driven here over the REAL mesh
+// direct channel so the live two-peer round-trip exercises the same code the
+// dweb actor's a2a_run uses (envelope tag + request/reply, the did-bound resolve).
+// why the DEEP import (not /peerd-runtime/index.js): the barrel transitively pulls
+// in browser-polyfill, which throws off an extension origin — this harness page
+// runs on plain http. a2a-dispatch.js is a pure, import-free module, so it loads
+// cleanly here. (tests/ is exempt from the no-deep-import rule.)
+import { makeMeshDispatch } from '/peerd-runtime/subagent/a2a-dispatch.js';
 
 const params = new URLSearchParams(location.search);
 const roomId = params.get('room') ?? 'harness';
 const url = params.get('url') ?? 'ws://localhost:8799/rendezvous';
 const name = params.get('name') ?? 'peer';
+const a2aOn = params.get('a2a') === '1';   // add the live ask/reply beat on top of gossip
 
 // The gossip topic the two peers exchange a hello on — proves the application
 // layer (gossip flood + dedup) works over the live mesh, not just that a data
@@ -42,6 +51,10 @@ let base = null;
 let myDid = null;
 /** @type {any} */
 let error = null;
+// a2a live round-trip state (only when a2aOn): did we send an ask and get the
+// peer's reply back, over the real mesh, via the production correlation core?
+let askReplied = false;
+/** @type {any} */ let askReply = null;
 
 const render = () => {
   const snap = base?.snapshot?.() ?? { linkedCount: 0, presentCount: 0 };
@@ -89,6 +102,44 @@ const boot = async () => {
       render();
     }, 1000);
 
+    // The a2a live round-trip: wire the production makeMeshDispatch to THIS peer's
+    // real direct channel. Each peer auto-replies PONG to any inbound ask, and —
+    // once it sees a linked peer — sends exactly one ask and records the reply.
+    // A green run proves the envelope protocol + the did-bound reply correlation
+    // survive real WebRTC between two browser contexts, not just the unit fakes.
+    let askBeat = null;
+    if (a2aOn) {
+      const dispatch = makeMeshDispatch({
+        sendDm: async (/** @type {string} */ to, /** @type {any} */ env) => {
+          try { const r = await base.node.direct.send(to, env); return { ok: true, id: r?.id }; }
+          catch (e) { return { ok: false, error: /** @type {{ message?: string }} */ (e)?.message ?? String(e) }; }
+        },
+        listPeers: async () => (base.snapshot().peers ?? []).map((/** @type {any} */ p) => ({ did: p.did, name: p.name })),
+        fetchCard: async () => null,
+        publishCard: async () => ({ ok: false, error: 'not in the two-peer harness' }),
+      });
+      // Inbound directs → the dispatch. An inbound ask is auto-answered with PONG.
+      base.node.direct.onMessage((/** @type {{ from: string, data: any }} */ { from, data }) => {
+        const routed = dispatch.handleInbound(from, data);
+        if (routed?.deliver?.kind === 'ask') {
+          dispatch.reply(from, routed.deliver.reqId, `PONG:${routed.deliver.message}`).catch(() => {});
+        }
+      });
+      let asked = false;
+      askBeat = setInterval(async () => {
+        if (asked) return;
+        const peer = (base.snapshot().peers ?? []).find((/** @type {any} */ p) => p.did && p.did !== myDid && p.linked);
+        if (!peer) return;
+        asked = true;
+        try {
+          // 8s ask timeout keeps the round-trip well inside the harness budget.
+          const r = await dispatch.dispatch('ask', { did: peer.did, message: `PING-${name}`, timeoutMs: 8000 }, { signs: true, allowed: () => true });
+          if (r?.ok && r.reply != null && !r.timedOut) { askReplied = true; askReply = r.reply; }
+        } catch { /* leave askReplied false — the harness fails on the timeout */ }
+        render();
+      }, 800);
+    }
+
     // why any cast: __DWEB__ is a harness-only global the CDP driver polls; it's
     // not part of the typed Window surface, so the boundary is `any` here.
     /** @type {any} */ (window).__DWEB__ = {
@@ -102,11 +153,13 @@ const boot = async () => {
           linked: snap.linkedCount,
           present: snap.presentCount,
           heard: heardFrom.size,
+          askReplied,
+          askReply,
           peers: snap.peers.map((/** @type {any} */ p) => ({ did: p.did, name: p.name, linked: p.linked, path: p.path })),
           error,
         };
       },
-      stop: () => { clearInterval(beat); base.close(); room.leave(); },
+      stop: () => { clearInterval(beat); if (askBeat) clearInterval(askBeat); base.close(); room.leave(); },
     };
   } catch (e) {
     error = /** @type {{ message?: string }} */ (e)?.message ?? String(e);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "version": "0.2.2",
-  "description": "Browser-native AI agent harness. Solo dev — Bun is for tests + one-shot vendor scripts only; the extension itself runs no build step.",
+  "description": "Browser-native AI agent harness. Solo dev \u2014 Bun is for tests + one-shot vendor scripts only; the extension itself runs no build step.",
   "license": "Apache-2.0",
   "homepage": "https://peerd.ai",
   "repository": {
@@ -18,6 +18,7 @@
     "test:watch": "bun test ./tests --watch",
     "test:netproc": "bun tests/peerd-distributed/netproc/run-cluster.ts",
     "test:twopeer": "bun scripts/cdp/run-dweb-twopeer.mjs",
+    "test:twopeer:a2a": "A2A=1 bun scripts/cdp/run-dweb-twopeer.mjs",
     "e2e:verify": "bun scripts/cdp/run-e2e-verify.mjs",
     "test:e2e": "bun scripts/cdp/run-e2e-verify.mjs --functional",
     "test:e2e:all": "bun scripts/cdp/run-e2e-verify.mjs --functional",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "version": "0.2.2",
-  "description": "Browser-native AI agent harness. Solo dev \u2014 Bun is for tests + one-shot vendor scripts only; the extension itself runs no build step.",
+  "description": "Browser-native AI agent harness. Solo dev — Bun is for tests + one-shot vendor scripts only; the extension itself runs no build step.",
   "license": "Apache-2.0",
   "homepage": "https://peerd.ai",
   "repository": {

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -52,7 +52,7 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // stack (a reasoning subagent is a tool-less ephemeral actor), deleting those four
 // phase-1 files; their code lives on in the (still // @ts-check'd) actor-* stack.
 // A legitimate decrease (files deleted, not directives dropped).
-const COVERED_FLOOR = 486;
+const COVERED_FLOOR = 487;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/scripts/cdp/run-dweb-twopeer.mjs
+++ b/scripts/cdp/run-dweb-twopeer.mjs
@@ -151,10 +151,14 @@ const main = async () => {
   ], { stdio: 'ignore' });
   const cdpPort = await waitForCdpPort();
 
-  // 4. two peers in the same room.
+  // 4. two peers in the same room. A2A=1 adds the live ask/reply round-trip on
+  // top of the gossip check (the page wires the production a2a correlation to the
+  // real direct channel); the pass gate then also requires each peer to have sent
+  // an ask and received the peer's reply over real WebRTC.
+  const a2a = process.env.A2A === '1';
   const room = `harness-${Math.random().toString(36).slice(2, 8)}`;
   const pageUrl = (who) => `http://localhost:${httpPort}/tests/dweb-twopeer.html`
-    + `?room=${room}&name=${who}&url=${encodeURIComponent(rendezvous)}`;
+    + `?room=${room}&name=${who}&url=${encodeURIComponent(rendezvous)}${a2a ? '&a2a=1' : ''}`;
   const alice = await openPeer(cdpPort, pageUrl('alice'));
   const bob = await openPeer(cdpPort, pageUrl('bob'));
   console.log(`[twopeer] two contexts joining room "${room}"`);
@@ -163,14 +167,16 @@ const main = async () => {
   const reportExpr = 'window.__DWEB__?.ready ? JSON.stringify(window.__DWEB__.report()) : ""';
   let a = null; let b = null;
   const deadline = Date.now() + RESULT_BUDGET_MS;
-  const done = (r) => r && r.linked >= 1 && r.heard >= 1;
+  // A2A mode additionally requires the live ask/reply round-trip on both peers.
+  const done = (r) => r && r.linked >= 1 && r.heard >= 1 && (!a2a || r.askReplied === true);
   while (Date.now() < deadline) {
     const [ja, jb] = await Promise.all([alice.evaluate(reportExpr), bob.evaluate(reportExpr)]);
     a = ja ? JSON.parse(ja) : a;
     b = jb ? JSON.parse(jb) : b;
     if (a?.error || b?.error) break;
     if (done(a) && done(b)) {
-      console.log(`[twopeer] ✅ PASS — alice⇄bob meshed (alice linked ${a.linked}/heard ${a.heard}, bob linked ${b.linked}/heard ${b.heard})`);
+      const a2aNote = a2a ? ` · a2a ask/reply ✓ (alice⇐"${a.askReply}", bob⇐"${b.askReply}")` : '';
+      console.log(`[twopeer] ✅ PASS — alice⇄bob meshed (alice linked ${a.linked}/heard ${a.heard}, bob linked ${b.linked}/heard ${b.heard})${a2aNote}`);
       cleanup();
       process.exit(0);
     }

--- a/tests/background/a2a-consent.test.ts
+++ b/tests/background/a2a-consent.test.ts
@@ -1,0 +1,60 @@
+// The a2a first-contact consent decisions. Guards the exact regression the
+// re-swarm found: "Allow once" must NOT persist as a standing signing grant,
+// while "Allow for session" is the intended revocable allowlist-add — and
+// a2a_contact must escape the actor per-turn downgrade so that distinction
+// can even be made for the (ephemeral) dweb actor.
+
+import { describe, test, expect } from 'bun:test';
+import { downgradesActorConfirm, a2aConsentOutcome } from '../../extension/background/a2a-consent.js';
+
+describe('downgradesActorConfirm — the actor per-turn rule + the a2a_contact exception', () => {
+  test('a NON-a2a actor confirm downgrades yes_session to one-shot (DESIGN-17)', () => {
+    expect(downgradesActorConfirm('fetch_url', true, 'yes_session')).toBe(true);
+  });
+  test('a2a_contact is the exception — its yes_session is NOT downgraded', () => {
+    // why it matters: the dweb actor is an ephemeral (kind:'actor') session, so
+    // without this exception every a2a "Allow for session" would be silently
+    // rewritten to yes_once and could never persist to the allowlist.
+    expect(downgradesActorConfirm('a2a_contact', true, 'yes_session')).toBe(false);
+  });
+  test('a NON-ephemeral (chat) confirm never downgrades', () => {
+    expect(downgradesActorConfirm('fetch_url', false, 'yes_session')).toBe(false);
+    expect(downgradesActorConfirm('a2a_contact', false, 'yes_session')).toBe(false);
+  });
+  test('only yes_session is a downgrade candidate — yes_once / no pass through', () => {
+    expect(downgradesActorConfirm('fetch_url', true, 'yes_once')).toBe(false);
+    expect(downgradesActorConfirm('fetch_url', true, 'no')).toBe(false);
+  });
+});
+
+describe('a2aConsentOutcome — persist only on yes_session', () => {
+  test('yes_session → allowed AND persisted (the revocable allowlist-add)', () => {
+    expect(a2aConsentOutcome('yes_session')).toEqual({ ok: true, persist: true });
+  });
+  test('yes_once → allowed for THIS call only, never persisted (the regression fix)', () => {
+    expect(a2aConsentOutcome('yes_once')).toEqual({ ok: true, persist: false });
+  });
+  test('no / dismissed → denied, not persisted', () => {
+    expect(a2aConsentOutcome('no')).toEqual({ ok: false, persist: false });
+    expect(a2aConsentOutcome('')).toEqual({ ok: false, persist: false });
+  });
+});
+
+// The end-to-end regression, in pure form: the two decisions composed exactly as
+// service-worker.js wires them (confirmAction downgrade → a2aResolveConsent
+// outcome) for the ephemeral dweb actor answering a2a_contact.
+describe('composed: the dweb actor (ephemeral) answering a2a_contact', () => {
+  const resolve = (rawAnswer: string) => {
+    const delivered = downgradesActorConfirm('a2a_contact', true, rawAnswer) ? 'yes_once' : rawAnswer;
+    return a2aConsentOutcome(delivered);
+  };
+  test('"Allow once" authorizes the call but does NOT persist the peer', () => {
+    expect(resolve('yes_once')).toEqual({ ok: true, persist: false });
+  });
+  test('"Allow for session" authorizes AND persists (survives the downgrade)', () => {
+    expect(resolve('yes_session')).toEqual({ ok: true, persist: true });
+  });
+  test('"No" denies', () => {
+    expect(resolve('no')).toEqual({ ok: false, persist: false });
+  });
+});

--- a/tests/peerd-distributed/agent-card.test.ts
+++ b/tests/peerd-distributed/agent-card.test.ts
@@ -59,3 +59,25 @@ describe('parsePeerCard — untrusted inbound', () => {
     expect(parsePeerCard('not a card')).toBe(null);
   });
 });
+
+// Wiring drift guard (cynical re-swarm, medium): the caps were dead code once —
+// agent-card.js was imported NOWHERE, so both the publish and fetch card paths
+// ran uncapped. Pin that the validators are (a) re-exported from the module's
+// public index and (b) actually CALLED on the card-set / card-get paths in the
+// offscreen base host, so they can't silently go inert again.
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+describe('agent-card caps are wired into the card paths (not dead code)', () => {
+  test('peerd-distributed/index.js re-exports the validators', () => {
+    const idx = readFileSync(join(import.meta.dir, '../../extension/peerd-distributed/index.js'), 'utf8');
+    for (const name of ['normalizeCard', 'validateCard', 'parsePeerCard']) {
+      expect(idx).toContain(name);
+    }
+  });
+  test('dweb-base.js validates on card-set and clamps on card-get', () => {
+    const src = readFileSync(join(import.meta.dir, '../../extension/offscreen/dweb-base.js'), 'utf8');
+    // card-set must reject/strip via validateCard; card-get must clamp via parsePeerCard.
+    expect(src).toContain('validateCard');
+    expect(src).toContain('parsePeerCard');
+  });
+});


### PR DESCRIPTION
## What & why

Follow-up to the merged A2A work (#148). Closes the two gaps flagged in an honest post-merge review: the a2a code had a full cynical swarm but its fixes were never *re-swarmed*, and the live two-peer mesh round-trip was deferred. Both done here.

### 1. Live two-peer ask/reply round-trip over real WebRTC (`d4260e4`)
The ask/reply correlation was unit-proven and the pipe was e2e-proven, but two real browser peers exchanging a real ask/reply was never driven live. The two-peer harness page (under `?a2a=1`) now wires the **production** `makeMeshDispatch` correlation core to its real base-network direct channel: each peer auto-replies PONG to an inbound ask and, once linked, sends one ask and records the reply. The harness (`A2A=1`) gates the pass on both peers completing the exchange — exercising the envelope protocol and the **did-bound resolve** (the security fix from the first swarm) end-to-end. Wired into the CI two-peer job with the same 3× headless-WebRTC flake retry. Local run: `alice⇐"PONG:PING-alice", bob⇐"PONG:PING-bob"`.

### 2. Re-swarm fixes (`63df9e0`)
A 4-dimension adversarial re-swarm of the *merged* a2a surface (verify the 8 fixes closed + hunt new) confirmed 3 findings (5 rejected as intended-design/mitigated). Fixed the two mediums:

- **The agent-card caps were dead code.** `normalizeCard`/`validateCard`/`parsePeerCard` and their ceilings (`MAX_CARD_BYTES=4096`, `MAX_SKILLS`, …) were imported *nowhere* — both card paths ran uncapped (a published card kept arbitrary fields/size; a fetched peer card reached the actor raw). Now enforced in the offscreen base host (reached via `loadDweb`, so the dweb boundary holds): `card-set` validates+strips+rejects my card before it hits the retained `~card` topic; `card-get` clamps the untrusted peer card before it reaches the actor. A source drift-guard test pins the wiring.
- **"Allow once" persisted as a session-wide grant.** `yes_once` was treated like `yes_session`. `a2a_contact` is now the sanctioned exception to the actor per-turn confirm downgrade (an explicit allowlist decision, the exact did shown): "Allow for session" persists (the intended, `dweb_block`-revocable contact-add), "Allow once" is a genuine one-shot. A one-time click can no longer become a standing signing grant.

**Deferred (low, documented):** Stop/abort doesn't terminate an in-flight offscreen a2a worker; it runs to its job timeout holding a shared headless slot. Bounded + self-healing, and a general property of the shared job runner (`js_run` shares the shape) — an abort-signal plumbing change to the runner is a separate focused piece, not bundled here.

## Checklist

- [x] `bun run preflight` passes (tests, typecheck, lint, in-browser, dweb-boundary, no manifest drift)
- [x] Commits are signed off — `git commit -s` (we use the DCO)
- [x] Only original or permissively-licensed code — **no GPL / AGPL / copyleft**
- [x] Tests added or updated (the live two-peer a2a harness + CI wiring; the agent-card wiring drift-guard)
- [x] No hand-edited generated files (`manifest.json`, `shared/channel-config.js`)
- [x] Touches a **danger zone** — dweb + a2a consent + the sealed-worker card paths. See below.

## Notes for reviewers

**Danger zone: consent + untrusted card ingest.** The consent change narrows authority (a one-shot no longer persists); it does not widen it. The card-cap wiring adds validation on both the emit and the ingest side; `dweb-base.js` reaches the validators via `loadDweb`, never a static `peerd-distributed` import, so the dweb-boundary gate stays green (verified). All caps live in the store-pruned dweb module.

**Verified:** 2557 Bun tests, strict typecheck, ESLint, dweb-boundary + packaged-imports, 596 in-browser real-worker tests, the `a2a-code-surface` e2e, and the new live two-peer ask/reply round-trip — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018scDZ7G3pkkAxKjmQkWY2q

---
_Generated by [Claude Code](https://claude.ai/code/session_018scDZ7G3pkkAxKjmQkWY2q)_