### PR TITLE
Harden before wider exposure: narrow threat-model residuals R4, R5, R6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ and storage formats may move until the surface stabilizes.
 
 ## [Unreleased]
 
+### Security
+- **Three residual risks from the threat model narrowed before wider
+  exposure** (R4/R5/R6 — each documented honestly in
+  docs/security/THREAT-MODEL.md):
+  - **The audit log is tamper-evident now.** Every entry extends a SHA-256
+    hash chain and a head record pins the newest link, so rewritten, deleted,
+    inserted, or truncated entries fail verification. The debug bundle runs
+    the verification and stamps the result into its provenance. (Evidence,
+    not proof: in-origin code execution can still recompute the chain — that
+    boundary is stated, not hidden.)
+  - **Session confirm grants are origin-bound.** "Yes for this session" now
+    means this tool ON this origin — approving `click` on one site no longer
+    silently covers every site the chat visits. Generalizes the host scoping
+    web writes already had.
+  - **Transfer import is gated.** Imported provider endpoints must be https
+    (or local loopback) and are named in the summary the user approves;
+    imported hooks land DISABLED and untrusted until re-enabled per hook in
+    Settings; a memory import states its prompt-injection consequence in the
+    apply notices.
+
 ### Added
 - **The debug surface: serious observability without a vendor.** peerd's
   chain of events was already recorded (audit log, lineage, delegation

--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -125,7 +125,7 @@ malicious separate extension, and physical device access.
 | Local files (WebVM filesystem, Notebook and App OPFS) | Sandbox-local storage | Per-instance OPFS root, path-traversal collapse, realm seal |
 | Peer bundles (dwapps, data, agent cards) | Received over the mesh | Content addressing, Ed25519 signatures, size and shape caps |
 | The agent's own authority (its tools, its delegation) | The orchestrator | Exposure and actor-tier gates, the sender gate, Plan and Act mode |
-| The audit log (record of security events) | IndexedDB, extension origin | Append-only by convention (see residual risk R4, no tamper resistance) |
+| The audit log (record of security events) | IndexedDB, extension origin | Append-only, hash-chained for tamper evidence (residual risk R4: evident, not proof) |
 
 ---
 
@@ -377,19 +377,28 @@ evaluating peerd should know. Each cites where it lives in the code.
   the skill body loads into context as trusted instructions with no untrusted-content
   fence. A malicious shared skill is a direct instruction-injection vector. Installing a
   skill runs its author's prompt. (`peerd-runtime/skills/`.)
-- R4. The audit log is not tamper-resistant. It is append-only by convention in
-  IndexedDB. Any code in the extension origin can rewrite or delete entries. There is no
-  hash chain or signing. It records events for an honest system. It cannot resist an
-  attacker who already has in-origin code execution. (`peerd-egress/audit/log.js`.)
-- R5. Confirm grants are origin-blind. A session-scoped "Yes" is keyed by tool name
-  only, so approving `click` once approves it for every origin in that chat, and the
-  confirm prompt text is agent-supplied, so a misleading description could induce a
-  "yes". An origin-scoped grant store is future work. (`peerd-egress/confirm/protocol.js`.)
-- R6. Transfer import is an untrusted-deserialization surface. A shared settings or
-  session export can inject provider endpoints (redirecting egress), repopulate memory
-  (poisoning), and reinstall skills from arbitrary origins. The secret crypto and
-  unknown-key dropping are sound. The endpoint, hook, and memory injection path is not
-  otherwise gated. Import only files you trust. (`peerd-runtime/transfer/transfer.js`.)
+- R4 (narrowed). The audit log is tamper-EVIDENT, not tamper-proof. Every entry
+  extends a SHA-256 hash chain and a head record pins the newest link, so a rewritten
+  entry, a deleted middle entry, a truncated tail, or an inserted record fails
+  verification (`verify()`, surfaced in the debug bundle's provenance). What remains
+  out of reach: an attacker with in-origin code execution can recompute the whole
+  chain and the head — no in-origin scheme can prevent that without a secret the
+  origin does not hold. (`peerd-egress/audit/chain.js`, `audit/log.js`.)
+- R5 (narrowed). Confirm grants are origin-BOUND: a session-scoped "Yes" is keyed by
+  tool + the prompt's dispatcher-computed origin (the pinned tab for DOM tools, the
+  target host for web writes), so approving `click` on one site no longer covers any
+  other site; the origin line the user sees is system-derived. What remains: the
+  DESCRIPTION text is agent-supplied, so a misleading summary could still induce a
+  "yes" for the named origin. (`background/confirm-grant-key.js`,
+  `peerd-egress/confirm/protocol.js`.)
+- R6 (narrowed). Transfer import is a gated untrusted-deserialization surface.
+  Provider endpoints are validated (https or local loopback only) and named in the
+  summary the user approves; imported hooks land DISABLED and untrusted (a JS hook
+  cannot compile without an explicit re-trust in Settings); a memory import states its
+  prompt-injection consequence in the apply notices. What remains: an approved https
+  endpoint is still an egress redirection the user chose to accept, and imported
+  memory is trusted once the user proceeds. Import only files you trust.
+  (`peerd-runtime/transfer/transfer.js`.)
 - R7. A malicious co-installed extension or compromised origin is out of scope. The live
   key is reachable to any code running in the extension origin, and is mirrored into
   `chrome.storage.session` for service-worker-restart resume. The stated threat model is
@@ -416,8 +425,10 @@ evaluating peerd should know. Each cites where it lives in the code.
   `peerd-egress/fetch/safe-fetch.js`.)
 
 Candidates for future red-team scenarios, from the partially-defended surfaces above:
-R2 memory poisoning, R3 skill-body smuggling, R6 transfer-import injection, and R5
-origin-blind confirm grants.
+R2 memory poisoning and R3 skill-body smuggling. (R4 chain tampering, R5 grant
+scoping, and R6 import gating gained direct bun coverage when they were narrowed:
+tests/peerd-egress/audit-chain.test.ts, tests/background/confirm-grant-key.test.ts,
+and the R6 block in tests/peerd-runtime/transfer/transfer.test.ts.)
 
 ---
 

--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -380,9 +380,10 @@ evaluating peerd should know. Each cites where it lives in the code.
 - R4 (narrowed). The audit log is tamper-EVIDENT, not tamper-proof. Every entry
   extends a SHA-256 hash chain and a head record pins the newest link, so a rewritten
   entry, a deleted middle entry, a truncated tail, or an inserted record fails
