### PR TITLE
oneShot: a crashed eval disarms the latch — the actor gets its recovery turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ and storage formats may move until the surface stabilizes.
 
 ## [Unreleased]
 
+### Fixed
+- **A oneShot delegation whose CODE crashed now gets its recovery turn.**
+  The oneShot contract always said "an errored round falls through to the
+  normal loop" — but the clean-round test only saw tool-LEVEL errors, and a
+  notebook eval whose code threw (a CompileError, a bad import) returns
+  ok:true with the `[ERROR]` text as its content. So the crash
+  short-circuited straight back to the orchestrator as the raw reply and
+  the actor never debugged its own sandbox (field transcript: a notebook
+  actor bounced the same CompileError back twice). `js_notebook` now marks
+  such results `evalError` and the one-shot latch disarms on it, exactly
+  like a tool failure — the actor recovers and iterates, as promised. A
+  headless CI test also now pins `peerd:wasi` + `demoModule()` as
+  importable and runnable from a `script` job (a field session reported
+  the import unreachable; current source proves green, so a stale install
+  is the likely culprit — reload the extension).
+
 ### Added
 - **`peerd:wasi` ships a self-test module.** `demoModule()` (exported next
   to `runWasi`) returns a tiny (187-byte) known-good wasm32-wasi hello

