### PR TITLE
Fix resp.bytes() in the sealed-realm fetch bridge: platform-shaped method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and storage formats may move until the surface stabilizes.
 
 ## [Unreleased]
 
+### Fixed
+- **`resp.bytes()` works in sandboxed code now.** The sealed-realm fetch
+  bridge (Notebook / script / a2a runs) listed `bytes` on its response but
+  as a raw data property, so `resp.bytes()` — the platform `Response.bytes()`
+  shape every model reaches for — threw "not a function". It's a method
+  returning `Promise<Uint8Array>` now, matching the platform. Found in the
+  field: an agent burned several turns rediscovering `arrayBuffer()` while
+  smoke-testing `runWasi`.
+
 ### Changed
 - **"Subagent" is now "actor" everywhere.** The heap-split already made a
   subagent an ephemeral actor on the same substrate as the bound (sandbox /

--- a/extension/notebook-tab/notebook-neutralizers.js
+++ b/extension/notebook-tab/notebook-neutralizers.js
@@ -152,7 +152,11 @@ export function applyRealmSeal(global) {
       text: async () => new TextDecoder().decode(bytes),
       json: async () => JSON.parse(new TextDecoder().decode(bytes)),
       arrayBuffer: async () => bytes.buffer,
-      bytes,
+      // why a method: the platform's Response.bytes() is a function returning
+      // Promise<Uint8Array>, and that's the shape a model reaches for. As a
+      // data property it LISTS in Object.keys but `resp.bytes()` throws
+      // "not a function" — observed burning several live agent turns.
+      bytes: async () => bytes,
     });
   });
   seal(global, 'fetch', bridgedFetch);

--- a/extension/tests/unit/notebook-tab/fixtures/seal-probe-worker.js
+++ b/extension/tests/unit/notebook-tab/fixtures/seal-probe-worker.js
@@ -21,6 +21,8 @@ import '/notebook-tab/realm-seal.js';
  * @property {Record<string, string>} headers
  * @property {() => Promise<string>} text
  * @property {() => Promise<unknown>} json
+ * @property {() => Promise<ArrayBuffer>} arrayBuffer
+ * @property {() => Promise<Uint8Array>} bytes
  */
 
 /**
@@ -129,6 +131,30 @@ self.addEventListener('message', async (ev) => {
     } catch (e) {
       const err = /** @type {{ message?: string }} */ (e);
       postMessage({ type: 'sabotage-result', ...result, fetch: { error: String(err?.message ?? e) } });
+    }
+    return;
+  }
+  if (m.type === 'binary-fetch') {
+    // The binary read path: bytes() must be a platform-shaped METHOD
+    // (Promise<Uint8Array>) and agree with arrayBuffer().
+    try {
+      const resp = await bridgeFetch(m.url);
+      const u8 = await resp.bytes();
+      const ab = await resp.arrayBuffer();
+      postMessage({
+        type: 'binary-result',
+        fetch: {
+          ok: resp.ok,
+          bytesIsFunction: typeof resp.bytes === 'function',
+          isUint8: u8 instanceof Uint8Array,
+          byteLength: u8.byteLength,
+          first: u8[0],
+          sameAsArrayBuffer: ab.byteLength === u8.byteLength,
+        },
+      });
+    } catch (e) {
+      const err = /** @type {{ message?: string }} */ (e);
+      postMessage({ type: 'binary-result', fetch: { error: String(err?.message ?? e) } });
     }
     return;
   }

--- a/extension/tests/unit/notebook-tab/notebook-seal.test.js
+++ b/extension/tests/unit/notebook-tab/notebook-seal.test.js
@@ -149,6 +149,34 @@ describe('notebook-tab realm seal (real worker realm)', () => {
     } finally { worker.terminate(); }
   });
 
+  it('bytes() is a platform-shaped method — binary reads work like Response.bytes()', async () => {
+    const worker = spawnFixture('seal-probe-worker.js');
+    try {
+      await nextMessage(worker, 'fixture-ready');
+      // \x00asm\x01\x00\x00\x00 — a wasm magic header, the binary-fetch case
+      // straight from the field: a model calls resp.bytes() (the platform
+      // Response shape) to feed WebAssembly.validate.
+      const wasmHeader = String.fromCharCode(0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00);
+      worker.addEventListener('message', (ev) => {
+        const m = ev.data;
+        if (!m || m.type !== 'fetch-request') return;
+        worker.postMessage({
+          type: 'fetch-response', rid: m.rid,
+          ok: true, status: 200, bodyB64: btoa(wasmHeader),
+        });
+      });
+      const reply = nextMessage(worker, 'binary-result');
+      worker.postMessage({ type: 'binary-fetch', url: 'https://example.test/module.wasm' });
+      const result = await reply;
+      expect(result.fetch.error).toBe(undefined);
+      expect(result.fetch.bytesIsFunction).toBe(true);
+      expect(result.fetch.isUint8).toBe(true);
+      expect(result.fetch.byteLength).toBe(8);
+      expect(result.fetch.first).toBe(0x00);
+      expect(result.fetch.sameAsArrayBuffer).toBe(true);
+    } finally { worker.terminate(); }
+  });
+
   it('seals BEFORE a statically-imported module body runs (the old prologue gap)', async () => {
     const worker = spawnFixture('seal-order-entry.js');
     try {


### PR DESCRIPTION
## What & why

Field-found during a live `runWasi` smoke test: the sealed-realm fetch bridge (the one shim serving Notebook tabs, headless `script` runs, and a2a runs) exposed `bytes` on its response object as a **raw `Uint8Array` data property**. The platform's `Response.bytes()` is a **method** returning `Promise<Uint8Array>` — the shape every model reaches for on a binary fetch. Result: `Object.keys(resp)` listed `bytes`, but `resp.bytes()` threw `"resp.bytes is not a function"` — the worst kind of API lie. The observed agent burned several turns rediscovering `arrayBuffer()`.

One-line fix in `notebook-neutralizers.js`: `bytes: async () => bytes`. No in-repo consumer relied on the property shape (the `resp.bytes` hits in `peerd-distributed` are a different RPC).

## Checklist

- [x] Gates green: typecheck, eslint, bun 2707, in-browser 619 (new binary-fetch seal test included)
- [x] Commits signed off — DCO
- [x] Tests added: `notebook-seal.test.js` now round-trips a wasm-magic-header body through the bridge and asserts `bytes()` is a function returning a `Uint8Array` that agrees with `arrayBuffer()`
- [x] No hand-edited generated files

## Notes for reviewers

The test plays the host side of the bridge exactly like the SW relay (base64 body over `fetch-response`), inside the real sealed worker realm — so it pins the model-facing response shape, not a mock's.

---
_Generated by [Claude Code](https://claude.ai/code/session_018scDZ7G3pkkAxKjmQkWY2q)_