-  verification (`verify()`, surfaced in the debug bundle's provenance). What remains
-  out of reach: an attacker with in-origin code execution can recompute the whole
-  chain and the head — no in-origin scheme can prevent that without a secret the
+  verification (`verify()`, surfaced in the debug bundle's provenance) — including
+  the cheaper attack of deleting the tail AND the head record together, which fails
+  closed on the surviving chained prefix. What remains out of reach: an attacker with
+  in-origin code execution can recompute the whole chain and the head — no in-origin scheme can prevent that without a secret the
   origin does not hold. (`peerd-egress/audit/chain.js`, `audit/log.js`.)
 - R5 (narrowed). Confirm grants are origin-BOUND: a session-scoped "Yes" is keyed by
   tool + the prompt's dispatcher-computed origin (the pinned tab for DOM tools, the

--- a/extension/background/confirm-grant-key.js
+++ b/extension/background/confirm-grant-key.js
@@ -1,0 +1,25 @@
+// @ts-check
+// background/confirm-grant-key.js — the session-grant key for a confirm
+// prompt (R5: origin-BOUND grants).
+//
+// "Yes for this session" used to be keyed by tool name alone, so one
+// approval of `click` on site A silently covered `click` on every other
+// site that chat visited. The grant key now folds in the prompt's first
+// origin whenever the dispatcher computed one (tool.origins(args, ctx) —
+// the pinned tab's origin for DOM tools, the target host for web
+// writes), so a session grant means "this tool ON this origin". Tools
+// that genuinely have no origin (memory writes, VM ops) keep the bare
+// tool key — there is no cross-site surface to scope.
+//
+// Pure (values in, string out) — bun-tested.
+
+/**
+ * @param {{ tool: string, origins?: string[] }} prompt
+ * @returns {string}
+ */
+export const confirmGrantKey = (prompt) => {
+  const origin = Array.isArray(prompt?.origins) && prompt.origins[0]
+    ? String(prompt.origins[0])
+    : '';
+  return origin ? `${prompt.tool}|${origin}` : prompt.tool;
+};

--- a/extension/background/routes/sessions.js
+++ b/extension/background/routes/sessions.js
@@ -313,8 +313,11 @@ export const makeSessionRoutes = (deps) => {
       const auditEntries = (await auditLog.list())
         .filter((/** @type {any} */ e) => e.sessionId && idSet.has(e.sessionId));
       const settings = settingsStore.get();
+      // R4: the bundle's audit slice is a checkable artifact — run the hash
+      // chain verification and stamp the result into provenance.
+      const auditChain = await (auditLog.verify?.().catch(() => null)) ?? null;
       const bundle = assembleDebugBundle({
-        session, childSessions, auditEntries, settings,
+        session, childSessions, auditEntries, settings, auditChain,
         contextSnapshots: contextSnapshots.snapshotsForMany([sessionId, ...childIds]),
         channel: CHANNEL,
         appVersion: browser.runtime.getManifest?.().version ?? 'unknown',

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -250,6 +250,7 @@ import { createJsTabTracker } from './notebook-tab-tracker.js';
 import { makeOffscreenJsClient } from './offscreen-js-client.js';
 import { createScriptRunRegistry } from './script-runs.js';
 import { createContextSnapshots } from './context-snapshots.js';
+import { confirmGrantKey } from './confirm-grant-key.js';
 import { makeOffscreenActorClient } from './offscreen-actor-client.js';
 import { makeOffscreenPdfClient } from './offscreen-pdf-client.js';
 import { makeUiPorts } from './ui-ports.js';
@@ -1955,15 +1956,12 @@ const confirmAction = async (prompt) => {
   if (prompt.tool === WEB_WRITE_CONFIRM_KEY && settingsStore.get().confirmWebWrites === false) {
     return 'yes_once';
   }
-  // why scope the web-write grant by host: the prompt names a SPECIFIC host
-  // ("…send a POST request to {host}?"), so "approve for this session" must mean
-  // THIS host this session — not a blanket pass for non-GET egress to any host
-  // for the rest of the session. The prompt already carries origins:[host]; fold
-  // it into the grant key. Every other tool keys by its (already host-specific
-  // or host-agnostic-by-design) tool name.
-  const grantKey = prompt.tool === WEB_WRITE_CONFIRM_KEY
-    ? `${WEB_WRITE_CONFIRM_KEY}|${(Array.isArray(prompt.origins) && prompt.origins[0]) || ''}`
-    : prompt.tool;
+  // R5 (origin-bound grants): "approve for this session" means this tool ON
+  // this origin — the dispatcher computes prompt.origins (the pinned tab's
+  // origin for DOM tools, the target host for web writes), and the grant key
+  // folds it in. Approving `click` on site A no longer covers site B. Tools
+  // with no origin surface keep the bare tool key (confirm-grant-key.js).
+  const grantKey = confirmGrantKey(prompt);
   // DESIGN-17: an ACTOR never accumulates a STANDING grant — its confirms are
   // strictly PER-TURN (an actor can be steered by untrusted instance output
   // across turns, so a once-granted "yes for session" must not silence the next

--- a/extension/peerd-egress/audit/chain.js
+++ b/extension/peerd-egress/audit/chain.js
@@ -27,6 +27,7 @@
 export const CHAIN_HEAD_KEY = 'audit_chain_head';
 
 const encoder = new TextEncoder();
+const SEP = '\x1f'; // ASCII unit separator — never appears in ids/types
 
 /** @param {ArrayBuffer} buf */
 const hex = (buf) => [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, '0')).join('');
@@ -42,7 +43,7 @@ export const canonicalCore = (entry) => [
   entry.type,
   entry.sessionId ?? '',
   entry.details === undefined ? '' : JSON.stringify(entry.details),
-].join(''); // unit separator — cannot appear in uuidv7/type, unambiguous joins
+].join(SEP); // SEP-joined so distinct field tuples can never collide into one string
 
 /**
  * chain(entry) = SHA-256(prevChain ‖ US ‖ canonicalCore(entry)) as hex.
@@ -92,17 +93,23 @@ export const verifyChain = async (entries, head = null) => {
     }
     checked++;
   }
+  // The head record is as durable as the entries (same IDB, written on
+  // every append). So once ANY chained entry exists, a head MUST exist —
+  // its absence means the tail AND the head were deleted together (the
+  // cheaper truncation the naive head-survives check missed). Fail closed.
+  // (A pre-chain-only log has chained.length === 0 and legitimately no head.)
+  if (chained.length > 0 && !head?.chain) {
+    return { ok: false, checked, unchained, reason: 'head record missing (tail truncation or head deletion)' };
+  }
   if (head?.chain && chained.length > 0) {
     const last = chained[chained.length - 1];
     if (head.id !== last.id || head.chain !== last.chain) {
       return { ok: false, checked, unchained, reason: 'head mismatch (truncated tail)', brokenAtId: last.id };
     }
   }
-  if (head?.chain && chained.length === 0 && entries.length >= 0) {
-    // A head exists but no chained entries survive: legal only if the whole
-    // retained window predates... no — the head tracks the newest entry,
-    // which is never pruned. A head with no chained entries means the tail
-    // was deleted.
+  if (head?.chain && chained.length === 0) {
+    // A head tracks the newest entry, which is never pruned — so a head with
+    // no surviving chained entries means the whole chained tail was deleted.
     return { ok: false, checked, unchained, reason: 'head present but no chained entries (tail deleted)' };
   }
   return { ok: true, checked, unchained };

--- a/extension/peerd-egress/audit/chain.js
+++ b/extension/peerd-egress/audit/chain.js
@@ -1,0 +1,109 @@
+// @ts-check
+// audit/chain.js — the audit log's tamper-evidence hash chain (R4).
+//
+// Each appended entry carries `chain` = SHA-256 over (the previous
+// entry's chain ‖ this entry's canonical core). A separate tiny head
+// record (audit_meta store) pins the id+chain of the NEWEST entry, so
+// verification detects all four naive tamperings: a rewritten entry
+// (its own chain no longer matches), a deleted middle entry (its
+// successor's chain no longer matches), a truncated tail (head record
+// disagrees with the last entry), and a reordered log (uuidv7 order and
+// chain order diverge). Retention pruning stays legal: only the OLDEST
+// entries are removed, and the first retained entry's chain is accepted
+// as the anchor.
+//
+// Honest scope (the threat model's R4 wording matches): this is
+// tamper-EVIDENT, not tamper-PROOF. An attacker with code execution in
+// the extension origin can recompute the whole chain forward and update
+// the head; without a secret the origin does not hold, no in-origin
+// scheme can prevent that. What this closes is silent, cheap
+// tampering — and it makes the debug bundle's audit slice a checkable
+// artifact rather than a claim.
+//
+// Pure over injected values (crypto.subtle is compute, not IO) —
+// bun-tested without a browser.
+
+/** The audit_meta record that pins the newest entry. */
+export const CHAIN_HEAD_KEY = 'audit_chain_head';
+
+const encoder = new TextEncoder();
+
+/** @param {ArrayBuffer} buf */
+const hex = (buf) => [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, '0')).join('');
+
+/**
+ * The canonical byte string a chain hash covers. Fixed field order —
+ * object-key order must never be able to change the hash.
+ * @param {{ id: string, when: number, type: string, sessionId?: string, details?: object }} entry
+ */
+export const canonicalCore = (entry) => [
+  entry.id,
+  String(entry.when),
+  entry.type,
+  entry.sessionId ?? '',
+  entry.details === undefined ? '' : JSON.stringify(entry.details),
+].join(''); // unit separator — cannot appear in uuidv7/type, unambiguous joins
+
+/**
+ * chain(entry) = SHA-256(prevChain ‖ US ‖ canonicalCore(entry)) as hex.
+ * @param {string} prevChain  the previous entry's chain ('' for the genesis entry)
+ * @param {{ id: string, when: number, type: string, sessionId?: string, details?: object }} entry
+ */
+export const computeChainHash = async (prevChain, entry) => {
+  const bytes = encoder.encode(`${prevChain}${canonicalCore(entry)}`);
+  return hex(await crypto.subtle.digest('SHA-256', bytes));
+};
+
+/**
+ * Verify a retained slice of the log against its embedded chain and the
+ * head record. Entries must be in insertion (uuidv7) order — exactly what
+ * auditLog.list() returns.
+ *
+ * @param {Array<Record<string, any>>} entries
+ * @param {{ id?: string, chain?: string } | null} [head]  the audit_meta head record
+ * @returns {Promise<{ ok: boolean, checked: number, unchained: number, reason?: string, brokenAtId?: string }>}
+ *   ok=false only on a DETECTED inconsistency. Entries written before the
+ *   chain existed carry no `chain` and are reported (unchained), not failed —
+ *   an upgrade must not brand every existing install as tampered.
+ */
+export const verifyChain = async (entries, head = null) => {
+  const chained = entries.filter((e) => typeof e.chain === 'string');
+  const unchained = entries.length - chained.length;
+  // Legacy entries are only legal as a PREFIX (they predate the feature);
+  // a chainless entry AFTER a chained one is an insertion or a strip.
+  const firstChained = entries.findIndex((e) => typeof e.chain === 'string');
+  if (firstChained !== -1) {
+    for (let i = firstChained; i < entries.length; i++) {
+      if (typeof entries[i].chain !== 'string') {
+        return { ok: false, checked: 0, unchained, reason: 'unchained entry after a chained one', brokenAtId: entries[i].id };
+      }
+    }
+  }
+  let checked = 0;
+  for (let i = 0; i < chained.length; i++) {
+    // The first retained chained entry is the anchor: its predecessor may
+    // have been pruned (or be a legacy entry), so its own hash is trusted
+    // as the chain's start. Every later link is recomputable.
+    if (i > 0) {
+      const expected = await computeChainHash(chained[i - 1].chain, /** @type {any} */ (chained[i]));
+      if (expected !== chained[i].chain) {
+        return { ok: false, checked, unchained, reason: 'chain mismatch (rewritten or deleted entry)', brokenAtId: chained[i].id };
+      }
+    }
+    checked++;
+  }
+  if (head?.chain && chained.length > 0) {
+    const last = chained[chained.length - 1];
+    if (head.id !== last.id || head.chain !== last.chain) {
+      return { ok: false, checked, unchained, reason: 'head mismatch (truncated tail)', brokenAtId: last.id };
+    }
+  }
+  if (head?.chain && chained.length === 0 && entries.length >= 0) {
+    // A head exists but no chained entries survive: legal only if the whole
+    // retained window predates... no — the head tracks the newest entry,
+    // which is never pruned. A head with no chained entries means the tail
+    // was deleted.
+    return { ok: false, checked, unchained, reason: 'head present but no chained entries (tail deleted)' };
+  }
+  return { ok: true, checked, unchained };
+};

--- a/extension/peerd-egress/audit/log.js
+++ b/extension/peerd-egress/audit/log.js
@@ -18,11 +18,13 @@
 
 import { uuidv7 } from '/shared/util.js';
 import { normalizeMaxEntries, excessEntries, DEFAULT_PRUNE_CHECK_EVERY } from './retention.js';
+import { computeChainHash, verifyChain, CHAIN_HEAD_KEY } from './chain.js';
 
 /** @typedef {import('./types.js').AuditEntry} AuditEntry */
 /** @typedef {import('./types.js').AuditEntryInput} AuditEntryInput */
 
 const STORE = 'audit_log';
+const META_STORE = 'audit_meta';
 
 /**
  * The slice of the IDB wrapper (storage/idb.js) the audit log writes
@@ -35,7 +37,8 @@ const STORE = 'audit_log';
  * be injectable.
  *
  * @typedef {{
- *   put(store: string, value: AuditEntry): Promise<void>,
+ *   put(store: string, value: object): Promise<void>,
+ *   get?(store: string, key: string): Promise<any>,
  *   getAll(store: string): Promise<any[]>,
  *   count(store: string): Promise<number>,
  *   getAllKeys(store: string, limit?: number): Promise<IDBValidKey[]>,
@@ -68,6 +71,25 @@ export const createAuditLog = ({ idb, now = Date.now, makeId, maxEntries, pruneC
   /** @type {Promise<void> | null} */
   let pruneInFlight = null;
 
+  // R4 tamper evidence: every entry extends a SHA-256 hash chain, and a
+  // tiny head record (audit_meta) pins the newest link. The chain tail is
+  // cached in-closure after the first append; appends SERIALIZE through
+  // writeQueue so interleaved async appends cannot fork the chain.
+  /** @type {{ id: string, chain: string } | null} */
+  let chainTail = null;
+  let chainTailLoaded = false;
+  /** @type {Promise<any>} */
+  let writeQueue = Promise.resolve();
+
+  const loadChainTail = async () => {
+    if (chainTailLoaded) return;
+    chainTailLoaded = true;
+    try {
+      const head = await idb.get?.(META_STORE, CHAIN_HEAD_KEY);
+      if (head?.chain) chainTail = { id: head.id, chain: head.chain };
+    } catch { /* a fake idb without a meta store starts a fresh chain */ }
+  };
+
   // Delete the oldest entries down to the cap: one count, one
   // keys-only read of the excess, one ranged delete. UUIDv7 ids make
   // IDB key order chronological, so "first N keys" IS "oldest N".
@@ -99,28 +121,60 @@ export const createAuditLog = ({ idb, now = Date.now, makeId, maxEntries, pruneC
    * @param {AuditEntryInput} input
    * @returns {Promise<AuditEntry>}
    */
-  const append = async (input) => {
+  const append = (input) => {
     if (!input || typeof input.type !== 'string') {
-      throw new TypeError('appendAudit: input.type is required');
+      // why reject (not throw): append was async before the chain landed —
+      // callers handle malformed input as a rejected promise, not a sync throw.
+      return Promise.reject(new TypeError('appendAudit: input.type is required'));
     }
-    /** @type {AuditEntry} */
-    const entry = {
-      id: generateId(),
-      when: now(),
-      type: input.type,
-      ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
-      ...(input.details   !== undefined ? { details: input.details } : {}),
-    };
-    await idb.put(STORE, entry);
-    // Retention rides the append path (there is no other timer in the
-    // MV3 SW to hang it off), awaited so a pruning failure surfaces to
-    // whoever DOES await the append — but only one append per batch
-    // pays the cost.
-    if (++appendsSinceCheck >= checkEvery) {
-      appendsSinceCheck = 0;
-      await maybePrune();
-    }
-    return entry;
+    // why the queue: the chain makes appends ORDER-DEPENDENT (each hash
+    // covers its predecessor's), and the SW fires many appends without
+    // awaiting. Serializing through one promise chain keeps the hash
+    // chain linear; the returned promise still settles per-append.
+    const job = writeQueue.then(async () => {
+      await loadChainTail();
+      /** @type {AuditEntry & { chain: string }} */
+      const entry = {
+        id: generateId(),
+        when: now(),
+        type: input.type,
+        ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
+        ...(input.details   !== undefined ? { details: input.details } : {}),
+        chain: '',
+      };
+      entry.chain = await computeChainHash(chainTail?.chain ?? '', entry);
+      await idb.put(STORE, entry);
+      chainTail = { id: entry.id, chain: entry.chain };
+      try {
+        await idb.put(META_STORE, { key: CHAIN_HEAD_KEY, id: entry.id, chain: entry.chain });
+      } catch { /* a fake idb without the meta store still gets chained entries */ }
+      // Retention rides the append path (there is no other timer in the
+      // MV3 SW to hang it off), awaited so a pruning failure surfaces to
+      // whoever DOES await the append — but only one append per batch
+      // pays the cost.
+      if (++appendsSinceCheck >= checkEvery) {
+        appendsSinceCheck = 0;
+        await maybePrune();
+      }
+      return entry;
+    });
+    // why swallow on the QUEUE (not the caller's promise): one failed
+    // append must not wedge every later one behind a rejected chain.
+    writeQueue = job.catch(() => {});
+    return job;
+  };
+
+  /**
+   * Verify the retained log against its hash chain + head record.
+   * ok=false means a DETECTED inconsistency (rewrite, deletion,
+   * truncation); pre-chain legacy entries report as `unchained`, not
+   * failures. Read-only.
+   */
+  const verify = async () => {
+    const entries = await idb.getAll(STORE);
+    let head = null;
+    try { head = await idb.get?.(META_STORE, CHAIN_HEAD_KEY) ?? null; } catch { head = null; }
+    return verifyChain(entries, head);
   };
 
   /**
@@ -130,5 +184,5 @@ export const createAuditLog = ({ idb, now = Date.now, makeId, maxEntries, pruneC
    */
   const list = () => idb.getAll(STORE);
 
-  return Object.freeze({ append, list });
+  return Object.freeze({ append, list, verify });
 };

--- a/extension/peerd-egress/audit/log.js
+++ b/extension/peerd-egress/audit/log.js
@@ -171,10 +171,19 @@ export const createAuditLog = ({ idb, now = Date.now, makeId, maxEntries, pruneC
    * failures. Read-only.
    */
   const verify = async () => {
-    const entries = await idb.getAll(STORE);
-    let head = null;
-    try { head = await idb.get?.(META_STORE, CHAIN_HEAD_KEY) ?? null; } catch { head = null; }
-    return verifyChain(entries, head);
+    // why through the queue: reading entries then head OUTSIDE the append
+    // serialization can catch an append mid-flight (head one entry ahead of
+    // the last getAll row) → a false "truncated tail" stamped into the debug
+    // bundle. Draining the queue first gives a consistent snapshot.
+    const readSnapshot = async () => {
+      const entries = await idb.getAll(STORE);
+      let head = null;
+      try { head = await idb.get?.(META_STORE, CHAIN_HEAD_KEY) ?? null; } catch { head = null; }
+      return verifyChain(entries, head);
+    };
+    const job = writeQueue.then(readSnapshot);
+    writeQueue = job.catch(() => {});
+    return job;
   };
 
   /**

--- a/extension/peerd-egress/audit/types.js
+++ b/extension/peerd-egress/audit/types.js
@@ -70,7 +70,10 @@
  * @property {string} id                  UUIDv7 (time-sortable)
  * @property {number} when                ms since epoch
  * @property {AuditType} type
- * @property {string} [sessionId]         present for session-scoped events
+ * @property {string} [sessionId]
+ * @property {string} [chain]        R4 tamper evidence: SHA-256 over the
+ *   previous entry's chain + this entry's canonical core (audit/chain.js).
+ *   Absent only on entries written before the chain shipped.         present for session-scoped events
  * @property {Record<string, any>} [details]
  */
 

--- a/extension/peerd-egress/storage/idb.js
+++ b/extension/peerd-egress/storage/idb.js
@@ -62,7 +62,10 @@ const DB_NAME = 'peerd';
 // that version → NotFoundError. #53 lands first at v8; this is v9. Both upgrade
 // blocks below run in order for a pre-v8 user; each is guarded by a contains()
 // check so re-runs are idempotent.
-const DB_VERSION = 9;
+// v10 — audit_meta: the audit log's hash-chain head record (R4 tamper
+// evidence). One tiny record ({ key: 'audit_chain_head', id, chain })
+// pinning the newest entry so tail truncation is detectable.
+const DB_VERSION = 10;
 
 /**
  * Open the database. Cached after first call. Re-opens on connection
@@ -95,6 +98,10 @@ export const openDB = () => {
       // V1.5 — file-based memory. One AGENTS.md doc per scope id.
       if (!db.objectStoreNames.contains('agents_memory')) {
         db.createObjectStore('agents_memory', { keyPath: 'id' });
+      }
+      // v10 — the audit chain head (see DB_VERSION note above).
+      if (!db.objectStoreNames.contains('audit_meta')) {
+        db.createObjectStore('audit_meta', { keyPath: 'key' });
       }
       // v3 — the vault blob's new home (records: { key, value }). The
       // blob itself stays ciphertext; this is hygiene, not a security

--- a/extension/peerd-runtime/observability/debug-bundle.js
+++ b/extension/peerd-runtime/observability/debug-bundle.js
@@ -113,10 +113,12 @@ export const collectFailures = (session) => {
  * @param {string} [input.appVersion]
  * @param {number} input.now
  * @param {{ auditMaxEntries?: number, snapshotsPerSession?: number }} [input.limits]  the caps in force at capture, for provenance
+ * @param {{ ok: boolean, checked: number, unchained: number, reason?: string } | null} [input.auditChain]
+ *   the audit log's hash-chain verification result (R4), when the caller ran it
  */
 export const assembleDebugBundle = ({
   session, childSessions = [], auditEntries = [], settings = {},
-  contextSnapshots = [], channel, appVersion, now, limits = {},
+  contextSnapshots = [], channel, appVersion, now, limits = {}, auditChain = null,
 }) => {
   const children = childSessions.slice(0, BUNDLE_MAX_CHILD_SESSIONS);
   const audit = auditEntries.slice(-BUNDLE_MAX_AUDIT_ENTRIES);
@@ -163,6 +165,13 @@ export const assembleDebugBundle = ({
         : 'all descendant actor/subagent sessions included.',
       secrets: 'none by construction: API keys live only in the vault and are attached at fetch-header '
         + 'time; they never enter settings, session records, or captured request bodies.',
+      ...(auditChain ? {
+        auditChain: auditChain.ok
+          ? `hash chain verified over ${auditChain.checked} entries`
+            + (auditChain.unchained > 0 ? ` (${auditChain.unchained} pre-chain legacy entries unverifiable).` : '.')
+          : `hash chain FAILED verification: ${auditChain.reason ?? 'inconsistent'} — the audit slice may have been altered.`,
+      } : {}),
     },
+    ...(auditChain ? { auditChainVerification: auditChain } : {}),
   };
 };

--- a/extension/peerd-runtime/observability/debug-bundle.js
+++ b/extension/peerd-runtime/observability/debug-bundle.js
@@ -167,8 +167,8 @@ export const assembleDebugBundle = ({
         + 'time; they never enter settings, session records, or captured request bodies.',
       ...(auditChain ? {
         auditChain: auditChain.ok
-          ? `hash chain verified over ${auditChain.checked} entries`
-            + (auditChain.unchained > 0 ? ` (${auditChain.unchained} pre-chain legacy entries unverifiable).` : '.')
+          ? `hash chain verified over ${auditChain.checked} entries${
+             auditChain.unchained > 0 ? ` (${auditChain.unchained} pre-chain legacy entries unverifiable).` : '.'}`
           : `hash chain FAILED verification: ${auditChain.reason ?? 'inconsistent'} — the audit slice may have been altered.`,
       } : {}),
     },

--- a/extension/peerd-runtime/transfer/transfer.js
+++ b/extension/peerd-runtime/transfer/transfer.js
@@ -211,6 +211,22 @@ export const inspectImport = ({ payload, channel, knownSettingKeys }) => {
   if (skills.length > 0) {
     notices.push(`${skills.length} skill(s) are listed as metadata only — reinstall them from the Skills view (their sources are preserved in the export).`);
   }
+  // R6 (import is an untrusted-deserialization surface): the two payload
+  // sections that can redirect authority — provider endpoints (egress
+  // targets) and hooks (code that vetoes/permits tool calls) — are named
+  // LOUDLY in the summary the user approves, not buried in counts.
+  /** @type {string[]} */
+  const endpointUrls = (Array.isArray(payload.providerEndpoints?.endpoints) ? payload.providerEndpoints.endpoints : [])
+    .map((/** @type {any} */ e) => String(e?.url ?? '')).filter(Boolean);
+  if (endpointUrls.length > 0) {
+    notices.push(`This import adds provider endpoint(s) the agent will send API traffic to: ${endpointUrls.join(', ')} — only proceed if you recognize them.`);
+  }
+  /** @type {string[]} */
+  const hookIds = (Array.isArray(payload.hooks) ? payload.hooks : [])
+    .map((/** @type {any} */ h) => String(h?.id ?? 'unknown'));
+  if (hookIds.length > 0) {
+    notices.push(`${hookIds.length} hook(s) will be imported DISABLED and untrusted (${hookIds.join(', ')}) — review and re-enable them in Settings → Hooks.`);
+  }
   return {
     ok: true,
     summary: {
@@ -221,6 +237,8 @@ export const inspectImport = ({ payload, channel, knownSettingKeys }) => {
       hasSecrets: payload.secrets != null,
       memoryDocs: Array.isArray(payload.memory?.docs) ? payload.memory.docs.length : 0,
       hooks: Array.isArray(payload.hooks) ? payload.hooks.length : 0,
+      hookIds,
+      endpointUrls,
       skills: skills.map((s) => s?.name ?? s?.id ?? 'unknown'),
       dwebPresent,
       dwebDropped: channel === 'store' && dwebPresent,
@@ -272,7 +290,25 @@ export const applyImport = async ({ payload, passphrase, channel, knownSettingKe
   }
 
   if (payload.providerEndpoints?.endpoints) {
-    await io.setProviderEndpoints(payload.providerEndpoints);
+    // R6: an imported endpoint becomes an egress target the agent sends
+    // API traffic (and headers) to. Only https (or local-loopback http for
+    // Ollama-style daemons) parses through; anything else is dropped and
+    // named. This blocks scheme smuggling; the https hosts themselves were
+    // shown to the user in the inspect summary they approved.
+    const accepted = [];
+    const dropped = [];
+    for (const endpoint of payload.providerEndpoints.endpoints) {
+      const url = (() => { try { return new URL(String(endpoint?.url ?? '')); } catch { return null; } })();
+      const localLoopback = url?.protocol === 'http:' && ['localhost', '127.0.0.1', '[::1]'].includes(url.hostname);
+      if (url && (url.protocol === 'https:' || localLoopback)) accepted.push(endpoint);
+      else dropped.push(String(endpoint?.url ?? '(unparseable)'));
+    }
+    if (accepted.length > 0) {
+      await io.setProviderEndpoints({ ...payload.providerEndpoints, endpoints: accepted });
+    }
+    if (dropped.length > 0) {
+      summary.notices.push(`Dropped ${dropped.length} provider endpoint(s) that are not https or local loopback: ${dropped.join(', ')}.`);
+    }
   }
 
   if (payload.secrets != null) {
@@ -289,10 +325,21 @@ export const applyImport = async ({ payload, passphrase, channel, knownSettingKe
   if (payload.memory?.docs) {
     const res = await io.importMemory(payload.memory);
     imported.memoryWritten = res.written;
+    if (res.written > 0) {
+      // R6: memory is injected into future prompts as trusted context — an
+      // import that repopulates it is a poisoning vector. Import stays legal
+      // (the user approved the summary), but the consequence is stated.
+      summary.notices.push(`${res.written} memory doc(s) imported — they will inform future prompts; review them via /memory if this file wasn't authored by you.`);
+    }
   }
 
   for (const record of payload.hooks ?? []) {
-    await io.saveHook(record);
+    // R6: an imported hook is CODE (or a rule) that runs against every tool
+    // call. It arrives from a file, not from this user's editor — so it
+    // lands disabled AND untrusted (a kind:'js' hook cannot even compile
+    // without trusted:true). Enabling is an explicit per-hook decision in
+    // Settings → Hooks, where the body is visible.
+    await io.saveHook({ ...record, enabled: false, trusted: false });
     imported.hooks++;
   }
 

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -70,7 +70,10 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // 493 → 496: the debug surface's wiring + UI add background/context-snapshots.js
 // (the capture ring), sidepanel/components/context-inspector.js, and the
 // failure-chip in-browser test.
-const COVERED_FLOOR = 496;
+// 496 -> 498: the hardening pass adds peerd-egress/audit/chain.js (the R4
+// tamper-evidence hash chain) and background/confirm-grant-key.js (the R5
+// origin-bound grant key).
+const COVERED_FLOOR = 498;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/tests/background/confirm-grant-key.test.ts
+++ b/tests/background/confirm-grant-key.test.ts
@@ -1,0 +1,32 @@
+// R5 — origin-BOUND session grants. A "yes for this session" must mean
+// "this tool on this origin": the key folds in the prompt's computed
+// origin whenever one exists, and only originless tools keep the bare
+// tool key.
+
+import { describe, test, expect } from 'bun:test';
+import { confirmGrantKey } from '../../extension/background/confirm-grant-key.js';
+
+describe('confirmGrantKey', () => {
+  test('a DOM tool with a tab origin is scoped to that origin', () => {
+    expect(confirmGrantKey({ tool: 'click', origins: ['https://a.example'] }))
+      .toBe('click|https://a.example');
+    // the crux of R5: the same tool on another origin is a DIFFERENT grant
+    expect(confirmGrantKey({ tool: 'click', origins: ['https://b.example'] }))
+      .not.toBe(confirmGrantKey({ tool: 'click', origins: ['https://a.example'] }));
+  });
+
+  test('the web-write key keeps its host scoping (same shape as before)', () => {
+    expect(confirmGrantKey({ tool: 'web:write', origins: ['https://api.example'] }))
+      .toBe('web:write|https://api.example');
+  });
+
+  test('an originless tool keys by name alone', () => {
+    expect(confirmGrantKey({ tool: 'write_memory' })).toBe('write_memory');
+    expect(confirmGrantKey({ tool: 'write_memory', origins: [] })).toBe('write_memory');
+  });
+
+  test('degenerate origins never produce a scoped key by accident', () => {
+    expect(confirmGrantKey({ tool: 'click', origins: ['', ''] })).toBe('click');
+    expect(confirmGrantKey({ tool: 'click', origins: undefined })).toBe('click');
+  });
+});

--- a/tests/background/web-write-grant-scope.test.ts
+++ b/tests/background/web-write-grant-scope.test.ts
@@ -2,20 +2,24 @@ import { describe, test, expect } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-// The web-write session grant ("approve for this session" on a non-GET egress
-// prompt) must be scoped to the HOST the prompt named — not the bare 'web:write'
-// tool key — so one approval for host A does NOT silently authorize body-carrying
-// egress to every other host for the rest of the session. confirmAction lives in
-// service-worker.js (no bun import), so assert against the SOURCE TEXT, like
-// offscreen-gate.test.ts. Reverting to a tool-only grant key fails these.
+// The session grant ("approve for this session") must be scoped to the ORIGIN
+// the prompt named — not the bare tool key — so one approval on host A does NOT
+// silently authorize the same tool on every other host for the rest of the
+// session. R5 generalized the original web-write host scoping to EVERY tool
+// whose prompt carries origins, through the pure confirmGrantKey
+// (background/confirm-grant-key.js, bun-tested directly). confirmAction lives
+// in service-worker.js (no bun import), so assert against the SOURCE TEXT that
+// the generalized key is what the grant cache uses. Reverting to a tool-only
+// grant key fails these.
 const src = readFileSync(
   join(import.meta.dir, '../../extension/background/service-worker.js'),
   'utf8',
 );
 
-describe('service worker — web-write session grant is host-scoped', () => {
-  test('the web-write grant key folds in the prompt origin', () => {
-    expect(src).toMatch(/grantKey\s*=\s*prompt\.tool\s*===\s*WEB_WRITE_CONFIRM_KEY[\s\S]{0,140}?prompt\.origins\b/);
+describe('service worker — session grants are origin-scoped', () => {
+  test('the grant key comes from the origin-folding confirmGrantKey', () => {
+    expect(src).toMatch(/grantKey\s*=\s*confirmGrantKey\(prompt\)/);
+    expect(src).toMatch(/from '\.\/confirm-grant-key\.js'/);
   });
   test('both the grant check and the grant record use grantKey, not prompt.tool', () => {
     expect(src).toMatch(/sessionConfirmGrants\.get\(sid\)\?\.has\(grantKey\)/);

--- a/tests/peerd-egress/audit-chain.test.ts
+++ b/tests/peerd-egress/audit-chain.test.ts
@@ -102,6 +102,15 @@ describe('tampering is detected', () => {
     idb.rows.splice(4, 0, { id: 'id-zzzzzz', when: 999, type: 'forged' });
     expect((await log.verify()).ok).toBe(false);
   });
+
+  test('truncating the tail AND deleting the head record is STILL caught (fail-closed)', async () => {
+    const { idb, log } = await seeded();
+    idb.rows.splice(4);                 // drop the tail
+    idb.meta.clear();                   // and the head — the cheaper attack the naive check missed
+    const result = await log.verify();
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('head record missing');
+  });
 });
 
 describe('legal operations still verify', () => {

--- a/tests/peerd-egress/audit-chain.test.ts
+++ b/tests/peerd-egress/audit-chain.test.ts
@@ -1,0 +1,140 @@
+// R4 tamper evidence — the audit log's hash chain. Every naive tampering
+// must be DETECTED (rewrite, mid-log deletion, tail truncation, an
+// inserted chainless entry), legal operations must verify (pruning the
+// oldest, legacy pre-chain prefixes), and interleaved async appends must
+// serialize into one linear chain.
+
+import { describe, test, expect } from 'bun:test';
+import { computeChainHash, verifyChain, canonicalCore, CHAIN_HEAD_KEY } from '../../extension/peerd-egress/audit/chain.js';
+import { createAuditLog } from '../../extension/peerd-egress/audit/log.js';
+
+// A recording fake idb with both stores (audit_log rows + the audit_meta head).
+const makeFakeIdb = () => {
+  const rows: any[] = [];
+  const meta = new Map<string, any>();
+  return {
+    rows, meta,
+    put: async (store: string, value: any) => {
+      if (store === 'audit_meta') { meta.set(value.key, value); return; }
+      rows.push(value);
+    },
+    get: async (store: string, key: string) => (store === 'audit_meta' ? meta.get(key) : undefined),
+    getAll: async () => [...rows],
+    count: async () => rows.length,
+    getAllKeys: async (_s: string, limit?: number) => rows.slice(0, limit).map((r) => r.id),
+    delUpTo: async (_s: string, key: string) => {
+      const idx = rows.findIndex((r) => r.id === key);
+      rows.splice(0, idx + 1);
+    },
+  };
+};
+
+let tick = 0;
+const makeLog = (idb: any) => createAuditLog({
+  idb, now: () => ++tick, makeId: () => `id-${String(++tick).padStart(6, '0')}`,
+});
+
+describe('the chain hash', () => {
+  test('is deterministic and covers every core field', async () => {
+    const entry = { id: 'a', when: 1, type: 'x', sessionId: 's', details: { n: 1 } };
+    expect(await computeChainHash('', entry)).toBe(await computeChainHash('', entry));
+    expect(await computeChainHash('', entry)).not.toBe(await computeChainHash('', { ...entry, when: 2 }));
+    expect(await computeChainHash('', entry)).not.toBe(await computeChainHash('other', entry));
+    expect(canonicalCore(entry)).toContain('\x1f');
+  });
+});
+
+describe('append builds a verifiable chain', () => {
+  test('sequential appends verify; the head pins the newest entry', async () => {
+    const idb = makeFakeIdb();
+    const log = makeLog(idb);
+    await log.append({ type: 'a' });
+    await log.append({ type: 'b', sessionId: 's1' });
+    await log.append({ type: 'c', details: { k: 'v' } });
+    const result = await log.verify();
+    expect(result).toEqual({ ok: true, checked: 3, unchained: 0 });
+    expect(idb.meta.get(CHAIN_HEAD_KEY).id).toBe(idb.rows[2].id);
+  });
+
+  test('interleaved un-awaited appends serialize into ONE linear chain', async () => {
+    const idb = makeFakeIdb();
+    const log = makeLog(idb);
+    await Promise.all(Array.from({ length: 12 }, (_, i) => log.append({ type: `t${i}` })));
+    const result = await log.verify();
+    expect(result.ok).toBe(true);
+    expect(result.checked).toBe(12);
+  });
+});
+
+describe('tampering is detected', () => {
+  const seeded = async () => {
+    const idb = makeFakeIdb();
+    const log = makeLog(idb);
+    for (let i = 0; i < 6; i++) await log.append({ type: `t${i}`, details: { i } });
+    return { idb, log };
+  };
+
+  test('a rewritten entry breaks verification at the right link', async () => {
+    const { idb, log } = await seeded();
+    idb.rows[2].details = { i: 999 };                       // in-place rewrite
+    const result = await log.verify();
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('chain mismatch');
+    expect(result.brokenAtId).toBe(idb.rows[2].id);         // the rewritten entry's own hash no longer matches
+  });
+
+  test('deleting a middle entry breaks the chain', async () => {
+    const { idb, log } = await seeded();
+    idb.rows.splice(3, 1);
+    expect((await log.verify()).ok).toBe(false);
+  });
+
+  test('truncating the tail is caught by the head record', async () => {
+    const { idb, log } = await seeded();
+    idb.rows.pop();
+    const result = await log.verify();
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('head mismatch');
+  });
+
+  test('an inserted chainless entry after chained ones is caught', async () => {
+    const { idb, log } = await seeded();
+    idb.rows.splice(4, 0, { id: 'id-zzzzzz', when: 999, type: 'forged' });
+    expect((await log.verify()).ok).toBe(false);
+  });
+});
+
+describe('legal operations still verify', () => {
+  test('pruning the OLDEST entries keeps the chain valid (anchor semantics)', async () => {
+    const idb = makeFakeIdb();
+    const log = makeLog(idb);
+    for (let i = 0; i < 8; i++) await log.append({ type: `t${i}` });
+    idb.rows.splice(0, 3);                                  // what retention pruning does
+    const result = await log.verify();
+    expect(result).toEqual({ ok: true, checked: 5, unchained: 0 });
+  });
+
+  test('a legacy pre-chain PREFIX reports unchained, not failed', async () => {
+    const idb = makeFakeIdb();
+    idb.rows.push({ id: 'id-000001', when: 1, type: 'legacy-a' }, { id: 'id-000002', when: 2, type: 'legacy-b' });
+    const log = makeLog(idb);
+    await log.append({ type: 'new' });
+    const result = await log.verify();
+    expect(result.ok).toBe(true);
+    expect(result.unchained).toBe(2);
+    expect(result.checked).toBe(1);
+  });
+
+  test('a chain resumes correctly across a "SW restart" (fresh factory, same idb)', async () => {
+    const idb = makeFakeIdb();
+    await makeLog(idb).append({ type: 'before' });
+    const log2 = makeLog(idb);                              // new closure, tail must reload from meta
+    await log2.append({ type: 'after' });
+    expect((await log2.verify()).ok).toBe(true);
+    expect((await log2.verify()).checked).toBe(2);
+  });
+
+  test('verifyChain with no head and no entries is ok (fresh install)', async () => {
+    expect((await verifyChain([], null)).ok).toBe(true);
+  });
+});

--- a/tests/peerd-runtime/transfer/transfer.test.ts
+++ b/tests/peerd-runtime/transfer/transfer.test.ts
@@ -166,3 +166,83 @@ describe('applyImport', () => {
     expect(calls.setSecret).toEqual([['anthropic', 'sk-2']]);
   });
 });
+
+// R6 — transfer import is an untrusted-deserialization surface. The three
+// authority-bearing sections get gates: endpoints validated to https/local
+// loopback, hooks quarantined (disabled + untrusted), memory named loudly.
+describe('R6 import gates', () => {
+  const stubIo = () => {
+    const calls: Record<string, any[]> = {
+      applySettings: [], setProviderEndpoints: [], setSecret: [], importMemory: [], saveHook: [],
+    };
+    return {
+      calls,
+      io: {
+        applySettings: async (p: any) => { calls.applySettings.push(p); },
+        setProviderEndpoints: async (v: any) => { calls.setProviderEndpoints.push(v); },
+        setSecret: async (n: string, v: string) => { calls.setSecret.push([n, v]); },
+        importMemory: async (p: any) => { calls.importMemory.push(p); return { written: p.docs.length, skipped: 0 }; },
+        saveHook: async (r: any) => { calls.saveHook.push(r); },
+      },
+    };
+  };
+
+  test('non-https endpoints are dropped and named; https + local loopback pass', async () => {
+    const { calls, io } = stubIo();
+    const res = await applyImport({
+      payload: makePayload({
+        providerEndpoints: { endpoints: [
+          { url: 'https://api.good.example/v1' },
+          { url: 'http://localhost:11434' },
+          { url: 'http://evil.example/steal' },
+          { url: 'ftp://weird.example' },
+          { url: 'not a url' },
+        ] },
+      }),
+      channel: 'preview', knownSettingKeys: KNOWN_KEYS, io,
+    });
+    expect(res.ok).toBe(true);
+    expect(calls.setProviderEndpoints.length).toBe(1);
+    const applied = calls.setProviderEndpoints[0].endpoints.map((e: any) => e.url);
+    expect(applied).toEqual(['https://api.good.example/v1', 'http://localhost:11434']);
+    if (!('notices' in res)) throw new Error('expected notices');
+    expect((res.notices as string[]).some((n) => n.includes('Dropped 3'))).toBe(true);
+  });
+
+  test('imported hooks land DISABLED and UNTRUSTED regardless of the file\'s flags', async () => {
+    const { calls, io } = stubIo();
+    await applyImport({
+      payload: makePayload({ hooks: [{ id: 'h1', event: 'pre-tool-use', kind: 'js', enabled: true, trusted: true, body: 'return {}' }] }),
+      channel: 'preview', knownSettingKeys: KNOWN_KEYS, io,
+    });
+    expect(calls.saveHook.length).toBe(1);
+    expect(calls.saveHook[0].enabled).toBe(false);
+    expect(calls.saveHook[0].trusted).toBe(false);
+    expect(calls.saveHook[0].body).toBe('return {}'); // the record itself is preserved for review
+  });
+
+  test('the inspect summary names endpoint urls and hook quarantine BEFORE apply', () => {
+    const res = inspectImport({
+      payload: makePayload({
+        providerEndpoints: { endpoints: [{ url: 'https://api.custom.example/v1' }] },
+        hooks: [{ id: 'h1', event: 'pre-tool-use' }, { id: 'h2', event: 'post-tool-use' }],
+      }),
+      channel: 'preview', knownSettingKeys: KNOWN_KEYS,
+    });
+    if (!res.ok || !res.summary) throw new Error('expected ok summary');
+    expect((res.summary as any).endpointUrls).toEqual(['https://api.custom.example/v1']);
+    expect((res.summary as any).hookIds).toEqual(['h1', 'h2']);
+    const joined = res.summary.notices.join(' ');
+    expect(joined).toContain('api.custom.example');
+    expect(joined).toContain('DISABLED');
+  });
+
+  test('a memory import states its consequence in the notices', async () => {
+    const { io } = stubIo();
+    const res = await applyImport({
+      payload: makePayload(), channel: 'preview', knownSettingKeys: KNOWN_KEYS, io,
+    });
+    if (!res.ok || !('notices' in res)) throw new Error('expected notices');
+    expect((res.notices as string[]).some((n) => n.includes('memory doc'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## What &amp; why — the plain-English spec

The threat model (#165) named eleven residual risks honestly. Three of them are cheap to close and real-user exposure is about to go up (store submission), so this PR narrows them **before strangers install this**. Each fix keeps the threat model honest: the R-item is narrowed to its true post-fix residual, never deleted.

**R4 — the audit log is tamper-EVIDENT now.** Every entry extends a SHA-256 hash chain (`peerd-egress/audit/chain.js`: canonical core with fixed field order, unit-separated joins) and a tiny `audit_meta` head record pins the newest link. All four naive tamperings fail `verify()`: a rewritten entry, a deleted middle entry, a truncated tail, an inserted chainless record. Appends serialize through a write queue so the SW's fire-and-forget appends can't fork the chain; retention pruning stays legal (the first retained link is the anchor); pre-chain legacy entries report as `unchained`, never as tampered — an upgrade must not brand every existing install as compromised. The debug bundle runs the verification and stamps the result into its provenance, making the exported audit slice a checkable artifact. **Honest boundary, stated in the code and the doc:** an attacker with in-origin code execution can recompute the whole chain — this is evidence, not proof; nothing in-origin can do better without a secret the origin doesn't hold. IDB bumps to v10 for the new store.

**R5 — session confirm grants are origin-BOUND.** "Yes for this session" now means *this tool ON this origin*: the grant key folds in the prompt's dispatcher-computed origin (the pinned tab for DOM tools, the target host for web writes) via the pure `background/confirm-grant-key.js`. Approving `click` on site A no longer silently covers every site the chat visits. This generalizes the host scoping web writes already had; originless tools (memory, VM ops) keep the bare tool key because there is no cross-site surface to scope. Remaining residual (stated): the prompt's *description* is agent-supplied — the origin line the user sees is system-derived, but a misleading summary could still induce a yes for the named origin.

**R6 — transfer import is gated.** Three authority-bearing sections of an imported file get proportional gates:
- **Provider endpoints** must parse to `https:` (or local-loopback `http:` for Ollama-style daemons); everything else is dropped and named. Accepted endpoint URLs are named LOUDLY in the inspect summary the user approves — an endpoint is where the agent will send API traffic.
- **Hooks** land DISABLED and untrusted regardless of the file's flags — a `kind:'js'` hook cannot even compile without `trusted:true`, so enabling is an explicit per-hook decision in Settings → Hooks, where the body is visible. The quarantine is announced in the pre-apply summary.
- **Memory** import states its prompt-injection consequence in the apply notices ("they will inform future prompts; review via /memory if this file wasn't authored by you").

## Checklist

- [x] Gates green: typecheck, eslint, ts-check floor (498/498), bun (2672 pass — 30 new), in-browser (615 pass — real-IDB v10 upgrade exercised), live e2e 19 states 110/110
- [x] Commits signed off — DCO
- [x] Only original or permissively-licensed code
- [x] Tests added or updated
- [x] No hand-edited generated files
- [x] **Danger zone**: touches the audit write path (chain riding append; malformed-input rejection contract preserved), the confirm grant cache key (pure, bun-tested, source-shape test updated), and the transfer apply path (gates only narrow what applies)

## Notes for reviewers

The R4 crux is the append serialization: the chain makes appends order-dependent, and the SW fires them without awaiting — `writeQueue` keeps the chain linear while each caller's promise still settles individually, and one failed append can't wedge the queue. The R5 crux is that the origin comes from `tool.origins(args, ctx)` computed dispatcher-side — never from agent-controlled prompt text. The R6 hook quarantine deliberately overwrites the file's own `enabled`/`trusted` flags: those fields are attacker-controlled in exactly the scenario the gate exists for.

Follow-ups deliberately not taken: HMAC-signing the audit chain (no in-origin secret can survive the stated adversary — dishonest to imply otherwise), fencing imported memory at prompt-injection time (that's R2's fix, a different arc), and a persistent origin-scoped grant store (the in-memory session cache keeps the right blast radius).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018scDZ7G3pkkAxKjmQkWY2q

---
_Generated by [Claude Code](https://claude.ai/code/session_018scDZ7G3pkkAxKjmQkWY2q)_