### PR TITLE
docs: surface peerd:wasi in outward-facing copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@
 Chrome/Firefox extension that runs a full agent loop *inside* the
 browser you already use, with your existing tabs and sessions.
 It reads and drives your pages, spins up sandboxed compute (JS
-Notebooks, full Linux VMs compiled to WebAssembly, personal client-side
-apps), and (on the preview channel) shares what it builds over a
+Notebooks, compiled WebAssembly tools, full Linux VMs, personal
+client-side apps), and (on the preview channel) shares what it builds over a
 peer-to-peer WebRTC network built for agent-to-agent communication. BYOK
 to the model provider of your choice. **No backend, no telemetry, no
 cloud component in the data path.**
@@ -355,7 +355,12 @@ tree, in a visible tab. ~hundreds of ms boot. `peerd.egress.fetch` is the
 worker's only network, routed through `peerd-egress` so it's honest. Each
 `js_notebook` run spawns a fresh worker, so in-memory state (`globalThis`,
 `let`/`const`) does NOT carry between runs; persist via
-`peerd.self.writeFile`/`readFile` to the OPFS file tree.
+`peerd.self.writeFile`/`readFile` to the OPFS file tree. The sealed worker
+also runs **compiled wasm32-wasi binaries** via the `peerd:wasi` builtin —
+SQLite over a user's `.sqlite` file, codecs, language runtimes — against an
+in-memory filesystem, with zero ambient capabilities (a wasm module has no
+network path even in principle; it sees only the stdin/files the call
+passes it).
 
 ```
 sandbox_create   js_notebook   script   js_write_file   js_read_file   js_delete

--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -271,7 +271,12 @@ Code: `peerd-runtime/subagent/delegation-lineage.js` (`mayMessageActor`,
 In a Notebook or headless worker realm, every raw network channel throws, the native
 `fetch` is deleted off the prototype chain, and the bridge is pinned non-writable and
 non-configurable so in-realm sabotage cannot unseat it. No fresh un-sealed realm can
-be created, and OPFS import paths collapse `..` inside the instance root. The App runs
+be created, and OPFS import paths collapse `..` inside the instance root. A wasm32-wasi
+module run in that realm via the `peerd:wasi` builtin holds strictly less than the realm
+itself: its only imports are the vendored shim's WASI preview1 syscalls, and every
+descriptor behind them is wrapper-built (stdin bytes, size-capped output collectors, an
+in-memory file table from the call) — no network channel exists for the seal to even
+block. The App runs
 at an opaque origin (the manifest sandbox omits `allow-same-origin` and
 `allow-top-navigation`) with all `chrome.*` stripped, and its inlined worker source is
 escaped against a `</script>` breakout. The WebVM's only network path is an HTTP bridge

--- a/docs/store/LISTING.md
+++ b/docs/store/LISTING.md
@@ -30,8 +30,10 @@ Give it a task in plain language (typed or spoken):
 
 The assistant reads the page you're on, clicks, types, and navigates,
 visibly, in your tabs. When a task needs real computation, it runs the
-work in a sandboxed Linux environment that exists entirely inside your
-browser tab (WebAssembly, nothing is installed on your machine).
+work in WebAssembly sandboxes that exist entirely inside your browser —
+from a quick script, to compiled tools (query a SQLite file, convert a
+format), to a full Linux environment. Nothing is installed on your
+machine.
 
 YOUR DATA STAYS YOURS
 

--- a/docs/store/REVIEWER-NOTES.md
+++ b/docs/store/REVIEWER-NOTES.md
@@ -11,8 +11,8 @@ and the demo video URL.
 peerd is an AI assistant in the browser side panel. The user types or
 speaks a task; the assistant performs it by reading and interacting
 with web pages, and by running computations in sandboxes (a WebAssembly
-Linux VM and a JavaScript sandbox) that exist entirely inside the
-browser. It is local-first: bring-your-own-API-key, no accounts, no
+Linux VM and a JavaScript sandbox that can also run WebAssembly (WASI)
+programs) that exist entirely inside the browser. It is local-first: bring-your-own-API-key, no accounts, no
 backend, no analytics or telemetry of any kind. The developer operates
 no servers and receives no data.
 
@@ -33,7 +33,7 @@ no servers and receives no data.
 **Demo video** (full agent flow, VM boot, automation, audit log):
 «VIDEO URL»
 
-## Remotely hosted code — none. Pre-answering the four places a scan
+## Remotely hosted code — none. Pre-answering the five places a scan
 will flag:
 
 1. **CheerpX (x86-in-WASM runtime) is fully vendored** in
@@ -66,6 +66,21 @@ will flag:
    no remote fetch of agent-actioned files can happen, even from a
    crafted message. The installer code ships but is unreachable; the
    remote paths return in a later version with their own review.
+5. **WASI modules (`notebook-tab/notebook-wasi.js`)** — the JavaScript
+   sandbox can run wasm32-wasi programs (e.g. query a SQLite file the
+   user provides, decode an archive) via `WebAssembly.compile`, under
+   the same `wasm-unsafe-eval` CSP allowance the bundled WASM above
+   already uses. The runtime that hosts them is fully vendored and
+   audited (`vendor/browser-wasi-shim/SOURCE.txt`); the module bytes
+   are user-directed data on the same footing as item 2's disk image —
+   and confined strictly tighter than the JS around them: a module's
+   only imports are the bundled shim's WASI syscalls, every descriptor
+   behind those syscalls is constructed by our wrapper (stdin bytes,
+   size-capped stdout/stderr, an in-memory file table built from the
+   call), and it has **no network, DOM, storage, or `chrome.*` reach —
+   no such import exists to link against**. It executes inside the
+   already-sealed Notebook/worker realm described below, bounded by
+   that run's timeout.
 
 ## How the assistant operates pages (no `debugger` in this build)
 


### PR DESCRIPTION
## What & why

Follow-up to #175: the capability shipped; this makes it visible where people actually read. Light-touch copy updates, invariant-level per the docs-defer-to-code rule:

- **README** — intro's sandboxed-compute list now names compiled WebAssembly tools; the Notebook section gets one paragraph on `peerd:wasi` (what it runs, the zero-ambient-capability posture).
- **docs/store/LISTING.md** — the computation line now spans the real spectrum ("from a quick script, to compiled tools…, to a full Linux environment") in store-listing plain language.
- **docs/store/REVIEWER-NOTES.md** — the remote-code section gains a fifth pre-answered scan point: WASI modules compiled from user-directed bytes, same register and honesty as the CheerpX disk-image item (bundled+audited runtime, wrapper-built descriptors, no network/DOM/`chrome.*` import exists to link against, sealed-realm hosting, run timeout).
- **docs/security/THREAT-MODEL.md** — INV-6 now states the wasm tier's position on the capability gradient: strictly less than the sealed realm hosting it.

Closes #

## Checklist

- [x] `bun run preflight` passes (tests, typecheck, lint, in-browser, dweb-boundary, no manifest drift) — docs-only change; `check:docpaths` run directly and green
- [x] Commits are signed off — `git commit -s` (we use the DCO)
- [x] Only original or permissively-licensed code — **no GPL / AGPL / copyleft** (prose only)
- [x] Tests added or updated (N/A — docs only)
- [x] No hand-edited generated files (`manifest.json`, `shared/channel-config.js`)
- [x] Called out below if this touches a **danger zone** (egress / vault / gates / runner & sandbox boundaries / dweb)

## Notes for reviewers

No code changes — four prose files. The REVIEWER-NOTES item is the one to read closely: it pre-answers the "does this execute remotely fetched code?" question for WASI modules the way item 2 already does for the streamed disk image, which is store-review-sensitive wording worth an owner pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbsZTftcbS2VoySVgsJfXx

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbsZTftcbS2VoySVgsJfXx)_