### PR TITLE
fix(prompt): web actor search hit a guaranteed redirect on duckduckgo.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and storage formats may move until the surface stabilizes.
 ## [Unreleased]
 
 ### Fixed
+- **The search shortcut in the web actor's own prompt pointed at a URL that
+  always redirects.** The prompt told the actor to search with
+  `fetch_url https://duckduckgo.com/html/?q=...`, but that path 302s to
+  `html.duckduckgo.com`, and `fetch_url` does not follow redirects (by
+  design: see `docs/security/THREAT-MODEL.md` INV-7). Every search burned a
+  turn on a guaranteed redirect error before the actor retried correctly.
+  The prompt now names the right host (`html.duckduckgo.com/html/?q=...`)
+  and says why the bare host fails, so search works on the first try.
 - **A oneShot delegation whose CODE crashed now gets its recovery turn.**
   The oneShot contract always said "an errored round falls through to the
   normal loop" — but the clean-round test only saw tool-LEVEL errors, and a

--- a/extension/peerd-runtime/loop/system-prompt.js
+++ b/extension/peerd-runtime/loop/system-prompt.js
@@ -347,10 +347,12 @@ JS-rendered DOM → render: navigate opens your tab, drive it; then you may fetc
 SAME site's endpoints WITH the session instead of re-scraping. Try fetch first when the
 data looks API-reachable; render if it's gated, needs auth, or comes back empty
 (fetch_url returns served html/json, not what JS builds).
-To SEARCH, go BACKGROUND-FIRST: fetch_url https://duckduckgo.com/html/?q=… — a JS-free
-results page, so it needs NO tab (sessionless, invisible, fast) — and read the result
-links/snippets from the served HTML. Open a tab (navigate) only when the fetched results
-come back empty/blocked or the task needs the rendered engine (news/images tabs, a
+To SEARCH, go BACKGROUND-FIRST: fetch_url https://html.duckduckgo.com/html/?q=… — a
+JS-free results page, so it needs NO tab (sessionless, invisible, fast) — and read the
+result links/snippets from the served HTML. Use the html. subdomain exactly: the bare
+duckduckgo.com/html/ path 302-redirects (fetch_url does not follow redirects), which
+wastes a turn for no reason. Open a tab (navigate) only when the fetched results come
+back empty/blocked or the task needs the rendered engine (news/images tabs, a
 JS-gated engine). There is no search tool; this fetch IS the search.
 
 YOUR TAB — you own 0-OR-1 tab. You start with NONE (fetch needs no tab); calling navigate


### PR DESCRIPTION
Reported from a live session: a search almost always tried `fetch_url` against `https://duckduckgo.com/html/?q=...`, got a `redirected: ... does not follow` error, then had to retry.

Root cause: the web actor's own prompt (`extension/peerd-runtime/loop/system-prompt.js`, the BACKGROUND-FIRST search line) told it to hit that exact URL. That path 302s to `html.duckduckgo.com` every time, confirmed by hand with curl. `fetch_url` never follows redirects on purpose (INV-7 in `docs/security/THREAT-MODEL.md`: an MV3 service worker can't safely re-validate a redirect target per hop, so `webFetch` fails closed rather than risk a public host pivoting to an internal one). So every single search was guaranteed to burn one turn on this error before the actor self-corrected.

Fix is prompt text only: point the shortcut at `html.duckduckgo.com/html/?q=...` (no redirect) and say why the bare host fails. No change to `fetch_url`, `webFetch`, or any egress/security boundary.

Verified:
- `bun test tests/peerd-runtime/actor-prompt.test.ts`: 26 pass (the existing `duckduckgo.com/html/?q=` substring assertion still holds, since it's a substring of the new host)
- Full suite: 2724 pass, typecheck clean, lint clean, `check:docpaths` clean
- Manually confirmed with curl: `duckduckgo.com/html/?q=...` → 302, `html.duckduckgo.com/html/?q=...` → 200 with real results HTML