### PR TITLE
chore: de-drift CLAUDE.md + changelog for the recent merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,22 @@ and storage formats may move until the surface stabilizes.
   (and advertising your own card) needs your explicit ok, remembered per did
   and revocable by blocking the peer; peer replies and cards are always
   fenced as untrusted. It's a dweb-actor tool only — the orchestrator never
-  holds it, and the store build prunes the whole surface.
+  holds it, and the store build prunes the whole surface. Hardened after an
+  adversarial re-review: the Agent Card size/field caps are enforced on both
+  the publish and fetch paths, first-contact "Allow once" is a genuine
+  one-shot (only "Allow for session" persists, and blocking a peer revokes
+  it), and the ask/reply round-trip is now covered by a live two-peer
+  WebRTC test.
+
+### Changed
+- **The service worker is slimmer and the worker bridges are unified.** Two
+  internal refactors, no behavior change. The four hand-rolled worker↔host
+  bridges (OPFS, subagent, base-network reads, the a2a mesh) collapse into a
+  single factory, so adding the next one is a one-liner. And the service
+  worker sheds the clusters that were logic rather than wiring — the model
+  picker's catalog, the tab-strip affordances, and a couple of pure actor
+  kernels now live in their own small, tested modules, keeping the service
+  worker to assembly and routing.
 
 ## [0.2.2] - 2026-07-04
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,12 +84,16 @@ prose orientation is this file, and the rest is the source itself.
   from `manifests/*.json` and `packaging/default-settings.mjs`. CI fails on
   drift. Versions live in `package.json` only.
 - **Docs defer to code and CI for live state.** Do not hard-code dynamic
-  facts in prose: test pass counts, tool counts, gate matrices, release
-  artifact lists, generated-file contents, extension IDs, channel behavior,
-  or provider/model inventories. Point readers at the source file, script,
-  generated artifact, or CI/preflight command that computes the answer.
-  Static architectural invariants are fine; operational state belongs in
-  code, generated output, or the release itself.
+  facts in prose: test/tool counts, gate matrices, release artifact lists,
+  generated-file contents, extension IDs, channel behavior, provider/model
+  inventories — and equally the things that quietly drift: **tunable
+  constants and thresholds** (timeouts, caps, depths, retry code lists),
+  **exact dates/PR numbers** as anything more than a passing anchor, and
+  **inventories of a directory's internal files** (they grow with the code).
+  Name the pattern and point at the source file / script / CI command that
+  holds the real value; don't transcribe it. Static architectural
+  invariants are fine; operational state belongs in code, generated output,
+  or the release itself. When in doubt, describe the SHAPE and cite the file.
 - **The dweb boundary.** Nothing outside `peerd-distributed/`
   imports it — not even its `index.js` (stricter than the per-module
   rule below; the store package prunes the module entirely). Core code
@@ -253,15 +257,15 @@ the canonical catalog: read the relevant module before assuming
 something isn't built. The bullets here are the postures and
 gotchas to know going in:
 
-- Anthropic provider with streaming, adaptive extended thinking on
-  4.6+ models, 3-of-4 prompt-cache breakpoints, 429/500/503/529 retry,
+- Anthropic provider with streaming, adaptive extended thinking on newer
+  models, prompt-cache breakpoints, retry on transient/overload statuses,
   and the `anthropic-dangerous-direct-browser-access` ack — plus an
   OpenRouter adapter (OpenAI-compatible gateway) and a keyless Ollama
   adapter (local inference; live `/api/tags` model inventory; GPU-fit
   model recommendation in Settings) (`peerd-provider/`).
 - Vault with passphrase unlock AND WebAuthn PRF (Touch ID / Windows
   Hello) — same DK from either path (`peerd-egress/vault/`). Idle
-  auto-lock ON by default (45min, user-settable); manual Lock button
+  auto-lock ON by default (user-settable); manual Lock button
   in the top bar.
 - `chrome.debugger` usage (CDP) — a CHANNEL-GATED required permission,
   NOT the default. Chrome forbids `debugger` under `optional_permissions`
