### PR TITLE
fix(provider): repair orphaned tool_result blocks that bricked sessions

### DIFF
--- a/extension/peerd-provider/format/to-anthropic.js
+++ b/extension/peerd-provider/format/to-anthropic.js
@@ -237,7 +237,7 @@ export const toAnthropicMessages = (messages, thinkingEnabled = false) => {
       if (typeof tu.id === 'string') causeByToolUseId.set(tu.id, cause);
     }
   }
-  return repairOrphanToolUses(out, causeByToolUseId);
+  return repairOrphanToolUses(repairOrphanToolResults(out), causeByToolUseId);
 };
 
 /**
@@ -261,6 +261,80 @@ const explainStopCause = (m) => {
     return `provider error before dispatch: ${excerpt}`;
   }
   return 'tool dispatch did not complete';
+};
+
+/**
+ * Demote one orphaned tool_result block to plain user-content blocks,
+ * preserving its payload. Nested blocks (text + image from the vision
+ * splice) are valid user content as-is, so they hoist up a level behind
+ * a one-line provenance marker; string content folds into a single text
+ * block with the marker.
+ *
+ * @param {AnthropicBlock} b
+ * @returns {AnthropicBlock[]}
+ */
+const demoteToolResultBlock = (b) => {
+  const marker = `[stale tool_result for ${b.tool_use_id} — its tool_use call `
+    + 'is no longer in the preceding assistant message (that turn was '
+    + 'interrupted or superseded); the tool output is preserved below]';
+  if (Array.isArray(b.content)) {
+    return [{ type: 'text', text: marker }, ...b.content];
+  }
+  const text = typeof b.content === 'string' && b.content.length > 0
+    ? `${marker}\n${b.content}`
+    : marker;
+  return [{ type: 'text', text }];
+};
+
+/**
+ * The INVERSE hazard of repairOrphanToolUses: a `tool_result` block whose
+ * matching `tool_use` is NOT among the tool_use ids of the immediately-
+ * preceding assistant message. The API 400s on it ("unexpected
+ * `tool_use_id` found in `tool_result` blocks"), which bricks the whole
+ * session — every subsequent call replays the same broken history.
+ *
+ * How a session gets here: a steer-live supersede aborts a turn while its
+ * LAST tool dispatch is in flight; the new turn's user message (and
+ * assistant stub) land in the session before the superseded loop unwinds
+ * and appends its tool-results message (the loop-side guard narrows this
+ * race but a persisted-before-the-fix session stays broken); or an actor
+ * session's batched persist partially fails, dropping the assistant
+ * tool_use message but keeping its results.
+ *
+ * Wire-format-only repair, like repairOrphanToolUses: the persisted
+ * session is untouched. Each orphan block is demoted to plain text so the
+ * model still sees the output, just not as a structural tool_result.
+ * Surviving REAL tool_result blocks keep their lead position (the API
+ * requires tool_result blocks before other content in the message).
+ *
+ * @param {AnthropicMessage[]} msgs
+ * @returns {AnthropicMessage[]}
+ */
+const repairOrphanToolResults = (msgs) => {
+  for (let i = 0; i < msgs.length; i++) {
+    const m = msgs[i];
+    if (m.role !== 'user' || !Array.isArray(m.content)) continue;
+    if (!m.content.some((b) => b?.type === 'tool_result')) continue;
+    const prev = msgs[i - 1];
+    const usable = new Set(
+      prev?.role === 'assistant' && Array.isArray(prev.content)
+        ? prev.content.flatMap((b) =>
+            (b?.type === 'tool_use' && typeof b.id === 'string' ? [b.id] : []))
+        : []);
+    /** @type {AnthropicBlock[]} */
+    const kept = [];
+    /** @type {AnthropicBlock[]} */
+    const demoted = [];
+    for (const b of m.content) {
+      if (b?.type === 'tool_result' && !usable.has(b.tool_use_id ?? '')) {
+        demoted.push(...demoteToolResultBlock(b));
+      } else {
+        kept.push(b);
+      }
+    }
+    if (demoted.length > 0) m.content = [...kept, ...demoted];
+  }
+  return msgs;
 };
 
 /**

--- a/extension/peerd-provider/format/to-openai.js
+++ b/extension/peerd-provider/format/to-openai.js
@@ -189,6 +189,16 @@ const toOpenAiMessages = (system, messages) => {
  * so the model still sees the output, just not as a structural tool reply.
  * Wire-format-only — the persisted session is untouched.
  *
+ * why the demotions are BUFFERED past the reply run (the imageFollowups
+ * technique above): a stale reply can sit BEFORE a valid one in the same
+ * run (the steer race persists the superseded turn's results between the
+ * new turn's assistant message and its own results). Demoting in place
+ * would strand the surviving real reply behind a role:'user' message —
+ * itself the 400 this repair exists to prevent — and repairOrphanToolCalls
+ * would then synthesize a duplicate, contradictory reply for it. Emitting
+ * the demotions only after the run ends keeps every surviving real reply
+ * contiguous with its assistant message.
+ *
  * @param {OpenAiMessage[]} msgs
  * @returns {OpenAiMessage[]}
  */
