### PR TITLE
The debug surface: bundle export, failure classes, context inspector, OTel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,35 @@ and storage formats may move until the surface stabilizes.
 ## [Unreleased]
 
 ### Added
+- **The debug surface: serious observability without a vendor.** peerd's
+  chain of events was already recorded (audit log, lineage, delegation
+  traces) but trapped across surfaces; now it comes OUT, locally, on the
+  user's say-so. Three pieces:
+  - **Debug bundle export** — a chip-sized `debug` button in the chat mode
+    row saves one JSON file per session: the full transcript INCLUDING every
+    descendant actor/subagent session (the delegation tree, walked by parent
+    links), the audit slice for that set, cost, a settings snapshot (keys
+    can't appear — they live only in the vault and attach at fetch-header
+    time), live context snapshots, a classified failure index, and a
+    provenance block that says plainly what may be missing (pruned audit,
+    evicted snapshots). Same data exports as an **OpenTelemetry trace**
+    (OTLP/JSON, delegation = span parentage, gen_ai semconv attributes) for
+    any OTel viewer the user already runs — converted in the panel from the
+    same payload, no second route, no wire, no vendor.
+  - **Failure-class chips** — every failed tool card and failed turn now
+    carries its classified failure neighborhood (policy / auth / limits /
+    provider / timeout / aborted / environment / agent / internal) as a
+    small chip next to the raw error, so triage starts at "whose fault,
+    roughly" instead of string-parsing. The same classifier annotates the
+    bundle and stamps OTel span status.
+  - **The context inspector** (dev mode) — "what did the model actually
+    see?": the service worker keeps a small in-memory ring of shaped
+    request snapshots per session (system prompt clipped, messages capped,
+    binary payloads stripped with a visible sentinel), captured at the two
+    seams that together cover every model call — the orchestrator's turn
+    driver and the actor/subagent relay route. A modal lists each call
+    (who, model, sizes, content) and is honest about the ring's lifetime:
+    it empties with the service worker, and says so.
 - **The orchestrator delegates from code: `script` grows an `actors` client.**
   The same bet that gave the web actor and the mesh their code surfaces now
   reaches the orchestrator itself: inside the `script` tool (the renamed

--- a/extension/background/context-snapshots.js
+++ b/extension/background/context-snapshots.js
@@ -1,0 +1,143 @@
+// @ts-check
+// background/context-snapshots.js — the context inspector's capture ring.
+//
+// "What did the model actually see?" — per model call, a SHAPED snapshot
+// of the request args (system, messages, tools, params) is recorded into
+// a per-session capped ring. Two SW seams feed it and together cover
+// every model call peerd makes: the turn driver's failover wrapper (the
+// orchestrator) and the 'actor/model-call' relay route (every actor and
+// subagent heap). Held in SW memory only — the same lifetime posture as
+// the script-runs op mirror — so it answers "what just happened", not
+// "what happened last week"; the debug bundle exports whatever is live
+// and its provenance says exactly that.
+//
+// Secrets: none can appear. The captured args are the PRE-WIRE callModel
+// args; API keys attach at fetch-header time inside the adapter and are
+// never part of the args struct. Size is the real risk (a vision turn
+// carries megabytes of base64), so shaping clips every string and drops
+// binary payloads with a visible sentinel — the "keep metadata, drop
+// bytes" posture the transcript's own redaction already uses.
+//
+// Pure factory (values + injected clock) — bun-tested without a browser.
+
+export const SNAPSHOTS_PER_SESSION = 10;
+export const SNAPSHOT_MAX_SESSIONS = 24;
+export const SNAPSHOT_SYSTEM_CHARS = 6000;
+export const SNAPSHOT_CONTENT_CHARS = 1500;
+export const SNAPSHOT_MAX_MESSAGES = 60;
+
+const STRIPPED = '<binary payload stripped for the snapshot>';
+
+/** @param {unknown} s @param {number} n */
+const clip = (s, n) => {
+  const str = typeof s === 'string' ? s : JSON.stringify(s ?? '') ?? '';
+  return str.length <= n ? str : `${str.slice(0, n - 1)}…`;
+};
+
+/**
+ * Shape one callModel args struct into a bounded, binary-free snapshot.
+ * Pure and defensive: unknown shapes degrade to clipped JSON, never throw.
+ * @param {Record<string, any>} args  pre-wire callModel args
+ */
+export const shapeModelCall = (args = {}) => {
+  const messages = Array.isArray(args.messages) ? args.messages : [];
+  const kept = messages.slice(-SNAPSHOT_MAX_MESSAGES);
+  return {
+    provider: args.provider ?? '',
+    model: args.model ?? '',
+    system: clip(args.system ?? '', SNAPSHOT_SYSTEM_CHARS),
+    systemChars: typeof args.system === 'string' ? args.system.length : 0,
+    reasoning: args.reasoning ?? null,
+    tools: (Array.isArray(args.tools) ? args.tools : []).map((t) => t?.name ?? '?'),
+    droppedMessages: messages.length - kept.length,
+    messages: kept.map((m) => ({
+      role: m?.role ?? '?',
+      content: clip(m?.content ?? '', SNAPSHOT_CONTENT_CHARS),
+      ...(m?.toolUses?.length ? {
+        toolUses: m.toolUses.map((/** @type {Record<string, any>} */ u) => ({
+          name: u?.name ?? '?', input: clip(u?.input, 400),
+        })),
+      } : {}),
+      ...(m?.toolResults?.length ? {
+        toolResults: m.toolResults.map((/** @type {Record<string, any>} */ r) => ({
+          tool_use_id: r?.tool_use_id, is_error: r?.is_error === true,
+          content: clip(r?.content ?? '', SNAPSHOT_CONTENT_CHARS),
+          ...(r?.images?.length ? { images: STRIPPED } : {}),
+        })),
+      } : {}),
+      ...(m?.attachments?.length ? {
+        attachments: m.attachments.map((/** @type {Record<string, any>} */ a) => ({
+          name: a?.name, mediaType: a?.mediaType, size: a?.size,
+          ...(a?.data ? { data: STRIPPED } : {}),
+        })),
+      } : {}),
+    })),
+  };
+};
+
+/**
+ * @param {{ capPerSession?: number, maxSessions?: number, now?: () => number }} [opts]
+ */
+export const createContextSnapshots = ({
+  capPerSession = SNAPSHOTS_PER_SESSION,
+  maxSessions = SNAPSHOT_MAX_SESSIONS,
+  now = Date.now,
+} = {}) => {
+  /** @type {Map<string, { touched: number, snaps: Array<Record<string, any>> }>} */
+  const bySession = new Map();
+  let seq = 0;
+
+  const evictIfNeeded = () => {
+    // why size-then-evict (not LRU bookkeeping per read): the SW is
+    // long-lived and sessions are few; a linear oldest-touched sweep on
+    // WRITE keeps the map bounded with zero read-path cost.
+    while (bySession.size > maxSessions) {
+      let oldestKey = null, oldestTouched = Infinity;
+      for (const [key, entry] of bySession) {
+        if (entry.touched < oldestTouched) { oldestTouched = entry.touched; oldestKey = key; }
+      }
+      if (oldestKey == null) return;
+      bySession.delete(oldestKey);
+    }
+  };
+
+  return {
+    /**
+     * Record one model call. Never throws — capture must not be able to
+     * break a turn.
+     * @param {{ sessionId?: string, label?: string } & Record<string, any>} call
+     */
+    record: (call = {}) => {
+      try {
+        const sessionId = call.sessionId;
+        if (!sessionId) return;
+        const entry = bySession.get(sessionId) ?? { touched: 0, snaps: [] };
+        entry.touched = now();
+        if (entry.snaps.length >= capPerSession) entry.snaps.shift();
+        entry.snaps.push({
+          seq: ++seq,
+          when: now(),
+          sessionId,
+          label: call.label ?? 'main',
+          ...shapeModelCall(call),
+        });
+        bySession.set(sessionId, entry);
+        evictIfNeeded();
+      } catch { /* capture is best-effort by contract */ }
+    },
+
+    /** The live snapshots for one session (copy), oldest first. @param {string} sessionId */
+    snapshotsFor: (sessionId) => [...(bySession.get(sessionId)?.snaps ?? [])],
+
+    /** The live snapshots for a session set (root + children), oldest first. @param {string[]} sessionIds */
+    snapshotsForMany: (sessionIds) => sessionIds
+      .flatMap((id) => bySession.get(id)?.snaps ?? [])
+      .sort((a, b) => a.seq - b.seq)
+      .map((s) => ({ ...s })),
+
+    /** The caps in force — the bundle's provenance block reports them. */
+    limits: () => ({ snapshotsPerSession: capPerSession, maxSessions }),
+
+    _size: () => bySession.size,
+  };
+};

--- a/extension/background/context-snapshots.js
+++ b/extension/background/context-snapshots.js
@@ -3,10 +3,11 @@
 //
 // "What did the model actually see?" — per model call, a SHAPED snapshot
 // of the request args (system, messages, tools, params) is recorded into
-// a per-session capped ring. Two SW seams feed it and together cover
+// a per-session capped ring. Three SW seams feed it and together cover
 // every model call peerd makes: the turn driver's failover wrapper (the
-// orchestrator) and the 'actor/model-call' relay route (every actor and
-// subagent heap). Held in SW memory only — the same lifetime posture as
+// orchestrator), the 'actor/model-call' relay route (every actor and
+// subagent heap), and spawn's capped wrapper (the in-SW fallback loop
+// when offscreen isn't available — Firefox). Held in SW memory only — the same lifetime posture as
 // the script-runs op mirror — so it answers "what just happened", not
 // "what happened last week"; the debug bundle exports whatever is live
 // and its provenance says exactly that.

--- a/extension/background/context-snapshots.js
+++ b/extension/background/context-snapshots.js
@@ -42,32 +42,40 @@ const clip = (s, n) => {
 export const shapeModelCall = (args = {}) => {
   const messages = Array.isArray(args.messages) ? args.messages : [];
   const kept = messages.slice(-SNAPSHOT_MAX_MESSAGES);
+  // why EVERY field is clipped/capped, not just the obvious bodies: on the
+  // actor seam these args arrive verbatim from a worker heap — exactly the
+  // adversary the heap split assumes compromised. An unshaped field (a
+  // megabyte "reasoning" object, a 10^6-entry tools array) would let that
+  // worker bloat SW memory and poison the bundle. DoS-only, but free to
+  // close: the whitelist admits nothing unbounded.
+  const capList = (/** @type {unknown} */ v, /** @type {number} */ n) => (Array.isArray(v) ? v.slice(0, n) : []);
   return {
-    provider: args.provider ?? '',
-    model: args.model ?? '',
+    provider: clip(args.provider ?? '', 200),
+    model: clip(args.model ?? '', 200),
     system: clip(args.system ?? '', SNAPSHOT_SYSTEM_CHARS),
     systemChars: typeof args.system === 'string' ? args.system.length : 0,
-    reasoning: args.reasoning ?? null,
-    tools: (Array.isArray(args.tools) ? args.tools : []).map((t) => t?.name ?? '?'),
+    reasoning: args.reasoning == null ? null : clip(args.reasoning, 400),
+    tools: capList(args.tools, 50).map((t) => clip(t?.name ?? '?', 120)),
     droppedMessages: messages.length - kept.length,
     messages: kept.map((m) => ({
-      role: m?.role ?? '?',
+      role: clip(m?.role ?? '?', 40),
       content: clip(m?.content ?? '', SNAPSHOT_CONTENT_CHARS),
       ...(m?.toolUses?.length ? {
-        toolUses: m.toolUses.map((/** @type {Record<string, any>} */ u) => ({
-          name: u?.name ?? '?', input: clip(u?.input, 400),
+        toolUses: capList(m.toolUses, 50).map((/** @type {Record<string, any>} */ u) => ({
+          name: clip(u?.name ?? '?', 120), input: clip(u?.input, 400),
         })),
       } : {}),
       ...(m?.toolResults?.length ? {
-        toolResults: m.toolResults.map((/** @type {Record<string, any>} */ r) => ({
-          tool_use_id: r?.tool_use_id, is_error: r?.is_error === true,
+        toolResults: capList(m.toolResults, 50).map((/** @type {Record<string, any>} */ r) => ({
+          tool_use_id: clip(r?.tool_use_id ?? '', 120), is_error: r?.is_error === true,
           content: clip(r?.content ?? '', SNAPSHOT_CONTENT_CHARS),
           ...(r?.images?.length ? { images: STRIPPED } : {}),
         })),
       } : {}),
       ...(m?.attachments?.length ? {
-        attachments: m.attachments.map((/** @type {Record<string, any>} */ a) => ({
-          name: a?.name, mediaType: a?.mediaType, size: a?.size,
+        attachments: capList(m.attachments, 20).map((/** @type {Record<string, any>} */ a) => ({
+          name: clip(a?.name ?? '', 200), mediaType: clip(a?.mediaType ?? '', 100),
+          size: Number.isFinite(a?.size) ? a.size : 0,
           ...(a?.data ? { data: STRIPPED } : {}),
         })),
       } : {}),

--- a/extension/background/offscreen-actor-client.js
+++ b/extension/background/offscreen-actor-client.js
@@ -34,10 +34,14 @@
  *   for engine/API actors (no tab) and the 0-tab web state.
  * @param {string} deps.EXPOSURE_ACTOR
  * @param {() => number} [deps.now]
+ * @param {(call: Record<string, any>) => void} [deps.recordModelCall]  the context
+ *   inspector's capture hook — fed every delegated model call with the runMeta-derived
+ *   identity (never the worker's own claim). Optional; defaults to a no-op.
  */
 export const makeOffscreenActorClient = ({
   ensureOffscreen, sendMessage, callModel, getSecret, safeFetch,
   sessions, buildToolContext, dispatchToolCall, pinActorCall, restrictCtxCapabilities, ownedTabFor, EXPOSURE_ACTOR, now = Date.now,
+  recordModelCall = () => {},
 }) => {
   let seq = 0;
   /** @type {Map<string, Set<AbortController>>} runId → in-flight model-call controllers */
@@ -51,6 +55,10 @@ export const makeOffscreenActorClient = ({
   const abortedRuns = new Set();
   /** @type {Map<string, (ev: object) => void>} runId → onEvent */
   const runOnEvent = new Map();
+  /** @type {Map<string, { sessionId: string, label: string }>} runId → identity for the
+   * context inspector: the model-call route only carries runId + body args, so the
+   * session (and a human label for WHOSE call this is) is stashed at run() time. */
+  const runMeta = new Map();
   /** @type {Map<string, AbortSignal>} sessionId → the in-flight run's abort signal.
    * Phase 4: a subagent's BLOCKING tool (message_actor awaitReply) runs SW-side via the
    * relay and races the reply against the child's cancel; the child's signal is only
@@ -66,6 +74,10 @@ export const makeOffscreenActorClient = ({
     await ensureOffscreen();
     const runId = `aw-${now().toString(36)}-${++seq}`;
     if (onEvent) runOnEvent.set(runId, onEvent);
+    runMeta.set(runId, {
+      sessionId: job.actorSessionId,
+      label: job.actorType ? `actor:${job.actorType}` : `subagent d${job.depth ?? 1}`,
+    });
     const abortRun = () => {
       abortedRuns.add(runId);   // cover a model-call that hasn't reached the route yet
       for (const ac of inflight.get(runId) ?? []) { try { ac.abort(); } catch { /* already */ } }
@@ -91,6 +103,7 @@ export const makeOffscreenActorClient = ({
       // it already fired under {once:true}); keeps nothing dangling on the turn signal.
       signal?.removeEventListener('abort', abortRun);
       runOnEvent.delete(runId);
+      runMeta.delete(runId);
       inflight.delete(runId);
       abortedRuns.delete(runId);
       if (signal && signalBySession.get(job.actorSessionId) === signal) signalBySession.delete(job.actorSessionId);
@@ -107,6 +120,12 @@ export const makeOffscreenActorClient = ({
       const ac = new AbortController();
       const set = inflight.get(key) ?? new Set();
       set.add(ac); inflight.set(key, set);
+      // The context inspector sees every DELEGATED model call here — the one
+      // relay every actor and subagent heap uses. Identity comes from the
+      // runMeta stash, never the worker's args (a worker must not be able to
+      // relabel whose context this was).
+      const meta = runMeta.get(key);
+      if (meta) recordModelCall({ ...(args ?? {}), sessionId: meta.sessionId, label: meta.label });
       /** @type {any[]} */
       const events = [];
       try {

--- a/extension/background/routes/sessions.js
+++ b/extension/background/routes/sessions.js
@@ -22,6 +22,10 @@ export const makeSessionRoutes = (deps) => {
     browser, originOfTabUrl, matchesDenylist, denylistStore,
     startGoalRun, haltGoalRun, ensureSession, actorMessaging,
     subagentLifecycle,
+    // The debug surface: the pure assembler + tree walk from
+    // peerd-runtime/observability, the SW's live snapshot ring, and the
+    // settings/channel/version identity the bundle stamps.
+    settingsStore, contextSnapshots, assembleDebugBundle, childSessionIdsOf, CHANNEL,
   } = deps;
 
   return {
@@ -285,6 +289,54 @@ export const makeSessionRoutes = (deps) => {
       const session = await sessions.get(sessionId);
       if (!session) return { ok: false, error: 'session-not-found' };
       return { ok: true, session };
+    },
+
+    // The debug bundle: one session's whole debugging story as one JSON
+    // payload (the panel does the file save). Root transcript + every
+    // descendant actor/subagent session, the audit slice for that set,
+    // cost, secret-free settings, live context snapshots, provenance.
+    // Read-only over the user's own data; the export itself is audited.
+    'session/debugBundle': async ({ sessionId } = {}) => {
+      if (vault.isLocked()) return { ok: false, error: 'locked' };
+      if (typeof sessionId !== 'string' || !sessionId) {
+        return { ok: false, error: 'sessionId-required' };
+      }
+      const session = await sessions.get(sessionId);
+      if (!session) return { ok: false, error: 'session-not-found' };
+      // why the STORE list (not the session/list route): the route hides
+      // actor/subagent rows from the chat list; the bundle wants exactly those.
+      const rows = await sessions.list();
+      const childIds = childSessionIdsOf(rows, sessionId);
+      const childSessions = (await Promise.all(childIds.map((/** @type {string} */ id) => sessions.get(id))))
+        .filter(Boolean);
+      const idSet = new Set([sessionId, ...childIds]);
+      const auditEntries = (await auditLog.list())
+        .filter((/** @type {any} */ e) => e.sessionId && idSet.has(e.sessionId));
+      const settings = settingsStore.get();
+      const bundle = assembleDebugBundle({
+        session, childSessions, auditEntries, settings,
+        contextSnapshots: contextSnapshots.snapshotsForMany([sessionId, ...childIds]),
+        channel: CHANNEL,
+        appVersion: browser.runtime.getManifest?.().version ?? 'unknown',
+        now: Date.now(),
+        limits: { auditMaxEntries: settings.auditLogMaxEntries, ...contextSnapshots.limits() },
+      });
+      auditLog.append({
+        type: 'debug_bundle_exported', sessionId,
+        details: { childSessions: childSessions.length, auditEntries: auditEntries.length },
+      }).catch(() => {});
+      return { ok: true, bundle };
+    },
+
+    // The context inspector's read: the live "what did the model see"
+    // snapshots for one session (SW-memory ring; empty after an SW restart
+    // — the inspector view says so rather than implying nothing ran).
+    'session/contextSnapshots': async ({ sessionId } = {}) => {
+      if (vault.isLocked()) return { ok: false, error: 'locked' };
+      if (typeof sessionId !== 'string' || !sessionId) {
+        return { ok: false, error: 'sessionId-required' };
+      }
+      return { ok: true, snapshots: contextSnapshots.snapshotsFor(sessionId) };
     },
 
     // --- subagents ---

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -246,6 +246,7 @@ import { createJsClient } from './notebook-client.js';
 import { createJsTabTracker } from './notebook-tab-tracker.js';
 import { makeOffscreenJsClient } from './offscreen-js-client.js';
 import { createScriptRunRegistry } from './script-runs.js';
+import { createContextSnapshots } from './context-snapshots.js';
 import { makeOffscreenActorClient } from './offscreen-actor-client.js';
 import { makeOffscreenPdfClient } from './offscreen-pdf-client.js';
 import { makeUiPorts } from './ui-ports.js';
@@ -1741,6 +1742,12 @@ const jsOffscreenClient = offscreenAvailable ? makeOffscreenJsClient({
 // consumers run) and read by the actors/call route below.
 const scriptRuns = createScriptRunRegistry();
 
+// The context inspector's capture ring — "what did the model see" per
+// session, SW-memory only. Fed from the two seams that together cover
+// every model call (the turn driver's failover wrapper, the actor relay
+// route below); read by the debug-bundle route and the inspector view.
+const contextSnapshots = createContextSnapshots();
+
 // The heap split: the ONE offscreen agent-loop client. It runs every non-
 // orchestrator loop — an ephemeral reasoning subagent (spawn.js, tools:[]) OR a
 // bound actor (VM/Notebook/App/web) — in its own dedicated Worker heap. Its
@@ -1765,6 +1772,7 @@ const actorClient = offscreenAvailable ? makeOffscreenActorClient({
   // adopted tab or undefined (0-tab state); buildToolContext fails closed on a stale id.
   ownedTabFor: (/** @type {string} */ sid) => webActorTabBindings.tabFor(sid),
   EXPOSURE_ACTOR,
+  recordModelCall: contextSnapshots.record,
 }) : null;
 
 // The PDF-extraction client (the read_pdf tool). ensureOffscreen, then a
@@ -2311,6 +2319,7 @@ const { runAgentTurn, maybeAutoResume } = makeTurnDriver({
   resolveFailoverChain, shouldFailover, callModel, runUserTurn, getSecret,
   safeFetch, REASONING_BUDGET_TOKENS, REASONING_EFFORT_LEVELS, DEFAULT_SETTINGS, trimEnricher,
   contextWindowFor, liveContextWindow, currentAppScope, checkpointMgr, detectInterruptedTurn,
+  recordModelCall: contextSnapshots.record,
   // postChatNote is declared just below this call — defer the reference so it
   // resolves at call-time (the same late-declared-dep pattern the orchestrator
   // wiring above uses, see the note at the postChatNote site).

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -236,6 +236,9 @@ import {
   // (addressing + same-origin-lock anchor), and the "what I learned" self-fence.
   makeApiActorBindings, normalizeApiOrigin, fenceApiActorSummary,
   finalAssistantText,
+  // The debug surface: the bundle assembler + the delegation-tree walk the
+  // session/debugBundle route runs (pure; the SW supplies the reads).
+  assembleDebugBundle, childSessionIdsOf,
 } from '/peerd-runtime/index.js';
 
 import { flattenCategorisedDenylist, normalizeDenylistPattern } from '/peerd-egress/index.js';
@@ -3505,6 +3508,8 @@ browser.runtime.onMessage.addListener(/** @type {any} */ (makeDispatcher({
     // PR #134 phase 5: agent/stop also cascades through the live subagent
     // subtree (children run under their own turn slots now).
     subagentLifecycle,
+    // The debug surface: session/debugBundle + session/contextSnapshots.
+    settingsStore, contextSnapshots, assembleDebugBundle, childSessionIdsOf, CHANNEL,
   }),
   ...makeEngineRoutes({
     vault, auditLog, pushState, browser, vmHttpFetch, appRegistry, vmRegistry, jsRegistry,

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -1244,6 +1244,9 @@ const spawnSubagentCore = makeSpawnSubagent({
   sessions,
   runUserTurn,
   callModel: /** @type {any} */ (callModel),
+  // why the closure: contextSnapshots is declared further down the module —
+  // defer the reference to call time (the postChatNote late-dep pattern).
+  recordModelCall: (/** @type {Record<string, any>} */ call) => contextSnapshots.record(call),
   getSecret,
   safeFetch,
   appendAudit: /** @type {any} */ (auditLog.append),

--- a/extension/options/sections/transfer.js
+++ b/extension/options/sections/transfer.js
@@ -7,11 +7,12 @@
 
 import m from '/vendor/mithril/mithril.js';
 import { CHANNEL } from '/shared/channel-config.js';
+import { bundleToOtlp } from '/peerd-runtime/index.js';
 
 /** @typedef {import('./reset-row.js').Send} Send */
 
 export const TransferSection = {
-  /** @param {{ state: any }} vnode */
+  /** @param {{ state: any, attrs: { send: Send } }} vnode */
   oninit(vnode) {
     vnode.state.exportPass = '';
     vnode.state.exportConfirm = '';
@@ -30,10 +31,55 @@ export const TransferSection = {
     vnode.state.artifactSummary = null;       // import/inspect summary
     vnode.state.artifactBusy = false;
     vnode.state.artifactMsg = null;           // { ok, text } | null
+    // Debug bundle (the debug surface's options-page entry point): a session
+    // picker over ALL chats — unlike the in-chat debug chip, this reaches any
+    // past session without opening it.
+    vnode.state.debugSessions = null;         // null = loading; [] = none
+    vnode.state.debugSessionId = '';
+    vnode.state.debugBusy = false;
+    vnode.state.debugMsg = null;              // { ok, text } | null
+    Promise.resolve(vnode.attrs.send({ type: 'session/list' })).then((reply) => {
+      vnode.state.debugSessions = reply?.ok !== false && Array.isArray(reply?.sessions) ? reply.sessions : [];
+      vnode.state.debugSessionId = vnode.state.debugSessions[0]?.sessionId ?? '';
+      m.redraw();
+    }).catch(() => { vnode.state.debugSessions = []; m.redraw(); });
   },
 
   /** @param {{ attrs: { send: Send }, state: any }} vnode */
   view: ({ attrs: { send }, state: ui }) => {
+    // The debug surface: same route + pure OTel mapper the in-chat chip uses;
+    // the options page adds only the session picker (any chat, not just the
+    // open one) and this save shell.
+    const exportDebug = async (/** @type {'json'|'otlp'} */ format) => {
+      if (ui.debugBusy || !ui.debugSessionId) return;
+      ui.debugBusy = true;
+      ui.debugMsg = null;
+      m.redraw();
+      try {
+        const reply = await send({ type: 'session/debugBundle', sessionId: ui.debugSessionId });
+        if (!reply?.ok) {
+          ui.debugMsg = {
+            ok: false,
+            text: reply?.error === 'locked' ? 'Vault is locked \u2014 unlock in the peerd panel first.' : (reply?.error ?? 'Export failed.'),
+          };
+          return;
+        }
+        const payload = format === 'otlp' ? bundleToOtlp(reply.bundle) : reply.bundle;
+        const stem = format === 'otlp' ? 'peerd-trace' : 'peerd-debug';
+        const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${stem}-${ui.debugSessionId.slice(0, 8)}-${new Date().toISOString().slice(0, 10)}.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+        ui.debugMsg = { ok: true, text: format === 'otlp' ? 'OTel trace saved.' : 'Debug bundle saved.' };
+      } finally {
+        ui.debugBusy = false;
+        m.redraw();
+      }
+    };
+
     const doExport = async () => {
       if (ui.exportBusy) return;
       ui.exportMsg = null;
@@ -252,6 +298,36 @@ export const TransferSection = {
       // file's hashes verify AND the user clicks Apply; imports always
       // create a NEW artifact (fresh id), never overwriting one.
       m('.settings-divider'),
+      m('h3', 'Debug bundle'),
+      m('p', 'Download one chat\u2019s whole debugging story as a local JSON file: '
+        + 'the transcript (including every actor and subagent it delegated to), the '
+        + 'audit slice, cost, settings, and live context snapshots \u2014 or the same '
+        + 'data as an OpenTelemetry trace for any OTel viewer. Nothing is sent '
+        + 'anywhere; API keys cannot appear in either file.'),
+      m('.input-row', [
+        m('label', { for: 'dbgsess' }, 'Chat'),
+        ui.debugSessions === null
+          ? m('span.muted', 'loading\u2026')
+          : ui.debugSessions.length === 0
+            ? m('span.muted', 'no chats yet')
+            : m('select', {
+                id: 'dbgsess', value: ui.debugSessionId, disabled: ui.debugBusy,
+                onchange: (/** @type {{ target: HTMLSelectElement }} */ e) => { ui.debugSessionId = e.target.value; },
+              }, ui.debugSessions.map((/** @type {any} */ row) => m('option', { value: row.sessionId },
+                `${row.title || '(untitled)'} \u00b7 ${new Date(row.createdAt).toLocaleString()}`))),
+      ]),
+      m('.button-row', [
+        m('button', {
+          disabled: ui.debugBusy || !ui.debugSessionId,
+          onclick: () => exportDebug('json'),
+        }, 'Export debug bundle'),
+        m('button.secondary', {
+          disabled: ui.debugBusy || !ui.debugSessionId,
+          onclick: () => exportDebug('otlp'),
+        }, 'Export OTel trace'),
+      ]),
+      ui.debugMsg ? m(ui.debugMsg.ok ? 'p.ok-msg' : 'p.err-msg', ui.debugMsg.text) : null,
+
       m('h3', 'Artifacts'),
       m('p', 'Import an app, Notebook, or VM recipe from a .peerd file '
         + '(exported via the Export button in the artifact’s own tab). '

--- a/extension/peerd-runtime/index.js
+++ b/extension/peerd-runtime/index.js
@@ -304,3 +304,13 @@ export {
   SessionNotFoundError,
   RuntimeContextIncompleteError,
 } from './errors.js';
+
+// --- observability (the debug surface: bundle export, failure classes,
+// OTel mapping — all pure; the SW route and the side panel consume them) --
+export { classifyFailure, FAILURE_KINDS } from './observability/failure-classify.js';
+export {
+  assembleDebugBundle, childSessionIdsOf, collectFailures,
+  DEBUG_BUNDLE_FORMAT, DEBUG_BUNDLE_VERSION,
+  BUNDLE_MAX_AUDIT_ENTRIES, BUNDLE_MAX_CHILD_SESSIONS,
+} from './observability/debug-bundle.js';
+export { bundleToOtlp, traceIdFromUuid, spanIdFrom } from './observability/otel-export.js';

--- a/extension/peerd-runtime/loop/turn-driver.js
+++ b/extension/peerd-runtime/loop/turn-driver.js
@@ -44,6 +44,9 @@ export const makeTurnDriver = (/** @type {any} */ deps) => {
     safeFetch, REASONING_BUDGET_TOKENS, REASONING_EFFORT_LEVELS, DEFAULT_SETTINGS, trimEnricher,
     contextWindowFor, liveContextWindow, currentAppScope,
     checkpointMgr, detectInterruptedTurn,
+    // The context inspector's capture hook (optional; a no-op default so the
+    // driver never depends on the debug surface being wired).
+    recordModelCall = () => {},
   } = deps;
 
 /**
@@ -399,6 +402,12 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
   const callModelWithFailover = async function* (/** @type {any} */ modelArgs) {
     const start = failoverLastGood ?? { provider: modelArgs.provider, model: modelArgs.model };
     const chain = resolveFailoverChain(start);
+    // The context inspector sees every ORCHESTRATOR model call here — the
+    // one seam every step of every main turn passes through. (Actors and
+    // subagents are captured at the SW's actor/model-call relay instead.)
+    // record() is contractually non-throwing; label with the provider the
+    // call will actually start on.
+    recordModelCall({ ...modelArgs, provider: start.provider, model: start.model, sessionId, label: 'main' });
     // why: the Ollama adapter reads `ollamaHost` to reach a remote daemon (issue
     // #104). Thread it from settings for every candidate; non-ollama adapters
     // ignore the extra arg. (The configured host is also on the egress allowlist.)

--- a/extension/peerd-runtime/observability/debug-bundle.js
+++ b/extension/peerd-runtime/observability/debug-bundle.js
@@ -1,0 +1,168 @@
+// @ts-check
+// observability/debug-bundle.js — the debug-bundle assembler.
+//
+// One session's whole debugging story in one local JSON file: the full
+// transcript (root session + every child actor/subagent session it
+// spawned), the audit slice for those sessions, cost, the secret-free
+// settings snapshot, any live context snapshots, and a provenance block
+// that says honestly what may be missing (pruned audit, evicted
+// snapshots). The SW route does the IO reads; THIS module is pure —
+// values in, one bundle out — so the whole shape is bun-testable.
+//
+// why local export and not telemetry: peerd has no backend by design.
+// Observability here means the user's own data leaves IndexedDB as a
+// file THE USER saves, on purpose, per session — never a wire.
+//
+// Secrets: none reach this module by construction. API keys live only
+// in the vault (settings and session records never hold them), and the
+// context snapshots are shaped key-free at capture. The assembler still
+// never touches a vault or kv handle — it can only emit what it is
+// handed.
+
+import { classifyFailure } from './failure-classify.js';
+import { normalizeTally } from '../cost/accumulator.js';
+
+export const DEBUG_BUNDLE_FORMAT = 'peerd-debug-bundle';
+export const DEBUG_BUNDLE_VERSION = 1;
+
+// Caps: a bundle is a debugging artifact, not an archive. The transcript
+// is included whole (it IS the story), but the unbounded collections are
+// clamped so a monster session still exports in one breath.
+export const BUNDLE_MAX_AUDIT_ENTRIES = 2000;
+export const BUNDLE_MAX_CHILD_SESSIONS = 40;
+
+/**
+ * Walk the parent links to collect every descendant session of the root
+ * (actors + subagents, transitively). Pure: operates on the already-read
+ * session rows, returns ids in stable creation order.
+ * @param {Array<{ sessionId: string, parentSessionId?: string, createdAt?: number }>} allSessions
+ * @param {string} rootId
+ * @returns {string[]}
+ */
+export const childSessionIdsOf = (allSessions, rootId) => {
+  /** @type {Map<string, string[]>} */
+  const byParent = new Map();
+  for (const s of allSessions) {
+    if (!s.parentSessionId) continue;
+    const list = byParent.get(s.parentSessionId) ?? [];
+    list.push(s.sessionId);
+    byParent.set(s.parentSessionId, list);
+  }
+  /** @type {string[]} */
+  const out = [];
+  const queue = [rootId];
+  const seen = new Set(queue);
+  while (queue.length > 0) {
+    const id = queue.shift();
+    for (const child of byParent.get(/** @type {string} */ (id)) ?? []) {
+      if (seen.has(child)) continue; // why: defensive — a corrupt parent cycle must not hang the export
+      seen.add(child);
+      out.push(child);
+      queue.push(child);
+    }
+  }
+  return out;
+};
+
+/**
+ * Scan one session's messages for every failure and classify each: the
+ * bundle's "what went wrong, where" index. Failed turns are message-level
+ * `error` strings; failed tools are result blocks with is_error.
+ * @param {Record<string, any>} session  a session record with messages
+ */
+export const collectFailures = (session) => {
+  /** @type {Array<Record<string, unknown>>} */
+  const failures = [];
+  for (const message of session.messages ?? []) {
+    if (typeof message.error === 'string' && message.error) {
+      failures.push({
+        sessionId: session.sessionId,
+        messageId: message.id,
+        when: message.when,
+        scope: 'turn',
+        ...classifyFailure(message.error, { stopReason: message.stopReason }),
+        error: message.error,
+      });
+    }
+    for (const result of message.toolResults ?? []) {
+      if (!result.is_error) continue;
+      const content = typeof result.content === 'string' ? result.content : JSON.stringify(result.content ?? '');
+      failures.push({
+        sessionId: session.sessionId,
+        messageId: message.id,
+        toolUseId: result.tool_use_id,
+        when: message.when,
+        scope: 'tool',
+        ...classifyFailure(content),
+        error: content.slice(0, 2000),
+      });
+    }
+  }
+  return failures;
+};
+
+/**
+ * Assemble the bundle. Everything is passed in; nothing is read here.
+ * @param {object} input
+ * @param {Record<string, any>} input.session          the full assembled root session (with messages)
+ * @param {Array<Record<string, any>>} [input.childSessions]  full assembled child sessions (actors/subagents)
+ * @param {Array<Record<string, any>>} [input.auditEntries]   the audit slice, already filtered to these sessions
+ * @param {Record<string, any>} [input.settings]       the merged secret-free settings snapshot
+ * @param {Array<Record<string, any>>} [input.contextSnapshots]  live model-request snapshots for these sessions
+ * @param {string} [input.channel]
+ * @param {string} [input.appVersion]
+ * @param {number} input.now
+ * @param {{ auditMaxEntries?: number, snapshotsPerSession?: number }} [input.limits]  the caps in force at capture, for provenance
+ */
+export const assembleDebugBundle = ({
+  session, childSessions = [], auditEntries = [], settings = {},
+  contextSnapshots = [], channel, appVersion, now, limits = {},
+}) => {
+  const children = childSessions.slice(0, BUNDLE_MAX_CHILD_SESSIONS);
+  const audit = auditEntries.slice(-BUNDLE_MAX_AUDIT_ENTRIES);
+  const failures = [session, ...children].flatMap((s) => collectFailures(s));
+  const cost = normalizeTally(session.cost);
+  const toolCalls = [session, ...children]
+    .flatMap((s) => s.messages ?? [])
+    .reduce((n, msg) => n + (msg.toolUses?.length ?? 0), 0);
+
+  return {
+    format: DEBUG_BUNDLE_FORMAT,
+    version: DEBUG_BUNDLE_VERSION,
+    exportedAt: new Date(now).toISOString(),
+    channel: channel ?? 'unknown',
+    appVersion: appVersion ?? 'unknown',
+    summary: {
+      sessionId: session.sessionId,
+      title: session.title ?? '',
+      provider: session.provider,
+      model: session.model,
+      turns: cost.turns,
+      messages: (session.messages ?? []).length,
+      toolCalls,
+      childSessions: children.length,
+      failures: failures.length,
+      cost,
+    },
+    session,
+    childSessions: children,
+    failures,
+    audit,
+    contextSnapshots,
+    settings,
+    provenance: {
+      // why: honesty over implication — a reader must know what absence means.
+      audit: `append-only log, retention-capped at ${limits.auditMaxEntries ?? 'default'} entries; `
+        + `entries for old sessions may have been pruned. This slice is filtered to the sessions above${
+         auditEntries.length > BUNDLE_MAX_AUDIT_ENTRIES ? `, then clamped to the last ${BUNDLE_MAX_AUDIT_ENTRIES}.` : '.'}`,
+      contextSnapshots: `in-memory ring (last ${limits.snapshotsPerSession ?? 'N'} model calls per session), `
+        + 'held for the service worker\'s lifetime only — empty after a browser restart or worker eviction, '
+        + 'not an error.',
+      childSessions: childSessions.length > BUNDLE_MAX_CHILD_SESSIONS
+        ? `clamped: ${childSessions.length} descendants existed, first ${BUNDLE_MAX_CHILD_SESSIONS} included.`
+        : 'all descendant actor/subagent sessions included.',
+      secrets: 'none by construction: API keys live only in the vault and are attached at fetch-header '
+        + 'time; they never enter settings, session records, or captured request bodies.',
+    },
+  };
+};

--- a/extension/peerd-runtime/observability/failure-classify.js
+++ b/extension/peerd-runtime/observability/failure-classify.js
@@ -44,20 +44,30 @@ const RULES = [
   // auth beats provider (a 401 is a key problem before an API problem).
   { kind: 'aborted', test: /^script_aborted:|stopped before the (actor|run)|aborted \(Stop\)|aborted \(timeout or cancel\)|\bstop was pressed\b/i },
   { kind: 'aborted', test: /^the turn was stopped\b|\bcancelled by the user\b/i },
-  { kind: 'policy', test: /^message_actor:|^subagent refused\b|^tool_blocked\b|not on the main agent's surface/i },
-  { kind: 'policy', test: /\begress denied\b|\bdenylist\b|\bblocked by (policy|the allowlist|plan mode)\b|EgressDeniedError|NotebookEgressBlocked/i },
+  // why gate_blocked/hook_blocked (not 'tool_blocked'): these are the
+  // dispatcher's ACTUAL refusal prefixes in tool results (dispatcher.js);
+  // tool_blocked is only the audit event's type and never reaches a card.
+  { kind: 'policy', test: /^message_actor:|^subagent refused\b|^gate_blocked:|^hook_blocked:/i },
+  { kind: 'policy', test: /\begress denied\b|\bdenylist\b|\bblocked by (policy|the allowlist|plan mode)\b|EgressDeniedError|NotebookEgressBlocked|\bUser declined\b|\bdeclined by (the )?user\b/i },
   { kind: 'auth', test: /\bvault is locked\b|VaultLockedError|\bunlock the vault\b/i },
-  { kind: 'auth', test: /\bAPI key\b.*\b(missing|not set|invalid|rejected)\b|ProviderKeyMissingError|HTTP 40[13]\b/i },
+  // why the 40[13] is anchored to the provider shape: bare "HTTP 403" also
+  // appears in asset-download failures (VM imports, skills, model files),
+  // which are environment trouble, not a credential problem.
+  { kind: 'auth', test: /\bAPI key\b.*\b(missing|not set|invalid|rejected)\b|ProviderKeyMissingError|^Provider '.+' HTTP 40[13]\b/i },
   // why this row sits ABOVE limits: the canned early-EOF string is
   // "provider stream ended early (likely rate limit or network drop)" —
   // the guess in the parenthetical must not reclassify a dead stream.
   { kind: 'provider', test: /\bprovider stream ended early\b/i },
   { kind: 'limits', test: /HTTP 402\b|HTTP 429\b|\busage limit\b|\bspend limit\b|\brate.?limit/i },
-  { kind: 'timeout', test: /\btimed? ?out\b|VMRunTimeoutError|\bwall.?clock\b.*\bexceeded\b/i },
-  { kind: 'provider', test: /^Provider '.+' HTTP \d+|OllamaNotRunning|\bOllama\b.*\b(not running|unreachable)\b/i },
-  { kind: 'environment', test: /^no_option_matching:|\bno element matching\b|\bactor tool relay failed\b/i },
-  { kind: 'environment', test: /VM(NotReady|BootFailed|TabClosed|NetworkDenied)|\bthe VM tab (was )?closed\b|\bsandbox\b.*\b(crash|failed to boot)\b|\bworker (crashed|terminated unexpectedly)\b/i },
+  // why agent sits ABOVE timeout: an actor-reported failure ("could not
+  // complete your request: … timed out …") is the AGENT's account — the
+  // delegated turn ran and failed in its own words; the timeout detail
+  // inside it must not reclassify who failed.
   { kind: 'agent', test: /\bcould not complete your request\b|\bthe actor turn failed\b|\bREPORTED FAILURE\b|\bproduced no text reply\b/i },
+  { kind: 'timeout', test: /\btimed? ?out\b|VMRunTimeoutError|\bwall.?clock\b.*\bexceeded\b/i },
+  { kind: 'provider', test: /^Provider '.+' HTTP \d+|OllamaNotRunning|\bOllama\b.*\b(not running|unreachable)\b|\bFailed to fetch\b/i },
+  { kind: 'environment', test: /^no_option_matching:|\bno element matching\b|\bactor tool relay failed\b|^fetch_failed:|\bfetch returned HTTP\b|\bHTTP \d+ for http/i },
+  { kind: 'environment', test: /VM(NotReady|BootFailed|TabClosed|NetworkDenied)|\bthe VM tab (was )?closed\b|\bsandbox\b.*\b(crash|failed to boot)\b|\bworker (crashed|terminated unexpectedly)\b/i },
 ];
 
 /**

--- a/extension/peerd-runtime/observability/failure-classify.js
+++ b/extension/peerd-runtime/observability/failure-classify.js
@@ -54,7 +54,7 @@ const RULES = [
   { kind: 'provider', test: /\bprovider stream ended early\b/i },
   { kind: 'limits', test: /HTTP 402\b|HTTP 429\b|\busage limit\b|\bspend limit\b|\brate.?limit/i },
   { kind: 'timeout', test: /\btimed? ?out\b|VMRunTimeoutError|\bwall.?clock\b.*\bexceeded\b/i },
-  { kind: 'provider', test: /^Provider '.+' HTTP \d+|\bprovider stream ended early\b|OllamaNotRunning|\bOllama\b.*\b(not running|unreachable)\b/i },
+  { kind: 'provider', test: /^Provider '.+' HTTP \d+|OllamaNotRunning|\bOllama\b.*\b(not running|unreachable)\b/i },
   { kind: 'environment', test: /^no_option_matching:|\bno element matching\b|\bactor tool relay failed\b/i },
   { kind: 'environment', test: /VM(NotReady|BootFailed|TabClosed|NetworkDenied)|\bthe VM tab (was )?closed\b|\bsandbox\b.*\b(crash|failed to boot)\b|\bworker (crashed|terminated unexpectedly)\b/i },
   { kind: 'agent', test: /\bcould not complete your request\b|\bthe actor turn failed\b|\bREPORTED FAILURE\b|\bproduced no text reply\b/i },
@@ -70,9 +70,12 @@ const RULES = [
 export const classifyFailure = (error, context = {}) => {
   // A turn the user stopped is 'aborted' regardless of what text survived.
   if (context.stopReason === 'aborted') return { kind: 'aborted', label: 'aborted' };
-  const text = typeof error === 'string'
+  // why the slice: the chip render path classifies raw transcript strings on
+  // every redraw; the class is always decided in the first bytes, and a
+  // bounded input keeps regex work O(1) even on a megabyte error dump.
+  const text = (typeof error === 'string'
     ? error
-    : String(/** @type {{ message?: unknown }} */ (error)?.message ?? error ?? '');
+    : String(/** @type {{ message?: unknown }} */ (error)?.message ?? error ?? '')).slice(0, 4000);
   for (const rule of RULES) {
     if (rule.test.test(text)) return { kind: rule.kind, label: rule.kind };
   }

--- a/extension/peerd-runtime/observability/failure-classify.js
+++ b/extension/peerd-runtime/observability/failure-classify.js
@@ -1,0 +1,80 @@
+// @ts-check
+// observability/failure-classify.js — the failure-reason classifier.
+//
+// One pure function that maps the error strings this codebase actually
+// produces (named TypedError messages, stable tool-result prefixes,
+// provider HTTP shapes, actor-reply failure leads) onto a SMALL stable
+// taxonomy. Consumed three ways: the side panel renders the kind as a
+// chip on failed cards/turns, the debug bundle annotates every failure,
+// and the OTel export stamps it as a span attribute.
+//
+// why a string classifier and not error-class dispatch: by the time a
+// failure is visible anywhere (transcript, audit, bundle) it has been
+// serialized to a string — the classes are long gone. The stable
+// surface IS the message text, so the taxonomy keys off the prefixes
+// and phrases the code deliberately keeps stable.
+//
+// Pure (values in, values out) — bun-tested.
+
+/**
+ * The taxonomy. Small on purpose: a debugging user needs the NEIGHBORHOOD
+ * of the failure (whose fault, roughly), not a per-error label — the raw
+ * message is always right next to the chip.
+ * - policy       — a peerd gate refused it (exposure, sender gate, denylist, egress)
+ * - auth         — locked vault / missing or rejected credentials
+ * - limits       — spend/usage/rate limits (yours or the provider's)
+ * - provider     — the model API failed (HTTP errors, dead streams, unreachable local host)
+ * - timeout      — a bounded wait expired
+ * - aborted      — Stop / cancellation ended it on purpose
+ * - environment  — the world didn't cooperate (page element missing, sandbox/VM trouble)
+ * - agent        — the delegated agent ran and reported failure in its own words
+ * - internal     — everything else: an unclassified bug
+ * @typedef {'policy'|'auth'|'limits'|'provider'|'timeout'|'aborted'|'environment'|'agent'|'internal'} FailureKind
+ */
+
+export const FAILURE_KINDS = Object.freeze([
+  'policy', 'auth', 'limits', 'provider', 'timeout', 'aborted', 'environment', 'agent', 'internal',
+]);
+
+/** @type {Array<{ kind: FailureKind, test: RegExp }>} */
+const RULES = [
+  // ORDER MATTERS: earlier rows win. Deliberate precedence:
+  // aborted beats timeout ("aborted (timeout or cancel)" is a Stop shape),
+  // limits beat provider (an HTTP 429 is a limit before it is an HTTP error),
+  // auth beats provider (a 401 is a key problem before an API problem).
+  { kind: 'aborted', test: /^script_aborted:|stopped before the (actor|run)|aborted \(Stop\)|aborted \(timeout or cancel\)|\bstop was pressed\b/i },
+  { kind: 'aborted', test: /^the turn was stopped\b|\bcancelled by the user\b/i },
+  { kind: 'policy', test: /^message_actor:|^subagent refused\b|^tool_blocked\b|not on the main agent's surface/i },
+  { kind: 'policy', test: /\begress denied\b|\bdenylist\b|\bblocked by (policy|the allowlist|plan mode)\b|EgressDeniedError|NotebookEgressBlocked/i },
+  { kind: 'auth', test: /\bvault is locked\b|VaultLockedError|\bunlock the vault\b/i },
+  { kind: 'auth', test: /\bAPI key\b.*\b(missing|not set|invalid|rejected)\b|ProviderKeyMissingError|HTTP 40[13]\b/i },
+  // why this row sits ABOVE limits: the canned early-EOF string is
+  // "provider stream ended early (likely rate limit or network drop)" —
+  // the guess in the parenthetical must not reclassify a dead stream.
+  { kind: 'provider', test: /\bprovider stream ended early\b/i },
+  { kind: 'limits', test: /HTTP 402\b|HTTP 429\b|\busage limit\b|\bspend limit\b|\brate.?limit/i },
+  { kind: 'timeout', test: /\btimed? ?out\b|VMRunTimeoutError|\bwall.?clock\b.*\bexceeded\b/i },
+  { kind: 'provider', test: /^Provider '.+' HTTP \d+|\bprovider stream ended early\b|OllamaNotRunning|\bOllama\b.*\b(not running|unreachable)\b/i },
+  { kind: 'environment', test: /^no_option_matching:|\bno element matching\b|\bactor tool relay failed\b/i },
+  { kind: 'environment', test: /VM(NotReady|BootFailed|TabClosed|NetworkDenied)|\bthe VM tab (was )?closed\b|\bsandbox\b.*\b(crash|failed to boot)\b|\bworker (crashed|terminated unexpectedly)\b/i },
+  { kind: 'agent', test: /\bcould not complete your request\b|\bthe actor turn failed\b|\bREPORTED FAILURE\b|\bproduced no text reply\b/i },
+];
+
+/**
+ * Classify one failure. Accepts the serialized error text plus optional
+ * context that can settle ambiguity without string-sniffing.
+ * @param {unknown} error  the error text (or an Error-like with .message)
+ * @param {{ stopReason?: string }} [context]
+ * @returns {{ kind: FailureKind, label: string }}
+ */
+export const classifyFailure = (error, context = {}) => {
+  // A turn the user stopped is 'aborted' regardless of what text survived.
+  if (context.stopReason === 'aborted') return { kind: 'aborted', label: 'aborted' };
+  const text = typeof error === 'string'
+    ? error
+    : String(/** @type {{ message?: unknown }} */ (error)?.message ?? error ?? '');
+  for (const rule of RULES) {
+    if (rule.test.test(text)) return { kind: rule.kind, label: rule.kind };
+  }
+  return { kind: 'internal', label: 'internal' };
+};

--- a/extension/peerd-runtime/observability/otel-export.js
+++ b/extension/peerd-runtime/observability/otel-export.js
@@ -29,7 +29,8 @@ const STATUS_ERROR = 2;
 export const traceIdFromUuid = (uuid) => {
   const hex = String(uuid ?? '').toLowerCase().replace(/[^0-9a-f]/g, '');
   // why pad/clamp instead of throwing: a corrupt id must not kill the export
-  return (hex + '0'.repeat(32)).slice(0, 32);
+  const id = (hex + '0'.repeat(32)).slice(0, 32);
+  return id === '0'.repeat(32) ? `1${id.slice(1)}` : id; // all-zero traceId is invalid in OTel
 };
 
 /**
@@ -158,8 +159,16 @@ export const bundleToOtlp = (bundle) => {
   const traceId = traceIdFromUuid(session.sessionId);
   const rootSpanId = spanIdFrom(`session:${session.sessionId}`);
   const spans = sessionSpans(session, traceId, undefined);
+  // why real parentage: the delegation TREE is the claim ("delegation =
+  // span parentage") — a grandchild (a VM actor a subagent spawned) must
+  // hang off its spawner, not flatten onto the chat root. Fall back to the
+  // root only when the parent isn't in the bundle (clamped out).
+  const included = new Set([session.sessionId, ...(bundle.childSessions ?? []).map((/** @type {Record<string, any>} */ c) => c.sessionId)]);
   for (const child of bundle.childSessions ?? []) {
-    spans.push(...sessionSpans(child, traceId, rootSpanId));
+    const parentId = child.parentSessionId && included.has(child.parentSessionId)
+      ? spanIdFrom(`session:${child.parentSessionId}`)
+      : rootSpanId;
+    spans.push(...sessionSpans(child, traceId, parentId));
   }
   const cost = bundle.summary?.cost ?? {};
   return {

--- a/extension/peerd-runtime/observability/otel-export.js
+++ b/extension/peerd-runtime/observability/otel-export.js
@@ -50,8 +50,13 @@ export const spanIdFrom = (s) => {
   return hex === '0'.repeat(16) ? '1'.repeat(16) : hex; // all-zero spanId is invalid in OTel
 };
 
-/** @param {number} ms */
-const ns = (ms) => String(Math.max(0, Math.round(ms)) * 1e6);
+/**
+ * ms → OTLP nanosecond string. BigInt because ms × 1e6 exceeds the float
+ * safe-integer range (a 2026 epoch is ~1.7e18 ns) and OTLP wants an exact
+ * integer string; non-finite input (a corrupt record) degrades to 0.
+ * @param {number} ms
+ */
+const ns = (ms) => String(BigInt(Number.isFinite(ms) ? Math.max(0, Math.round(ms)) : 0) * 1_000_000n);
 
 /** @param {string} key @param {unknown} value */
 const attr = (key, value) => (typeof value === 'number' && Number.isFinite(value)

--- a/extension/peerd-runtime/observability/otel-export.js
+++ b/extension/peerd-runtime/observability/otel-export.js
@@ -1,0 +1,178 @@
+// @ts-check
+// observability/otel-export.js — debug bundle → OTLP/JSON spans.
+//
+// A pure mapper from the peerd debug bundle to an OpenTelemetry
+// OTLP/JSON trace document (the body of an ExportTraceServiceRequest),
+// so a session can be dropped into any OTel-speaking viewer the user
+// already runs. Span tree: one root span per session (the chat session
+// and each descendant actor/subagent session), a child span per model
+// turn, and a grandchild span per tool call. Failures carry span status
+// ERROR plus the classified `peerd.failure.kind` attribute.
+//
+// why a second FORMAT and not a second export path: the mapper is pure
+// over the already-assembled bundle, so the side panel converts locally
+// and saves a second file — same route, same data, no vendor, no wire.
+// GenAI attributes follow the OTel gen_ai.* semconv where peerd has the
+// value (system/model/token usage); everything peerd-specific is under
+// the peerd.* namespace.
+
+import { classifyFailure } from './failure-classify.js';
+
+const SPAN_KIND_INTERNAL = 1;
+const STATUS_OK = 0; // OTel STATUS_CODE_UNSET — the honest default for "it ran"
+const STATUS_ERROR = 2;
+
+/**
+ * uuid → 32-char lowercase hex traceId (uuids are already 32 hex digits + dashes).
+ * @param {unknown} uuid
+ */
+export const traceIdFromUuid = (uuid) => {
+  const hex = String(uuid ?? '').toLowerCase().replace(/[^0-9a-f]/g, '');
+  // why pad/clamp instead of throwing: a corrupt id must not kill the export
+  return (hex + '0'.repeat(32)).slice(0, 32);
+};
+
+/**
+ * Deterministic 16-hex spanId from any string (FNV-1a, folded to 64 bits).
+ * Tool-use ids are not hex ("toolu_…"), so they get hashed; message uuids
+ * go through the same door for uniformity.
+ * @param {unknown} s
+ */
+export const spanIdFrom = (s) => {
+  let h1 = 0x811c9dc5, h2 = 0xcbf29ce4;
+  const str = String(s ?? '');
+  for (let i = 0; i < str.length; i++) {
+    const c = str.charCodeAt(i);
+    h1 = Math.imul(h1 ^ c, 0x01000193) >>> 0;
+    h2 = Math.imul(h2 ^ c, 0x01000197) >>> 0;
+  }
+  const hex = (h1.toString(16).padStart(8, '0') + h2.toString(16).padStart(8, '0'));
+  return hex === '0'.repeat(16) ? '1'.repeat(16) : hex; // all-zero spanId is invalid in OTel
+};
+
+/** @param {number} ms */
+const ns = (ms) => String(Math.max(0, Math.round(ms)) * 1e6);
+
+/** @param {string} key @param {unknown} value */
+const attr = (key, value) => (typeof value === 'number' && Number.isFinite(value)
+  ? { key, value: Number.isInteger(value) ? { intValue: String(value) } : { doubleValue: value } }
+  : { key, value: { stringValue: String(value ?? '') } });
+
+/**
+ * Spans for ONE session record (root span + turns + tool calls).
+ * @param {Record<string, any>} session
+ * @param {string} traceId
+ * @param {string} [parentSpanId]
+ */
+const sessionSpans = (session, traceId, parentSpanId) => {
+  const messages = session.messages ?? [];
+  const started = session.createdAt ?? messages[0]?.when ?? 0;
+  const ended = messages[messages.length - 1]?.when ?? started;
+  const rootId = spanIdFrom(`session:${session.sessionId}`);
+  const kind = session.kind ?? 'chat';
+
+  const root = {
+    traceId, spanId: rootId, ...(parentSpanId ? { parentSpanId } : {}),
+    name: `peerd.session ${kind}${session.actorType ? `:${session.actorType}` : ''}`,
+    kind: SPAN_KIND_INTERNAL,
+    startTimeUnixNano: ns(started), endTimeUnixNano: ns(ended),
+    attributes: [
+      attr('peerd.session.id', session.sessionId),
+      attr('peerd.session.kind', kind),
+      ...(session.actorType ? [attr('peerd.actor.type', session.actorType)] : []),
+      ...(session.depth != null ? [attr('peerd.session.depth', session.depth)] : []),
+      attr('gen_ai.system', session.provider ?? ''),
+      attr('gen_ai.request.model', session.model ?? ''),
+    ],
+    status: { code: STATUS_OK },
+  };
+
+  const spans = /** @type {Array<Record<string, any>>} */ ([root]);
+  // why index-walk: a tool call's END is only observable as the arrival of
+  // its result, which rides the NEXT (user) message — the walk needs lookahead.
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    if (message.role !== 'assistant') continue;
+    const prevWhen = messages[i - 1]?.when ?? started;
+    // why the sessionId prefix: span ids must be unique across the WHOLE
+    // trace, and tool_use/message ids are only unique within one session.
+    const turnId = spanIdFrom(`msg:${session.sessionId}:${message.id}`);
+    const failed = typeof message.error === 'string' && message.error !== '';
+    spans.push({
+      traceId, spanId: turnId, parentSpanId: rootId,
+      name: 'peerd.model_turn',
+      kind: SPAN_KIND_INTERNAL,
+      startTimeUnixNano: ns(prevWhen), endTimeUnixNano: ns(message.when ?? prevWhen),
+      attributes: [
+        attr('gen_ai.request.model', message.model ?? session.model ?? ''),
+        attr('gen_ai.system', message.provider ?? session.provider ?? ''),
+        ...(message.stopReason ? [attr('peerd.turn.stop_reason', message.stopReason)] : []),
+        attr('peerd.turn.tool_calls', message.toolUses?.length ?? 0),
+      ],
+      status: failed
+        ? { code: STATUS_ERROR, message: String(message.error).slice(0, 500) }
+        : { code: STATUS_OK },
+    });
+    if (failed) {
+      spans[spans.length - 1].attributes.push(attr('peerd.failure.kind', classifyFailure(message.error, { stopReason: message.stopReason }).kind));
+    }
+
+    const next = messages[i + 1];
+    const resultsById = new Map((next?.toolResults ?? []).map((/** @type {Record<string, any>} */ r) => [r.tool_use_id, r]));
+    for (const use of message.toolUses ?? []) {
+      const result = resultsById.get(use.id);
+      const isError = result?.is_error === true;
+      const content = typeof result?.content === 'string' ? result.content : '';
+      spans.push({
+        traceId, spanId: spanIdFrom(`tool:${session.sessionId}:${use.id}`), parentSpanId: turnId,
+        name: `peerd.tool ${use.name}`,
+        kind: SPAN_KIND_INTERNAL,
+        startTimeUnixNano: ns(message.when ?? prevWhen),
+        endTimeUnixNano: ns(next?.when ?? message.when ?? prevWhen),
+        attributes: [
+          attr('peerd.tool.name', use.name),
+          ...(isError ? [attr('peerd.failure.kind', classifyFailure(content).kind)] : []),
+        ],
+        status: isError
+          ? { code: STATUS_ERROR, message: content.slice(0, 500) }
+          : { code: STATUS_OK },
+      });
+    }
+  }
+  return spans;
+};
+
+/**
+ * The whole bundle as one OTLP/JSON trace document. One trace, rooted at
+ * the chat session; each descendant session's tree hangs off the root so
+ * the delegation structure is visible as span parentage.
+ * @param {Record<string, any>} bundle  an assembleDebugBundle() result
+ */
+export const bundleToOtlp = (bundle) => {
+  const session = bundle.session ?? {};
+  const traceId = traceIdFromUuid(session.sessionId);
+  const rootSpanId = spanIdFrom(`session:${session.sessionId}`);
+  const spans = sessionSpans(session, traceId, undefined);
+  for (const child of bundle.childSessions ?? []) {
+    spans.push(...sessionSpans(child, traceId, rootSpanId));
+  }
+  const cost = bundle.summary?.cost ?? {};
+  return {
+    resourceSpans: [{
+      resource: {
+        attributes: [
+          attr('service.name', 'peerd'),
+          attr('service.version', bundle.appVersion ?? 'unknown'),
+          attr('peerd.channel', bundle.channel ?? 'unknown'),
+          attr('gen_ai.usage.input_tokens', cost.inputTokens ?? 0),
+          attr('gen_ai.usage.output_tokens', cost.outputTokens ?? 0),
+          attr('peerd.cost.usd', cost.cost ?? 0),
+        ],
+      },
+      scopeSpans: [{
+        scope: { name: 'peerd.observability', version: String(bundle.version ?? 1) },
+        spans,
+      }],
+    }],
+  };
+};

--- a/extension/peerd-runtime/subagent/spawn.js
+++ b/extension/peerd-runtime/subagent/spawn.js
@@ -241,6 +241,9 @@ export const finalAssistantText = (session) => {
  *   and subagentCancel all reach it via the slot's controller. The default is a
  *   standalone stub (a fresh controller per spawn, stop() a no-op) so orchestrators
  *   that never stop children (tests, cheap-call harnesses) need no wiring.
+ * @param {(call: Record<string, any>) => void} [deps.recordModelCall]
+ *   The context inspector's capture hook — sees the in-SW fallback loop's model
+ *   calls (the offscreen path is captured at the actor relay). Optional no-op.
  * @param {(fn: () => void, ms: number) => unknown} [deps.setTimer]
  * @param {(handle: unknown) => void} [deps.clearTimer]
  *   Injected timer pair (setTimeout/clearTimeout in the SW) so the timeout is
@@ -265,6 +268,9 @@ export const makeSpawnSubagent = (deps) => {
       stop: () => false,
     },
     setTimer = (/** @type {() => void} */ fn, /** @type {number} */ ms) => setTimeout(fn, ms),
+    // The context inspector's capture hook (optional no-op, same contract as
+    // the turn driver's): sees the in-SW fallback loop's model calls.
+    recordModelCall = () => {},
     clearTimer = (/** @type {unknown} */ handle) => clearTimeout(/** @type {any} */ (handle)),
     // Heap-split phase 1: run a PURE-REASONING (empty granted toolset) child in a
     // dedicated offscreen Worker — its own heap, no key, no chrome.*, egress-less.
@@ -570,8 +576,14 @@ export const makeSpawnSubagent = (deps) => {
     const getSystemPrompt = () => renderSystemPrompt({ taskOverride: task });
 
     // Guardrail 5 (output cap): inject maxTokens into every model call.
+    // Also the context inspector's THIRD seam: this wrapper only feeds the
+    // in-SW fallback loop (Firefox / offscreen never started) — the
+    // offscreen path's calls are captured at the actor/model-call relay.
     /** @param {object} modelArgs */
-    const cappedCallModel = (modelArgs) => callModel({ ...modelArgs, maxTokens: maxOutputTokens });
+    const cappedCallModel = (modelArgs) => {
+      recordModelCall({ ...modelArgs, sessionId: child.sessionId, label: `subagent d${depth} (in-SW)` });
+      return callModel({ ...modelArgs, maxTokens: maxOutputTokens });
+    };
 
     // why: the child's model usage is yielded as 'usage' events but is NOT
     // folded into the parent/main turn tally (the main SW only accumulates its

--- a/extension/sidepanel/components/chat-view.js
+++ b/extension/sidepanel/components/chat-view.js
@@ -9,7 +9,7 @@
 
 import m from '/vendor/mithril/mithril.js';
 import { LINUX_PATH, HTML5_PATH } from '/vendor/simple-icons/brand-paths.js';
-import { manifestLabel } from '/peerd-runtime/index.js';
+import { manifestLabel, bundleToOtlp } from '/peerd-runtime/index.js';
 import { openOptions } from '/shared/open-options.js';
 import { mapError, errorSettingsTarget } from '../error-display.js';
 import { MessageList } from './message-list.js';
@@ -17,6 +17,20 @@ import { InputBar } from './input-bar.js';
 import { ModeSelector, EffortDial, GoalToggle } from './mode-badge.js';
 import { GoalBar } from './goal-bar.js';
 import { AsyncTasksBar } from './async-tasks-bar.js';
+import { ContextInspector } from './context-inspector.js';
+
+// The transfer section's Blob + anchor pattern — the panel document is a
+// normal DOM context, so a synthetic download link is all a file save takes.
+/** @param {unknown} payload @param {string} filename */
+const saveJsonFile = (payload, filename) => {
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+};
 
 /** @typedef {import('../chat-reducer.js').ChatState} ChatState */
 /** @typedef {(msg: object) => Promise<any>} Send */
@@ -27,6 +41,9 @@ import { AsyncTasksBar } from './async-tasks-bar.js';
  * @typedef {Object} ChatViewState
  * @property {boolean} goalArmed             the Goal toggle's arm state (UI-only)
  * @property {string|null|undefined} _sid    which chat the arm state belongs to
+ * @property {boolean} [debugMenuOpen]       the debug-export flyout's open state
+ * @property {boolean} [inspectorOpen]       the context-inspector modal's open state
+ * @property {Array<Record<string, any>>|null} [snapshots]  the inspector's fetched snapshots (null = loading)
  */
 
 /**
@@ -186,6 +203,49 @@ export const ChatView = {
         state.session?.toolManifest ? m('span.session-sys-badge', {
           title: `Tool manifest active: ${manifestLabel(state.session.toolManifest)} - only that toolset is exposed to the agent this chat.\n\n"/tools" shows it - "/tools full" restores everything.`,
         }, `/tools ${manifestLabel(state.session.toolManifest)}`) : null,
+        // The debug surface's chat entry point: export this session's debug
+        // bundle (transcript + children + audit slice + cost + settings +
+        // live context snapshots) as one local JSON file, or the same data
+        // as OTLP spans. devMode adds the context inspector. Chip-sized on
+        // purpose — support tooling, not a headline control.
+        state.session?.sessionId ? m('.debug-export', [
+          m('button.debug-export-btn', {
+            title: 'Debug: export this chat\'s debug bundle (a local file — nothing is sent anywhere)',
+            onclick: () => { ui.debugMenuOpen = !ui.debugMenuOpen; },
+          }, 'debug'),
+          ui.debugMenuOpen ? m('.debug-menu', [
+            m('button.debug-menu-item', {
+              onclick: async () => {
+                ui.debugMenuOpen = false;
+                const sessionId = state.session?.sessionId;
+                const reply = await send({ type: 'session/debugBundle', sessionId });
+                if (!reply?.ok) return;
+                saveJsonFile(reply.bundle, `peerd-debug-${String(sessionId).slice(0, 8)}-${new Date().toISOString().slice(0, 10)}.json`);
+              },
+            }, 'export debug bundle (.json)'),
+            m('button.debug-menu-item', {
+              onclick: async () => {
+                ui.debugMenuOpen = false;
+                const sessionId = state.session?.sessionId;
+                const reply = await send({ type: 'session/debugBundle', sessionId });
+                if (!reply?.ok) return;
+                // why converted HERE: bundleToOtlp is pure, so the second
+                // format costs no second route and no SW round trip.
+                saveJsonFile(bundleToOtlp(reply.bundle), `peerd-trace-${String(sessionId).slice(0, 8)}-${new Date().toISOString().slice(0, 10)}.json`);
+              },
+            }, 'export OTel trace (.json)'),
+            state.settings?.devMode ? m('button.debug-menu-item', {
+              onclick: async () => {
+                ui.debugMenuOpen = false;
+                ui.inspectorOpen = true;
+                ui.snapshots = null;
+                const reply = await send({ type: 'session/contextSnapshots', sessionId: state.session?.sessionId });
+                ui.snapshots = reply?.ok ? reply.snapshots : [];
+                m.redraw();
+              },
+            }, 'context inspector') : null,
+          ]) : null,
+        ]) : null,
       ]),
 
       // (The per-chat usage chip lives inside the InputBar action row,
@@ -195,6 +255,12 @@ export const ChatView = {
         goalArmed: ui.goalArmed,
         onGoalSent: () => { ui.goalArmed = false; },
       }),
+
+      // The context inspector modal (devMode, opened from the debug menu).
+      ui.inspectorOpen ? m(ContextInspector, {
+        snapshots: ui.snapshots ?? null,
+        onClose: () => { ui.inspectorOpen = false; },
+      }) : null,
     ]);
   },
 };

--- a/extension/sidepanel/components/chat-view.js
+++ b/extension/sidepanel/components/chat-view.js
@@ -44,6 +44,7 @@ const saveJsonFile = (payload, filename) => {
  * @property {boolean} [debugMenuOpen]       the debug-export flyout's open state
  * @property {boolean} [inspectorOpen]       the context-inspector modal's open state
  * @property {Array<Record<string, any>>|null} [snapshots]  the inspector's fetched snapshots (null = loading)
+ * @property {string|null} [snapshotsError]  why the fetch failed (locked vault, etc.), for an honest modal
  */
 
 /**
@@ -67,7 +68,16 @@ export const ChatView = {
   /** @param {ChatViewVnode} vnode */
   view: ({ attrs: { state, send, voiceManager, uiActions, surface, activeTabIsWeb }, state: ui }) => {
     const sid = state.session?.sessionId;
-    if (sid !== ui._sid) { ui._sid = sid; ui.goalArmed = false; }
+    if (sid !== ui._sid) {
+      ui._sid = sid;
+      ui.goalArmed = false;
+      // The debug surface is per-session UI: a flyout or inspector left open
+      // on chat A must not survive a switch to chat B (B would silently show
+      // A's snapshots).
+      ui.debugMenuOpen = false;
+      ui.inspectorOpen = false;
+      ui.snapshots = null;
+    }
     const messages = state.session?.messages ?? [];
     const hasKey = state.providers?.hasKey;
     // Fingerprint of the settings that shape the model-picker options. The
@@ -213,6 +223,9 @@ export const ChatView = {
             title: 'Debug: export this chat\'s debug bundle (a local file — nothing is sent anywhere)',
             onclick: () => { ui.debugMenuOpen = !ui.debugMenuOpen; },
           }, 'debug'),
+          ui.debugMenuOpen ? m('.debug-menu-backdrop', {
+            onclick: () => { ui.debugMenuOpen = false; },
+          }) : null,
           ui.debugMenuOpen ? m('.debug-menu', [
             m('button.debug-menu-item', {
               onclick: async () => {
@@ -239,8 +252,14 @@ export const ChatView = {
                 ui.debugMenuOpen = false;
                 ui.inspectorOpen = true;
                 ui.snapshots = null;
-                const reply = await send({ type: 'session/contextSnapshots', sessionId: state.session?.sessionId });
-                ui.snapshots = reply?.ok ? reply.snapshots : [];
+                try {
+                  const reply = await send({ type: 'session/contextSnapshots', sessionId: state.session?.sessionId });
+                  ui.snapshots = reply?.ok ? reply.snapshots : [];
+                  ui.snapshotsError = reply?.ok ? null : (reply?.error ?? 'request failed');
+                } catch (e) {
+                  ui.snapshots = [];
+                  ui.snapshotsError = /** @type {{ message?: string }} */ (e)?.message ?? String(e);
+                }
                 m.redraw();
               },
             }, 'context inspector') : null,
@@ -259,6 +278,7 @@ export const ChatView = {
       // The context inspector modal (devMode, opened from the debug menu).
       ui.inspectorOpen ? m(ContextInspector, {
         snapshots: ui.snapshots ?? null,
+        error: ui.snapshotsError ?? null,
         onClose: () => { ui.inspectorOpen = false; },
       }) : null,
     ]);

--- a/extension/sidepanel/components/context-inspector.js
+++ b/extension/sidepanel/components/context-inspector.js
@@ -1,0 +1,79 @@
+// @ts-check
+// Context inspector — "what did the model actually see this turn?"
+//
+// A modal over the chat rendering the SW's live per-session snapshot
+// ring: one entry per model call (orchestrator turns AND delegated
+// actor/subagent calls), each showing the shaped request — clipped
+// system prompt, message roster, tool names, params. This is the
+// debugging view for the two hardest bug classes peerd has: compaction
+// surprises ("why did it forget?") and fence regressions ("what
+// exactly entered the context?").
+//
+// Dev-facing by design: the OPEN affordance is devMode-gated in the
+// chat view (the normal user never sees actor plumbing), and the modal
+// says plainly that the ring is SW-memory only — an empty list after a
+// browser restart means "nothing captured yet", not "nothing ran".
+
+import m from '/vendor/mithril/mithril.js';
+
+/** @param {number} when */
+const timeOf = (when) => new Date(when).toLocaleTimeString();
+
+/** One snapshot as a collapsible block. */
+const Snapshot = {
+  /** @param {{ attrs: { snap: Record<string, any> } }} vnode */
+  view: ({ attrs: { snap } }) => m('details.ctx-snap', [
+    m('summary.ctx-snap-summary', [
+      m('span.ctx-snap-label', snap.label),
+      m('span.ctx-snap-meta',
+        `${snap.provider}/${snap.model} · ${snap.messages.length} msgs`
+        + `${snap.droppedMessages ? ` (+${snap.droppedMessages} older dropped)` : ''}`
+        + ` · system ${Math.round((snap.systemChars ?? 0) / 1000)}k chars · ${timeOf(snap.when)}`),
+    ]),
+    m('.ctx-snap-body', [
+      snap.tools?.length
+        ? m('.ctx-snap-tools', `tools: ${snap.tools.join(', ')}`)
+        : null,
+      m('details.ctx-snap-system', [
+        m('summary', 'system prompt (clipped)'),
+        m('pre.ctx-pre', snap.system),
+      ]),
+      snap.messages.map((/** @type {Record<string, any>} */ msg, /** @type {number} */ i) =>
+        m('.ctx-msg', { key: i }, [
+          m('span.ctx-msg-role', msg.role),
+          msg.content ? m('pre.ctx-pre', msg.content) : null,
+          (msg.toolUses ?? []).map((/** @type {Record<string, any>} */ u) =>
+            m('.ctx-msg-tool', `→ ${u.name} ${u.input}`)),
+          (msg.toolResults ?? []).map((/** @type {Record<string, any>} */ r) =>
+            m(`.ctx-msg-result${r.is_error ? '.failed' : ''}`, [
+              m('span.ctx-msg-role', r.is_error ? 'result (error)' : 'result'),
+              m('pre.ctx-pre', r.content),
+            ])),
+        ])),
+    ]),
+  ]),
+};
+
+/**
+ * @typedef {{ snapshots: Array<Record<string, any>> | null, onClose: () => void }} ContextInspectorAttrs
+ */
+export const ContextInspector = {
+  /** @param {{ attrs: ContextInspectorAttrs }} vnode */
+  view: ({ attrs: { snapshots, onClose } }) => m('.peerd-modal-backdrop', { onclick: onClose },
+    m('.peerd-modal.context-inspector', { onclick: (/** @type {Event} */ e) => e.stopPropagation() }, [
+      m('.ctx-header', [
+        m('span.ctx-title', 'context inspector'),
+        m('span.ctx-subtitle', 'what each model call carried, newest first'),
+        m('.spacer'),
+        m('button.ctx-close', { onclick: onClose, title: 'close' }, '✕'),
+      ]),
+      snapshots === null
+        ? m('.ctx-empty', 'loading…')
+        : snapshots.length === 0
+          ? m('.ctx-empty',
+              'No live snapshots for this chat. The ring holds the most recent model calls '
+              + 'in the service worker\'s memory only — after a browser restart or worker '
+              + 'eviction it starts empty. Send a message and reopen.')
+          : [...snapshots].reverse().map((snap) => m(Snapshot, { snap, key: snap.seq })),
+    ])),
+};

--- a/extension/sidepanel/components/context-inspector.js
+++ b/extension/sidepanel/components/context-inspector.js
@@ -55,11 +55,11 @@ const Snapshot = {
 };
 
 /**
- * @typedef {{ snapshots: Array<Record<string, any>> | null, onClose: () => void }} ContextInspectorAttrs
+ * @typedef {{ snapshots: Array<Record<string, any>> | null, error?: string | null, onClose: () => void }} ContextInspectorAttrs
  */
 export const ContextInspector = {
   /** @param {{ attrs: ContextInspectorAttrs }} vnode */
-  view: ({ attrs: { snapshots, onClose } }) => m('.peerd-modal-backdrop', { onclick: onClose },
+  view: ({ attrs: { snapshots, error = null, onClose } }) => m('.peerd-modal-backdrop', { onclick: onClose },
     m('.peerd-modal.context-inspector', { onclick: (/** @type {Event} */ e) => e.stopPropagation() }, [
       m('.ctx-header', [
         m('span.ctx-title', 'context inspector'),
@@ -69,7 +69,9 @@ export const ContextInspector = {
       ]),
       snapshots === null
         ? m('.ctx-empty', 'loading…')
-        : snapshots.length === 0
+        : error
+          ? m('.ctx-empty', `couldn't read the snapshots: ${error}`)
+          : snapshots.length === 0
           ? m('.ctx-empty',
               'No live snapshots for this chat. The ring holds the most recent model calls '
               + 'in the service worker\'s memory only — after a browser restart or worker '

--- a/extension/sidepanel/components/message-list.js
+++ b/extension/sidepanel/components/message-list.js
@@ -25,7 +25,7 @@
 import m from '/vendor/mithril/mithril.js';
 import { renderMarkdown } from '/shared/markdown.js';
 import { stripUntrustedFences } from '/shared/util.js';
-import { formatBytes } from '/peerd-runtime/index.js';
+import { formatBytes, classifyFailure } from '/peerd-runtime/index.js';
 
 /** @typedef {import('../chat-reducer.js').ChatMessage} ChatMessage */
 /** @typedef {import('../chat-reducer.js').SubagentSession} SubagentSession */
@@ -354,6 +354,14 @@ const AssistantMessage = {
           : message.error
             ? m('.bubble.bubble-error', m('.error-line', message.error))
             : null,
+      // Failure-class chip — the classified NEIGHBORHOOD of a failed turn
+      // (policy / provider / timeout / …), so a user triaging doesn't have
+      // to parse the raw error to know whose fault it roughly was.
+      message.error
+        ? m('span.failure-kind-chip',
+            { title: 'failure class' },
+            classifyFailure(message.error, { stopReason: message.stopReason }).kind)
+        : null,
       // Stop-reason chip — truncations and caps must never be silent.
       // max_tokens with neither text nor tools = the thinking-only
       // truncation the loop auto-continues; say so. max_steps = the
@@ -536,6 +544,13 @@ const ToolCall = {
           { title: status === 'failed' ? 'failed' : status === 'pending' ? 'running' : status === 'cancelled' ? 'cancelled' : 'ok' }),
         m('span.tool-name', toolUse.name),
         m('span.tool-args', argsSummary(toolUse.input)),
+        // Failure-class chip on a failed card: the classified neighborhood
+        // (policy / environment / timeout / …) at a glance; the raw error
+        // stays one click away in the expanded result body.
+        status === 'failed'
+          ? m('span.failure-kind-chip', { title: 'failure class' },
+              classifyFailure(typeof toolResult?.content === 'string' ? toolResult.content : '').kind)
+          : null,
         m('.spacer'),
         status === 'pending' ? m('span.tool-pending', 'running…')
           : status === 'cancelled' ? m('span.tool-cancelled', 'cancelled')

--- a/extension/sidepanel/styles.css
+++ b/extension/sidepanel/styles.css
@@ -2589,6 +2589,12 @@ button.icon:hover { background: var(--bg); }
   cursor: pointer;
 }
 .debug-export-btn:hover { color: var(--fg); border-color: var(--fg-muted); }
+.debug-menu-backdrop {
+  /* click-away for the flyout: transparent, under the menu, over the page */
+  position: fixed;
+  inset: 0;
+  z-index: 29;
+}
 .debug-menu {
   position: absolute;
   right: 0;

--- a/extension/sidepanel/styles.css
+++ b/extension/sidepanel/styles.css
@@ -2552,3 +2552,107 @@ button.icon:hover { background: var(--bg); }
 /* The pre-first-token beachball, sitting bare where the bubble will
    appear — same left rhythm as a bubble, none of its chrome. */
 .thinking-solo { padding: 6px 2px; }
+
+/* --- the debug surface (failure chips, debug export, context inspector) ---
+   Grayscale per the brand rule; --danger only as the failure chip's border
+   accent (the one semantic exception). */
+.failure-kind-chip {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.6;
+  color: var(--fg-muted);
+  border: 1px solid var(--danger);
+  border-radius: 999px;
+  padding: 0 7px;
+  margin-left: 6px;
+  white-space: nowrap;
+  /* a message container is a flex COLUMN — without this the turn-level
+     chip stretches into a full-width bar. */
+  align-self: flex-start;
+  width: fit-content;
+}
+.message .failure-kind-chip { margin: 4px 0 0; }
+
+.debug-export { position: relative; display: inline-flex; }
+.debug-export-btn {
+  /* chip-shaped like .session-sys-badge, but its OWN class: it's an action,
+     not a presence chip, and the presence-chip tests count that class. */
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.6;
+  color: var(--fg-muted);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0 7px;
+  white-space: nowrap;
+  background: transparent;
+  cursor: pointer;
+}
+.debug-export-btn:hover { color: var(--fg); border-color: var(--fg-muted); }
+.debug-menu {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 4px);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  z-index: 30;
+  min-width: 200px;
+}
+.debug-menu-item {
+  background: transparent;
+  border: none;
+  color: var(--fg);
+  font-size: 12px;
+  text-align: left;
+  padding: 7px 10px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.debug-menu-item:hover { background: var(--bg); }
+
+.context-inspector {
+  width: min(560px, calc(100vw - 32px));
+  max-height: min(80vh, 640px);
+  overflow-y: auto;
+  font-size: 12px;
+}
+.ctx-header { display: flex; align-items: baseline; gap: 8px; margin-bottom: 10px; }
+.ctx-title { font-family: var(--font-mono); font-size: 13px; }
+.ctx-subtitle { color: var(--fg-muted); font-size: 11px; }
+.ctx-close {
+  background: transparent;
+  border: none;
+  color: var(--fg-muted);
+  cursor: pointer;
+  font-size: 13px;
+}
+.ctx-close:hover { color: var(--fg); }
+.ctx-empty { color: var(--fg-muted); line-height: 1.5; padding: 8px 0; }
+.ctx-snap { border-top: 1px solid var(--border); padding: 6px 0; }
+.ctx-snap-summary { cursor: pointer; display: flex; gap: 8px; align-items: baseline; }
+.ctx-snap-label { font-family: var(--font-mono); font-size: 11px; }
+.ctx-snap-meta { color: var(--fg-muted); font-size: 10px; }
+.ctx-snap-body { padding: 6px 0 2px 12px; }
+.ctx-snap-tools { color: var(--fg-muted); font-size: 11px; margin-bottom: 6px; }
+.ctx-snap-system summary { cursor: pointer; color: var(--fg-muted); font-size: 11px; }
+.ctx-pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 10px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 6px;
+  margin: 4px 0;
+  max-height: 200px;
+  overflow-y: auto;
+}
+.ctx-msg { margin: 6px 0; }
+.ctx-msg-role { font-family: var(--font-mono); font-size: 10px; color: var(--fg-muted); }
+.ctx-msg-tool { font-size: 10px; color: var(--fg-muted); margin: 2px 0 2px 8px; }
+.ctx-msg-result { margin: 2px 0 2px 8px; }
+.ctx-msg-result.failed .ctx-msg-role { color: var(--danger); }

--- a/extension/tests/index.js
+++ b/extension/tests/index.js
@@ -96,6 +96,7 @@ import './unit/sidepanel/api-integrations.test.js';
 import './unit/sidepanel/tools-chip.test.js';
 import './unit/sidepanel/attachments.test.js';
 import './unit/sidepanel/message-list.test.js';
+import './unit/sidepanel/failure-chip.test.js';
 
 // --- home (chassis): the full-tab Library page ---
 import './unit/home/library-section.test.js';

--- a/extension/tests/unit/sidepanel/failure-chip.test.js
+++ b/extension/tests/unit/sidepanel/failure-chip.test.js
@@ -1,0 +1,78 @@
+// @ts-check
+// The failure-class chip — a failed tool card and a failed turn each carry
+// the classified failure NEIGHBORHOOD (policy / provider / …) as a chip, so
+// triage doesn't require parsing the raw error string. The chip must appear
+// ONLY on failures: a clean card with a chip would cry wolf.
+
+import m from '/vendor/mithril/mithril.js';
+import { describe, it, expect } from '../../framework.js';
+import { MessageList } from '/sidepanel/components/message-list.js';
+
+const flush = async () => {
+  await new Promise((r) => setTimeout(r, 0));
+  m.redraw.sync();
+};
+
+/** @param {any[]} messages */
+const mount = (messages) => {
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  m.mount(root, { view: () => m(MessageList, { messages }) });
+  return { root, unmount: () => { m.mount(root, null); root.remove(); } };
+};
+
+describe('sidepanel.failure-kind chip', () => {
+  it('a failed tool card carries the classified kind; an ok card carries none', async () => {
+    const { root, unmount } = mount([
+      {
+        role: 'assistant', id: 'a1', content: '',
+        // why generic tool names: message_actor/spawn_subagent take the
+        // dedicated actor-card render path, not the generic ToolCall header
+        // this chip lives in.
+        toolUses: [
+          { id: 't-ok', name: 'view', input: {} },
+          { id: 't-bad', name: 'script', input: {} },
+        ],
+      },
+      {
+        role: 'user', id: 'u1', content: '',
+        toolResults: [
+          { tool_use_id: 't-ok', content: '42', is_error: false },
+          { tool_use_id: 't-bad', content: 'message_actor: oneShot is sandbox-only (webvm/notebook/app)', is_error: true },
+        ],
+      },
+    ]);
+    try {
+      await flush();
+      const cards = [...root.querySelectorAll('.tool-call')];
+      expect(cards.length).toBe(2);
+      const failed = /** @type {Element} */ (root.querySelector('.tool-call.tool-failed'));
+      const chip = /** @type {Element} */ (failed.querySelector('.failure-kind-chip'));
+      expect(chip).toBeTruthy();
+      expect(chip.textContent).toBe('policy');
+      const okCard = cards.find((c) => !c.classList.contains('tool-failed'));
+      expect(/** @type {Element} */ (okCard).querySelector('.failure-kind-chip')).toBeFalsy();
+    } finally { unmount(); }
+  });
+
+  it('a failed TURN (message-level error) carries the classified kind', async () => {
+    const { root, unmount } = mount([{
+      role: 'assistant', id: 'a2', content: 'partial',
+      error: "Provider 'ollama' HTTP 400: {\"error\":\"bad request\"}",
+    }]);
+    try {
+      await flush();
+      const chip = /** @type {Element} */ (root.querySelector('.message-assistant .failure-kind-chip'));
+      expect(chip).toBeTruthy();
+      expect(chip.textContent).toBe('provider');
+    } finally { unmount(); }
+  });
+
+  it('a clean turn renders no chip', async () => {
+    const { root, unmount } = mount([{ role: 'assistant', id: 'a3', content: 'all done' }]);
+    try {
+      await flush();
+      expect(root.querySelector('.failure-kind-chip')).toBeFalsy();
+    } finally { unmount(); }
+  });
+});

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -67,7 +67,10 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // 490 → 493: the debug surface adds observability/failure-classify.js,
 // observability/debug-bundle.js, and observability/otel-export.js (the pure
 // cores of the debug-bundle export + failure classifier + OTel mapper).
-const COVERED_FLOOR = 493;
+// 493 → 496: the debug surface's wiring + UI add background/context-snapshots.js
+// (the capture ring), sidepanel/components/context-inspector.js, and the
+// failure-chip in-browser test.
+const COVERED_FLOOR = 496;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -64,7 +64,10 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // red-team tier — real-realm seal + CSP-fence assertions).
 // 488 → 490: the actors-in-script surface adds subagent/actors-api.js (the
 // pure delegation core) and background/script-runs.js (the live-run registry).
-const COVERED_FLOOR = 490;
+// 490 → 493: the debug surface adds observability/failure-classify.js,
+// observability/debug-bundle.js, and observability/otel-export.js (the pure
+// cores of the debug-bundle export + failure classifier + OTel mapper).
+const COVERED_FLOOR = 493;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/scripts/cdp/states.mjs
+++ b/scripts/cdp/states.mjs
@@ -334,7 +334,86 @@ export const STATES = [
       rec.check('a provider error surfaces inline (error-line)', !!out.errorText, JSON.stringify(out.errorText));
       rec.check('the error names the HTTP failure honestly', /HTTP 400/.test(out.errorText || ''));
       rec.check('the failed turn comes to rest (not stuck busy)', out.busy === false);
+      // The failure-class chip: the classified neighborhood renders next to
+      // the raw error, and an injected provider HTTP failure classifies as
+      // 'provider' (the debug surface's triage contract).
+      const chip = await evalIn(ctx.page,
+        `document.querySelector('.message-assistant .failure-kind-chip')?.textContent ?? null`);
+      rec.check("the failure-class chip renders and reads 'provider'", chip === 'provider', JSON.stringify(chip));
       await rec.shot('final');
+    },
+  },
+
+  // --- functional: the debug surface (bundle export + context capture) -------
+  // Proves the chain the observability PR adds: a real turn is captured into
+  // the SW's context-snapshot ring, the session/debugBundle route assembles
+  // transcript + audit slice + snapshots + secret-free settings with honest
+  // provenance, and the chat's debug flyout renders its export actions.
+  {
+    name: 'debug-bundle', kind: 'functional', phase: 'post-unlock',
+    responder: () => ({ sse: sseText('debug-bundle-reply') }),
+    async run(ctx, rec) {
+      await rpc(ctx.page, { type: 'agent/send', text: 'say something for the bundle' });
+      await waitFor(async () => { const o = await probe(ctx); return o.assistantText && !o.busy; }, { budgetMs: 20_000 });
+
+      const rows = await rpc(ctx.page, { type: 'session/list' });
+      const sessionId = rows?.sessions?.[0]?.sessionId;
+      rec.check('session/list yields the live chat', !!sessionId, JSON.stringify(sessionId));
+
+      const reply = await rpc(ctx.page, { type: 'session/debugBundle', sessionId });
+      rec.check('session/debugBundle returns ok', reply?.ok === true, JSON.stringify(reply?.error));
+      const bundle = reply?.bundle ?? {};
+      rec.check('the bundle carries the format stamp + the transcript',
+        bundle.format === 'peerd-debug-bundle' && (bundle.session?.messages?.length ?? 0) >= 2,
+        `format=${bundle.format} messages=${bundle.session?.messages?.length}`);
+      rec.check('the ORCHESTRATOR model call was captured into the context ring (live capture proof)',
+        (bundle.contextSnapshots ?? []).some((s) => s.label === 'main'),
+        `snapshots=${(bundle.contextSnapshots ?? []).length}`);
+      rec.check('the bundle states its provenance (what absence means)',
+        typeof bundle.provenance?.contextSnapshots === 'string' && typeof bundle.provenance?.secrets === 'string');
+      const settingsJson = JSON.stringify(bundle.settings ?? {});
+      rec.check('the settings snapshot is secret-free (no key-shaped fields)',
+        !/apiKey|api_key|secret|passphrase/i.test(settingsJson), settingsJson.slice(0, 120));
+
+      // The chat's debug flyout: chip-button opens the two export actions.
+      await evalIn(ctx.page, `document.querySelector('.debug-export-btn')?.click()`);
+      let menu = {};
+      await waitFor(async () => {
+        menu = await evalIn(ctx.page, `(() => ({
+          open: !!document.querySelector('.debug-menu'),
+          items: [...document.querySelectorAll('.debug-menu-item')].map((b) => b.textContent),
+        }))()`) || {};
+        return menu.open === true;
+      }, { budgetMs: 5_000 });
+      rec.check('the debug flyout opens with the bundle + OTel export actions',
+        menu.open === true && (menu.items || []).length >= 2, JSON.stringify(menu.items));
+      await rec.shot('debug-menu-open');
+
+      // devMode adds the context inspector; the modal renders the live
+      // snapshot captured above (label 'main'), proving ring → route → view.
+      await rpc(ctx.page, { type: 'settings/update', patch: { devMode: true } });
+      let inspector = {};
+      await waitFor(async () => {
+        // why click-in-loop: the 'context inspector' item only renders after
+        // the devMode state push lands — a one-shot click can race it.
+        inspector = await evalIn(ctx.page, `(() => {
+          if (!document.querySelector('.context-inspector')) {
+            if (!document.querySelector('.debug-menu')) document.querySelector('.debug-export-btn')?.click();
+            [...document.querySelectorAll('.debug-menu-item')]
+              .find((b) => b.textContent === 'context inspector')?.click();
+          }
+          return {
+            open: !!document.querySelector('.context-inspector'),
+            snaps: [...document.querySelectorAll('.ctx-snap-label')].map((el) => el.textContent),
+          };
+        })()`) || {};
+        return inspector.open === true && (inspector.snaps || []).length > 0;
+      }, { budgetMs: 8_000 });
+      rec.check("the context inspector opens on the live 'main' snapshot (devMode)",
+        inspector.open === true && (inspector.snaps || []).includes('main'), JSON.stringify(inspector.snaps));
+      await rec.shot('context-inspector');
+      await evalIn(ctx.page, `document.querySelector('.ctx-close')?.click()`);
+      await rpc(ctx.page, { type: 'settings/update', patch: { devMode: false } });
     },
   },
 

--- a/tests/background/context-snapshots.test.ts
+++ b/tests/background/context-snapshots.test.ts
@@ -37,6 +37,35 @@ describe('shapeModelCall — bounded and binary-free', () => {
     expect(shaped.messages[0].content).toBe('m15');                // the OLDEST are what's dropped
   });
 
+  test('EVERY worker-controllable field is bounded (a compromised heap cannot bloat the ring)', () => {
+    const shaped = shapeModelCall({
+      provider: 'p'.repeat(10_000), model: 'm'.repeat(10_000),
+      reasoning: { blob: 'r'.repeat(100_000) },
+      tools: Array.from({ length: 500 }, (_, i) => ({ name: `t${i}`.repeat(1000) })),
+      messages: [{
+        role: 'x'.repeat(500), content: '',
+        toolUses: Array.from({ length: 500 }, () => ({ name: 'n'.repeat(9000), input: {} })),
+        toolResults: Array.from({ length: 500 }, () => ({ tool_use_id: 'i'.repeat(9000), content: '' })),
+        attachments: Array.from({ length: 500 }, () => ({ name: 'a'.repeat(9000), mediaType: 'z'.repeat(9000), size: 1 })),
+      }],
+    });
+    expect(shaped.provider.length).toBeLessThanOrEqual(200);
+    expect(shaped.model.length).toBeLessThanOrEqual(200);
+    expect((shaped.reasoning as string).length).toBeLessThanOrEqual(400);
+    expect(shaped.tools.length).toBe(50);
+    expect(shaped.tools[0].length).toBeLessThanOrEqual(120);
+    const msg = shaped.messages[0];
+    expect(msg.role.length).toBeLessThanOrEqual(40);
+    expect(msg.toolUses!.length).toBe(50);
+    expect(msg.toolUses![0].name.length).toBeLessThanOrEqual(120);
+    expect(msg.toolResults!.length).toBe(50);
+    expect(msg.toolResults![0].tool_use_id.length).toBeLessThanOrEqual(120);
+    expect(msg.attachments!.length).toBe(20);
+    expect(msg.attachments![0].name.length).toBeLessThanOrEqual(200);
+    // the whole snapshot stays small even under a hostile payload
+    expect(JSON.stringify(shaped).length).toBeLessThan(120_000);
+  });
+
   test('degenerate shapes never throw', () => {
     expect(() => shapeModelCall(undefined as any)).not.toThrow();
     expect(shapeModelCall({ messages: 'not-an-array' as any }).messages).toEqual([]);

--- a/tests/background/context-snapshots.test.ts
+++ b/tests/background/context-snapshots.test.ts
@@ -1,0 +1,92 @@
+// The context inspector's capture ring: shaping (clips + binary strip,
+// never throws), the per-session cap, idle-session eviction, and the
+// copy-on-read contract. Pure factory — no browser.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  createContextSnapshots, shapeModelCall,
+  SNAPSHOTS_PER_SESSION, SNAPSHOT_CONTENT_CHARS, SNAPSHOT_MAX_MESSAGES,
+} from '../../extension/background/context-snapshots.js';
+
+describe('shapeModelCall — bounded and binary-free', () => {
+  test('clips long content, keeps structure, strips base64 with a visible sentinel', () => {
+    const shaped = shapeModelCall({
+      provider: 'anthropic', model: 'claude-x',
+      system: 's'.repeat(10_000),
+      tools: [{ name: 'script', input_schema: {} }, { name: 'message_actor' }],
+      messages: [
+        { role: 'user', content: 'x'.repeat(5000), attachments: [{ name: 'shot.png', mediaType: 'image/png', size: 12345, data: 'AAAA'.repeat(90_000) }] },
+        { role: 'assistant', content: 'ok', toolUses: [{ name: 'script', input: { code: 'y'.repeat(3000) } }] },
+        { role: 'user', content: '', toolResults: [{ tool_use_id: 't1', is_error: false, content: 'z'.repeat(9000), images: ['<big>'] }] },
+      ],
+    });
+    expect(shaped.system.length).toBeLessThanOrEqual(6000);
+    expect(shaped.systemChars).toBe(10_000);                       // the true size is preserved as metadata
+    expect(shaped.tools).toEqual(['script', 'message_actor']);
+    expect(shaped.messages[0].content.length).toBeLessThanOrEqual(SNAPSHOT_CONTENT_CHARS);
+    expect(shaped.messages[0].attachments![0].data).toContain('stripped');
+    expect(JSON.stringify(shaped)).not.toContain('AAAAAAAA');      // no base64 survives
+    expect(shaped.messages[2].toolResults![0].images).toContain('stripped');
+  });
+
+  test('caps message count and reports what was dropped', () => {
+    const many = Array.from({ length: SNAPSHOT_MAX_MESSAGES + 15 }, (_, i) => ({ role: 'user', content: `m${i}` }));
+    const shaped = shapeModelCall({ messages: many });
+    expect(shaped.messages.length).toBe(SNAPSHOT_MAX_MESSAGES);
+    expect(shaped.droppedMessages).toBe(15);
+    expect(shaped.messages[0].content).toBe('m15');                // the OLDEST are what's dropped
+  });
+
+  test('degenerate shapes never throw', () => {
+    expect(() => shapeModelCall(undefined as any)).not.toThrow();
+    expect(shapeModelCall({ messages: 'not-an-array' as any }).messages).toEqual([]);
+    expect(shapeModelCall({ system: { odd: true } as any }).systemChars).toBe(0);
+  });
+});
+
+describe('createContextSnapshots — the ring', () => {
+  test('caps per session at the limit, oldest out first', () => {
+    let t = 0;
+    const ring = createContextSnapshots({ now: () => ++t });
+    for (let i = 0; i < SNAPSHOTS_PER_SESSION + 3; i++) {
+      ring.record({ sessionId: 's1', label: 'main', provider: 'p', model: 'm', messages: [{ role: 'user', content: `call ${i}` }] });
+    }
+    const snaps = ring.snapshotsFor('s1');
+    expect(snaps.length).toBe(SNAPSHOTS_PER_SESSION);
+    expect(snaps[0].messages[0].content).toBe('call 3');           // 0..2 evicted
+    expect(snaps.at(-1)!.messages[0].content).toBe(`call ${SNAPSHOTS_PER_SESSION + 2}`);
+  });
+
+  test('evicts the oldest-touched session when the session cap is hit', () => {
+    let t = 0;
+    const ring = createContextSnapshots({ maxSessions: 2, now: () => ++t });
+    ring.record({ sessionId: 'old', messages: [] });
+    ring.record({ sessionId: 'mid', messages: [] });
+    ring.record({ sessionId: 'new', messages: [] });
+    expect(ring._size()).toBe(2);
+    expect(ring.snapshotsFor('old')).toEqual([]);
+    expect(ring.snapshotsFor('new').length).toBe(1);
+  });
+
+  test('snapshotsForMany merges sessions in capture order; reads are copies', () => {
+    let t = 0;
+    const ring = createContextSnapshots({ now: () => ++t });
+    ring.record({ sessionId: 'root', label: 'main', messages: [] });
+    ring.record({ sessionId: 'child', label: 'actor:web', messages: [] });
+    ring.record({ sessionId: 'root', label: 'main', messages: [] });
+    const merged = ring.snapshotsForMany(['root', 'child']);
+    expect(merged.map((s) => s.label)).toEqual(['main', 'actor:web', 'main']);
+    merged[0].label = 'tampered';
+    expect(ring.snapshotsFor('root')[0].label).toBe('main');       // the store is untouched
+  });
+
+  test('recording without a sessionId is a silent no-op (capture is best-effort)', () => {
+    const ring = createContextSnapshots();
+    expect(() => ring.record({} as any)).not.toThrow();
+    expect(ring._size()).toBe(0);
+  });
+
+  test('limits() reports the caps the bundle provenance needs', () => {
+    expect(createContextSnapshots({ capPerSession: 7 }).limits().snapshotsPerSession).toBe(7);
+  });
+});

--- a/tests/peerd-runtime/observability.test.ts
+++ b/tests/peerd-runtime/observability.test.ts
@@ -1,0 +1,199 @@
+// The debug surface's pure cores: the failure classifier (real error
+// strings from across the codebase → the small stable taxonomy), the
+// bundle assembler (shape, child collection, caps, provenance honesty),
+// and the OTel mapper (span tree, status + failure attrs, id validity).
+
+import { describe, test, expect } from 'bun:test';
+import { classifyFailure, FAILURE_KINDS } from '../../extension/peerd-runtime/observability/failure-classify.js';
+import {
+  assembleDebugBundle, childSessionIdsOf, collectFailures,
+  DEBUG_BUNDLE_FORMAT, BUNDLE_MAX_AUDIT_ENTRIES, BUNDLE_MAX_CHILD_SESSIONS,
+} from '../../extension/peerd-runtime/observability/debug-bundle.js';
+import { bundleToOtlp, traceIdFromUuid, spanIdFrom } from '../../extension/peerd-runtime/observability/otel-export.js';
+
+describe('classifyFailure — the strings the codebase actually produces', () => {
+  const cases: Array<[string, ReturnType<typeof classifyFailure>['kind']]> = [
+    // [error text as produced, expected kind]
+    ["message_actor: 4 actor messages already in flight for this turn", 'policy'],
+    ['subagent refused: max depth 2 exceeded (requested depth 3)', 'policy'],
+    ['EgressDeniedError: https://evil.example is not on the allowlist', 'policy'],
+    ['egress denied: denylist matched host tracker.example', 'policy'],
+    ['vault is locked — unlock to continue', 'auth'],
+    ["Provider 'anthropic' HTTP 401: {\"error\":\"invalid x-api-key\"}", 'auth'],
+    ["Provider 'openrouter' HTTP 429: rate limited", 'limits'],
+    ['spend limit reached for this session', 'limits'],
+    ["Provider 'ollama' HTTP 400: {\"error\":{\"message\":\"bad request\"}}", 'provider'],
+    ['provider stream ended early (likely rate limit or network drop)', 'provider'],
+    ["actors.ask: timed out after 5000ms awaiting 'vm-9'", 'timeout'],
+    ['script_aborted: the turn was stopped before the run started', 'aborted'],
+    ["actors.ask: aborted (Stop) while awaiting 'vm-9'", 'aborted'],
+    ['the request was aborted (timeout or cancel) before the actor replied.', 'aborted'],
+    ['no_option_matching: "Submit order" — available: Cancel | Back', 'environment'],
+    ['actor tool relay failed', 'environment'],
+    ['The webvm actor builder (vm-9) could not complete your request:', 'agent'],
+    ['the actor turn failed: pytest exited 1', 'agent'],
+    ['(the actor produced no text reply)', 'agent'],
+    ['TypeError: cannot read properties of undefined', 'internal'],
+  ];
+  for (const [text, kind] of cases) {
+    test(`"${text.slice(0, 52)}…" → ${kind}`, () => {
+      expect(classifyFailure(text).kind).toBe(kind);
+    });
+  }
+
+  test('a Stop-aborted turn is aborted regardless of surviving text', () => {
+    expect(classifyFailure('anything at all', { stopReason: 'aborted' }).kind).toBe('aborted');
+  });
+
+  test('every kind the classifier can emit is in the published set', () => {
+    for (const [text] of cases) {
+      expect(FAILURE_KINDS).toContain(classifyFailure(text).kind);
+    }
+  });
+
+  test('non-string inputs never throw', () => {
+    expect(classifyFailure(undefined).kind).toBe('internal');
+    expect(classifyFailure(new Error('vault is locked')).kind).toBe('auth');
+    expect(classifyFailure({ message: 42 }).kind).toBe('internal');
+  });
+});
+
+describe('childSessionIdsOf — the delegation tree walk', () => {
+  test('collects descendants transitively, ignores unrelated trees, survives cycles', () => {
+    const rows = [
+      { sessionId: 'root' },
+      { sessionId: 'web-1', parentSessionId: 'root' },
+      { sessionId: 'sub-1', parentSessionId: 'root' },
+      { sessionId: 'vm-1', parentSessionId: 'sub-1' },     // grandchild via subagent
+      { sessionId: 'other', parentSessionId: 'elsewhere' }, // unrelated
+      { sessionId: 'loop', parentSessionId: 'loop' },       // corrupt self-cycle
+    ];
+    expect(childSessionIdsOf(rows, 'root').sort()).toEqual(['sub-1', 'vm-1', 'web-1']);
+    expect(childSessionIdsOf(rows, 'loop')).toEqual([]); // the cycle terminates
+  });
+});
+
+const SESSION = {
+  sessionId: '01912345-6789-7abc-8def-0123456789ab',
+  kind: 'chat', provider: 'anthropic', model: 'claude-x', title: 'find the widget',
+  createdAt: 1000,
+  cost: { inputTokens: 100, outputTokens: 40, cacheReadTokens: 0, cacheWriteTokens: 0, cost: 0.01, turns: 2 },
+  messages: [
+    { role: 'user', id: 'u1', when: 1000, content: 'go', toolResults: [] },
+    {
+      role: 'assistant', id: 'a1', when: 2000, content: '', model: 'claude-x',
+      toolUses: [{ id: 'toolu_ok', name: 'script', input: {} }, { id: 'toolu_bad', name: 'message_actor', input: {} }],
+    },
+    {
+      role: 'user', id: 'u2', when: 3000, content: '',
+      toolResults: [
+        { tool_use_id: 'toolu_ok', content: '42', is_error: false },
+        { tool_use_id: 'toolu_bad', content: 'message_actor: oneShot is sandbox-only', is_error: true },
+      ],
+    },
+    { role: 'assistant', id: 'a2', when: 4000, content: 'partial', error: "Provider 'anthropic' HTTP 529: overloaded" },
+  ],
+};
+
+describe('collectFailures — the "what went wrong" index', () => {
+  test('finds the failed tool AND the failed turn, classified', () => {
+    const failures = collectFailures(SESSION);
+    expect(failures.length).toBe(2);
+    const tool = failures.find((f: any) => f.scope === 'tool') as any;
+    expect(tool.toolUseId).toBe('toolu_bad');
+    expect(tool.kind).toBe('policy');
+    const turn = failures.find((f: any) => f.scope === 'turn') as any;
+    expect(turn.messageId).toBe('a2');
+    expect(turn.kind).toBe('provider');
+  });
+});
+
+describe('assembleDebugBundle', () => {
+  const child = { ...SESSION, sessionId: 'child-1', kind: 'actor', actorType: 'web', messages: SESSION.messages.slice(0, 3) };
+  const bundle = assembleDebugBundle({
+    session: SESSION,
+    childSessions: [child],
+    auditEntries: [{ id: 'e1', when: 1500, type: 'tool_executed', sessionId: SESSION.sessionId }],
+    settings: { providerName: 'anthropic', devMode: true },
+    contextSnapshots: [{ sessionId: SESSION.sessionId, label: 'main', when: 1900 }],
+    channel: 'preview', appVersion: '0.2.4', now: 10_000,
+    limits: { auditMaxEntries: 20_000, snapshotsPerSession: 10 },
+  });
+
+  test('carries format/version, the whole transcript, and an honest summary', () => {
+    expect(bundle.format).toBe(DEBUG_BUNDLE_FORMAT);
+    expect(bundle.session.messages.length).toBe(4);
+    expect(bundle.summary.toolCalls).toBe(4); // 2 in root + 2 in child
+    expect(bundle.summary.failures).toBe(3);  // 2 root + 1 child (tool)
+    expect(bundle.summary.cost.turns).toBe(2);
+    expect(bundle.exportedAt).toBe(new Date(10_000).toISOString());
+  });
+
+  test('provenance names the caps and the secrets posture', () => {
+    expect(bundle.provenance.audit).toContain('20000');
+    expect(bundle.provenance.contextSnapshots).toContain('service worker');
+    expect(bundle.provenance.secrets).toContain('vault');
+  });
+
+  test('caps clamp: audit to the newest entries, children to the max', () => {
+    const many = assembleDebugBundle({
+      session: SESSION,
+      childSessions: Array.from({ length: BUNDLE_MAX_CHILD_SESSIONS + 5 }, (_, i) => ({ sessionId: `c${i}`, messages: [] })),
+      auditEntries: Array.from({ length: BUNDLE_MAX_AUDIT_ENTRIES + 10 }, (_, i) => ({ id: `e${i}`, when: i, type: 'x' })),
+      now: 0,
+    });
+    expect(many.audit.length).toBe(BUNDLE_MAX_AUDIT_ENTRIES);
+    expect(many.audit[0].id).toBe('e10'); // oldest dropped, newest kept
+    expect(many.childSessions.length).toBe(BUNDLE_MAX_CHILD_SESSIONS);
+    expect(many.provenance.childSessions).toContain('clamped');
+  });
+
+  test('normalizes a missing/corrupt cost tally instead of exporting garbage', () => {
+    const noCost = assembleDebugBundle({ session: { ...SESSION, cost: undefined }, now: 0 });
+    expect(noCost.summary.cost.inputTokens).toBe(0);
+    expect(noCost.summary.cost.turns).toBe(0);
+  });
+});
+
+describe('bundleToOtlp — the span tree', () => {
+  const child = { ...SESSION, sessionId: '01912345-6789-7abc-8def-0123456789ff', kind: 'actor', actorType: 'web', messages: SESSION.messages.slice(0, 3) };
+  const bundle = assembleDebugBundle({ session: SESSION, childSessions: [child], now: 0 });
+  const otlp = bundleToOtlp(bundle);
+  const spans = otlp.resourceSpans[0].scopeSpans[0].spans;
+
+  test('ids are OTel-valid: 32-hex trace, 16-hex non-zero spans, one shared trace', () => {
+    expect(traceIdFromUuid(SESSION.sessionId)).toMatch(/^[0-9a-f]{32}$/);
+    for (const s of spans) {
+      expect(s.traceId).toBe(traceIdFromUuid(SESSION.sessionId));
+      expect(s.spanId).toMatch(/^[0-9a-f]{16}$/);
+      expect(s.spanId).not.toBe('0'.repeat(16));
+    }
+    expect(new Set(spans.map((s: any) => s.spanId)).size).toBe(spans.length);
+  });
+
+  test('the delegation structure is span parentage: child session root hangs off the chat root', () => {
+    const chatRoot = spans.find((s: any) => s.name === 'peerd.session chat') as any;
+    const actorRoot = spans.find((s: any) => s.name === 'peerd.session actor:web') as any;
+    expect(chatRoot.parentSpanId).toBeUndefined();
+    expect(actorRoot.parentSpanId).toBe(chatRoot.spanId);
+  });
+
+  test('failures carry ERROR status + the classified peerd.failure.kind', () => {
+    const failedTool = spans.find((s: any) => s.name === 'peerd.tool message_actor' && s.status.code === 2) as any;
+    expect(failedTool).toBeDefined();
+    expect(failedTool.attributes.some((a: any) => a.key === 'peerd.failure.kind' && a.value.stringValue === 'policy')).toBe(true);
+    const failedTurn = spans.find((s: any) => s.name === 'peerd.model_turn' && s.status.code === 2) as any;
+    expect(failedTurn.status.message).toContain('HTTP 529');
+  });
+
+  test('token usage rides the resource as gen_ai semconv attributes', () => {
+    const res = otlp.resourceSpans[0].resource.attributes as any[];
+    const input = res.find((a) => a.key === 'gen_ai.usage.input_tokens');
+    expect(input.value.intValue).toBe('100');
+  });
+
+  test('spanIdFrom is deterministic and corrupt uuids do not throw', () => {
+    expect(spanIdFrom('toolu_abc')).toBe(spanIdFrom('toolu_abc'));
+    expect(traceIdFromUuid('???')).toMatch(/^[0-9a-f]{32}$/);
+  });
+});

--- a/tests/peerd-runtime/observability.test.ts
+++ b/tests/peerd-runtime/observability.test.ts
@@ -16,10 +16,21 @@ describe('classifyFailure — the strings the codebase actually produces', () =>
     // [error text as produced, expected kind]
     ["message_actor: 4 actor messages already in flight for this turn", 'policy'],
     ['subagent refused: max depth 2 exceeded (requested depth 3)', 'policy'],
+    // the dispatcher's REAL refusal prefixes (dispatcher.js) — the review
+    // found the first draft matched only invented strings here
+    ['gate_blocked:plan-act:plan mode is read-only; blocks page_mutation actions', 'policy'],
+    ["gate_blocked:exposure:'view' is actor-only — message a tab's actor instead", 'policy'],
+    ['gate_blocked:confirmation:rejected by user', 'policy'],
+    ['hook_blocked:pre-tool-use:matched deny pattern', 'policy'],
+    ['User declined the outbound write.', 'policy'],
     ['EgressDeniedError: https://evil.example is not on the allowlist', 'policy'],
     ['egress denied: denylist matched host tracker.example', 'policy'],
     ['vault is locked — unlock to continue', 'auth'],
     ["Provider 'anthropic' HTTP 401: {\"error\":\"invalid x-api-key\"}", 'auth'],
+    // a bare HTTP 403 in an asset-download failure is NOT a credential
+    // problem — only the provider-anchored shape may classify auth
+    ['fetch_failed: HTTP 403', 'environment'],
+    ['fetch returned HTTP 403', 'environment'],
     ["Provider 'openrouter' HTTP 429: rate limited", 'limits'],
     ['spend limit reached for this session', 'limits'],
     ["Provider 'ollama' HTTP 400: {\"error\":{\"message\":\"bad request\"}}", 'provider'],
@@ -31,6 +42,10 @@ describe('classifyFailure — the strings the codebase actually produces', () =>
     ['no_option_matching: "Submit order" — available: Cancel | Back', 'environment'],
     ['actor tool relay failed', 'environment'],
     ['The webvm actor builder (vm-9) could not complete your request:', 'agent'],
+    // agent beats timeout: the actor REPORTED failure; the timeout detail
+    // inside its account must not reclassify who failed
+    ['The web actor could not complete your request: the ask timed out after 120000ms', 'agent'],
+    ['Failed to fetch', 'provider'],
     ['the actor turn failed: pytest exited 1', 'agent'],
     ['(the actor produced no text reply)', 'agent'],
     ['TypeError: cannot read properties of undefined', 'internal'],
@@ -156,7 +171,7 @@ describe('assembleDebugBundle', () => {
 });
 
 describe('bundleToOtlp — the span tree', () => {
-  const child = { ...SESSION, sessionId: '01912345-6789-7abc-8def-0123456789ff', kind: 'actor', actorType: 'web', messages: SESSION.messages.slice(0, 3) };
+  const child = { ...SESSION, sessionId: '01912345-6789-7abc-8def-0123456789ff', kind: 'actor', actorType: 'web', parentSessionId: SESSION.sessionId, messages: SESSION.messages.slice(0, 3) };
   const bundle = assembleDebugBundle({ session: SESSION, childSessions: [child], now: 0 });
   const otlp = bundleToOtlp(bundle);
   const spans = otlp.resourceSpans[0].scopeSpans[0].spans;
@@ -176,6 +191,21 @@ describe('bundleToOtlp — the span tree', () => {
     const actorRoot = spans.find((s: any) => s.name === 'peerd.session actor:web') as any;
     expect(chatRoot.parentSpanId).toBeUndefined();
     expect(actorRoot.parentSpanId).toBe(chatRoot.spanId);
+  });
+
+  test('a GRANDCHILD hangs off its real spawner, not flattened onto the chat root', () => {
+    const sub = { sessionId: 'sub-1', kind: 'subagent', parentSessionId: SESSION.sessionId, messages: [] };
+    const vm = { sessionId: 'vm-1', kind: 'actor', actorType: 'webvm', parentSessionId: 'sub-1', messages: [] };
+    const orphan = { sessionId: 'or-1', kind: 'actor', actorType: 'app', parentSessionId: 'clamped-away', messages: [] };
+    const b = assembleDebugBundle({ session: SESSION, childSessions: [sub, vm, orphan], now: 0 });
+    const tree = bundleToOtlp(b).resourceSpans[0].scopeSpans[0].spans;
+    const root = tree.find((s: any) => s.name === 'peerd.session chat') as any;
+    const subRoot = tree.find((s: any) => s.name === 'peerd.session subagent') as any;
+    const vmRoot = tree.find((s: any) => s.name === 'peerd.session actor:webvm') as any;
+    const orphanRoot = tree.find((s: any) => s.name === 'peerd.session actor:app') as any;
+    expect(subRoot.parentSpanId).toBe(root.spanId);
+    expect(vmRoot.parentSpanId).toBe(subRoot.spanId);        // the real spawner
+    expect(orphanRoot.parentSpanId).toBe(root.spanId);       // clamped-out parent → root fallback
   });
 
   test('failures carry ERROR status + the classified peerd.failure.kind', () => {


### PR DESCRIPTION
## What &amp; why — the plain-English spec

**The critique this answers:** "without trace export, failure classification, and context visibility, it's a cool local demo, not a harness serious teams can debug." Half of that was already built (audit log, lineage, delegation traces) but trapped across surfaces with no way OUT. This PR is the way out — local, user-initiated, no vendor, no wire. Observability without telemetry is the differentiator, stated as architecture: everything already lives on the user's device; what was missing was an export button, not a pipeline.

**Three pieces + one format:**

1. **Debug bundle export.** A chip-sized `debug` button in the chat mode row saves ONE local JSON file for the session: the full transcript **including every descendant actor/subagent session** (the delegation tree, walked transitively by parent links — cycle-safe), the audit slice filtered to that session set, normalized cost, the settings snapshot, live context snapshots, a **classified failure index**, and a **provenance block** that states plainly what may be missing (retention-pruned audit, SW-evicted snapshots, clamped children) and why no secrets can be present. The export itself lands in the audit log.

2. **Failure-class chips.** One pure classifier maps the error strings the codebase actually produces (gate prefixes like `message_actor:`, provider HTTP shapes, actor failure leads, Stop/timeout phrasing) onto a small stable taxonomy — `policy / auth / limits / provider / timeout / aborted / environment / agent / internal`. Every failed tool card and failed turn now carries its kind as a chip next to the raw error: triage starts at "whose fault, roughly." The same classifier annotates the bundle and stamps OTel span status.

3. **The context inspector** (devMode). "What did the model actually see?" — the SW keeps an in-memory capped ring of shaped request snapshots per session, captured at the **two seams that together cover every model call**: the turn driver's failover wrapper (orchestrator) and the `actor/model-call` relay route (every actor + subagent heap, identity taken from a runId→session stash the worker cannot spoof). Shaping clips every string and strips binary payloads with a visible sentinel; `record()` is contractually non-throwing. The modal is honest about the ring's lifetime (it empties with the SW, and says so).

4. **OTel export.** The same bundle converts panel-side (`bundleToOtlp` is pure — one route, two formats) to an OTLP/JSON trace: delegation structure = span parentage, failures = span status ERROR + `peerd.failure.kind`, token usage as `gen_ai.*` semconv attributes, session-namespaced span ids, BigInt-exact nanosecond timestamps.

**Secrets posture (the load-bearing claim):** keys cannot appear in any export **by construction** — they live only in the vault and attach at fetch-header time inside the adapters; settings, session records, and the pre-wire captured request args never hold them. The bundle's provenance block states this; the e2e state asserts the settings snapshot is key-shape-free.

**Deliberately not built:** episode replay (a false promise against the live web — sessions re-render and the e2e harness replays the deterministic side) and LangSmith (a hosted vendor contradicts no-backend; OTel covers interop).

## Phases (one commit each)
1. Pure cores: `observability/{failure-classify,debug-bundle,otel-export}.js` + 34 bun tests.
2. Context capture: `background/context-snapshots.js` ring + the two seam hooks + 8 bun tests.
3. Routes + UI: `session/debugBundle` + `session/contextSnapshots`, the debug flyout, failure chips, the inspector modal + in-browser tests + two e2e states.
4. Changelog; OTel timestamp hardening.

## Checklist

- [x] Gates green: typecheck, eslint, ts-check floor (496/496), bun (2642 pass — 42 new), in-browser (615 pass — 3 new chip cases), **live e2e: 19 states, 110/110** — the new `debug-bundle` state proves the chain live (real turn → orchestrator call captured into the ring → bundle route returns format/transcript/provenance/secret-free settings → flyout renders → inspector opens on the live `main` snapshot), and the `error` state now asserts the `provider` chip
- [x] Commits signed off — DCO
- [x] Only original or permissively-licensed code
- [x] Tests added or updated
- [x] No hand-edited generated files
- [x] **Danger zone**: none of the gate chain is touched — both routes are read-only over the user's own data behind the vault-lock guard + first-party sender gate; the capture hooks are optional no-op-default deps

## Notes for reviewers

The security crux is the capture path: snapshots take identity from the SW-side `runMeta` stash keyed by runId (never the worker's args), and the captured struct is the pre-wire callModel args, which are key-free by construction. The rendering crux is the inspector modal: all captured content renders as plain Mithril text children (auto-escaped), never `m.trust`. An adversarial review pass (secret leakage, untrusted-byte rendering, route abuse, ring spoofing/bloat) ran before ready-for-review; its confirmed findings are fixed in the tail commits.

Follow-ups seeded: outside-click close for the debug flyout; consider persisting the snapshot ring to a capped IDB store so the inspector survives SW eviction; a failure-kind facet in the options Activity page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018scDZ7G3pkkAxKjmQkWY2q

---
_Generated by [Claude Code](https://claude.ai/code/session_018scDZ7G3pkkAxKjmQkWY2q)_