### PR TITLE
release: v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,17 @@ and storage formats may move until the surface stabilizes.
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-07-05
+
 ### Changed
 - **`oneShot` delegation is sandbox-only now.** `message_actor`'s oneShot mode
   (skip the actor's summary turn, hand the raw result straight back) is
   honored only for the agent's own engine sandboxes (webvm/notebook/app) and
-  refused loudly for every other target — the summary turn is what
+  refused loudly for every other target. The summary turn is what
   incidentally compresses untrusted content, so a web/API/dweb reply always
   comes back summarized. The orchestrator prompt now actually teaches the
   shortcut ("run `pytest`" → oneShot:true) instead of leaving it buried in
-  schema fine print, where models — small local ones especially — never
+  schema fine print, where models (small local ones especially) never
   found it.
 
 ## [0.2.3] - 2026-07-05

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "peerd (dev)",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "An AI assistant that automates tasks in your browser. Local-first: your own API key, no account, no servers, no tracking.",
   "side_panel": {
     "default_path": "sidepanel/sidepanel.html"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "peerd",
   "private": true,
   "type": "module",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Browser-native AI agent harness. Solo dev — Bun is for tests + one-shot vendor scripts only; the extension itself runs no build step.",
   "license": "Apache-2.0",
   "homepage": "https://peerd.ai",


### PR DESCRIPTION
Cuts v0.2.4. One change since v0.2.3: `oneShot` delegation is sandbox-only (refused for web/API/dweb targets, so untrusted replies always come back summarized), and the orchestrator prompt now teaches the shortcut (#162). Changelog promoted and converted to plain English; the release body comes from it automatically.