@@ -197,17 +207,19 @@ const demoteOrphanToolResults = (msgs) => {
   const out = [];
   /** @type {Set<string>} ids still answerable in the current reply run */
   let open = new Set();
+  /** @type {OpenAiMessage[]} demotions held until the current reply run ends */
+  let demoted = [];
+  const flushDemoted = () => {
+    if (demoted.length > 0) { out.push(...demoted); demoted = []; }
+  };
   for (const m of msgs) {
-    if (m.role === 'assistant') {
-      open = new Set((Array.isArray(m.tool_calls) ? m.tool_calls : []).map((tc) => tc.id));
-      out.push(m);
-    } else if (m.role === 'tool') {
+    if (m.role === 'tool') {
       if (typeof m.tool_call_id === 'string' && open.has(m.tool_call_id)) {
         // One reply per id — a duplicate reply is itself an orphan.
         open.delete(m.tool_call_id);
         out.push(m);
       } else {
-        out.push({
+        demoted.push({
           role: 'user',
           content: `[stale tool result for ${m.tool_call_id ?? '(unknown id)'} — its tool `
             + 'call is no longer in the preceding assistant message (that turn was '
@@ -215,12 +227,17 @@ const demoteOrphanToolResults = (msgs) => {
             + `${typeof m.content === 'string' ? m.content : ''}`,
         });
       }
-    } else {
-      // Any other role ends the contiguous reply run.
-      open = new Set();
-      out.push(m);
+      continue;
     }
+    // Any other role ends the contiguous reply run: emit the held
+    // demotions first, so they land AFTER the run they were pulled from.
+    flushDemoted();
+    open = m.role === 'assistant'
+      ? new Set((Array.isArray(m.tool_calls) ? m.tool_calls : []).map((tc) => tc.id))
+      : new Set();
+    out.push(m);
   }
+  flushDemoted();
   return out;
 };
 

--- a/extension/peerd-provider/format/to-openai.js
+++ b/extension/peerd-provider/format/to-openai.js
@@ -175,7 +175,53 @@ const toOpenAiMessages = (system, messages) => {
       }
     }
   }
-  return repairOrphanToolCalls(out);
+  return repairOrphanToolCalls(demoteOrphanToolResults(out));
+};
+
+/**
+ * The INVERSE hazard of repairOrphanToolCalls: a role:'tool' message whose
+ * tool_call_id is not answered by the immediately-preceding assistant
+ * message's tool_calls (an interleaved message broke the contiguous reply
+ * run, or the assistant message was never persisted). OpenAI 400s on it —
+ * "messages with role 'tool' must be a response to a preceding message
+ * with 'tool_calls'" — which bricks the session, since every later call
+ * replays the same broken history. Demote each orphan to a user message
+ * so the model still sees the output, just not as a structural tool reply.
+ * Wire-format-only — the persisted session is untouched.
+ *
+ * @param {OpenAiMessage[]} msgs
+ * @returns {OpenAiMessage[]}
+ */
+const demoteOrphanToolResults = (msgs) => {
+  /** @type {OpenAiMessage[]} */
+  const out = [];
+  /** @type {Set<string>} ids still answerable in the current reply run */
+  let open = new Set();
+  for (const m of msgs) {
+    if (m.role === 'assistant') {
+      open = new Set((Array.isArray(m.tool_calls) ? m.tool_calls : []).map((tc) => tc.id));
+      out.push(m);
+    } else if (m.role === 'tool') {
+      if (typeof m.tool_call_id === 'string' && open.has(m.tool_call_id)) {
+        // One reply per id — a duplicate reply is itself an orphan.
+        open.delete(m.tool_call_id);
+        out.push(m);
+      } else {
+        out.push({
+          role: 'user',
+          content: `[stale tool result for ${m.tool_call_id ?? '(unknown id)'} — its tool `
+            + 'call is no longer in the preceding assistant message (that turn was '
+            + 'interrupted or superseded); the tool output is preserved below]\n'
+            + `${typeof m.content === 'string' ? m.content : ''}`,
+        });
+      }
+    } else {
+      // Any other role ends the contiguous reply run.
+      open = new Set();
+      out.push(m);
+    }
+  }
+  return out;
 };
 
 /**

--- a/extension/peerd-runtime/loop/agent-loop.js
+++ b/extension/peerd-runtime/loop/agent-loop.js
@@ -871,7 +871,16 @@ export async function* runUserTurn(ctx) {
         if (abortedMidBatch) break;
       }
     }
-    if (abortedMidBatch) {
+    // why the extra wasAborted(): the per-wave checks run BEFORE each dispatch,
+    // so an abort landing DURING the batch's FINAL dispatch is seen by neither —
+    // the loop would fall through and append the tool-results message. Under a
+    // steer-live supersede that append races the NEW turn (claim() aborts and
+    // starts it immediately, without waiting for this loop to unwind), landing
+    // the results AFTER the steer's user message + assistant stub — a history
+    // whose tool_result no longer follows its tool_use, which the provider
+    // rejects on every later call (the format layer's orphan-tool_result
+    // demotion is the wire-side backstop for sessions already shaped that way).
+    if (abortedMidBatch || wasAborted()) {
       // Mirror the pre-dispatch abort guard (:683): mark a DELIBERATE stop (not a
       // resumable tools-pending interruption) and drop the partial tool_result
       // message, so the turn ends cleanly on the aborted assistant message and

--- a/extension/tests/unit/peerd-provider/to-anthropic.test.js
+++ b/extension/tests/unit/peerd-provider/to-anthropic.test.js
@@ -271,20 +271,28 @@ describe('to-anthropic', () => {
     });
 
     it('user with toolResults encodes as tool_result blocks', () => {
+      // Paired with its tool_use turn — an unpaired result would (correctly)
+      // be demoted by the orphan tool_result repair, tested below.
       const out = toAnthropicMessages([{
+        role: 'assistant', content: '', id: 'a', when: 0,
+        toolUses: [
+          { id: 'toolu_X', name: 'foo', input: {} },
+          { id: 'toolu_Y', name: 'foo', input: {} },
+        ],
+      }, {
         role: 'user', content: '', id: 'u', when: 0,
         toolResults: [
           { tool_use_id: 'toolu_X', content: '{"foo":1}' },
           { tool_use_id: 'toolu_Y', content: 'failed', is_error: true },
         ],
       }]);
-      expect(out).toEqual([{
+      expect(out[1]).toEqual({
         role: 'user',
         content: [
           { type: 'tool_result', tool_use_id: 'toolu_X', content: '{"foo":1}' },
           { type: 'tool_result', tool_use_id: 'toolu_Y', content: 'failed', is_error: true },
         ],
-      }]);
+      });
     });
 
     it('does NOT collapse block-content messages with adjacent plain-text', () => {
@@ -383,6 +391,93 @@ describe('to-anthropic', () => {
       const blocks = /** @type {AnthropicBlock[]} */ (out[1].content);
       expect(blocks[0].tool_use_id).toBe('toolu_X');
       expect(out[2].role).toBe('assistant');
+    });
+  });
+
+  describe('orphan tool_result demotion', () => {
+    it('demotes a tool_result whose tool_use is not in the previous message (steer-race history)', () => {
+      // The field 400: "unexpected `tool_use_id` found in `tool_result`
+      // blocks". A steer-live supersede let the old turn append its tool
+      // results AFTER the new turn's messages, so the results no longer
+      // follow their tool_use. The wire repair must (a) demote the orphaned
+      // result to text, preserving its payload, and (b) still synthesize an
+      // error result for the assistant tool_use left unanswered.
+      const out = toAnthropicMessages([
+        {
+          role: 'assistant', content: '', id: 'a1', when: 0,
+          toolUses: [{ id: 'toolu_B', name: 'vm_boot', input: {} }],
+        },
+        userMsg('actually, do something else'),
+        {
+          role: 'user', content: '', id: 'u2', when: 0,
+          toolResults: [{ tool_use_id: 'toolu_B', content: 'boot ok' }],
+        },
+      ]);
+      // No tool_result anywhere may reference an id absent from its
+      // immediately-preceding assistant message.
+      for (let i = 0; i < out.length; i++) {
+        const content = out[i].content;
+        if (!Array.isArray(content)) continue;
+        const prev = out[i - 1];
+        const usable = new Set(
+          prev?.role === 'assistant' && Array.isArray(prev.content)
+            ? prev.content.filter((b) => b.type === 'tool_use').map((b) => b.id)
+            : []);
+        for (const b of content) {
+          if (b.type === 'tool_result') expect(usable.has(b.tool_use_id)).toBe(true);
+        }
+      }
+      // The orphaned result's payload survives as text on the last message.
+      const last = /** @type {AnthropicBlock[]} */ (out[out.length - 1].content);
+      expect(last.some((b) => b.type === 'text' && /boot ok/.test(b.text ?? ''))).toBe(true);
+      expect(last.some((b) => b.type === 'tool_result')).toBe(false);
+    });
+
+    it('keeps matched results and demotes only the stale sibling (the content.1 shape)', () => {
+      // assistant#1(tool_use B) → user text → assistant#2(tool_use A) →
+      // user(results B). The tool_use repair prepends a synthetic result
+      // for A; the REAL result B (content.1 in the field error) must be
+      // demoted, not left to 400 the request.
+      const out = toAnthropicMessages([
+        {
+          role: 'assistant', content: '', id: 'a1', when: 0,
+          toolUses: [{ id: 'toolu_B', name: 'vm_boot', input: {} }],
+        },
+        userMsg('steer'),
+        {
+          role: 'assistant', content: '', id: 'a2', when: 0,
+          toolUses: [{ id: 'toolu_A', name: 'read_page', input: {} }],
+        },
+        {
+          role: 'user', content: '', id: 'u2', when: 0,
+          toolResults: [{ tool_use_id: 'toolu_B', content: 'late result' }],
+        },
+      ]);
+      const last = /** @type {AnthropicBlock[]} */ (out[out.length - 1].content);
+      // Synthetic result for A leads; the stale B is text, and tool_results
+      // stay ahead of the demoted text (API ordering rule).
+      const results = last.filter((b) => b.type === 'tool_result');
+      expect(results.length).toBe(1);
+      expect(results[0].tool_use_id).toBe('toolu_A');
+      expect(last.indexOf(results[0])).toBe(0);
+      expect(last.some((b) => b.type === 'text' && /late result/.test(b.text ?? ''))).toBe(true);
+    });
+
+    it('hoists nested vision blocks out of a demoted tool_result', () => {
+      const out = toAnthropicMessages([
+        userMsg('hi'),
+        {
+          role: 'user', content: '', id: 'u2', when: 0,
+          toolResults: [{
+            tool_use_id: 'toolu_Z', content: 'screenshot meta',
+            images: [{ mediaType: 'image/png', data: 'AAAA' }],
+          }],
+        },
+      ]);
+      const last = /** @type {AnthropicBlock[]} */ (out[out.length - 1].content);
+      expect(last.some((b) => b.type === 'tool_result')).toBe(false);
+      expect(last.some((b) => b.type === 'image')).toBe(true);
+      expect(last.some((b) => b.type === 'text' && /screenshot meta/.test(b.text ?? ''))).toBe(true);
     });
   });
 });