@@ -284,7 +288,7 @@ gotchas to know going in:
   true` on Trusted-Types pages (Gmail/Notion/Slack), and `page_keys`'
   trusted (`isTrusted`) input. Pool lives in
   `background/debugger-pool.js`.
-- Subagents — depth-bounded recursion (default `MAX_DEPTH=5`), tool
+- Subagents — depth-bounded recursion, tool
   narrowing, output cap. Real implementation at
   `peerd-runtime/subagent/spawn.js` — not a stub. Since the async-actor
   unification (PR #134): a child runs under its own turn slot with an
@@ -334,10 +338,10 @@ gotchas to know going in:
   audit. The legacy permission-mode axis was REMOVED
   2026-06-12 — Plan/Act + the denylist carry the safety weight; Plan
   permits pure URL loads only, never clicks (enforced in `gates.js`).
-- The ten-feature buildout — memory, edit + checkpoints, Plan/Act,
-  composer (slash commands + @-refs), goal mode (autonomous loop), cost telemetry, skills,
-  review subagent, and hooks — all integrated. (The tenth, do/get/check,
-  was CULLED 2026-07-01: the web actor drives pages directly, so one
+- The feature buildout — memory, edit + checkpoints, Plan/Act,
+  composer (slash commands + @-refs), goal mode (autonomous loop), cost
+  telemetry, skills, review subagent, and hooks — all integrated.
+  (do/get/check was CULLED: the web actor drives pages directly, so one
   delegation reaches the page instead of two.) Per-feature
   detail lives in the code under `peerd-runtime/`.
 - Dual distribution: store (no dweb) + preview channels, generated
@@ -366,8 +370,8 @@ gotchas to know going in:
   and MONITORS inbound mesh traffic: peers reach it on the reserved
   `peerd-agent` room, whose `direct` events wake it as fenced, INBOUND
   (untrusted) turns — the sender gate means an inbound message can never make
-  it delegate. Rate-capped (3/min per did, 30/hr global) before any model
-  call; notable findings trickle up to the active chat as an attributed
+  it delegate. Rate-capped (per-did + global caps, `background/dweb-inbound-rate-cap.js`)
+  before any model call; notable findings trickle up to the active chat as an attributed
   actor-reply bubble (runWhenIdle — never steals a live turn). The envoy for
   agent-to-agent over the mesh: "a peer's agent" is just an actor whose heap
   is on another machine.


### PR DESCRIPTION
## What & why

Post-merge housekeeping after the A2A + service-worker work landed (#148–#151). Docs-only, no code.

**CLAUDE.md — apply its own "defer to code" rule harder.** The doc is mostly well-designed to point at code rather than transcribe it, but a few tunable constants had leaked into the prose (subagent recursion depth, the vault idle-lock interval, the dweb inbound rate caps, provider retry-code list + cache breakpoints) plus a hard "ten-feature" count that was already off. This:
- Strengthens the rule to name the drift-prone classes explicitly — constants/thresholds, exact dates/PR numbers, and inventories of a directory's *internal* files (they grow with the code).
- De-specifies the offenders to point at the source that holds the real value.

Notably it does **not** add the new `background/` modules from the SW slim-down: the service-worker layering description was already pattern-based ("wiring + thin handlers, logic in modules"), so it stayed accurate through the refactor — which is exactly the property we want and why enumerating the modules would be the wrong fix.

**CHANGELOG** — record the three merges that weren't in Unreleased yet: the `makeBridge` bridge unification (#149), the service-worker slim-down (#150), and the A2A hardening (#151, folded into the existing A2A entry).

## Checklist

- [x] `bun run preflight` equivalents pass (2567 Bun tests, packaging suite, `check:docpaths`)
- [x] Commits are signed off — `git commit -s`
- [x] Docs only — no code, no generated files
- [x] Not a danger zone

## Notes for reviewers

`check:docpaths` passes (no dead path references introduced). The historical `2026-06-12`-style dates left in place are decision attributions (they timestamp past owner calls; they don't drift) — only the *live-value* constants were pulled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018scDZ7G3pkkAxKjmQkWY2q

---
_Generated by [Claude Code](https://claude.ai/code/session_018scDZ7G3pkkAxKjmQkWY2q)_