--- a/extension/peerd-runtime/loop/agent-loop.js
+++ b/extension/peerd-runtime/loop/agent-loop.js
@@ -822,6 +822,10 @@ export async function* runUserTurn(ctx) {
 
     /** @type {ToolResultBlock[]} */
     const toolResults = [];
+    // One-shot honesty: a tool can succeed while the CODE it evaluated crashed
+    // (a notebook eval's ok:true + in-band [ERROR] — the evalError marker).
+    // Such a round must NOT short-circuit as "clean"; track it per round.
+    let roundHadEvalError = false;
     // partitionToolBatch groups CONSECUTIVE safe calls into concurrent
     // waves and leaves everything else as single sequential waves, in the
     // model's emitted order — a safe call is never hoisted past an unsafe
@@ -849,6 +853,7 @@ export async function* runUserTurn(ctx) {
         const blocksById = new Map();
         for await (const { tu, dispatchResult, block } of asCompleted(wave.calls.map(dispatchOne))) {
           yield { type: 'tool-result', sessionId, toolUseId: tu.id, result: dispatchResult };
+          if (/** @type {{ evalError?: boolean }} */ (dispatchResult).evalError === true) roundHadEvalError = true;
           blocksById.set(tu.id, block);
         }
         // Persist in the model's emitted order for stable transcripts
@@ -866,6 +871,7 @@ export async function* runUserTurn(ctx) {
           };
           const { dispatchResult, block } = await dispatchOne(tu);
           yield { type: 'tool-result', sessionId, toolUseId: tu.id, result: dispatchResult };
+          if (/** @type {{ evalError?: boolean }} */ (dispatchResult).evalError === true) roundHadEvalError = true;
           toolResults.push(block);
         }
         if (abortedMidBatch) break;
@@ -921,7 +927,7 @@ export async function* runUserTurn(ctx) {
     // FAILED, one round did NOT suffice — disarm one-shot (below) so the model gets
     // its normal recover/explain turns for the REST of this turn. The first CLEAN
     // round short-circuits; multi-step work simply never sets the flag.
-    if (oneShotArmed && toolResults.length > 0 && !toolResults.some((b) => b.is_error)) {
+    if (oneShotArmed && toolResults.length > 0 && !toolResults.some((b) => b.is_error) && !roundHadEvalError) {
       const toolOut = toolResults
         .map((b) => (typeof b.content === 'string' ? b.content : JSON.stringify(b.content)))
         .join('\n').trim();

--- a/extension/peerd-runtime/tools/defs/js-notebook.js
+++ b/extension/peerd-runtime/tools/defs/js-notebook.js
@@ -102,7 +102,10 @@ export const jsNotebookTool = {
         sessionId: ctx.session?.sessionId,
         notebookId: targetNotebookId,
       });
-      return { ok: true, content: formatEvalResult(args.code, result) };
+      // evalError: the eval infrastructure succeeded but the CODE crashed —
+      // ok:true (the [ERROR] text IS the result) with the marker the one-shot
+      // latch reads, so an actor delegation gets its recovery turn.
+      return { ok: true, content: formatEvalResult(args.code, result), ...(result.error ? { evalError: true } : {}) };
     } catch (e) {
       const err = /** @type {{ name?: string, message?: string }} */ (e);
       return { ok: false, error: `js_notebook_failed: ${err?.name ?? 'Error'}: ${err?.message ?? String(e)}` };

--- a/extension/shared/tool-types.js
+++ b/extension/shared/tool-types.js
@@ -83,6 +83,11 @@
  *   persists the bytes (send-once-then-strip, like attachments). content carries
  *   the bytes-free metadata.
  * @property {ToolMeta} [meta]         populated by the dispatcher, not by tools
+ * @property {boolean} [evalError]     the tool ran fine but the CODE it evaluated
+ *   errored (a notebook eval's in-band [ERROR]). ok stays true — the error text
+ *   is the legitimate result — but the one-shot latch reads this to give the
+ *   actor its promised recovery turn instead of short-circuiting a crash back
+ *   as the raw reply (the oneShot contract: "an errored round falls through").
  */
 
 /**

--- a/extension/tests/unit/offscreen/job-runner.test.js
+++ b/extension/tests/unit/offscreen/job-runner.test.js
@@ -101,6 +101,27 @@ describe('offscreen job-runner (real sealed worker)', () => {
     expect(v.seed).toBe('kept');   // the virtual FS round-trips through the run
   });
 
+  // The runtime self-test fixture, headless: demoModule() must be importable
+  // and runnable from a headless job through the SAME builtin resolver chain
+  // the live agent uses — pins "peerd:wasi is reachable from script" as a CI
+  // fact (a field session reported it unreachable; this is the regression net).
+  it('peerd:wasi demoModule() self-test runs green inside a headless job', async () => {
+    const r = await runJob(
+      {
+        code: [
+          'import { runWasi, demoModule } from "peerd:wasi";',
+          'const run = await runWasi(demoModule());',
+          'return { exitCode: run.exitCode, stdout: run.stdout };',
+        ].join('\n'),
+      },
+      { sendToSW: async () => ({ ok: true }) },
+    );
+    expect(r.error).toBe(null);
+    const v = /** @type {{ exitCode: number, stdout: string }} */ (r.value);
+    expect(v.exitCode).toBe(0);
+    expect(v.stdout).toBe('hello from wasi\n');
+  });
+
   // The a2a run is the dweb actor's MESH-ONLY surface (cynical-swarm HIGH): its
   // tool allow-set grants no egress and no delegation, so the same sealed worker
   // run with { a2a:true } must NOT be able to re-grant itself either via the

--- a/tests/peerd-runtime/loop/one-shot.test.ts
+++ b/tests/peerd-runtime/loop/one-shot.test.ts
@@ -206,6 +206,30 @@ describe('runUserTurn — one-shot', () => {
     expect(s.messages.some((m: any) => m.stopReason === 'one_shot')).toBe(false);
   });
 
+  test('an ok:true eval whose CODE crashed (evalError) also falls through — the field bug', async () => {
+    // The live failure: a notebook actor ran oneShot code that threw a
+    // CompileError. js_notebook returns ok:true (the eval ran; [ERROR] is the
+    // result) so is_error never fires — and the raw crash short-circuited back
+    // as the reply instead of the promised recovery turn. The evalError marker
+    // must disarm the latch exactly like a tool-level error.
+    const store = makeStore();
+    store.seed('s1');
+    const { model, state } = makeCountingModel();
+    const ctx = baseCtx(store, {
+      callModel: model,
+      oneShot: true,
+      toolDispatch: async () => ({ ok: true, content: '> code\n[0ms]\n[ERROR]\nCompileError: bad wasm', evalError: true, meta: {} }),
+    });
+    await drain(runUserTurn(ctx));
+
+    // the crash round did NOT suffice -> the model got its recovery turn.
+    expect(state.calls).toBe(2);
+    const s = await store.get('s1');
+    const last = s.messages[s.messages.length - 1];
+    expect(last.content).toBe('summary');
+    expect(s.messages.some((m: any) => m.stopReason === 'one_shot')).toBe(false);
+  });
+
   test('without oneShot (default) the loop runs the full turn — summarize inference happens', async () => {
     const store = makeStore();
     store.seed('s1');


### PR DESCRIPTION
## What & why — the second failure mode from the wasi feed

The notebook actor handed the same raw `CompileError` back to the orchestrator twice while the orchestrator hand-patched wasm bytes across messages. The actor should have debugged its own sandbox — and the oneShot contract even promised it would: *"an errored round falls through to the normal loop."*

**The gap:** the one-shot clean-round test only saw tool-level `is_error`. `js_notebook` reports a crashed eval as `ok:true` with the `[ERROR]` text as content — correct in general (the eval infrastructure worked; the error text IS the result), but it made a crash round look "clean," so the latch short-circuited the raw crash back as the actor's reply. The promised recovery turn never ran.

**The fix, at the seam:**
- `js_notebook` marks such results `evalError: true` (`ok` stays `true` — nothing else changes about how errors read in normal turns).
- The one-shot latch disarms on the marker exactly like a tool failure, so the recovery rounds run as a normal turn (recover AND explain).
- The marker rides the dispatcher's result spread and the offscreen relay's structured clone, so the in-SW and worker-heap actor paths both honor it.

## Also: the first failure mode, pinned in CI

The same feed reported `peerd:wasi` unreachable from a headless `script` worker ("Failed to fetch dynamically imported module"). Source + packaging are correct (the builtin map derives URLs from `import.meta.url`; packaging copies everything outside the prune lists) — and the new in-browser test imports `{ runWasi, demoModule }` from `peerd:wasi` inside a real headless job and runs it green. Current source is proven working in the real substrate; the field failure pattern matches a stale install (the wasi feature merged very recently) — reload/update the extension.

## Checklist

- [x] Gates green: typecheck, eslint, bun 2724 (new one-shot disarm test), in-browser 621 (new headless demoModule test)
- [x] Commits signed off — DCO
- [x] Tests added: the exact field shape (`ok:true` + `[ERROR]` content + `evalError`) must yield a recovery model call and no `one_shot` stop
- [x] No hand-edited generated files

## Notes for reviewers

Scope is deliberately notebook-eval-only: a WebVM command exiting non-zero stays raw under oneShot — a failing `pytest` run's output IS the answer there, whereas a notebook eval that never produced its value is an unfinished job.

---
_Generated by [Claude Code](https://claude.ai/code/session_018scDZ7G3pkkAxKjmQkWY2q)_