--- a/tests/peerd-provider/openai-format.test.ts
+++ b/tests/peerd-provider/openai-format.test.ts
@@ -104,6 +104,51 @@ describe('to-openai message mapping', () => {
     expect(demoted).toBeTruthy();
   });
 
+  test('a stale reply BEFORE a valid one in the same run does not strand or duplicate the valid reply', () => {
+    // Review-swarm confirmed failure: the steer race persists the
+    // superseded turn's results BETWEEN the new turn's assistant message
+    // and its own results — wire order assistant(C), tool(stale A),
+    // tool(real C). Demoting in place stranded the real tool(C) behind a
+    // user message AND let repairOrphanToolCalls synthesize a duplicate
+    // contradictory reply for C. The demotion must buffer past the run:
+    // real replies stay contiguous, stale ones follow as user text.
+    const msgs = _toOpenAiMessagesForTests('', [
+      { role: 'user', content: 'steer', id: '1', when: 0 },
+      {
+        role: 'assistant', content: '', id: '2', when: 0,
+        toolUses: [{ id: 'call_c', name: 'read_page', input: {} }],
+      },
+      {
+        role: 'user', content: '', id: '3', when: 0,
+        toolResults: [{ tool_use_id: 'call_a', content: 'stale output' }],
+      },
+      {
+        role: 'user', content: '', id: '4', when: 0,
+        toolResults: [{ tool_use_id: 'call_c', content: 'real output' }],
+      },
+    ]) as OpenAiMsg[];
+    // Contiguity: every tool message answers the run opened by the
+    // immediately-preceding assistant; one reply per id.
+    const seen = new Map<string, number>();
+    let open = new Set<string>();
+    for (const m of msgs) {
+      if (m.role === 'assistant') open = new Set((m.tool_calls ?? []).map((tc) => tc.id));
+      else if (m.role === 'tool') {
+        expect(open.has(m.tool_call_id ?? '')).toBe(true);
+        seen.set(m.tool_call_id ?? '', (seen.get(m.tool_call_id ?? '') ?? 0) + 1);
+        open.delete(m.tool_call_id ?? '');
+      } else open = new Set();
+    }
+    // Exactly ONE reply for call_c — the REAL one, not a synthesized
+    // 'did not complete' duplicate.
+    expect(seen.get('call_c')).toBe(1);
+    const replyC = msgs.find((m) => m.role === 'tool' && m.tool_call_id === 'call_c');
+    expect(replyC?.content).toBe('real output');
+    // The stale reply survives as demoted user text after the run.
+    const demoted = msgs.findIndex((m) => m.role === 'user' && /stale output/.test(String(m.content)));
+    expect(demoted).toBeGreaterThan(msgs.indexOf(replyC!));
+  });
+
   test('toOpenAiBody emits tools + tool_choice when tools provided', () => {
     const body = toOpenAiBody({
       model: 'm', system: 'S', messages: [],

--- a/tests/peerd-provider/openai-format.test.ts
+++ b/tests/peerd-provider/openai-format.test.ts
@@ -73,6 +73,37 @@ describe('to-openai message mapping', () => {
     expect(tool.content).toContain('did not complete');
   });
 
+  test('an orphan tool message (steer-race history) is demoted to a user message', () => {
+    // assistant(tool_calls B) → user steer text → tool(B). The tool reply no
+    // longer answers the immediately-preceding assistant, so sending it as
+    // role:'tool' 400s. It must be demoted to user text (payload preserved),
+    // and the assistant's unanswered call still gets a synthesized reply.
+    const msgs = _toOpenAiMessagesForTests('', [
+      {
+        role: 'assistant', content: '', id: '1', when: 0,
+        toolUses: [{ id: 'call_b', name: 'vm_boot', input: {} }],
+      },
+      { role: 'user', content: 'actually, do something else', id: '2', when: 0 },
+      {
+        role: 'user', content: '', id: '3', when: 0,
+        toolResults: [{ tool_use_id: 'call_b', content: 'boot ok' }],
+      },
+    ]) as OpenAiMsg[];
+    // Every surviving tool message answers the contiguous run after an
+    // assistant that declared its id.
+    let open = new Set<string>();
+    for (const m of msgs) {
+      if (m.role === 'assistant') open = new Set((m.tool_calls ?? []).map((tc) => tc.id));
+      else if (m.role === 'tool') {
+        expect(open.has(m.tool_call_id ?? '')).toBe(true);
+        open.delete(m.tool_call_id ?? '');
+      } else open = new Set();
+    }
+    // The stale reply survives as user text.
+    const demoted = msgs.find((m) => m.role === 'user' && /boot ok/.test(String(m.content)));
+    expect(demoted).toBeTruthy();
+  });
+
   test('toOpenAiBody emits tools + tool_choice when tools provided', () => {
     const body = toOpenAiBody({
       model: 'm', system: 'S', messages: [],

--- a/tests/peerd-provider/to-anthropic.test.ts
+++ b/tests/peerd-provider/to-anthropic.test.ts
@@ -6,6 +6,7 @@
 import { describe, test, expect } from 'bun:test';
 import {
   toAnthropicBody,
+  toAnthropicMessages,
   usesAdaptiveThinking,
 } from '../../extension/peerd-provider/format/to-anthropic.js';
 import type { InternalMessage } from '../../extension/peerd-provider/types.js';
@@ -107,6 +108,85 @@ describe('toAnthropicBody — output ceiling + effort', () => {
   test('no output_config when effort is absent (platform default = high)', () => {
     const body = toAnthropicBody({ model: 'claude-opus-4-8', system: 's', messages: [userMsg('hi')] });
     expect('output_config' in body).toBe(false);
+  });
+});
+
+describe('toAnthropicMessages — orphan tool_result demotion', () => {
+  // The field 400: "unexpected `tool_use_id` found in `tool_result` blocks.
+  // Each `tool_result` block must have a corresponding `tool_use` block in
+  // the previous message." A steer-live supersede let the old turn append
+  // its tool results AFTER the new turn's messages; every later call then
+  // replays the broken history and the session bricks. The wire repair must
+  // demote the stranded result to text (payload preserved) so the request
+  // stays structurally valid.
+  const asst = (id: string, toolId: string): InternalMessage => ({
+    role: 'assistant', content: '', id, when: 0,
+    toolUses: [{ id: toolId, name: 'vm_boot', input: {} }],
+  });
+
+  const noOrphanResults = (out: Array<{ role: string, content: unknown }>) => {
+    for (let i = 0; i < out.length; i++) {
+      const content = out[i].content;
+      if (!Array.isArray(content)) continue;
+      const prev = out[i - 1] as any;
+      const usable = new Set(
+        prev?.role === 'assistant' && Array.isArray(prev.content)
+          ? prev.content.filter((b: any) => b.type === 'tool_use').map((b: any) => b.id)
+          : []);
+      for (const b of content as any[]) {
+        if (b.type === 'tool_result') expect(usable.has(b.tool_use_id)).toBe(true);
+      }
+    }
+  };
+
+  test('a tool_result stranded behind an interleaved user message is demoted to text', () => {
+    const out = toAnthropicMessages([
+      asst('a1', 'toolu_B'),
+      userMsg('actually, do something else'),
+      {
+        role: 'user', content: '', id: 'u2', when: 0,
+        toolResults: [{ tool_use_id: 'toolu_B', content: 'boot ok' }],
+      },
+    ]);
+    noOrphanResults(out);
+    const last = out[out.length - 1].content as any[];
+    expect(last.some((b) => b.type === 'text' && /boot ok/.test(b.text))).toBe(true);
+    expect(last.some((b) => b.type === 'tool_result')).toBe(false);
+  });
+
+  test('matched results survive; only the stale sibling is demoted, behind the lead results', () => {
+    // assistant#1(B) → steer → assistant#2(A) → user(results B): the
+    // tool_use repair prepends a synthetic result for A; the stale B
+    // becomes trailing text. This is the exact "messages.N.content.1"
+    // shape from the field report.
+    const out = toAnthropicMessages([
+      asst('a1', 'toolu_B'),
+      userMsg('steer'),
+      asst('a2', 'toolu_A'),
+      {
+        role: 'user', content: '', id: 'u2', when: 0,
+        toolResults: [{ tool_use_id: 'toolu_B', content: 'late result' }],
+      },
+    ]);
+    noOrphanResults(out);
+    const last = out[out.length - 1].content as any[];
+    const results = last.filter((b) => b.type === 'tool_result');
+    expect(results.length).toBe(1);
+    expect(results[0].tool_use_id).toBe('toolu_A');
+    expect(last.indexOf(results[0])).toBe(0);
+    expect(last.some((b) => b.type === 'text' && /late result/.test(b.text))).toBe(true);
+  });
+
+  test('a valid tool round is untouched', () => {
+    const out = toAnthropicMessages([
+      asst('a1', 'toolu_A'),
+      {
+        role: 'user', content: '', id: 'u1', when: 0,
+        toolResults: [{ tool_use_id: 'toolu_A', content: 'ok' }],
+      },
+    ]);
+    const last = out[out.length - 1].content as any[];
+    expect(last).toEqual([{ type: 'tool_result', tool_use_id: 'toolu_A', content: 'ok' }]);
   });
 });
 

--- a/tests/peerd-runtime/loop/concurrent-dispatch.test.ts
+++ b/tests/peerd-runtime/loop/concurrent-dispatch.test.ts
@@ -272,6 +272,41 @@ describe('runUserTurn — concurrent tool dispatch', () => {
     expect(s.messages.some((m: any) => m.stopReason === 'aborted')).toBe(true);
   });
 
+  test('an abort landing DURING the final dispatch drops the tool-results message', async () => {
+    // The steer-race that bricked sessions in the field: claim() aborts the
+    // old turn and starts the new one immediately, so if the abort lands
+    // while the batch's LAST dispatch is in flight, no per-wave check ever
+    // sees it — the old loop would fall through and append its tool-results
+    // message AFTER the steering turn's messages, leaving a history whose
+    // tool_result no longer follows its tool_use (Anthropic 400s on every
+    // later call). The post-batch guard must catch it and drop the results.
+    const store = makeStore();
+    store.seed('s1');
+    const ac = new AbortController();
+    const ctx = baseCtx(store, {
+      callModel: makeToolModel([{ id: 't_w1', name: 'click' }]),
+      tools: [{ name: 'click', description: '', schema: {} }],
+      classifyToolCall: () => WRITE_VERDICT,
+      signal: ac.signal,
+      toolDispatch: async () => {
+        // The abort arrives while the ONLY (hence final) dispatch runs.
+        ac.abort();
+        await sleep(5);
+        return { ok: true, content: 'r', meta: {} };
+      },
+    });
+
+    const events = await drain(runUserTurn(ctx));
+
+    const s = await store.get('s1');
+    // No tool-results message may be appended after the abort...
+    expect(s.messages.some((m: any) => Array.isArray(m.toolResults))).toBe(false);
+    // ...and the turn ends on a deliberate abort.
+    const stops = events.filter((e: any) => e.type === 'stop');
+    expect(stops.at(-1)?.stopReason).toBe('aborted');
+    expect(s.messages.some((m: any) => m.stopReason === 'aborted')).toBe(true);
+  });
+
   test('one failing sibling in a concurrent wave becomes its own error block, not a batch failure', async () => {
     const store = makeStore();
     store.seed('s1');


### PR DESCRIPTION
## What & why

Fixes the field-reported Anthropic HTTP 400 — `unexpected tool_use_id found in tool_result blocks... Each tool_result block must have a corresponding tool_use block in the previous message` — which bricked a chat permanently: every subsequent call replays the same broken history, so the session never recovers.

**Root cause:** a steer-live supersede (`turn-slots` `claim()`) aborts the old turn and starts the new one immediately, but the superseded loop's abort checks all run *before* each tool dispatch. An abort landing *during the batch's final dispatch* is seen by none of them, so the old loop falls through and appends its tool-results message **after** the steering turn's user message + assistant stub — a history whose `tool_result` no longer follows its `tool_use`.

Three-part fix:
- **agent-loop**: extend the post-batch abort guard to catch an abort that landed during the final dispatch (drop the results, end on the aborted assistant message) — closes the race at the source.
- **to-anthropic**: add `repairOrphanToolResults`, the inverse of the existing `repairOrphanToolUses` — a `tool_result` whose `tool_use` isn't in the immediately-preceding assistant message is demoted to plain text blocks (payload + vision blocks preserved). Wire-format-only, so **already-broken persisted sessions unbrick on their next call**.
- **to-openai**: same hazard (`role:'tool'` must answer the preceding `tool_calls`), same demotion, so OpenRouter/Ollama don't 400 either.

## Checklist

- [x] `bun test ./tests` (2658 pass), `bun run typecheck`, ESLint on touched files, and the in-browser CDP suite (618 pass) all green; no manifest drift
- [ ] Commits are signed off — `git commit -s` (we use the DCO)
- [x] Only original or permissively-licensed code — **no GPL / AGPL / copyleft**
- [x] Tests added or updated (bun: both formatters + the loop race; in-browser: orphan tool_result demotion suite)
- [x] No hand-edited generated files (`manifest.json`, `shared/channel-config.js`)
- [x] Called out below if this touches a **danger zone** (egress / vault / gates / runner & sandbox boundaries / dweb)

## Notes for reviewers

- Touches the agent loop (runner boundary): the change is one extra `wasAborted()` check on the existing post-batch abort path — same drop-partial-results semantics the mid-batch guard already has.
- Both repairs are wire-format-only (mirroring the existing orphan `tool_use` repair): the persisted session record is never mutated, so `/undo` and the session view still show the real history.
- Demotion is deliberately conservative: it fires only when the `tool_result`'s id is absent from the immediately-preceding assistant wire message, and it preserves the tool output (and any vision blocks) as text so the model keeps the context.
- One pre-existing in-browser encoding test fed an unpaired history (results with no `tool_use` anywhere) to assert block encoding; it's now paired so it asserts the same encoding on a valid round.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7HdYrURBFTcLcGYoQiREa)_