### PR TITLE
fix(gates): web actor's own-tab reads were wrongly refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and storage formats may move until the surface stabilizes.
 ## [Unreleased]
 
 ### Fixed
+- **A web actor could be wrongly refused a read of its own tab.** The
+  dispatcher gate that pins a web actor to the one tab it owns compared an
+  explicit `tabId` argument against `actorInstanceId`. That field is the
+  fixed literal `'web'`, the actor's stable `message_actor` address, not a
+  tab id (only an API actor's instanceId is still a real identifier, its
+  origin). So the comparison could never match, and any DOM tool call that
+  named its own tab explicitly (`read_page`, `click`, and so on) was refused
+  with a confusing "pinned to tab web" error, even though it was the actor's
+  own tab. The gate now compares against the actor's actually-owned tab
+  instead. This was a false-positive refusal, not a security gap: the
+  independent execute-time resolver already only ever targeted the owned
+  tab or failed closed.
 - **The search shortcut in the web actor's own prompt pointed at a URL that
   always redirects.** The prompt told the actor to search with
   `fetch_url https://duckduckgo.com/html/?q=...`, but that path 302s to

--- a/extension/peerd-runtime/tools/exposure.js
+++ b/extension/peerd-runtime/tools/exposure.js
@@ -260,11 +260,14 @@ export const actorTargetId = (name, args) => {
 // DESIGN-17 web actor — the tab pin. A web actor owns ONE tab; the DOM
 // tools resolve their target via `resolveTargetTab`, which honors an explicit
 // numeric `args.tabId`. So the pin is on tabId (a number), not an instance-id
-// string — `actorTargetId` (string-only) can't express it. The web actor's
-// `actorInstanceId` is its owned tabId AS A STRING. The GATE runs before
-// `resolveTargetTab` (async) and can only see the explicit arg, so this checks
-// the EXPLICIT `args.tabId`: absent → defaults to the bound tab (fine); present
-// and ≠ the owned tab → refused.
+// string — `actorTargetId` (string-only) can't express it. The GATE (gates.js
+// actorTierGate) compares this against ctx.activeTab.id, the actor's owned
+// tab — NOT ctx.actorInstanceId, which is the fixed literal 'web' for the
+// per-chat singleton actor (its message_actor address, stable across
+// re-navigation, not a tab id). The GATE runs before `resolveTargetTab`
+// (async) and can only see the explicit arg, so this checks the EXPLICIT
+// `args.tabId`: absent → defaults to the bound tab (fine); present and ≠ the
+// owned tab → refused.
 /**
  * The explicit numeric `tabId` a DOM-tool call names, or undefined. Pure.
  * @param {Record<string, any> | null | undefined} args

--- a/extension/peerd-runtime/tools/gates.js
+++ b/extension/peerd-runtime/tools/gates.js
@@ -158,16 +158,31 @@ export const actorTierGate = (tool, args, ctx) => {
   // DESIGN-17 web actor — the tab pin. The DOM tools resolve their tab from an
   // explicit numeric `args.tabId` (or the bound tab if absent), so the pin is on
   // tabId, not an instance-id string. An explicit tabId that isn't the owned tab
-  // is refused; absent → the bound tab (fine). actorInstanceId = owned tabId
-  // as a string. (Runs before resolveTargetTab, so it sees only the explicit arg
-  // — the in-execute denylist re-check in resolveTargetTab is the second wall.)
+  // is refused; absent → the bound tab (fine). (Runs before resolveTargetTab, so
+  // it sees only the explicit arg — the in-execute denylist re-check in
+  // resolveTargetTab is the second wall.)
+  //
+  // ctx.activeTab.id is the owned tab, NOT ctx.actorInstanceId. Since the
+  // per-chat web actor became addressable by the fixed name 'web'
+  // (message_actor("web", …)), actorInstanceId is that constant literal —
+  // stable across re-navigation — not the tab id (only an API actor's
+  // instanceId is still a real identifier, its fixed origin, and API actors
+  // are excluded above). buildToolContext resolves ctx.activeTab from the
+  // actor's actually-owned tab for exactly this comparison. Comparing against
+  // actorInstanceId here used to be correct (an earlier design where a web
+  // actor's instanceId WAS its tab id) but silently became a false-positive
+  // refusal for every own-tab call once that changed: 'web' !== any numeric
+  // tab id, always. Confirmed live (a `read_page` on its own tab refused with
+  // "pinned to tab web"). Not a security gap either way — resolveTargetTab
+  // independently fails closed on a missing ctx.activeTab — just wrongly
+  // blocked the legitimate case.
   if (ctx.actorType === 'web' && ctx.backing !== 'api') {
     const tab = actorWebTabTarget(args);
-    // String() BOTH sides (M6): actorInstanceId SHOULD be the tabId as a
-    // string, but coercing defensively means a numeric mint can't lock the
-    // actor out of its own tab ('42' !== 42).
-    if (tab !== undefined && String(tab) !== String(ctx.actorInstanceId)) {
-      return { allowed: false, reason: `web actor is pinned to tab ${ctx.actorInstanceId ?? '?'}; refusing ${tool.name} targeting tab ${tab}` };
+    const ownedTab = ctx.activeTab?.id;
+    // String() BOTH sides: ownedTab is a number, tab is a number, but coercing
+    // defensively means neither side's type can silently defeat the check.
+    if (tab !== undefined && String(tab) !== String(ownedTab)) {
+      return { allowed: false, reason: `web actor is pinned to tab ${ownedTab ?? 'none yet'}; refusing ${tool.name} targeting tab ${tab}` };
     }
   }
   return null;

--- a/tests/peerd-runtime/exposure.test.ts
+++ b/tests/peerd-runtime/exposure.test.ts
@@ -245,8 +245,18 @@ describe('DESIGN-17 actor tier — the gate (the wall)', () => {
 });
 
 describe('DESIGN-17 web actor — the fourth kind (DOM toolset + tab pin)', () => {
+  // Production shape (buildToolContext, service-worker.js): the per-chat web
+  // actor's actorInstanceId is the FIXED literal 'web' (its message_actor
+  // address — stable across re-navigation), never a tab id. The actor's
+  // actually-owned tab lives at ctx.activeTab.id, resolved separately. A
+  // prior version of this fixture encoded the tab id INTO actorInstanceId
+  // ('42') — which matched an earlier design but not the real ctx shape after
+  // the singleton-actor-address change, and silently stopped exercising the
+  // real bug: gates.js compared against actorInstanceId ('web' in
+  // production), so every own-tab call was refused. Fixed in gates.js; this
+  // fixture now matches what buildToolContext actually produces.
   const web = (over: object = {}) =>
-    ({ exposure: EXPOSURE_ACTOR, actorType: 'web', actorInstanceId: '42', ...over });
+    ({ exposure: EXPOSURE_ACTOR, actorType: 'web', actorInstanceId: 'web', activeTab: { id: 42, url: 'https://example.test/', origin: 'https://example.test' }, ...over });
 
   test('WEB_ACTOR_DOM_TOOLS is the DOM read/mutate set (no code-exec)', () => {
     // The web actor owns page reads + DOM mutators but NOT page_eval/page_exec —
@@ -328,6 +338,26 @@ describe('DESIGN-17 web actor — the fourth kind (DOM toolset + tab pin)', () =
     expect(rt({ name: 'click' }, { tabId: 99 }, web())?.allowed).toBe(false); // sibling tab
     expect(rt({ name: 'click' }, { tabId: 42 }, web())).toBeNull();           // own tab
     expect(rt({ name: 'click' }, {}, web())).toBeNull();                      // default → bound
+  });
+
+  // Regression: gates.js used to compare the explicit tabId against
+  // ctx.actorInstanceId. In production that's the fixed literal 'web' (the
+  // singleton actor's message_actor address), never a tab id, so EVERY
+  // own-tab call was refused — confirmed live: a read_page on the actor's own
+  // tab was refused with "pinned to tab web". The check must key off
+  // ctx.activeTab.id (the actor's real owned tab), independent of whatever
+  // string actorInstanceId happens to hold.
+  test('the tab pin keys off ctx.activeTab.id, not actorInstanceId', () => {
+    const ctx = { exposure: EXPOSURE_ACTOR, actorType: 'web', actorInstanceId: 'web', activeTab: { id: 1006003486, url: 'https://example.test/', origin: 'https://example.test' } };
+    // Exactly the reported failure: same numeric tab as the owned one, named explicitly.
+    expect(rt({ name: 'read_page' }, { tabId: 1006003486 }, ctx)).toBeNull();
+    // The security guarantee is untouched: a DIFFERENT explicit tab is still refused.
+    const refused = rt({ name: 'read_page' }, { tabId: 999 }, ctx);
+    expect(refused?.allowed).toBe(false);
+    expect(refused?.reason).toContain('1006003486');
+    // No owned tab yet (0-tab state) — an explicit tabId still fails closed.
+    const noTab = rt({ name: 'read_page' }, { tabId: 1 }, { exposure: EXPOSURE_ACTOR, actorType: 'web', actorInstanceId: 'web' });
+    expect(noTab?.allowed).toBe(false);
   });
 
   test('actorDescriptors filters a web actor to its DOM toolset', () => {


### PR DESCRIPTION
Reported live: a web actor's `read_page` on its own tab was refused with

`gate_blocked:exposure:web actor is pinned to tab web; refusing read_page targeting tab 1006003486`

**Root cause.** The gate that pins a web actor to the one tab it owns (`extension/peerd-runtime/tools/gates.js`, `actorTierGate`) compared an explicit `tabId` argument against `ctx.actorInstanceId`. That field is the fixed literal `'web'`, the per-chat actor's stable `message_actor` address (it stays `'web'` across re-navigation so the actor can always be addressed the same way), not a tab id. So the comparison could never match a real numeric tab id, and any DOM tool call that named its own tab explicitly (`read_page(tabId: …)`, `click`, etc.) was refused, unconditionally, regardless of whether it was actually the actor's own tab.

**Fix.** Compare against `ctx.activeTab.id` instead, the actor's actually-owned tab (already resolved by `buildToolContext` for exactly this purpose). This is what the independent execute-time resolver (`resolveTargetTab`) already does correctly today.

**Why this is safe (danger-zone file, so spelling this out).** Not a security loosening: `resolveTargetTab` already independently fails closed when the owned tab can't be resolved. This bug only ever *over-refused* the legitimate case; it never let a foreign tab through. The fix makes the gate agree with the resolver, nothing more.

**Also fixed:**
- The matching stale comment in `exposure.js` that asserted the same wrong `actorInstanceId` = tab-id assumption.
- The test fixture in `exposure.test.ts`, which encoded the tab id INTO `actorInstanceId` (`'42'`) — a shape that matched an *earlier* design (before the web actor became a fixed-address singleton) but not what `buildToolContext` produces today. That drift is exactly why this shipped without a failing test: the fixture gave false confidence without ever exercising the real ctx shape.

**Verification:**
- New regression test reproduces the exact reported failure (tab `1006003486`), and confirms a *foreign* tab is still correctly refused (no security regression).
- Confirmed the new test **fails against the pre-fix `gates.js` with the exact reported error message**, and passes with the fix (reverted, ran, restored).
- Full suite: 2725 pass. Typecheck clean. Lint clean. Red-team suite green. `check:docpaths` clean.