### PR TITLE
fetch_url content pipeline: clean-markdown extraction + spill-and-page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,10 @@ scripts/cdp/bench-results/
 # the vendored CheerpX/xterm assets kept directly in dist/) into /dist/
 # for Cloudflare Pages.
 /dist/
+
+# Online-Mind2Web (gated dataset + exported trajectories/screenshots + the
+# upstream scorer repo cloned on demand by score.mjs)
+scripts/cdp/om2w/data/
+scripts/cdp/om2w/out/
+scripts/cdp/om2w/vendor-repo/
+scripts/cdp/om2w/.venv/

--- a/extension/background/offscreen-web-client.js
+++ b/extension/background/offscreen-web-client.js
@@ -1,0 +1,33 @@
+// @ts-check
+// background/offscreen-web-client.js — SW-side client for HTML → markdown
+// extraction (fetch_url's clean-content path).
+//
+// fetch_url runs in the SW, but Readability/Turndown need a DOM Document that
+// only the OFFSCREEN document can build (offscreen/web-extract.js). This
+// client ensures the offscreen doc exists and dispatches the extraction.
+// Dependencies are injected (ensureOffscreen + sendMessage) so it stays a
+// pure, testable shell — the same shape as offscreen-pdf-client.js.
+
+// Cap what crosses runtime.sendMessage: a multi-MB page is structured-cloned
+// into the offscreen doc, and article content virtually always lives in the
+// document's head. The extractor holds a second wall (MAX_HTML_CHARS there).
+const MAX_SEND_CHARS = 2_000_000;
+
+/**
+ * @param {Object} deps
+ * @param {() => Promise<void>} deps.ensureOffscreen   create the offscreen doc if absent
+ * @param {(msg: object) => Promise<any>} deps.sendMessage   runtime.sendMessage → offscreen
+ */
+export const makeOffscreenWebClient = ({ ensureOffscreen, sendMessage }) => ({
+  /**
+   * @param {{ html: string, url?: string }} source   the fetched page
+   * @returns {Promise<{ readerable: boolean, markdown?: string, title?: string | null, byline?: string | null, htmlTruncated: boolean }>}
+   */
+  extractMarkdown: async ({ html, url }) => {
+    await ensureOffscreen();
+    const clipped = typeof html === 'string' && html.length > MAX_SEND_CHARS ? html.slice(0, MAX_SEND_CHARS) : html;
+    const reply = await sendMessage({ type: 'web/extract', html: clipped, url });
+    if (!reply?.ok) throw new Error(reply?.error ?? 'web extract failed');
+    return reply.result;
+  },
+});

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -3231,7 +3231,10 @@ const runActorTurnOffscreen = async (/** @type {any} */ { actorSessionId, messag
       try {
         const localProvider = !!listProviders().find((/** @type {any} */ p) => p.name === rec.provider)?.keyless;
         const cost = costOf(/** @type {any} */ (rec.model), /** @type {any} */ (r.usage), /** @type {any} */ (settingsStore.get().pricingOverrides), { localProvider });
-        uiPorts.broadcast({ type: 'turn/actor-cost', parentToolUseId: display.parentToolUseId, cost });
+        // usage rides along RAW: costOf returns only { cost: USD } — consumers
+        // that account TOKENS (the eval runner's ACTOR bucket) need the fields
+        // costOf collapsed. Additive; the sidepanel reducer reads `cost` only.
+        uiPorts.broadcast({ type: 'turn/actor-cost', parentToolUseId: display.parentToolUseId, cost, usage: r.usage });
       } catch { /* cost telemetry is best-effort */ }
     }
     auditLog.append({ type: 'actor_ran_offscreen', details: { heapSplit: true, kind, instanceId, ok: r.ok === true, aborted: r.aborted === true, persistOk } }).catch(() => {});

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -255,6 +255,7 @@ import { createContextSnapshots } from './context-snapshots.js';
 import { confirmGrantKey } from './confirm-grant-key.js';
 import { makeOffscreenActorClient } from './offscreen-actor-client.js';
 import { makeOffscreenPdfClient } from './offscreen-pdf-client.js';
+import { makeOffscreenWebClient } from './offscreen-web-client.js';
 import { makeUiPorts } from './ui-ports.js';
 import { createAppClient, APP_TAB_GROUP_TITLE } from './app-client.js';
 import { createAppTabTracker } from './app-tab-tracker.js';
@@ -983,6 +984,11 @@ const buildToolContext = async (/** @type {any} */ { sessionId: overrideSessionI
     // read_pdf — PDF text extraction in the offscreen doc (pdf.js needs a
     // Worker the SW can't host). Defined after ensureOffscreen below.
     pdfOffscreenClient,
+    // fetch_url's clean-content extraction — HTML -> markdown in the offscreen
+    // doc (Readability needs a DOM Document the SW can't build). Defined after
+    // ensureOffscreen below. NOT in spawn.js CAPABILITY_CONSUMERS (like
+    // pdfOffscreenClient), so it survives the web actor's capability strip.
+    webOffscreenClient,
     // why: App kind — DOM-bearing artifact the agent built for the
     // user. appClient combines registry (metadata) + body store (IDB).
     appClient,
@@ -1787,6 +1793,16 @@ const actorClient = offscreenAvailable ? makeOffscreenActorClient({
 // The PDF-extraction client (the read_pdf tool). ensureOffscreen, then a
 // 'pdf/extract' message to offscreen/pdf-extract.js (pdf.js in a Worker).
 const pdfOffscreenClient = offscreenAvailable ? makeOffscreenPdfClient({
+  ensureOffscreen,
+  sendMessage: (m) => browser.runtime.sendMessage(m),
+}) : null;
+
+// The HTML -> markdown extraction client (fetch_url's clean-content path).
+// Readability/Turndown need a DOM Document only the offscreen doc can build
+// ('web/extract' in offscreen/web-extract.js). null where offscreen is
+// unavailable (Firefox) - fetch_url then degrades to today's raw-text
+// behavior (the read_pdf precedent for capability-absent contexts).
+const webOffscreenClient = offscreenAvailable ? makeOffscreenWebClient({
   ensureOffscreen,
   sendMessage: (m) => browser.runtime.sendMessage(m),
 }) : null;

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -566,6 +566,32 @@ const getSecret = (/** @type {string} */ name) => vault.getSecret(name);
 // ---------------------------------------------------------------------------
 const VM_HTTP_CACHE_STORE = 'vm_http_cache';
 
+// fetch_url's spill-and-page store (idb v11). Keys are time-prefixed so IDB's
+// sorted key order IS chronological order — eviction is then delUpTo on the
+// cutoff key (the vm_http_cache posture: fetched public bytes, best-effort,
+// safe to clear). Bounded so unbounded page-spills can't grow the profile.
+const WEB_EXTRACT_CACHE_STORE = 'web_extract_cache';
+const WEB_EXTRACT_CACHE_MAX_ENTRIES = 40;
+let webCacheSeq = 0;
+const webCache = {
+  /** Mint a new time-ordered cache key. */
+  key: () => `wc-${Date.now().toString(36)}-${(webCacheSeq += 1).toString(36)}`,
+  /** @param {{ key: string, url?: string, format?: string, text: string, storedAt?: number }} record */
+  put: async (record) => {
+    await idb.put(WEB_EXTRACT_CACHE_STORE, { storedAt: Date.now(), ...record });
+    // Best-effort eviction: keys sort chronologically (time-prefixed), so
+    // dropping everything up to the (count-MAX)th key keeps the newest MAX.
+    try {
+      const keys = /** @type {string[]} */ (await idb.getAllKeys(WEB_EXTRACT_CACHE_STORE));
+      if (keys.length > WEB_EXTRACT_CACHE_MAX_ENTRIES) {
+        await idb.delUpTo(WEB_EXTRACT_CACHE_STORE, keys[keys.length - WEB_EXTRACT_CACHE_MAX_ENTRIES - 1]);
+      }
+    } catch { /* eviction is hygiene, never a failure */ }
+  },
+  /** @param {string} key */
+  get: (key) => idb.get(WEB_EXTRACT_CACHE_STORE, key),
+};
+
 // The bridge fetch is now an IO-injected factory (vm-net/vm-http-fetch.js) so
 // its security-critical logic — the anti-exfil write gate, host-bound git-auth
 // injection, and the revalidating IDB cache — is bun-testable. The SW supplies
@@ -1082,6 +1108,10 @@ const buildToolContext = async (/** @type {any} */ { sessionId: overrideSessionI
     // any future tool that legitimately needs to hit a provider.
     safeFetch,
     webFetch,
+    // fetch_url's spill-and-page store: oversized fetched text spills here and
+    // read_web_cache pages it back. Stripped to exactly those two tools by
+    // spawn.js CAPABILITY_CONSUMERS.webCache.
+    webCache,
     // why: web tools open background tabs unconditionally (never-steal-
     // focus policy, 2026-06-12); settings ride along for other consumers.
     settings: { ...settingsStore.get() },

--- a/extension/eval/runner.html
+++ b/extension/eval/runner.html
@@ -32,6 +32,7 @@
     <select id="suite" class="cfg" title="Simple = the fast 30-task suite. Robust = +25 check/get/do precision probes (longer).">
       <option value="simple">Simple suite (30 tasks)</option>
       <option value="robust">Robust suite (55 tasks)</option>
+      <option value="fetch">Fetch suite (content pipeline)</option>
     </select>
     <button id="run">Run all tasks</button>
     <button id="pin" class="secondary" disabled>Pin as baseline</button>

--- a/extension/eval/runner.js
+++ b/extension/eval/runner.js
@@ -19,7 +19,7 @@ import { sleep } from '/shared/util.js';
 
 /**
  * @typedef {{ inputTokens?: number, outputTokens?: number, cacheReadTokens?: number, cacheWriteTokens?: number, cost?: number }} Usage
- * @typedef {{ session: any, tools: string[], tokens: number, cost: Usage | null, runner: { inputTokens: number, outputTokens: number, cacheReadTokens: number, cacheWriteTokens: number }, error: string | null, started: boolean, resolveDone: ((value?: any) => void) | null }} Turn
+ * @typedef {{ session: any, tools: string[], tokens: number, cost: Usage | null, runner: { inputTokens: number, outputTokens: number, cacheReadTokens: number, cacheWriteTokens: number }, error: string | null, started: boolean, resolveDone: ((value?: any) => void) | null, lastActivityAt: number, runnerUsd: number }} Turn
  */
 
 // The runner's own $ for a task — 'local' is FREE, a cloud runner is priced from
@@ -79,17 +79,48 @@ let turn = fresh();
 // scorecard stays honest (main is low, the actor's spend appears — not "free").
 // The bucket keeps the `runner` name for continuity with the runnerModel A/B.
 /** @returns {Turn} */
-function fresh() { return { session: null, tools: [], tokens: 0, cost: null, runner: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 }, error: null, started: false, resolveDone: null }; }
+function fresh() { return { session: null, tools: [], tokens: 0, cost: null, runner: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 }, error: null, started: false, resolveDone: null, lastActivityAt: 0, runnerUsd: 0 }; }
 
 // 'eval' (not 'sidepanel') so an open home page doesn't think the side panel
 // popped out — joins uiPorts for turn/* all the same. See service-worker onConnect.
+// A task is "done" only when the WHOLE flow has gone quiet — not on the first
+// idle. why: peerd's web work is an ASYNC actor round-trip (the orchestrator
+// delegates via message_actor, its turn ends on the ack, the web actor drives
+// the page in its OWN session, then its reply wakes the orchestrator to report).
+// The old "resolve on the first streaming:false" scored that intermediate ack —
+// so a delegated task's answer was "I've asked the web actor…", never the real
+// result (and the REAL answer then bled into the NEXT task's window). Instead we
+// watch for a QUIET-SETTLE window: any activity event resets the timer, and we
+// only score after SETTLE_MS of total silence across the orchestrator AND its
+// actor. Bounded by the task's timeoutMs (runTask races this against a sleep).
+// why 15s: a delegated task has real inter-event gaps — the ack-idle before the
+// actor spins up, and a snapshot-heavy actor step whose model call is slow. At
+// 8s a snapshot-heavy task settled EARLY, mid-flight. 15s clears the largest
+// observed gap; a stuck turn still bails on the task's own timeoutMs, and
+// durationMs is measured to LAST ACTIVITY so the idle wait doesn't inflate it.
+const SETTLE_MS = 15_000;
+/** @type {ReturnType<typeof setTimeout> | null} */
+let settleTimer = null;
+// Reset the settle countdown on activity; when it elapses with no new event,
+// the delegated round-trip is finished → resolve the task's done promise.
+const bumpSettle = () => {
+  if (!turn.started || !turn.resolveDone) return;   // no active task / not begun
+  turn.lastActivityAt = Date.now();                 // for the work-time duration metric
+  if (settleTimer) clearTimeout(settleTimer);
+  settleTimer = setTimeout(() => {
+    settleTimer = null;
+    if (turn.resolveDone) { const r = turn.resolveDone; turn.resolveDone = null; r(); }
+  }, SETTLE_MS);
+};
+
 const port = browser.runtime.connect({ name: 'eval' });
 port.onMessage.addListener((/** @type {any} */ msg) => {
   switch (msg?.type) {
-    case 'turn/state': turn.session = msg.session; turn.started = true; break;
-    case 'turn/delta': turn.started = true; break;
-    case 'turn/tool-use': turn.started = true; turn.tools.push(msg.name); break;
-    case 'turn/cost': if (msg.turn) { turn.tokens = tally(msg.turn); turn.cost = msg.turn; } break;
+    case 'turn/state': turn.session = msg.session; turn.started = true; bumpSettle(); break;
+    case 'turn/delta': turn.started = true; bumpSettle(); break;
+    case 'turn/tool-use': turn.started = true; turn.tools.push(msg.name); bumpSettle(); break;
+    case 'turn/tool-result': bumpSettle(); break;
+    case 'turn/cost': if (msg.turn) { turn.tokens = tally(msg.turn); turn.cost = msg.turn; } bumpSettle(); break;
     case 'turn/spawned-cost':
       if (msg.usage) {
         turn.runner.inputTokens += msg.usage.inputTokens || 0;
@@ -97,12 +128,31 @@ port.onMessage.addListener((/** @type {any} */ msg) => {
         turn.runner.cacheReadTokens += msg.usage.cacheReadTokens || 0;
         turn.runner.cacheWriteTokens += msg.usage.cacheWriteTokens || 0;
       }
+      bumpSettle();
       break;
-    case 'turn/error': turn.error = msg.error; break;
-    case 'turn/streaming':
-      if (msg.streaming) turn.started = true;
-      else if (turn.started && turn.resolveDone) { const r = turn.resolveDone; turn.resolveDone = null; r(); }
+    // The OFFSCREEN actor heap's spend (heap-split actors broadcast
+    // turn/actor-cost, not turn/spawned-cost) — same ACTOR bucket, so the
+    // scorecard's avgRunnerTokens keeps seeing delegated web work. Tokens ride
+    // in msg.usage (msg.cost is costOf's { cost: USD } only); the priced USD is
+    // accumulated too so the row can report the actor's ACTUAL spend.
+    case 'turn/actor-cost':
+      if (msg.usage) {
+        turn.runner.inputTokens += msg.usage.inputTokens || 0;
+        turn.runner.outputTokens += msg.usage.outputTokens || 0;
+        turn.runner.cacheReadTokens += msg.usage.cacheReadTokens || 0;
+        turn.runner.cacheWriteTokens += msg.usage.cacheWriteTokens || 0;
+      }
+      if (typeof msg.cost?.cost === 'number') turn.runnerUsd += msg.cost.cost;
+      bumpSettle();
       break;
+    // Actor lifecycle events are ACTIVITY — they must hold the settle window
+    // open while the delegated work runs.
+    case 'turn/actor-start': case 'turn/actor-state': case 'turn/actor-done': bumpSettle(); break;
+    case 'turn/error': turn.error = msg.error; bumpSettle(); break;
+    // streaming:true = the orchestrator (or a wake) is producing output → keep
+    // waiting. streaming:false = it went idle → START the settle countdown (a
+    // later actor reply-wake will bump it again and push the finish back).
+    case 'turn/streaming': turn.started = true; bumpSettle(); break;
     // Local-model download progress (broadcast by the SW while Gemma loads).
     case 'local-model/progress': handleDlProgress(msg.progress || {}); break;
     default: break;
@@ -253,6 +303,9 @@ function finalAnswer(session) {
 
 /** @param {any} task @param {string} [runnerCfg] */
 async function runTask(task, runnerCfg) {
+  // Kill any settle timer left pending from the previous task before we swap in
+  // a fresh turn — otherwise its late fire could resolve THIS task's donePromise.
+  if (settleTimer) { clearTimeout(settleTimer); settleTimer = null; }
   turn = fresh();
   log(`\n▶ ${task.id} — ${task.title}`);
   await browser.runtime.sendMessage({ type: 'session/reset' });
@@ -273,9 +326,15 @@ async function runTask(task, runnerCfg) {
     return { id: task.id, pass: false, detail, error: reply?.error, steps: 0, tokens: 0, ...ZERO_COST, durationMs: 0, tools: [] };
   }
   await Promise.race([donePromise, sleep(task.timeoutMs ?? 90_000)]);
-  const durationMs = Date.now() - start;
+  // Work time = start → last activity, EXCLUDING the quiet-settle idle wait (and
+  // any post-work idle) so the duration metric reflects real work, not the fixed
+  // settle window we add on top. Falls back to now for a silent turn.
+  const durationMs = (turn.lastActivityAt || Date.now()) - start;
   const timedOut = !!turn.resolveDone;
   turn.resolveDone = null;
+  // Stop the settle timer either way: on the timeout path it's still pending, and
+  // a late fire must never bleed into the next task's donePromise.
+  if (settleTimer) { clearTimeout(settleTimer); settleTimer = null; }
   if (timedOut) log('  ⏱ timed out (still scoring end state)');
 
   await settleSubject();
@@ -296,7 +355,10 @@ async function runTask(task, runnerCfg) {
   // whole function (TDZ), breaking `turn = fresh()` at the top of runTask.
   const freshTok = cost.inputTokens + cost.outputTokens; // full-price input+output (MAIN context)
   const runnerTokens = turn.runner.inputTokens + turn.runner.outputTokens + turn.runner.cacheReadTokens + turn.runner.cacheWriteTokens;
-  const runnerCostUsd = priceRunnerUsd(runnerCfg, turn.runner);
+  // Prefer the ACTUAL accumulated actor spend (turn/actor-cost, priced by the
+  // SW from the actor's real model) over re-pricing by runnerCfg — cfg-based
+  // pricing exists for the runner-model A/B and reads 'local' (=$0) otherwise.
+  const runnerCostUsd = turn.runnerUsd > 0 ? turn.runnerUsd : priceRunnerUsd(runnerCfg, turn.runner);
   log(`  ${res.pass ? '✓ PASS' : '✗ FAIL'} — ${res.detail}  [${state.steps} steps · main ${freshTok} fresh + ${cost.cacheReadTokens} cache · runner ${runnerTokens} tok ($${runnerCostUsd.toFixed(4)}) · main $${cost.costUsd.toFixed(4)} · ${(durationMs / 1000).toFixed(1)}s]`);
   // why: per-task observability. The scorecard's failure rows only carry
   // id/detail/error — not WHICH tools ran or what the agent concluded. For a

--- a/extension/eval/tasks.js
+++ b/extension/eval/tasks.js
@@ -847,6 +847,7 @@ export const ROBUST_TASKS = [...SIMPLE_TASKS, ...ROBUST_EXTRA];
 // stable facts (wikipedia/MDN/RFC precedent: stable live pages over fixtures —
 // no fixture server on the eval path today) + one JSON API (extraction must
 // not touch JSON) + one tiny non-article page (the readerable:false fallback).
+/** @type {Task[]} */
 export const FETCH_TASKS = [
   {
     id: 'fetch-article-wiki',

--- a/extension/eval/tasks.js
+++ b/extension/eval/tasks.js
@@ -836,10 +836,74 @@ const ROBUST_EXTRA = [
 // strict superset (every simple result is in there too).
 export const ROBUST_TASKS = [...SIMPLE_TASKS, ...ROBUST_EXTRA];
 
+// --- the fetch suite: fetch_url-shaped tasks -------------------------------
+// Measures the CONTENT PIPELINE (tokens-per-fetch), not navigation skill: each
+// task names one URL and asks for a fact IN that page, so the web actor's
+// background-first lore reliably takes the fetch_url path (no tab). The
+// interesting number is the scorecard's avgRunnerTokens (the actor's spend —
+// where the fetched bytes land), compared before/after a content-pipeline
+// change (e.g. HTML→markdown extraction) on the SAME tasks; the checks only
+// guard that quality didn't drop. Targets are long-lived public pages with
+// stable facts (wikipedia/MDN/RFC precedent: stable live pages over fixtures —
+// no fixture server on the eval path today) + one JSON API (extraction must
+// not touch JSON) + one tiny non-article page (the readerable:false fallback).
+export const FETCH_TASKS = [
+  {
+    id: 'fetch-article-wiki',
+    title: 'fetch a wikipedia article for a fact',
+    prompt: 'From https://en.wikipedia.org/wiki/Ada_Lovelace find the year Ada Lovelace was born and reply with just the year.',
+    timeoutMs: 120_000,
+    check: (s) => s.error ? no(`errored: ${s.error}`)
+      : includesCI(s.answer, '1815') ? ok('found 1815')
+        : no(`expected 1815 in the answer, got "${(s.answer || '').slice(0, 120)}"`),
+  },
+  {
+    id: 'fetch-article-mdn',
+    title: 'fetch an MDN reference page for a default',
+    prompt: 'From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat what is the default depth argument of Array.prototype.flat()? Reply with the number.',
+    timeoutMs: 120_000,
+    check: (s) => s.error ? no(`errored: ${s.error}`)
+      : /\b1\b/.test(s.answer || '') ? ok('found depth 1')
+        : no(`expected depth 1 in the answer, got "${(s.answer || '').slice(0, 120)}"`),
+  },
+  {
+    id: 'fetch-article-rfc',
+    title: 'fetch a large RFC for a fact',
+    // why this target: rfc-editor's HTML for RFC 9110 is ~800k chars — it
+    // exercises the truncation/overflow path on top of extraction.
+    prompt: 'From https://www.rfc-editor.org/rfc/rfc9110.html which RFC number does RFC 9110 obsolete for HTTP semantics? Reply with the RFC number.',
+    timeoutMs: 120_000,
+    check: (s) => s.error ? no(`errored: ${s.error}`)
+      : includesCI(s.answer, '7231') ? ok('found 7231')
+        : no(`expected 7231 in the answer, got "${(s.answer || '').slice(0, 120)}"`),
+  },
+  {
+    id: 'fetch-json-api',
+    title: 'fetch a JSON endpoint (extraction must not touch JSON)',
+    prompt: 'Fetch https://httpbin.org/json and reply with the author of the slideshow in the response.',
+    timeoutMs: 120_000,
+    check: (s) => s.error ? no(`errored: ${s.error}`)
+      : includesCI(s.answer, 'Yours Truly') ? ok('found the author')
+        : no(`expected "Yours Truly" in the answer, got "${(s.answer || '').slice(0, 120)}"`),
+  },
+  {
+    id: 'fetch-nonarticle-fallback',
+    title: 'fetch a tiny non-article page (raw fallback)',
+    // why: example.com is far below any readability threshold — the extraction
+    // pre-check must fall back to raw text and the fact still comes through.
+    prompt: 'Fetch https://example.com/ and reply with what the page says the domain is for.',
+    timeoutMs: 120_000,
+    check: (s) => s.error ? no(`errored: ${s.error}`)
+      : (includesCI(s.answer, 'illustrative') || includesCI(s.answer, 'example') || includesCI(s.answer, 'documentation')) ? ok('described the page')
+        : no(`expected the illustrative-examples description, got "${(s.answer || '').slice(0, 120)}"`),
+  },
+];
+
 // The suite registry the eval UI picks from.
 export const SUITES = Object.freeze({
   simple: { id: 'simple', label: 'Simple', tasks: SIMPLE_TASKS },
   robust: { id: 'robust', label: 'Robust', tasks: ROBUST_TASKS },
+  fetch: { id: 'fetch', label: 'Fetch (content pipeline)', tasks: FETCH_TASKS },
 });
 
 // Back-compat: existing importers (runner.js) use TASKS — keep it the simple set.

--- a/extension/offscreen/offscreen.js
+++ b/extension/offscreen/offscreen.js
@@ -30,6 +30,10 @@ import { runActor, abortActor } from './actor-runner.js';
 // PDF text extraction (the read_pdf runner tool): pdf.js needs a Worker, which
 // the SW can't host. Self-registers a 'pdf/extract' message handler.
 import './pdf-extract.js';
+// HTML -> markdown extraction (fetch_url's clean-content path): Readability +
+// Turndown need a DOM Document, which the SW can't build. Self-registers a
+// 'web/extract' message handler.
+import './web-extract.js';
 import { initLocalModel, generateLocal, localModelStatus, probeWebgpu, teardownLocalModel } from './local-model.js';
 import { isTrustedSender } from '/shared/messaging.js';
 // The always-on base network (S1b). Self-registers a dweb/base-host/* handler;

--- a/extension/offscreen/web-extract.js
+++ b/extension/offscreen/web-extract.js
@@ -1,0 +1,104 @@
+// @ts-check
+// offscreen/web-extract.js — HTML → clean markdown for fetch_url.
+//
+// fetch_url's execute() runs in the SW, which has no DOMParser — so the
+// extraction lives HERE, in the offscreen document, reached via
+// background/offscreen-web-client.js → a 'web/extract' message → this handler
+// (the exact shape of the pdf-extract pipeline, its sibling above).
+//
+// Two vendored halves (see each SOURCE.txt): Readability (Firefox Reader
+// View's extractor) isolates the article from the boilerplate; Turndown
+// converts that article HTML to markdown — the dense representation the model
+// actually reads. A cheap isProbablyReaderable pre-check skips extraction on
+// non-article pages (dashboards, listings, search results) so the caller falls
+// back to today's raw-text behavior instead of getting a mangled fragment.
+//
+// why client-side at all: the hosted "clean content" APIs other agents lean on
+// (Firecrawl etc.) are forbidden here — BYOK / no backend / no third party
+// sees the user's browsing. This is peerd's privacy-preserving substitute.
+
+import browser from '/vendor/browser-polyfill.js';
+import { isTrustedSender } from '/shared/messaging.js';
+
+// Both libs are loaded LAZILY (dynamic import), mirroring loadPdfjs: the
+// offscreen document always loads, but most sessions never fetch an article —
+// keep the ~120KB of parser off the startup path and pay it once, on first
+// use. why Promise.all in one gate: turndown's browser build probes DOMParser
+// at IMPORT time, so it must only ever be imported in a DOM context — this
+// module — and never from the SW.
+/** @type {Promise<{ Readability: any, isProbablyReaderable: any, TurndownService: any }> | null} */
+let libsPromise = null;
+const loadLibs = () => (libsPromise ??= Promise.all([
+  import('/vendor/readability/Readability.js'),
+  import('/vendor/readability/Readability-readerable.js'),
+  import('/vendor/turndown/turndown.browser.es.js'),
+]).then(([r, rr, t]) => ({ Readability: r.default, isProbablyReaderable: rr.default, TurndownService: t.default })));
+
+// Bound the PARSE work — a pathological page must not wedge the offscreen
+// renderer (the shared host for voice + the SW keepalive). Article content
+// virtually always lives in the head of the document; the client also caps
+// what it sends (offscreen-web-client.js), this is the second wall.
+const MAX_HTML_CHARS = 3_000_000;
+
+/**
+ * Extract the readable core of an HTML page as markdown.
+ *
+ * @param {{ html?: string, url?: string }} msg
+ * @returns {Promise<{ ok: true, result: { readerable: boolean, markdown?: string, title?: string | null, byline?: string | null, htmlTruncated: boolean } } | { ok: false, error: string }>}
+ */
+const extractWeb = async ({ html, url } = {}) => {
+  if (typeof html !== 'string' || !html) return { ok: false, error: 'html_required' };
+  const htmlTruncated = html.length > MAX_HTML_CHARS;
+  const input = htmlTruncated ? html.slice(0, MAX_HTML_CHARS) : html;
+  const { Readability, isProbablyReaderable, TurndownService } = await loadLibs();
+
+  // A FRESH document per extraction — Readability MUTATES what it parses.
+  const doc = new DOMParser().parseFromString(input, 'text/html');
+  // The parsed doc inherits THIS page's baseURI (a chrome-extension:// URL);
+  // point it at the fetched page instead so relative hrefs/srcs resolve
+  // against the real origin, not the extension.
+  if (typeof url === 'string' && url) {
+    try {
+      const base = doc.createElement('base');
+      base.href = url;
+      doc.head.prepend(base);
+    } catch { /* malformed url — links stay relative, extraction still works */ }
+  }
+
+  // Non-article page → tell the caller to keep its raw-text behavior. This is
+  // the safety valve against Readability mangling dashboards and listings.
+  if (!isProbablyReaderable(doc)) {
+    return { ok: true, result: { readerable: false, htmlTruncated } };
+  }
+
+  const article = new Readability(doc).parse();
+  if (!article?.content) {
+    return { ok: true, result: { readerable: false, htmlTruncated } };
+  }
+
+  const turndown = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced' });
+  const markdown = turndown.turndown(article.content);
+  return {
+    ok: true,
+    result: {
+      readerable: true,
+      markdown,
+      title: article.title ?? null,
+      byline: article.byline ?? null,
+      htmlTruncated,
+    },
+  };
+};
+
+// Gated on isTrustedSender like every sibling handler (pdf/extract, job/run,
+// voice) — fail-closed defense-in-depth; see pdf-extract.js's note.
+// why cast: the polyfill's OnMessageListener return-type is stricter than this
+// fire-and-respond handler (mirrors the sibling listeners).
+browser.runtime.onMessage.addListener(/** @type {any} */ ((/** @type {any} */ msg, /** @type {any} */ sender, /** @type {any} */ sendResponse) => {
+  if (msg?.type !== 'web/extract') return undefined;
+  if (!isTrustedSender(sender)) { sendResponse({ ok: false, error: 'untrusted-sender' }); return true; }
+  extractWeb(msg)
+    .then((out) => sendResponse(out))
+    .catch((e) => sendResponse({ ok: false, error: e?.name ? `${e.name}: ${e.message}` : (e?.message ?? String(e)) }));
+  return true;     // async sendResponse contract
+}));

--- a/extension/peerd-egress/storage/idb.js
+++ b/extension/peerd-egress/storage/idb.js
@@ -65,7 +65,13 @@ const DB_NAME = 'peerd';
 // v10 — audit_meta: the audit log's hash-chain head record (R4 tamper
 // evidence). One tiny record ({ key: 'audit_chain_head', id, chain })
 // pinning the newest entry so tail truncation is detectable.
-const DB_VERSION = 10;
+// v11 — web_extract_cache: fetch_url's spill-and-page store. When a fetched
+// body overflows the tool budget, the FULL text is spilled here (records
+// { key, url, format, text, storedAt }) and the model gets a head+tail window
+// plus the exact read_web_cache paging call — instead of silently losing the
+// middle. Same posture as vm_http_cache: fetched public bytes, unencrypted
+// extension-scoped disk, best-effort, safe to clear at any time.
+const DB_VERSION = 11;
 
 /**
  * Open the database. Cached after first call. Re-opens on connection
@@ -102,6 +108,10 @@ export const openDB = () => {
       // v10 — the audit chain head (see DB_VERSION note above).
       if (!db.objectStoreNames.contains('audit_meta')) {
         db.createObjectStore('audit_meta', { keyPath: 'key' });
+      }
+      // v11 — fetch_url's spill-and-page store (see DB_VERSION note above).
+      if (!db.objectStoreNames.contains('web_extract_cache')) {
+        db.createObjectStore('web_extract_cache', { keyPath: 'key' });
       }
       // v3 — the vault blob's new home (records: { key, value }). The
       // blob itself stays ciphertext; this is hygiene, not a security

--- a/extension/peerd-provider/format/to-anthropic.js
+++ b/extension/peerd-provider/format/to-anthropic.js
@@ -519,9 +519,12 @@ export const toAnthropicBody = ({ model, system, messages, tools, maxTokens = 64
     stream: true,
   };
   // Effort (GA on 4.6+/Fable): the only bound on ADAPTIVE thinking depth
-  // (budget_tokens is removed there). Pass-through when the caller sets
-  // it; absent = the platform default (high).
-  if (typeof reasoning?.effort === 'string' && reasoning.effort) {
+  // (budget_tokens is removed there). ONLY the adaptive-shape models accept
+  // output_config.effort — sending it to a PRE-4.6 model (Haiku 4.5, Sonnet
+  // 4.5, the 3.x line) 400s with "does not support the effort parameter", so
+  // gate it on the SAME predicate as the thinking shape. Absent = platform
+  // default (high). Pass-through when the caller sets it on an adaptive model.
+  if (usesAdaptiveThinking(model) && typeof reasoning?.effort === 'string' && reasoning.effort) {
     body.output_config = { effort: reasoning.effort };
   }
   // why: an empty/whitespace system prompt must OMIT the field — the

--- a/extension/peerd-runtime/actor/spawn.js
+++ b/extension/peerd-runtime/actor/spawn.js
@@ -126,6 +126,7 @@ export const CAPABILITY_CONSUMERS = Object.freeze({
   getSecret:          [],
   safeFetch:          [],
   webFetch:           ['vm_import', 'fetch_url'],
+  webCache:           ['fetch_url', 'read_web_cache'],
   memory:             ['read_memory', 'remember'],
   kv:                 ['inspect'],
   idb:                ['inspect'],

--- a/extension/peerd-runtime/tools/defs/fetch-url.js
+++ b/extension/peerd-runtime/tools/defs/fetch-url.js
@@ -19,6 +19,7 @@
 import { fetchUrl } from '../web/primitives.js';
 import { originOfUrl } from './dom-helpers.js';
 import { wrapUntrusted } from '../prompt-wrap.js';
+import { windowText, pagingFooter } from '../web/spill.js';
 import { needsWebWriteConfirm } from '/peerd-engine/index.js';
 
 const MAX_BODY_CHARS = 16_000;   // hard cap to avoid context-blast on huge payloads
@@ -140,29 +141,50 @@ export const fetchUrlTool = {
           }
         } catch { /* extraction failed — raw fallback */ }
       }
-      const truncated = workingBody.length > MAX_BODY_CHARS;
-      const text = truncated ? workingBody.slice(0, MAX_BODY_CHARS) : workingBody;
+      // Spill-and-page for an oversized body (Hermes-style): the FULL text is
+      // stored locally and the model sees a head+tail WINDOW plus the exact
+      // read_web_cache paging call — instead of the old silent head-only slice
+      // that lost the tail without saying so. Falls back to the old slice when
+      // the cache capability is absent (a ctx without webCache).
+      const webCache = /** @type {{ key?: () => string, put?: (r: object) => Promise<void> } | undefined} */ (
+        /** @type {any} */ (ctx).webCache);
+      const win = windowText(workingBody, MAX_BODY_CHARS);
+      let text = win.window;
+      const truncated = win.windowed;
+      /** @type {string | null} */
+      let footer = null;
+      if (win.windowed && webCache?.key && webCache?.put) {
+        const cacheKey = webCache.key();
+        try {
+          await webCache.put({ key: cacheKey, url: res.finalUrl || args.url, format, text: workingBody });
+          footer = pagingFooter({ key: cacheKey, total: win.total, headChars: win.headChars, tailChars: win.tailChars });
+        } catch { /* spill failed — the window (with its elision marker) still ships */ }
+      } else if (win.windowed && !webCache) {
+        // No cache capability → the pre-spill behavior (head-only slice).
+        text = workingBody.slice(0, MAX_BODY_CHARS);
+      }
       let parsedJson = null;
-      if (/(json|graphql)/i.test(ct)) { try { parsedJson = JSON.parse(text); } catch { parsedJson = null; } }
+      if (/(json|graphql)/i.test(ct)) { try { parsedJson = JSON.parse(truncated ? workingBody.slice(0, MAX_BODY_CHARS) : text); } catch { parsedJson = null; } }
       // The body is open-web content the page/host controls — fence it as DATA,
-      // not instructions (the same boundary call_api / read_page enforce).
-      return {
-        ok: true,
-        content: wrapUntrusted({
-          origin: originOfUrl(res.finalUrl || args.url),
-          tool: 'fetch_url',
-          body: JSON.stringify({
-            status: res.status,
-            finalUrl: res.finalUrl,
-            contentType: ct || null,
-            format,
-            ...(title ? { title } : {}),
-            truncated,
-            body: text,
-            json: parsedJson,
-          }, null, 2),
-        }),
-      };
+      // not instructions (the same boundary call_api / read_page enforce). The
+      // paging footer is TOOL-AUTHORED (caller-computed values only, never
+      // fetched bytes) and rides OUTSIDE the fence — page content must never
+      // be able to forge or suppress it.
+      const fenced = wrapUntrusted({
+        origin: originOfUrl(res.finalUrl || args.url),
+        tool: 'fetch_url',
+        body: JSON.stringify({
+          status: res.status,
+          finalUrl: res.finalUrl,
+          contentType: ct || null,
+          format,
+          ...(title ? { title } : {}),
+          truncated,
+          body: text,
+          json: parsedJson,
+        }, null, 2),
+      });
+      return { ok: true, content: footer ? `${fenced}\n${footer}` : fenced };
     } catch (e) {
       const err = /** @type {{ reason?: string, message?: string }} */ (e);
       if (err?.reason === 'redirect_blocked') {

--- a/extension/peerd-runtime/tools/defs/fetch-url.js
+++ b/extension/peerd-runtime/tools/defs/fetch-url.js
@@ -53,7 +53,8 @@ export const fetchUrlTool = {
     'client-side, drive a tab instead — but once you HAVE rendered a site, fetch_url',
     "carries its session, so hit that SAME origin's endpoints here instead of",
     're-scraping. Rides the denylist + SSRF + audit egress chain; does NOT follow',
-    'redirects. Returns status, final URL, body + parsed JSON (capped 16k).',
+    'redirects. Returns status, final URL, body + parsed JSON (capped 16k). HTML',
+    'is extracted to clean markdown by default (raw:true for the full HTML).',
   ].join(' '),
   schema: {
     type: 'object',
@@ -61,6 +62,7 @@ export const fetchUrlTool = {
     properties: {
       url: { type: 'string', description: 'Absolute URL (must include an http(s) scheme).' },
       method: { type: 'string', enum: ['GET', 'POST'], description: 'HTTP method. Default GET.' },
+      raw: { type: 'boolean', description: 'HTML responses are extracted to clean markdown by default (boilerplate stripped). Pass true to get the raw HTML instead — e.g. when you need markup, attributes, or embedded script/JSON the extraction would drop.' },
       headers: {
         type: 'object',
         description: 'Request headers. Tool-supplied Cookie / Authorization are always stripped (you cannot inject a credential). Content-Type is set automatically for JSON bodies.',
@@ -114,10 +116,33 @@ export const fetchUrlTool = {
         { method, headers, body: /** @type {string | undefined} */ (body) },
         ctx,
       );
-      const truncated = res.body.length > MAX_BODY_CHARS;
-      const text = truncated ? res.body.slice(0, MAX_BODY_CHARS) : res.body;
-      let parsedJson = null;
       const ct = res.headers['content-type'] ?? '';
+      // HTML → clean markdown (the default; raw:true opts out). Boilerplate is
+      // most of a page's bytes, and the JSON envelope below escapes every
+      // quote in it — raw HTML routinely burns the whole 16k budget on nav and
+      // script tags. Readability+Turndown (offscreen — the SW has no DOMParser)
+      // return the readable core instead. FAIL-OPEN by design: a non-article
+      // page (readerable:false), a missing client (Firefox — no offscreen
+      // doc), or an extraction error all fall back to today's raw behavior —
+      // extraction is an optimization, never a gate on the fetch.
+      let workingBody = res.body;
+      let format = 'raw';
+      let title = null;
+      const webClient = /** @type {{ extractMarkdown?: (s: { html: string, url?: string }) => Promise<{ readerable: boolean, markdown?: string, title?: string | null }> } | null | undefined} */ (
+        /** @type {any} */ (ctx).webOffscreenClient);
+      if (args.raw !== true && /text\/html|application\/xhtml/i.test(ct) && webClient?.extractMarkdown) {
+        try {
+          const ex = await webClient.extractMarkdown({ html: res.body, url: res.finalUrl || args.url });
+          if (ex.readerable && typeof ex.markdown === 'string' && ex.markdown.trim()) {
+            workingBody = ex.markdown;
+            format = 'markdown';
+            title = ex.title ?? null;
+          }
+        } catch { /* extraction failed — raw fallback */ }
+      }
+      const truncated = workingBody.length > MAX_BODY_CHARS;
+      const text = truncated ? workingBody.slice(0, MAX_BODY_CHARS) : workingBody;
+      let parsedJson = null;
       if (/(json|graphql)/i.test(ct)) { try { parsedJson = JSON.parse(text); } catch { parsedJson = null; } }
       // The body is open-web content the page/host controls — fence it as DATA,
       // not instructions (the same boundary call_api / read_page enforce).
@@ -130,6 +155,8 @@ export const fetchUrlTool = {
             status: res.status,
             finalUrl: res.finalUrl,
             contentType: ct || null,
+            format,
+            ...(title ? { title } : {}),
             truncated,
             body: text,
             json: parsedJson,

--- a/extension/peerd-runtime/tools/defs/index.js
+++ b/extension/peerd-runtime/tools/defs/index.js
@@ -22,6 +22,7 @@ import { typeTool }                  from './type.js';
 import { navigateTool }              from './navigate.js';
 import { readPdfTool }               from './read-pdf.js';
 import { fetchUrlTool }              from './fetch-url.js';
+import { readWebCacheTool }          from './read-web-cache.js';
 import { actorListTool }             from './actor-list.js';
 import { openTabTool }               from './open-tab.js';
 import { vmBootTool }                 from './vm-boot.js';
@@ -155,6 +156,9 @@ export const BUILTIN_TOOLS = Object.freeze([
   // Registered + hidden from main (actor-only, like the DOM tools); allowed
   // for kind:'web' in ACTOR_TYPE_TOOLS.web and keyless by construction.
   fetchUrlTool,
+  // fetch_url's spill-and-page read side — same exposure (web actor only; the
+  // cache holds fetched page content).
+  readWebCacheTool,
   // engine — sandbox_create is the one cross-kind bootstrap (it folded
   // vm_create/js_create/app_create); the per-kind ops below are all
   // actor-only (ACTOR_ONLY_TOOLS) and reach the model via the actors.

--- a/extension/peerd-runtime/tools/defs/read-web-cache.js
+++ b/extension/peerd-runtime/tools/defs/read-web-cache.js
@@ -1,0 +1,76 @@
+// @ts-check
+// read_web_cache — page through a spilled fetch_url body.
+//
+// When fetch_url's text overflows its budget, the FULL text is spilled to the
+// local web_extract_cache store and the model sees a head+tail window plus a
+// footer naming this tool (tools/web/spill.js). This is the read side: an
+// offset/limit slice of that stored text. Web-actor-only, same exposure as
+// fetch_url itself — the cache holds fetched page content, which is the web
+// actor's tier (the main agent delegates via message_actor).
+//
+// The slice is STILL untrusted page content — it goes back out wrapped in the
+// same fence fetch_url uses; only the tool-authored paging status rides
+// outside it.
+
+import { wrapUntrusted } from '../prompt-wrap.js';
+import { originOfUrl } from './dom-helpers.js';
+import { pageSlice } from '../web/spill.js';
+
+// Same per-call ceiling as fetch_url's body budget — one page of cache reads
+// like one fetch.
+const MAX_SLICE_CHARS = 16_000;
+
+/** @type {import('/shared/tool-types.js').Tool} */
+export const readWebCacheTool = {
+  name: 'read_web_cache',
+  primitive: 'web',
+  description: [
+    'Read a slice of a spilled fetch_url body. When a fetch overflows its budget the',
+    'full text is stored locally and the result names the cache key — page through it',
+    'here with { key, offset, limit }. Offsets are character positions into the stored',
+    'text; the result reports what remains after the slice.',
+  ].join(' '),
+  schema: {
+    type: 'object',
+    required: ['key'],
+    properties: {
+      key: { type: 'string', description: 'The cache key from the fetch_url paging note.' },
+      offset: { type: 'number', description: 'Start character offset. Default 0.' },
+      limit: { type: 'number', description: `Max characters to return (capped at ${MAX_SLICE_CHARS}). Default the cap.` },
+    },
+  },
+  sideEffect: 'read',
+  // The cache is local — no network origin is touched by a page read.
+  origins: () => [],
+  execute: async (args, ctx) => {
+    if (typeof args?.key !== 'string' || !args.key) return { ok: false, error: 'key_required' };
+    const webCache = /** @type {{ get?: (key: string) => Promise<{ key: string, url?: string, format?: string, text: string } | undefined> } | undefined} */ (
+      /** @type {any} */ (ctx).webCache);
+    if (!webCache?.get) return { ok: false, error: 'web_cache_unavailable' };
+    const rec = await webCache.get(args.key).catch(() => undefined);
+    if (!rec || typeof rec.text !== 'string') {
+      return { ok: false, error: `no_such_key: ${args.key} — the cache entry may have been evicted; re-fetch the URL.` };
+    }
+    const limit = Math.min(typeof args.limit === 'number' && args.limit > 0 ? args.limit : MAX_SLICE_CHARS, MAX_SLICE_CHARS);
+    const page = pageSlice(rec.text, typeof args.offset === 'number' ? args.offset : 0, limit);
+    // The slice is fetched page content — fenced exactly like the fetch that
+    // produced it. The paging status is tool-authored → outside the fence.
+    const fenced = wrapUntrusted({
+      origin: originOfUrl(rec.url ?? '') ?? 'cache',
+      tool: 'read_web_cache',
+      body: JSON.stringify({
+        key: rec.key,
+        url: rec.url ?? null,
+        format: rec.format ?? 'raw',
+        offset: page.offset,
+        end: page.end,
+        total: page.total,
+        body: page.slice,
+      }, null, 2),
+    });
+    const status = page.remaining > 0
+      ? `[paging] chars ${page.offset}–${page.end} of ${page.total}; ${page.remaining} remain — next: { "key": "${rec.key}", "offset": ${page.end} }.`
+      : `[paging] chars ${page.offset}–${page.end} of ${page.total}; end of stored text.`;
+    return { ok: true, content: `${fenced}\n${status}` };
+  },
+};

--- a/extension/peerd-runtime/tools/exposure.js
+++ b/extension/peerd-runtime/tools/exposure.js
@@ -46,6 +46,9 @@ export const MAIN_AGENT_HIDDEN_TOOLS = Object.freeze(new Set([
   // never holds it. With call_api/read_article/web_search/submit_form removed, the
   // web actor (fetch_url + drive-a-tab) is the single entry point for ALL web work.
   'fetch_url',
+  // read_web_cache pages a SPILLED fetch_url body — the same fetched page
+  // content, so the same web-actor-only tier.
+  'read_web_cache',
 ]));
 
 /** Is this tool hidden from the main agent (actor-only)? Pure. @param {string} name */
@@ -157,7 +160,7 @@ const ACTOR_TYPE_TOOLS = Object.freeze({
   // clean DOM-only list. The web actor is the only ctx allowed fetch_url, and
   // the capability strip (spawn.js) keeps it keyless: webFetch survives,
   // getSecret / safeFetch do not.
-  web: Object.freeze(new Set([...WEB_ACTOR_DOM_TOOLS, 'fetch_url'])),
+  web: Object.freeze(new Set([...WEB_ACTOR_DOM_TOOLS, 'fetch_url', 'read_web_cache'])),
   // The dweb actor — the mesh's operator (global singleton, handle "dweb").
   // Exactly the dweb family, nothing else: no egress tools, no DOM, no engine
   // mutation — the envoy posture. Its worst case must be a wrong reply, so the
@@ -184,7 +187,7 @@ export const isAllowedForActorType = (name, kind) => actorAllowedTools(kind).has
 // from its allow-set. It keeps only the keyless, tab-free fetch_url. Used by BOTH the
 // gate (refuse a DOM tool for an API backing) and the capability strip (drop the DOM
 // capabilities), so an API actor is genuinely fetch-only, not just gated.
-const WEB_API_TOOLS = Object.freeze(new Set(['fetch_url']));
+const WEB_API_TOOLS = Object.freeze(new Set(['fetch_url', 'read_web_cache']));
 
 /**
  * The Set an actor may call given its kind AND (for a web actor) its backing — the

--- a/extension/peerd-runtime/tools/web/spill.js
+++ b/extension/peerd-runtime/tools/web/spill.js
@@ -1,0 +1,70 @@
+// @ts-check
+// tools/web/spill — pure windowing + paging for oversized fetched text.
+//
+// The old behavior silently sliced an oversized body at the budget: the model
+// lost the tail (and never knew what it lost). Spill-and-page instead keeps
+// the FULL text (the caller stores it) and shows a head+tail WINDOW plus a
+// footer naming the exact paging call — so the model can decide whether the
+// middle matters and read on deliberately. Head-heavy split because openings
+// carry the thesis; the tail catches conclusions/footers (and proves to the
+// model that content was elided in between).
+//
+// Pure functions, no IO — the fetch_url/read_web_cache tools own the store.
+
+// 75/25 head/tail split of the window budget.
+const HEAD_FRACTION = 0.75;
+
+/**
+ * Window an oversized text: head + tail with an elision marker between.
+ * Text at or under the budget is returned whole (windowed:false).
+ *
+ * @param {string} text
+ * @param {number} budget  max chars the caller wants to show
+ * @returns {{ windowed: boolean, window: string, headChars: number, tailChars: number, total: number }}
+ */
+export const windowText = (text, budget) => {
+  const total = text.length;
+  if (total <= budget) {
+    return { windowed: false, window: text, headChars: total, tailChars: 0, total };
+  }
+  const headChars = Math.floor(budget * HEAD_FRACTION);
+  const tailChars = budget - headChars;
+  const head = text.slice(0, headChars);
+  const tail = text.slice(total - tailChars);
+  const elided = total - headChars - tailChars;
+  return {
+    windowed: true,
+    window: `${head}\n\n[… ${elided} characters elided — see the paging note below …]\n\n${tail}`,
+    headChars,
+    tailChars,
+    total,
+  };
+};
+
+/**
+ * The paging footer — a TRUSTED, tool-authored instruction. It must ride
+ * OUTSIDE the untrusted fence (page content must never be able to forge or
+ * suppress it) and contain ONLY caller-computed values, never fetched bytes.
+ *
+ * @param {{ key: string, total: number, headChars: number, tailChars: number }} p
+ * @returns {string}
+ */
+export const pagingFooter = ({ key, total, headChars, tailChars }) => [
+  `[paging] The full text (${total} chars) is stored locally. You saw the first ${headChars} and last ${tailChars} chars.`,
+  `To read more call read_web_cache with { "key": "${key}", "offset": <char offset>, "limit": <chars, max 16000> } — e.g. offset ${headChars} continues where the head stopped.`,
+].join('\n');
+
+/**
+ * Page a stored text: a bounds-clamped slice + what remains.
+ *
+ * @param {string} text
+ * @param {number} offset  start char (clamped to [0, length])
+ * @param {number} limit   max chars to return (caller pre-clamps its own cap)
+ * @returns {{ slice: string, offset: number, end: number, total: number, remaining: number }}
+ */
+export const pageSlice = (text, offset, limit) => {
+  const total = text.length;
+  const start = Math.max(0, Math.min(Math.floor(offset) || 0, total));
+  const end = Math.min(start + Math.max(1, Math.floor(limit) || 1), total);
+  return { slice: text.slice(start, end), offset: start, end, total, remaining: total - end };
+};

--- a/extension/vendor/readability/Readability-readerable.js
+++ b/extension/vendor/readability/Readability-readerable.js
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2010 Arc90 Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This code is heavily based on Arc90's readability.js (1.7.1) script
+ * available at: http://code.google.com/p/arc90labs-readability
+ */
+
+var REGEXPS = {
+  // NOTE: These two regular expressions are duplicated in
+  // Readability.js. Please keep both copies in sync.
+  unlikelyCandidates:
+    /-ad-|ai2html|banner|breadcrumbs|combx|comment|community|cover-wrap|disqus|extra|footer|gdpr|header|legends|menu|related|remark|replies|rss|shoutbox|sidebar|skyscraper|social|sponsor|supplemental|ad-break|agegate|pagination|pager|popup|yom-remote/i,
+  okMaybeItsACandidate: /and|article|body|column|content|main|shadow/i,
+};
+
+function isNodeVisible(node) {
+  // Have to null-check node.style and node.className.includes to deal with SVG and MathML nodes.
+  return (
+    (!node.style || node.style.display != "none") &&
+    !node.hasAttribute("hidden") &&
+    //check for "fallback-image" so that wikimedia math images are displayed
+    (!node.hasAttribute("aria-hidden") ||
+      node.getAttribute("aria-hidden") != "true" ||
+      (node.className &&
+        node.className.includes &&
+        node.className.includes("fallback-image")))
+  );
+}
+
+/**
+ * Decides whether or not the document is reader-able without parsing the whole thing.
+ * @param {Object} options Configuration object.
+ * @param {number} [options.minContentLength=140] The minimum node content length used to decide if the document is readerable.
+ * @param {number} [options.minScore=20] The minumum cumulated 'score' used to determine if the document is readerable.
+ * @param {Function} [options.visibilityChecker=isNodeVisible] The function used to determine if a node is visible.
+ * @return {boolean} Whether or not we suspect Readability.parse() will suceeed at returning an article object.
+ */
+function isProbablyReaderable(doc, options = {}) {
+  // For backward compatibility reasons 'options' can either be a configuration object or the function used
+  // to determine if a node is visible.
+  if (typeof options == "function") {
+    options = { visibilityChecker: options };
+  }
+
+  var defaultOptions = {
+    minScore: 20,
+    minContentLength: 140,
+    visibilityChecker: isNodeVisible,
+  };
+  options = Object.assign(defaultOptions, options);
+
+  var nodes = doc.querySelectorAll("p, pre, article");
+
+  // Get <div> nodes which have <br> node(s) and append them into the `nodes` variable.
+  // Some articles' DOM structures might look like
+  // <div>
+  //   Sentences<br>
+  //   <br>
+  //   Sentences<br>
+  // </div>
+  var brNodes = doc.querySelectorAll("div > br");
+  if (brNodes.length) {
+    var set = new Set(nodes);
+    [].forEach.call(brNodes, function (node) {
+      set.add(node.parentNode);
+    });
+    nodes = Array.from(set);
+  }
+
+  var score = 0;
+  // This is a little cheeky, we use the accumulator 'score' to decide what to return from
+  // this callback:
+  return [].some.call(nodes, function (node) {
+    if (!options.visibilityChecker(node)) {
+      return false;
+    }
+
+    var matchString = node.className + " " + node.id;
+    if (
+      REGEXPS.unlikelyCandidates.test(matchString) &&
+      !REGEXPS.okMaybeItsACandidate.test(matchString)
+    ) {
+      return false;
+    }
+
+    if (node.matches("li p")) {
+      return false;
+    }
+
+    var textContentLength = node.textContent.trim().length;
+    if (textContentLength < options.minContentLength) {
+      return false;
+    }
+
+    score += Math.sqrt(textContentLength - options.minContentLength);
+
+    if (score > options.minScore) {
+      return true;
+    }
+    return false;
+  });
+}
+
+if (typeof module === "object") {
+  /* eslint-disable-next-line no-redeclare */
+  /* global module */
+  module.exports = isProbablyReaderable;
+}
+
+// peerd vendoring note: upstream file is byte-identical above this line; the
+// ES-module export below is the only addition (see SOURCE.txt).
+export default isProbablyReaderable;

--- a/extension/vendor/readability/Readability.js
+++ b/extension/vendor/readability/Readability.js
@@ -1,0 +1,2790 @@
+/*
+ * Copyright (c) 2010 Arc90 Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This code is heavily based on Arc90's readability.js (1.7.1) script
+ * available at: http://code.google.com/p/arc90labs-readability
+ */
+
+/**
+ * Public constructor.
+ * @param {HTMLDocument} doc     The document to parse.
+ * @param {Object}       options The options object.
+ */
+function Readability(doc, options) {
+  // In some older versions, people passed a URI as the first argument. Cope:
+  if (options && options.documentElement) {
+    doc = options;
+    options = arguments[2];
+  } else if (!doc || !doc.documentElement) {
+    throw new Error(
+      "First argument to Readability constructor should be a document object."
+    );
+  }
+  options = options || {};
+
+  this._doc = doc;
+  this._docJSDOMParser = this._doc.firstChild.__JSDOMParser__;
+  this._articleTitle = null;
+  this._articleByline = null;
+  this._articleDir = null;
+  this._articleSiteName = null;
+  this._attempts = [];
+  this._metadata = {};
+
+  // Configurable options
+  this._debug = !!options.debug;
+  this._maxElemsToParse =
+    options.maxElemsToParse || this.DEFAULT_MAX_ELEMS_TO_PARSE;
+  this._nbTopCandidates =
+    options.nbTopCandidates || this.DEFAULT_N_TOP_CANDIDATES;
+  this._charThreshold = options.charThreshold || this.DEFAULT_CHAR_THRESHOLD;
+  this._classesToPreserve = this.CLASSES_TO_PRESERVE.concat(
+    options.classesToPreserve || []
+  );
+  this._keepClasses = !!options.keepClasses;
+  this._serializer =
+    options.serializer ||
+    function (el) {
+      return el.innerHTML;
+    };
+  this._disableJSONLD = !!options.disableJSONLD;
+  this._allowedVideoRegex = options.allowedVideoRegex || this.REGEXPS.videos;
+  this._linkDensityModifier = options.linkDensityModifier || 0;
+
+  // Start with all flags set
+  this._flags =
+    this.FLAG_STRIP_UNLIKELYS |
+    this.FLAG_WEIGHT_CLASSES |
+    this.FLAG_CLEAN_CONDITIONALLY;
+
+  // Control whether log messages are sent to the console
+  if (this._debug) {
+    let logNode = function (node) {
+      if (node.nodeType == node.TEXT_NODE) {
+        return `${node.nodeName} ("${node.textContent}")`;
+      }
+      let attrPairs = Array.from(node.attributes || [], function (attr) {
+        return `${attr.name}="${attr.value}"`;
+      }).join(" ");
+      return `<${node.localName} ${attrPairs}>`;
+    };
+    this.log = function () {
+      if (typeof console !== "undefined") {
+        let args = Array.from(arguments, arg => {
+          if (arg && arg.nodeType == this.ELEMENT_NODE) {
+            return logNode(arg);
+          }
+          return arg;
+        });
+        args.unshift("Reader: (Readability)");
+        // eslint-disable-next-line no-console
+        console.log(...args);
+      } else if (typeof dump !== "undefined") {
+        /* global dump */
+        var msg = Array.prototype.map
+          .call(arguments, function (x) {
+            return x && x.nodeName ? logNode(x) : x;
+          })
+          .join(" ");
+        dump("Reader: (Readability) " + msg + "\n");
+      }
+    };
+  } else {
+    this.log = function () {};
+  }
+}
+
+Readability.prototype = {
+  FLAG_STRIP_UNLIKELYS: 0x1,
+  FLAG_WEIGHT_CLASSES: 0x2,
+  FLAG_CLEAN_CONDITIONALLY: 0x4,
+
+  // https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
+  ELEMENT_NODE: 1,
+  TEXT_NODE: 3,
+
+  // Max number of nodes supported by this parser. Default: 0 (no limit)
+  DEFAULT_MAX_ELEMS_TO_PARSE: 0,
+
+  // The number of top candidates to consider when analysing how
+  // tight the competition is among candidates.
+  DEFAULT_N_TOP_CANDIDATES: 5,
+
+  // Element tags to score by default.
+  DEFAULT_TAGS_TO_SCORE: "section,h2,h3,h4,h5,h6,p,td,pre"
+    .toUpperCase()
+    .split(","),
+
+  // The default number of chars an article must have in order to return a result
+  DEFAULT_CHAR_THRESHOLD: 500,
+
+  // All of the regular expressions in use within readability.
+  // Defined up here so we don't instantiate them repeatedly in loops.
+  REGEXPS: {
+    // NOTE: These two regular expressions are duplicated in
+    // Readability-readerable.js. Please keep both copies in sync.
+    unlikelyCandidates:
+      /-ad-|ai2html|banner|breadcrumbs|combx|comment|community|cover-wrap|disqus|extra|footer|gdpr|header|legends|menu|related|remark|replies|rss|shoutbox|sidebar|skyscraper|social|sponsor|supplemental|ad-break|agegate|pagination|pager|popup|yom-remote/i,
+    okMaybeItsACandidate: /and|article|body|column|content|main|shadow/i,
+
+    positive:
+      /article|body|content|entry|hentry|h-entry|main|page|pagination|post|text|blog|story/i,
+    negative:
+      /-ad-|hidden|^hid$| hid$| hid |^hid |banner|combx|comment|com-|contact|footer|gdpr|masthead|media|meta|outbrain|promo|related|scroll|share|shoutbox|sidebar|skyscraper|sponsor|shopping|tags|widget/i,
+    extraneous:
+      /print|archive|comment|discuss|e[\-]?mail|share|reply|all|login|sign|single|utility/i,
+    byline: /byline|author|dateline|writtenby|p-author/i,
+    replaceFonts: /<(\/?)font[^>]*>/gi,
+    normalize: /\s{2,}/g,
+    videos:
+      /\/\/(www\.)?((dailymotion|youtube|youtube-nocookie|player\.vimeo|v\.qq)\.com|(archive|upload\.wikimedia)\.org|player\.twitch\.tv)/i,
+    shareElements: /(\b|_)(share|sharedaddy)(\b|_)/i,
+    nextLink: /(next|weiter|continue|>([^\|]|$)|»([^\|]|$))/i,
+    prevLink: /(prev|earl|old|new|<|«)/i,
+    tokenize: /\W+/g,
+    whitespace: /^\s*$/,
+    hasContent: /\S$/,
+    hashUrl: /^#.+/,
+    srcsetUrl: /(\S+)(\s+[\d.]+[xw])?(\s*(?:,|$))/g,
+    b64DataUrl: /^data:\s*([^\s;,]+)\s*;\s*base64\s*,/i,
+    // Commas as used in Latin, Sindhi, Chinese and various other scripts.
+    // see: https://en.wikipedia.org/wiki/Comma#Comma_variants
+    commas: /\u002C|\u060C|\uFE50|\uFE10|\uFE11|\u2E41|\u2E34|\u2E32|\uFF0C/g,
+    // See: https://schema.org/Article
+    jsonLdArticleTypes:
+      /^Article|AdvertiserContentArticle|NewsArticle|AnalysisNewsArticle|AskPublicNewsArticle|BackgroundNewsArticle|OpinionNewsArticle|ReportageNewsArticle|ReviewNewsArticle|Report|SatiricalArticle|ScholarlyArticle|MedicalScholarlyArticle|SocialMediaPosting|BlogPosting|LiveBlogPosting|DiscussionForumPosting|TechArticle|APIReference$/,
+    // used to see if a node's content matches words commonly used for ad blocks or loading indicators
+    adWords:
+      /^(ad(vertising|vertisement)?|pub(licité)?|werb(ung)?|广告|Реклама|Anuncio)$/iu,
+    loadingWords:
+      /^((loading|正在加载|Загрузка|chargement|cargando)(…|\.\.\.)?)$/iu,
+  },
+
+  UNLIKELY_ROLES: [
+    "menu",
+    "menubar",
+    "complementary",
+    "navigation",
+    "alert",
+    "alertdialog",
+    "dialog",
+  ],
+
+  DIV_TO_P_ELEMS: new Set([
+    "BLOCKQUOTE",
+    "DL",
+    "DIV",
+    "IMG",
+    "OL",
+    "P",
+    "PRE",
+    "TABLE",
+    "UL",
+  ]),
+
+  ALTER_TO_DIV_EXCEPTIONS: ["DIV", "ARTICLE", "SECTION", "P", "OL", "UL"],
+
+  PRESENTATIONAL_ATTRIBUTES: [
+    "align",
+    "background",
+    "bgcolor",
+    "border",
+    "cellpadding",
+    "cellspacing",
+    "frame",
+    "hspace",
+    "rules",
+    "style",
+    "valign",
+    "vspace",
+  ],
+
+  DEPRECATED_SIZE_ATTRIBUTE_ELEMS: ["TABLE", "TH", "TD", "HR", "PRE"],
+
+  // The commented out elements qualify as phrasing content but tend to be
+  // removed by readability when put into paragraphs, so we ignore them here.
+  PHRASING_ELEMS: [
+    // "CANVAS", "IFRAME", "SVG", "VIDEO",
+    "ABBR",
+    "AUDIO",
+    "B",
+    "BDO",
+    "BR",
+    "BUTTON",
+    "CITE",
+    "CODE",
+    "DATA",
+    "DATALIST",
+    "DFN",
+    "EM",
+    "EMBED",
+    "I",
+    "IMG",
+    "INPUT",
+    "KBD",
+    "LABEL",
+    "MARK",
+    "MATH",
+    "METER",
+    "NOSCRIPT",
+    "OBJECT",
+    "OUTPUT",
+    "PROGRESS",
+    "Q",
+    "RUBY",
+    "SAMP",
+    "SCRIPT",
+    "SELECT",
+    "SMALL",
+    "SPAN",
+    "STRONG",
+    "SUB",
+    "SUP",
+    "TEXTAREA",
+    "TIME",
+    "VAR",
+    "WBR",
+  ],
+
+  // These are the classes that readability sets itself.
+  CLASSES_TO_PRESERVE: ["page"],
+
+  // These are the list of HTML entities that need to be escaped.
+  HTML_ESCAPE_MAP: {
+    lt: "<",
+    gt: ">",
+    amp: "&",
+    quot: '"',
+    apos: "'",
+  },
+
+  /**
+   * Run any post-process modifications to article content as necessary.
+   *
+   * @param Element
+   * @return void
+   **/
+  _postProcessContent(articleContent) {
+    // Readability cannot open relative uris so we convert them to absolute uris.
+    this._fixRelativeUris(articleContent);
+
+    this._simplifyNestedElements(articleContent);
+
+    if (!this._keepClasses) {
+      // Remove classes.
+      this._cleanClasses(articleContent);
+    }
+  },
+
+  /**
+   * Iterates over a NodeList, calls `filterFn` for each node and removes node
+   * if function returned `true`.
+   *
+   * If function is not passed, removes all the nodes in node list.
+   *
+   * @param NodeList nodeList The nodes to operate on
+   * @param Function filterFn the function to use as a filter
+   * @return void
+   */
+  _removeNodes(nodeList, filterFn) {
+    // Avoid ever operating on live node lists.
+    if (this._docJSDOMParser && nodeList._isLiveNodeList) {
+      throw new Error("Do not pass live node lists to _removeNodes");
+    }
+    for (var i = nodeList.length - 1; i >= 0; i--) {
+      var node = nodeList[i];
+      var parentNode = node.parentNode;
+      if (parentNode) {
+        if (!filterFn || filterFn.call(this, node, i, nodeList)) {
+          parentNode.removeChild(node);
+        }
+      }
+    }
+  },
+
+  /**
+   * Iterates over a NodeList, and calls _setNodeTag for each node.
+   *
+   * @param NodeList nodeList The nodes to operate on
+   * @param String newTagName the new tag name to use
+   * @return void
+   */
+  _replaceNodeTags(nodeList, newTagName) {
+    // Avoid ever operating on live node lists.
+    if (this._docJSDOMParser && nodeList._isLiveNodeList) {
+      throw new Error("Do not pass live node lists to _replaceNodeTags");
+    }
+    for (const node of nodeList) {
+      this._setNodeTag(node, newTagName);
+    }
+  },
+
+  /**
+   * Iterate over a NodeList, which doesn't natively fully implement the Array
+   * interface.
+   *
+   * For convenience, the current object context is applied to the provided
+   * iterate function.
+   *
+   * @param  NodeList nodeList The NodeList.
+   * @param  Function fn       The iterate function.
+   * @return void
+   */
+  _forEachNode(nodeList, fn) {
+    Array.prototype.forEach.call(nodeList, fn, this);
+  },
+
+  /**
+   * Iterate over a NodeList, and return the first node that passes
+   * the supplied test function
+   *
+   * For convenience, the current object context is applied to the provided
+   * test function.
+   *
+   * @param  NodeList nodeList The NodeList.
+   * @param  Function fn       The test function.
+   * @return void
+   */
+  _findNode(nodeList, fn) {
+    return Array.prototype.find.call(nodeList, fn, this);
+  },
+
+  /**
+   * Iterate over a NodeList, return true if any of the provided iterate
+   * function calls returns true, false otherwise.
+   *
+   * For convenience, the current object context is applied to the
+   * provided iterate function.
+   *
+   * @param  NodeList nodeList The NodeList.
+   * @param  Function fn       The iterate function.
+   * @return Boolean
+   */
+  _someNode(nodeList, fn) {
+    return Array.prototype.some.call(nodeList, fn, this);
+  },
+
+  /**
+   * Iterate over a NodeList, return true if all of the provided iterate
+   * function calls return true, false otherwise.
+   *
+   * For convenience, the current object context is applied to the
+   * provided iterate function.
+   *
+   * @param  NodeList nodeList The NodeList.
+   * @param  Function fn       The iterate function.
+   * @return Boolean
+   */
+  _everyNode(nodeList, fn) {
+    return Array.prototype.every.call(nodeList, fn, this);
+  },
+
+  _getAllNodesWithTag(node, tagNames) {
+    if (node.querySelectorAll) {
+      return node.querySelectorAll(tagNames.join(","));
+    }
+    return [].concat.apply(
+      [],
+      tagNames.map(function (tag) {
+        var collection = node.getElementsByTagName(tag);
+        return Array.isArray(collection) ? collection : Array.from(collection);
+      })
+    );
+  },
+
+  /**
+   * Removes the class="" attribute from every element in the given
+   * subtree, except those that match CLASSES_TO_PRESERVE and
+   * the classesToPreserve array from the options object.
+   *
+   * @param Element
+   * @return void
+   */
+  _cleanClasses(node) {
+    var classesToPreserve = this._classesToPreserve;
+    var className = (node.getAttribute("class") || "")
+      .split(/\s+/)
+      .filter(cls => classesToPreserve.includes(cls))
+      .join(" ");
+
+    if (className) {
+      node.setAttribute("class", className);
+    } else {
+      node.removeAttribute("class");
+    }
+
+    for (node = node.firstElementChild; node; node = node.nextElementSibling) {
+      this._cleanClasses(node);
+    }
+  },
+
+  /**
+   * Tests whether a string is a URL or not.
+   *
+   * @param {string} str The string to test
+   * @return {boolean} true if str is a URL, false if not
+   */
+  _isUrl(str) {
+    try {
+      new URL(str);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  /**
+   * Converts each <a> and <img> uri in the given element to an absolute URI,
+   * ignoring #ref URIs.
+   *
+   * @param Element
+   * @return void
+   */
+  _fixRelativeUris(articleContent) {
+    var baseURI = this._doc.baseURI;
+    var documentURI = this._doc.documentURI;
+    function toAbsoluteURI(uri) {
+      // Leave hash links alone if the base URI matches the document URI:
+      if (baseURI == documentURI && uri.charAt(0) == "#") {
+        return uri;
+      }
+
+      // Otherwise, resolve against base URI:
+      try {
+        return new URL(uri, baseURI).href;
+      } catch (ex) {
+        // Something went wrong, just return the original:
+      }
+      return uri;
+    }
+
+    var links = this._getAllNodesWithTag(articleContent, ["a"]);
+    this._forEachNode(links, function (link) {
+      var href = link.getAttribute("href");
+      if (href) {
+        // Remove links with javascript: URIs, since
+        // they won't work after scripts have been removed from the page.
+        if (href.indexOf("javascript:") === 0) {
+          // if the link only contains simple text content, it can be converted to a text node
+          if (
+            link.childNodes.length === 1 &&
+            link.childNodes[0].nodeType === this.TEXT_NODE
+          ) {
+            var text = this._doc.createTextNode(link.textContent);
+            link.parentNode.replaceChild(text, link);
+          } else {
+            // if the link has multiple children, they should all be preserved
+            var container = this._doc.createElement("span");
+            while (link.firstChild) {
+              container.appendChild(link.firstChild);
+            }
+            link.parentNode.replaceChild(container, link);
+          }
+        } else {
+          link.setAttribute("href", toAbsoluteURI(href));
+        }
+      }
+    });
+
+    var medias = this._getAllNodesWithTag(articleContent, [
+      "img",
+      "picture",
+      "figure",
+      "video",
+      "audio",
+      "source",
+    ]);
+
+    this._forEachNode(medias, function (media) {
+      var src = media.getAttribute("src");
+      var poster = media.getAttribute("poster");
+      var srcset = media.getAttribute("srcset");
+
+      if (src) {
+        media.setAttribute("src", toAbsoluteURI(src));
+      }
+
+      if (poster) {
+        media.setAttribute("poster", toAbsoluteURI(poster));
+      }
+
+      if (srcset) {
+        var newSrcset = srcset.replace(
+          this.REGEXPS.srcsetUrl,
+          function (_, p1, p2, p3) {
+            return toAbsoluteURI(p1) + (p2 || "") + p3;
+          }
+        );
+
+        media.setAttribute("srcset", newSrcset);
+      }
+    });
+  },
+
+  _simplifyNestedElements(articleContent) {
+    var node = articleContent;
+
+    while (node) {
+      if (
+        node.parentNode &&
+        ["DIV", "SECTION"].includes(node.tagName) &&
+        !(node.id && node.id.startsWith("readability"))
+      ) {
+        if (this._isElementWithoutContent(node)) {
+          node = this._removeAndGetNext(node);
+          continue;
+        } else if (
+          this._hasSingleTagInsideElement(node, "DIV") ||
+          this._hasSingleTagInsideElement(node, "SECTION")
+        ) {
+          var child = node.children[0];
+          for (var i = 0; i < node.attributes.length; i++) {
+            child.setAttributeNode(node.attributes[i].cloneNode());
+          }
+          node.parentNode.replaceChild(child, node);
+          node = child;
+          continue;
+        }
+      }
+
+      node = this._getNextNode(node);
+    }
+  },
+
+  /**
+   * Get the article title as an H1.
+   *
+   * @return string
+   **/
+  _getArticleTitle() {
+    var doc = this._doc;
+    var curTitle = "";
+    var origTitle = "";
+
+    try {
+      curTitle = origTitle = doc.title.trim();
+
+      // If they had an element with id "title" in their HTML
+      if (typeof curTitle !== "string") {
+        curTitle = origTitle = this._getInnerText(
+          doc.getElementsByTagName("title")[0]
+        );
+      }
+    } catch (e) {
+      /* ignore exceptions setting the title. */
+    }
+
+    var titleHadHierarchicalSeparators = false;
+    function wordCount(str) {
+      return str.split(/\s+/).length;
+    }
+
+    // If there's a separator in the title, first remove the final part
+    if (/ [\|\-\\\/>»] /.test(curTitle)) {
+      titleHadHierarchicalSeparators = / [\\\/>»] /.test(curTitle);
+      let allSeparators = Array.from(origTitle.matchAll(/ [\|\-\\\/>»] /gi));
+      curTitle = origTitle.substring(0, allSeparators.pop().index);
+
+      // If the resulting title is too short, remove the first part instead:
+      if (wordCount(curTitle) < 3) {
+        curTitle = origTitle.replace(/^[^\|\-\\\/>»]*[\|\-\\\/>»]/gi, "");
+      }
+    } else if (curTitle.includes(": ")) {
+      // Check if we have an heading containing this exact string, so we
+      // could assume it's the full title.
+      var headings = this._getAllNodesWithTag(doc, ["h1", "h2"]);
+      var trimmedTitle = curTitle.trim();
+      var match = this._someNode(headings, function (heading) {
+        return heading.textContent.trim() === trimmedTitle;
+      });
+
+      // If we don't, let's extract the title out of the original title string.
+      if (!match) {
+        curTitle = origTitle.substring(origTitle.lastIndexOf(":") + 1);
+
+        // If the title is now too short, try the first colon instead:
+        if (wordCount(curTitle) < 3) {
+          curTitle = origTitle.substring(origTitle.indexOf(":") + 1);
+          // But if we have too many words before the colon there's something weird
+          // with the titles and the H tags so let's just use the original title instead
+        } else if (wordCount(origTitle.substr(0, origTitle.indexOf(":"))) > 5) {
+          curTitle = origTitle;
+        }
+      }
+    } else if (curTitle.length > 150 || curTitle.length < 15) {
+      var hOnes = doc.getElementsByTagName("h1");
+
+      if (hOnes.length === 1) {
+        curTitle = this._getInnerText(hOnes[0]);
+      }
+    }
+
+    curTitle = curTitle.trim().replace(this.REGEXPS.normalize, " ");
+    // If we now have 4 words or fewer as our title, and either no
+    // 'hierarchical' separators (\, /, > or ») were found in the original
+    // title or we decreased the number of words by more than 1 word, use
+    // the original title.
+    var curTitleWordCount = wordCount(curTitle);
+    if (
+      curTitleWordCount <= 4 &&
+      (!titleHadHierarchicalSeparators ||
+        curTitleWordCount !=
+          wordCount(origTitle.replace(/[\|\-\\\/>»]+/g, "")) - 1)
+    ) {
+      curTitle = origTitle;
+    }
+
+    return curTitle;
+  },
+
+  /**
+   * Prepare the HTML document for readability to scrape it.
+   * This includes things like stripping javascript, CSS, and handling terrible markup.
+   *
+   * @return void
+   **/
+  _prepDocument() {
+    var doc = this._doc;
+
+    // Remove all style tags in head
+    this._removeNodes(this._getAllNodesWithTag(doc, ["style"]));
+
+    if (doc.body) {
+      this._replaceBrs(doc.body);
+    }
+
+    this._replaceNodeTags(this._getAllNodesWithTag(doc, ["font"]), "SPAN");
+  },
+
+  /**
+   * Finds the next node, starting from the given node, and ignoring
+   * whitespace in between. If the given node is an element, the same node is
+   * returned.
+   */
+  _nextNode(node) {
+    var next = node;
+    while (
+      next &&
+      next.nodeType != this.ELEMENT_NODE &&
+      this.REGEXPS.whitespace.test(next.textContent)
+    ) {
+      next = next.nextSibling;
+    }
+    return next;
+  },
+
+  /**
+   * Replaces 2 or more successive <br> elements with a single <p>.
+   * Whitespace between <br> elements are ignored. For example:
+   *   <div>foo<br>bar<br> <br><br>abc</div>
+   * will become:
+   *   <div>foo<br>bar<p>abc</p></div>
+   */
+  _replaceBrs(elem) {
+    this._forEachNode(this._getAllNodesWithTag(elem, ["br"]), function (br) {
+      var next = br.nextSibling;
+
+      // Whether 2 or more <br> elements have been found and replaced with a
+      // <p> block.
+      var replaced = false;
+
+      // If we find a <br> chain, remove the <br>s until we hit another node
+      // or non-whitespace. This leaves behind the first <br> in the chain
+      // (which will be replaced with a <p> later).
+      while ((next = this._nextNode(next)) && next.tagName == "BR") {
+        replaced = true;
+        var brSibling = next.nextSibling;
+        next.remove();
+        next = brSibling;
+      }
+
+      // If we removed a <br> chain, replace the remaining <br> with a <p>. Add
+      // all sibling nodes as children of the <p> until we hit another <br>
+      // chain.
+      if (replaced) {
+        var p = this._doc.createElement("p");
+        br.parentNode.replaceChild(p, br);
+
+        next = p.nextSibling;
+        while (next) {
+          // If we've hit another <br><br>, we're done adding children to this <p>.
+          if (next.tagName == "BR") {
+            var nextElem = this._nextNode(next.nextSibling);
+            if (nextElem && nextElem.tagName == "BR") {
+              break;
+            }
+          }
+
+          if (!this._isPhrasingContent(next)) {
+            break;
+          }
+
+          // Otherwise, make this node a child of the new <p>.
+          var sibling = next.nextSibling;
+          p.appendChild(next);
+          next = sibling;
+        }
+
+        while (p.lastChild && this._isWhitespace(p.lastChild)) {
+          p.lastChild.remove();
+        }
+
+        if (p.parentNode.tagName === "P") {
+          this._setNodeTag(p.parentNode, "DIV");
+        }
+      }
+    });
+  },
+
+  _setNodeTag(node, tag) {
+    this.log("_setNodeTag", node, tag);
+    if (this._docJSDOMParser) {
+      node.localName = tag.toLowerCase();
+      node.tagName = tag.toUpperCase();
+      return node;
+    }
+
+    var replacement = node.ownerDocument.createElement(tag);
+    while (node.firstChild) {
+      replacement.appendChild(node.firstChild);
+    }
+    node.parentNode.replaceChild(replacement, node);
+    if (node.readability) {
+      replacement.readability = node.readability;
+    }
+
+    for (var i = 0; i < node.attributes.length; i++) {
+      replacement.setAttributeNode(node.attributes[i].cloneNode());
+    }
+    return replacement;
+  },
+
+  /**
+   * Prepare the article node for display. Clean out any inline styles,
+   * iframes, forms, strip extraneous <p> tags, etc.
+   *
+   * @param Element
+   * @return void
+   **/
+  _prepArticle(articleContent) {
+    this._cleanStyles(articleContent);
+
+    // Check for data tables before we continue, to avoid removing items in
+    // those tables, which will often be isolated even though they're
+    // visually linked to other content-ful elements (text, images, etc.).
+    this._markDataTables(articleContent);
+
+    this._fixLazyImages(articleContent);
+
+    // Clean out junk from the article content
+    this._cleanConditionally(articleContent, "form");
+    this._cleanConditionally(articleContent, "fieldset");
+    this._clean(articleContent, "object");
+    this._clean(articleContent, "embed");
+    this._clean(articleContent, "footer");
+    this._clean(articleContent, "link");
+    this._clean(articleContent, "aside");
+
+    // Clean out elements with little content that have "share" in their id/class combinations from final top candidates,
+    // which means we don't remove the top candidates even they have "share".
+
+    var shareElementThreshold = this.DEFAULT_CHAR_THRESHOLD;
+
+    this._forEachNode(articleContent.children, function (topCandidate) {
+      this._cleanMatchedNodes(topCandidate, function (node, matchString) {
+        return (
+          this.REGEXPS.shareElements.test(matchString) &&
+          node.textContent.length < shareElementThreshold
+        );
+      });
+    });
+
+    this._clean(articleContent, "iframe");
+    this._clean(articleContent, "input");
+    this._clean(articleContent, "textarea");
+    this._clean(articleContent, "select");
+    this._clean(articleContent, "button");
+    this._cleanHeaders(articleContent);
+
+    // Do these last as the previous stuff may have removed junk
+    // that will affect these
+    this._cleanConditionally(articleContent, "table");
+    this._cleanConditionally(articleContent, "ul");
+    this._cleanConditionally(articleContent, "div");
+
+    // replace H1 with H2 as H1 should be only title that is displayed separately
+    this._replaceNodeTags(
+      this._getAllNodesWithTag(articleContent, ["h1"]),
+      "h2"
+    );
+
+    // Remove extra paragraphs
+    this._removeNodes(
+      this._getAllNodesWithTag(articleContent, ["p"]),
+      function (paragraph) {
+        // At this point, nasty iframes have been removed; only embedded video
+        // ones remain.
+        var contentElementCount = this._getAllNodesWithTag(paragraph, [
+          "img",
+          "embed",
+          "object",
+          "iframe",
+        ]).length;
+        return (
+          contentElementCount === 0 && !this._getInnerText(paragraph, false)
+        );
+      }
+    );
+
+    this._forEachNode(
+      this._getAllNodesWithTag(articleContent, ["br"]),
+      function (br) {
+        var next = this._nextNode(br.nextSibling);
+        if (next && next.tagName == "P") {
+          br.remove();
+        }
+      }
+    );
+
+    // Remove single-cell tables
+    this._forEachNode(
+      this._getAllNodesWithTag(articleContent, ["table"]),
+      function (table) {
+        var tbody = this._hasSingleTagInsideElement(table, "TBODY")
+          ? table.firstElementChild
+          : table;
+        if (this._hasSingleTagInsideElement(tbody, "TR")) {
+          var row = tbody.firstElementChild;
+          if (this._hasSingleTagInsideElement(row, "TD")) {
+            var cell = row.firstElementChild;
+            cell = this._setNodeTag(
+              cell,
+              this._everyNode(cell.childNodes, this._isPhrasingContent)
+                ? "P"
+                : "DIV"
+            );
+            table.parentNode.replaceChild(cell, table);
+          }
+        }
+      }
+    );
+  },
+
+  /**
+   * Initialize a node with the readability object. Also checks the
+   * className/id for special names to add to its score.
+   *
+   * @param Element
+   * @return void
+   **/
+  _initializeNode(node) {
+    node.readability = { contentScore: 0 };
+
+    switch (node.tagName) {
+      case "DIV":
+        node.readability.contentScore += 5;
+        break;
+
+      case "PRE":
+      case "TD":
+      case "BLOCKQUOTE":
+        node.readability.contentScore += 3;
+        break;
+
+      case "ADDRESS":
+      case "OL":
+      case "UL":
+      case "DL":
+      case "DD":
+      case "DT":
+      case "LI":
+      case "FORM":
+        node.readability.contentScore -= 3;
+        break;
+
+      case "H1":
+      case "H2":
+      case "H3":
+      case "H4":
+      case "H5":
+      case "H6":
+      case "TH":
+        node.readability.contentScore -= 5;
+        break;
+    }
+
+    node.readability.contentScore += this._getClassWeight(node);
+  },
+
+  _removeAndGetNext(node) {
+    var nextNode = this._getNextNode(node, true);
+    node.remove();
+    return nextNode;
+  },
+
+  /**
+   * Traverse the DOM from node to node, starting at the node passed in.
+   * Pass true for the second parameter to indicate this node itself
+   * (and its kids) are going away, and we want the next node over.
+   *
+   * Calling this in a loop will traverse the DOM depth-first.
+   *
+   * @param {Element} node
+   * @param {boolean} ignoreSelfAndKids
+   * @return {Element}
+   */
+  _getNextNode(node, ignoreSelfAndKids) {
+    // First check for kids if those aren't being ignored
+    if (!ignoreSelfAndKids && node.firstElementChild) {
+      return node.firstElementChild;
+    }
+    // Then for siblings...
+    if (node.nextElementSibling) {
+      return node.nextElementSibling;
+    }
+    // And finally, move up the parent chain *and* find a sibling
+    // (because this is depth-first traversal, we will have already
+    // seen the parent nodes themselves).
+    do {
+      node = node.parentNode;
+    } while (node && !node.nextElementSibling);
+    return node && node.nextElementSibling;
+  },
+
+  // compares second text to first one
+  // 1 = same text, 0 = completely different text
+  // works the way that it splits both texts into words and then finds words that are unique in second text
+  // the result is given by the lower length of unique parts
+  _textSimilarity(textA, textB) {
+    var tokensA = textA
+      .toLowerCase()
+      .split(this.REGEXPS.tokenize)
+      .filter(Boolean);
+    var tokensB = textB
+      .toLowerCase()
+      .split(this.REGEXPS.tokenize)
+      .filter(Boolean);
+    if (!tokensA.length || !tokensB.length) {
+      return 0;
+    }
+    var uniqTokensB = tokensB.filter(token => !tokensA.includes(token));
+    var distanceB = uniqTokensB.join(" ").length / tokensB.join(" ").length;
+    return 1 - distanceB;
+  },
+
+  /**
+   * Checks whether an element node contains a valid byline
+   *
+   * @param node {Element}
+   * @param matchString {string}
+   * @return boolean
+   */
+  _isValidByline(node, matchString) {
+    var rel = node.getAttribute("rel");
+    var itemprop = node.getAttribute("itemprop");
+    var bylineLength = node.textContent.trim().length;
+
+    return (
+      (rel === "author" ||
+        (itemprop && itemprop.includes("author")) ||
+        this.REGEXPS.byline.test(matchString)) &&
+      !!bylineLength &&
+      bylineLength < 100
+    );
+  },
+
+  _getNodeAncestors(node, maxDepth) {
+    maxDepth = maxDepth || 0;
+    var i = 0,
+      ancestors = [];
+    while (node.parentNode) {
+      ancestors.push(node.parentNode);
+      if (maxDepth && ++i === maxDepth) {
+        break;
+      }
+      node = node.parentNode;
+    }
+    return ancestors;
+  },
+
+  /***
+   * grabArticle - Using a variety of metrics (content score, classname, element types), find the content that is
+   *         most likely to be the stuff a user wants to read. Then return it wrapped up in a div.
+   *
+   * @param page a document to run upon. Needs to be a full document, complete with body.
+   * @return Element
+   **/
+  /* eslint-disable-next-line complexity */
+  _grabArticle(page) {
+    this.log("**** grabArticle ****");
+    var doc = this._doc;
+    var isPaging = page !== null;
+    page = page ? page : this._doc.body;
+
+    // We can't grab an article if we don't have a page!
+    if (!page) {
+      this.log("No body found in document. Abort.");
+      return null;
+    }
+
+    var pageCacheHtml = page.innerHTML;
+
+    while (true) {
+      this.log("Starting grabArticle loop");
+      var stripUnlikelyCandidates = this._flagIsActive(
+        this.FLAG_STRIP_UNLIKELYS
+      );
+
+      // First, node prepping. Trash nodes that look cruddy (like ones with the
+      // class name "comment", etc), and turn divs into P tags where they have been
+      // used inappropriately (as in, where they contain no other block level elements.)
+      var elementsToScore = [];
+      var node = this._doc.documentElement;
+
+      let shouldRemoveTitleHeader = true;
+
+      while (node) {
+        if (node.tagName === "HTML") {
+          this._articleLang = node.getAttribute("lang");
+        }
+
+        var matchString = node.className + " " + node.id;
+
+        if (!this._isProbablyVisible(node)) {
+          this.log("Removing hidden node - " + matchString);
+          node = this._removeAndGetNext(node);
+          continue;
+        }
+
+        // User is not able to see elements applied with both "aria-modal = true" and "role = dialog"
+        if (
+          node.getAttribute("aria-modal") == "true" &&
+          node.getAttribute("role") == "dialog"
+        ) {
+          node = this._removeAndGetNext(node);
+          continue;
+        }
+
+        // If we don't have a byline yet check to see if this node is a byline; if it is store the byline and remove the node.
+        if (
+          !this._articleByline &&
+          !this._metadata.byline &&
+          this._isValidByline(node, matchString)
+        ) {
+          // Find child node matching [itemprop="name"] and use that if it exists for a more accurate author name byline
+          var endOfSearchMarkerNode = this._getNextNode(node, true);
+          var next = this._getNextNode(node);
+          var itemPropNameNode = null;
+          while (next && next != endOfSearchMarkerNode) {
+            var itemprop = next.getAttribute("itemprop");
+            if (itemprop && itemprop.includes("name")) {
+              itemPropNameNode = next;
+              break;
+            } else {
+              next = this._getNextNode(next);
+            }
+          }
+          this._articleByline = (itemPropNameNode ?? node).textContent.trim();
+          node = this._removeAndGetNext(node);
+          continue;
+        }
+
+        if (shouldRemoveTitleHeader && this._headerDuplicatesTitle(node)) {
+          this.log(
+            "Removing header: ",
+            node.textContent.trim(),
+            this._articleTitle.trim()
+          );
+          shouldRemoveTitleHeader = false;
+          node = this._removeAndGetNext(node);
+          continue;
+        }
+
+        // Remove unlikely candidates
+        if (stripUnlikelyCandidates) {
+          if (
+            this.REGEXPS.unlikelyCandidates.test(matchString) &&
+            !this.REGEXPS.okMaybeItsACandidate.test(matchString) &&
+            !this._hasAncestorTag(node, "table") &&
+            !this._hasAncestorTag(node, "code") &&
+            node.tagName !== "BODY" &&
+            node.tagName !== "A"
+          ) {
+            this.log("Removing unlikely candidate - " + matchString);
+            node = this._removeAndGetNext(node);
+            continue;
+          }
+
+          if (this.UNLIKELY_ROLES.includes(node.getAttribute("role"))) {
+            this.log(
+              "Removing content with role " +
+                node.getAttribute("role") +
+                " - " +
+                matchString
+            );
+            node = this._removeAndGetNext(node);
+            continue;
+          }
+        }
+
+        // Remove DIV, SECTION, and HEADER nodes without any content(e.g. text, image, video, or iframe).
+        if (
+          (node.tagName === "DIV" ||
+            node.tagName === "SECTION" ||
+            node.tagName === "HEADER" ||
+            node.tagName === "H1" ||
+            node.tagName === "H2" ||
+            node.tagName === "H3" ||
+            node.tagName === "H4" ||
+            node.tagName === "H5" ||
+            node.tagName === "H6") &&
+          this._isElementWithoutContent(node)
+        ) {
+          node = this._removeAndGetNext(node);
+          continue;
+        }
+
+        if (this.DEFAULT_TAGS_TO_SCORE.includes(node.tagName)) {
+          elementsToScore.push(node);
+        }
+
+        // Turn all divs that don't have children block level elements into p's
+        if (node.tagName === "DIV") {
+          // Put phrasing content into paragraphs.
+          var p = null;
+          var childNode = node.firstChild;
+          while (childNode) {
+            var nextSibling = childNode.nextSibling;
+            if (this._isPhrasingContent(childNode)) {
+              if (p !== null) {
+                p.appendChild(childNode);
+              } else if (!this._isWhitespace(childNode)) {
+                p = doc.createElement("p");
+                node.replaceChild(p, childNode);
+                p.appendChild(childNode);
+              }
+            } else if (p !== null) {
+              while (p.lastChild && this._isWhitespace(p.lastChild)) {
+                p.lastChild.remove();
+              }
+              p = null;
+            }
+            childNode = nextSibling;
+          }
+
+          // Sites like http://mobile.slate.com encloses each paragraph with a DIV
+          // element. DIVs with only a P element inside and no text content can be
+          // safely converted into plain P elements to avoid confusing the scoring
+          // algorithm with DIVs with are, in practice, paragraphs.
+          if (
+            this._hasSingleTagInsideElement(node, "P") &&
+            this._getLinkDensity(node) < 0.25
+          ) {
+            var newNode = node.children[0];
+            node.parentNode.replaceChild(newNode, node);
+            node = newNode;
+            elementsToScore.push(node);
+          } else if (!this._hasChildBlockElement(node)) {
+            node = this._setNodeTag(node, "P");
+            elementsToScore.push(node);
+          }
+        }
+        node = this._getNextNode(node);
+      }
+
+      /**
+       * Loop through all paragraphs, and assign a score to them based on how content-y they look.
+       * Then add their score to their parent node.
+       *
+       * A score is determined by things like number of commas, class names, etc. Maybe eventually link density.
+       **/
+      var candidates = [];
+      this._forEachNode(elementsToScore, function (elementToScore) {
+        if (
+          !elementToScore.parentNode ||
+          typeof elementToScore.parentNode.tagName === "undefined"
+        ) {
+          return;
+        }
+
+        // If this paragraph is less than 25 characters, don't even count it.
+        var innerText = this._getInnerText(elementToScore);
+        if (innerText.length < 25) {
+          return;
+        }
+
+        // Exclude nodes with no ancestor.
+        var ancestors = this._getNodeAncestors(elementToScore, 5);
+        if (ancestors.length === 0) {
+          return;
+        }
+
+        var contentScore = 0;
+
+        // Add a point for the paragraph itself as a base.
+        contentScore += 1;
+
+        // Add points for any commas within this paragraph.
+        contentScore += innerText.split(this.REGEXPS.commas).length;
+
+        // For every 100 characters in this paragraph, add another point. Up to 3 points.
+        contentScore += Math.min(Math.floor(innerText.length / 100), 3);
+
+        // Initialize and score ancestors.
+        this._forEachNode(ancestors, function (ancestor, level) {
+          if (
+            !ancestor.tagName ||
+            !ancestor.parentNode ||
+            typeof ancestor.parentNode.tagName === "undefined"
+          ) {
+            return;
+          }
+
+          if (typeof ancestor.readability === "undefined") {
+            this._initializeNode(ancestor);
+            candidates.push(ancestor);
+          }
+
+          // Node score divider:
+          // - parent:             1 (no division)
+          // - grandparent:        2
+          // - great grandparent+: ancestor level * 3
+          if (level === 0) {
+            var scoreDivider = 1;
+          } else if (level === 1) {
+            scoreDivider = 2;
+          } else {
+            scoreDivider = level * 3;
+          }
+          ancestor.readability.contentScore += contentScore / scoreDivider;
+        });
+      });
+
+      // After we've calculated scores, loop through all of the possible
+      // candidate nodes we found and find the one with the highest score.
+      var topCandidates = [];
+      for (var c = 0, cl = candidates.length; c < cl; c += 1) {
+        var candidate = candidates[c];
+
+        // Scale the final candidates score based on link density. Good content
+        // should have a relatively small link density (5% or less) and be mostly
+        // unaffected by this operation.
+        var candidateScore =
+          candidate.readability.contentScore *
+          (1 - this._getLinkDensity(candidate));
+        candidate.readability.contentScore = candidateScore;
+
+        this.log("Candidate:", candidate, "with score " + candidateScore);
+
+        for (var t = 0; t < this._nbTopCandidates; t++) {
+          var aTopCandidate = topCandidates[t];
+
+          if (
+            !aTopCandidate ||
+            candidateScore > aTopCandidate.readability.contentScore
+          ) {
+            topCandidates.splice(t, 0, candidate);
+            if (topCandidates.length > this._nbTopCandidates) {
+              topCandidates.pop();
+            }
+            break;
+          }
+        }
+      }
+
+      var topCandidate = topCandidates[0] || null;
+      var neededToCreateTopCandidate = false;
+      var parentOfTopCandidate;
+
+      // If we still have no top candidate, just use the body as a last resort.
+      // We also have to copy the body node so it is something we can modify.
+      if (topCandidate === null || topCandidate.tagName === "BODY") {
+        // Move all of the page's children into topCandidate
+        topCandidate = doc.createElement("DIV");
+        neededToCreateTopCandidate = true;
+        // Move everything (not just elements, also text nodes etc.) into the container
+        // so we even include text directly in the body:
+        while (page.firstChild) {
+          this.log("Moving child out:", page.firstChild);
+          topCandidate.appendChild(page.firstChild);
+        }
+
+        page.appendChild(topCandidate);
+
+        this._initializeNode(topCandidate);
+      } else if (topCandidate) {
+        // Find a better top candidate node if it contains (at least three) nodes which belong to `topCandidates` array
+        // and whose scores are quite closed with current `topCandidate` node.
+        var alternativeCandidateAncestors = [];
+        for (var i = 1; i < topCandidates.length; i++) {
+          if (
+            topCandidates[i].readability.contentScore /
+              topCandidate.readability.contentScore >=
+            0.75
+          ) {
+            alternativeCandidateAncestors.push(
+              this._getNodeAncestors(topCandidates[i])
+            );
+          }
+        }
+        var MINIMUM_TOPCANDIDATES = 3;
+        if (alternativeCandidateAncestors.length >= MINIMUM_TOPCANDIDATES) {
+          parentOfTopCandidate = topCandidate.parentNode;
+          while (parentOfTopCandidate.tagName !== "BODY") {
+            var listsContainingThisAncestor = 0;
+            for (
+              var ancestorIndex = 0;
+              ancestorIndex < alternativeCandidateAncestors.length &&
+              listsContainingThisAncestor < MINIMUM_TOPCANDIDATES;
+              ancestorIndex++
+            ) {
+              listsContainingThisAncestor += Number(
+                alternativeCandidateAncestors[ancestorIndex].includes(
+                  parentOfTopCandidate
+                )
+              );
+            }
+            if (listsContainingThisAncestor >= MINIMUM_TOPCANDIDATES) {
+              topCandidate = parentOfTopCandidate;
+              break;
+            }
+            parentOfTopCandidate = parentOfTopCandidate.parentNode;
+          }
+        }
+        if (!topCandidate.readability) {
+          this._initializeNode(topCandidate);
+        }
+
+        // Because of our bonus system, parents of candidates might have scores
+        // themselves. They get half of the node. There won't be nodes with higher
+        // scores than our topCandidate, but if we see the score going *up* in the first
+        // few steps up the tree, that's a decent sign that there might be more content
+        // lurking in other places that we want to unify in. The sibling stuff
+        // below does some of that - but only if we've looked high enough up the DOM
+        // tree.
+        parentOfTopCandidate = topCandidate.parentNode;
+        var lastScore = topCandidate.readability.contentScore;
+        // The scores shouldn't get too low.
+        var scoreThreshold = lastScore / 3;
+        while (parentOfTopCandidate.tagName !== "BODY") {
+          if (!parentOfTopCandidate.readability) {
+            parentOfTopCandidate = parentOfTopCandidate.parentNode;
+            continue;
+          }
+          var parentScore = parentOfTopCandidate.readability.contentScore;
+          if (parentScore < scoreThreshold) {
+            break;
+          }
+          if (parentScore > lastScore) {
+            // Alright! We found a better parent to use.
+            topCandidate = parentOfTopCandidate;
+            break;
+          }
+          lastScore = parentOfTopCandidate.readability.contentScore;
+          parentOfTopCandidate = parentOfTopCandidate.parentNode;
+        }
+
+        // If the top candidate is the only child, use parent instead. This will help sibling
+        // joining logic when adjacent content is actually located in parent's sibling node.
+        parentOfTopCandidate = topCandidate.parentNode;
+        while (
+          parentOfTopCandidate.tagName != "BODY" &&
+          parentOfTopCandidate.children.length == 1
+        ) {
+          topCandidate = parentOfTopCandidate;
+          parentOfTopCandidate = topCandidate.parentNode;
+        }
+        if (!topCandidate.readability) {
+          this._initializeNode(topCandidate);
+        }
+      }
+
+      // Now that we have the top candidate, look through its siblings for content
+      // that might also be related. Things like preambles, content split by ads
+      // that we removed, etc.
+      var articleContent = doc.createElement("DIV");
+      if (isPaging) {
+        articleContent.id = "readability-content";
+      }
+
+      var siblingScoreThreshold = Math.max(
+        10,
+        topCandidate.readability.contentScore * 0.2
+      );
+      // Keep potential top candidate's parent node to try to get text direction of it later.
+      parentOfTopCandidate = topCandidate.parentNode;
+      var siblings = parentOfTopCandidate.children;
+
+      for (var s = 0, sl = siblings.length; s < sl; s++) {
+        var sibling = siblings[s];
+        var append = false;
+
+        this.log(
+          "Looking at sibling node:",
+          sibling,
+          sibling.readability
+            ? "with score " + sibling.readability.contentScore
+            : ""
+        );
+        this.log(
+          "Sibling has score",
+          sibling.readability ? sibling.readability.contentScore : "Unknown"
+        );
+
+        if (sibling === topCandidate) {
+          append = true;
+        } else {
+          var contentBonus = 0;
+
+          // Give a bonus if sibling nodes and top candidates have the example same classname
+          if (
+            sibling.className === topCandidate.className &&
+            topCandidate.className !== ""
+          ) {
+            contentBonus += topCandidate.readability.contentScore * 0.2;
+          }
+
+          if (
+            sibling.readability &&
+            sibling.readability.contentScore + contentBonus >=
+              siblingScoreThreshold
+          ) {
+            append = true;
+          } else if (sibling.nodeName === "P") {
+            var linkDensity = this._getLinkDensity(sibling);
+            var nodeContent = this._getInnerText(sibling);
+            var nodeLength = nodeContent.length;
+
+            if (nodeLength > 80 && linkDensity < 0.25) {
+              append = true;
+            } else if (
+              nodeLength < 80 &&
+              nodeLength > 0 &&
+              linkDensity === 0 &&
+              nodeContent.search(/\.( |$)/) !== -1
+            ) {
+              append = true;
+            }
+          }
+        }
+
+        if (append) {
+          this.log("Appending node:", sibling);
+
+          if (!this.ALTER_TO_DIV_EXCEPTIONS.includes(sibling.nodeName)) {
+            // We have a node that isn't a common block level element, like a form or td tag.
+            // Turn it into a div so it doesn't get filtered out later by accident.
+            this.log("Altering sibling:", sibling, "to div.");
+
+            sibling = this._setNodeTag(sibling, "DIV");
+          }
+
+          articleContent.appendChild(sibling);
+          // Fetch children again to make it compatible
+          // with DOM parsers without live collection support.
+          siblings = parentOfTopCandidate.children;
+          // siblings is a reference to the children array, and
+          // sibling is removed from the array when we call appendChild().
+          // As a result, we must revisit this index since the nodes
+          // have been shifted.
+          s -= 1;
+          sl -= 1;
+        }
+      }
+
+      if (this._debug) {
+        this.log("Article content pre-prep: " + articleContent.innerHTML);
+      }
+      // So we have all of the content that we need. Now we clean it up for presentation.
+      this._prepArticle(articleContent);
+      if (this._debug) {
+        this.log("Article content post-prep: " + articleContent.innerHTML);
+      }
+
+      if (neededToCreateTopCandidate) {
+        // We already created a fake div thing, and there wouldn't have been any siblings left
+        // for the previous loop, so there's no point trying to create a new div, and then
+        // move all the children over. Just assign IDs and class names here. No need to append
+        // because that already happened anyway.
+        topCandidate.id = "readability-page-1";
+        topCandidate.className = "page";
+      } else {
+        var div = doc.createElement("DIV");
+        div.id = "readability-page-1";
+        div.className = "page";
+        while (articleContent.firstChild) {
+          div.appendChild(articleContent.firstChild);
+        }
+        articleContent.appendChild(div);
+      }
+
+      if (this._debug) {
+        this.log("Article content after paging: " + articleContent.innerHTML);
+      }
+
+      var parseSuccessful = true;
+
+      // Now that we've gone through the full algorithm, check to see if
+      // we got any meaningful content. If we didn't, we may need to re-run
+      // grabArticle with different flags set. This gives us a higher likelihood of
+      // finding the content, and the sieve approach gives us a higher likelihood of
+      // finding the -right- content.
+      var textLength = this._getInnerText(articleContent, true).length;
+      if (textLength < this._charThreshold) {
+        parseSuccessful = false;
+        // eslint-disable-next-line no-unsanitized/property
+        page.innerHTML = pageCacheHtml;
+
+        this._attempts.push({
+          articleContent,
+          textLength,
+        });
+
+        if (this._flagIsActive(this.FLAG_STRIP_UNLIKELYS)) {
+          this._removeFlag(this.FLAG_STRIP_UNLIKELYS);
+        } else if (this._flagIsActive(this.FLAG_WEIGHT_CLASSES)) {
+          this._removeFlag(this.FLAG_WEIGHT_CLASSES);
+        } else if (this._flagIsActive(this.FLAG_CLEAN_CONDITIONALLY)) {
+          this._removeFlag(this.FLAG_CLEAN_CONDITIONALLY);
+        } else {
+          // No luck after removing flags, just return the longest text we found during the different loops
+          this._attempts.sort(function (a, b) {
+            return b.textLength - a.textLength;
+          });
+
+          // But first check if we actually have something
+          if (!this._attempts[0].textLength) {
+            return null;
+          }
+
+          articleContent = this._attempts[0].articleContent;
+          parseSuccessful = true;
+        }
+      }
+
+      if (parseSuccessful) {
+        // Find out text direction from ancestors of final top candidate.
+        var ancestors = [parentOfTopCandidate, topCandidate].concat(
+          this._getNodeAncestors(parentOfTopCandidate)
+        );
+        this._someNode(ancestors, function (ancestor) {
+          if (!ancestor.tagName) {
+            return false;
+          }
+          var articleDir = ancestor.getAttribute("dir");
+          if (articleDir) {
+            this._articleDir = articleDir;
+            return true;
+          }
+          return false;
+        });
+        return articleContent;
+      }
+    }
+  },
+
+  /**
+   * Converts some of the common HTML entities in string to their corresponding characters.
+   *
+   * @param str {string} - a string to unescape.
+   * @return string without HTML entity.
+   */
+  _unescapeHtmlEntities(str) {
+    if (!str) {
+      return str;
+    }
+
+    var htmlEscapeMap = this.HTML_ESCAPE_MAP;
+    return str
+      .replace(/&(quot|amp|apos|lt|gt);/g, function (_, tag) {
+        return htmlEscapeMap[tag];
+      })
+      .replace(/&#(?:x([0-9a-f]+)|([0-9]+));/gi, function (_, hex, numStr) {
+        var num = parseInt(hex || numStr, hex ? 16 : 10);
+
+        // these character references are replaced by a conforming HTML parser
+        if (num == 0 || num > 0x10ffff || (num >= 0xd800 && num <= 0xdfff)) {
+          num = 0xfffd;
+        }
+
+        return String.fromCodePoint(num);
+      });
+  },
+
+  /**
+   * Try to extract metadata from JSON-LD object.
+   * For now, only Schema.org objects of type Article or its subtypes are supported.
+   * @return Object with any metadata that could be extracted (possibly none)
+   */
+  _getJSONLD(doc) {
+    var scripts = this._getAllNodesWithTag(doc, ["script"]);
+
+    var metadata;
+
+    this._forEachNode(scripts, function (jsonLdElement) {
+      if (
+        !metadata &&
+        jsonLdElement.getAttribute("type") === "application/ld+json"
+      ) {
+        try {
+          // Strip CDATA markers if present
+          var content = jsonLdElement.textContent.replace(
+            /^\s*<!\[CDATA\[|\]\]>\s*$/g,
+            ""
+          );
+          var parsed = JSON.parse(content);
+
+          if (Array.isArray(parsed)) {
+            parsed = parsed.find(it => {
+              return (
+                it["@type"] &&
+                it["@type"].match(this.REGEXPS.jsonLdArticleTypes)
+              );
+            });
+            if (!parsed) {
+              return;
+            }
+          }
+
+          var schemaDotOrgRegex = /^https?\:\/\/schema\.org\/?$/;
+          var matches =
+            (typeof parsed["@context"] === "string" &&
+              parsed["@context"].match(schemaDotOrgRegex)) ||
+            (typeof parsed["@context"] === "object" &&
+              typeof parsed["@context"]["@vocab"] == "string" &&
+              parsed["@context"]["@vocab"].match(schemaDotOrgRegex));
+
+          if (!matches) {
+            return;
+          }
+
+          if (!parsed["@type"] && Array.isArray(parsed["@graph"])) {
+            parsed = parsed["@graph"].find(it => {
+              return (it["@type"] || "").match(this.REGEXPS.jsonLdArticleTypes);
+            });
+          }
+
+          if (
+            !parsed ||
+            !parsed["@type"] ||
+            !parsed["@type"].match(this.REGEXPS.jsonLdArticleTypes)
+          ) {
+            return;
+          }
+
+          metadata = {};
+
+          if (
+            typeof parsed.name === "string" &&
+            typeof parsed.headline === "string" &&
+            parsed.name !== parsed.headline
+          ) {
+            // we have both name and headline element in the JSON-LD. They should both be the same but some websites like aktualne.cz
+            // put their own name into "name" and the article title to "headline" which confuses Readability. So we try to check if either
+            // "name" or "headline" closely matches the html title, and if so, use that one. If not, then we use "name" by default.
+
+            var title = this._getArticleTitle();
+            var nameMatches = this._textSimilarity(parsed.name, title) > 0.75;
+            var headlineMatches =
+              this._textSimilarity(parsed.headline, title) > 0.75;
+
+            if (headlineMatches && !nameMatches) {
+              metadata.title = parsed.headline;
+            } else {
+              metadata.title = parsed.name;
+            }
+          } else if (typeof parsed.name === "string") {
+            metadata.title = parsed.name.trim();
+          } else if (typeof parsed.headline === "string") {
+            metadata.title = parsed.headline.trim();
+          }
+          if (parsed.author) {
+            if (typeof parsed.author.name === "string") {
+              metadata.byline = parsed.author.name.trim();
+            } else if (
+              Array.isArray(parsed.author) &&
+              parsed.author[0] &&
+              typeof parsed.author[0].name === "string"
+            ) {
+              metadata.byline = parsed.author
+                .filter(function (author) {
+                  return author && typeof author.name === "string";
+                })
+                .map(function (author) {
+                  return author.name.trim();
+                })
+                .join(", ");
+            }
+          }
+          if (typeof parsed.description === "string") {
+            metadata.excerpt = parsed.description.trim();
+          }
+          if (parsed.publisher && typeof parsed.publisher.name === "string") {
+            metadata.siteName = parsed.publisher.name.trim();
+          }
+          if (typeof parsed.datePublished === "string") {
+            metadata.datePublished = parsed.datePublished.trim();
+          }
+        } catch (err) {
+          this.log(err.message);
+        }
+      }
+    });
+    return metadata ? metadata : {};
+  },
+
+  /**
+   * Attempts to get excerpt and byline metadata for the article.
+   *
+   * @param {Object} jsonld — object containing any metadata that
+   * could be extracted from JSON-LD object.
+   *
+   * @return Object with optional "excerpt" and "byline" properties
+   */
+  _getArticleMetadata(jsonld) {
+    var metadata = {};
+    var values = {};
+    var metaElements = this._doc.getElementsByTagName("meta");
+
+    // property is a space-separated list of values
+    var propertyPattern =
+      /\s*(article|dc|dcterm|og|twitter)\s*:\s*(author|creator|description|published_time|title|site_name)\s*/gi;
+
+    // name is a single value
+    var namePattern =
+      /^\s*(?:(dc|dcterm|og|twitter|parsely|weibo:(article|webpage))\s*[-\.:]\s*)?(author|creator|pub-date|description|title|site_name)\s*$/i;
+
+    // Find description tags.
+    this._forEachNode(metaElements, function (element) {
+      var elementName = element.getAttribute("name");
+      var elementProperty = element.getAttribute("property");
+      var content = element.getAttribute("content");
+      if (!content) {
+        return;
+      }
+      var matches = null;
+      var name = null;
+
+      if (elementProperty) {
+        matches = elementProperty.match(propertyPattern);
+        if (matches) {
+          // Convert to lowercase, and remove any whitespace
+          // so we can match below.
+          name = matches[0].toLowerCase().replace(/\s/g, "");
+          // multiple authors
+          values[name] = content.trim();
+        }
+      }
+      if (!matches && elementName && namePattern.test(elementName)) {
+        name = elementName;
+        if (content) {
+          // Convert to lowercase, remove any whitespace, and convert dots
+          // to colons so we can match below.
+          name = name.toLowerCase().replace(/\s/g, "").replace(/\./g, ":");
+          values[name] = content.trim();
+        }
+      }
+    });
+
+    // get title
+    metadata.title =
+      jsonld.title ||
+      values["dc:title"] ||
+      values["dcterm:title"] ||
+      values["og:title"] ||
+      values["weibo:article:title"] ||
+      values["weibo:webpage:title"] ||
+      values.title ||
+      values["twitter:title"] ||
+      values["parsely-title"];
+
+    if (!metadata.title) {
+      metadata.title = this._getArticleTitle();
+    }
+
+    const articleAuthor =
+      typeof values["article:author"] === "string" &&
+      !this._isUrl(values["article:author"])
+        ? values["article:author"]
+        : undefined;
+
+    // get author
+    metadata.byline =
+      jsonld.byline ||
+      values["dc:creator"] ||
+      values["dcterm:creator"] ||
+      values.author ||
+      values["parsely-author"] ||
+      articleAuthor;
+
+    // get description
+    metadata.excerpt =
+      jsonld.excerpt ||
+      values["dc:description"] ||
+      values["dcterm:description"] ||
+      values["og:description"] ||
+      values["weibo:article:description"] ||
+      values["weibo:webpage:description"] ||
+      values.description ||
+      values["twitter:description"];
+
+    // get site name
+    metadata.siteName = jsonld.siteName || values["og:site_name"];
+
+    // get article published time
+    metadata.publishedTime =
+      jsonld.datePublished ||
+      values["article:published_time"] ||
+      values["parsely-pub-date"] ||
+      null;
+
+    // in many sites the meta value is escaped with HTML entities,
+    // so here we need to unescape it
+    metadata.title = this._unescapeHtmlEntities(metadata.title);
+    metadata.byline = this._unescapeHtmlEntities(metadata.byline);
+    metadata.excerpt = this._unescapeHtmlEntities(metadata.excerpt);
+    metadata.siteName = this._unescapeHtmlEntities(metadata.siteName);
+    metadata.publishedTime = this._unescapeHtmlEntities(metadata.publishedTime);
+
+    return metadata;
+  },
+
+  /**
+   * Check if node is image, or if node contains exactly only one image
+   * whether as a direct child or as its descendants.
+   *
+   * @param Element
+   **/
+  _isSingleImage(node) {
+    while (node) {
+      if (node.tagName === "IMG") {
+        return true;
+      }
+      if (node.children.length !== 1 || node.textContent.trim() !== "") {
+        return false;
+      }
+      node = node.children[0];
+    }
+    return false;
+  },
+
+  /**
+   * Find all <noscript> that are located after <img> nodes, and which contain only one
+   * <img> element. Replace the first image with the image from inside the <noscript> tag,
+   * and remove the <noscript> tag. This improves the quality of the images we use on
+   * some sites (e.g. Medium).
+   *
+   * @param Element
+   **/
+  _unwrapNoscriptImages(doc) {
+    // Find img without source or attributes that might contains image, and remove it.
+    // This is done to prevent a placeholder img is replaced by img from noscript in next step.
+    var imgs = Array.from(doc.getElementsByTagName("img"));
+    this._forEachNode(imgs, function (img) {
+      for (var i = 0; i < img.attributes.length; i++) {
+        var attr = img.attributes[i];
+        switch (attr.name) {
+          case "src":
+          case "srcset":
+          case "data-src":
+          case "data-srcset":
+            return;
+        }
+
+        if (/\.(jpg|jpeg|png|webp)/i.test(attr.value)) {
+          return;
+        }
+      }
+
+      img.remove();
+    });
+
+    // Next find noscript and try to extract its image
+    var noscripts = Array.from(doc.getElementsByTagName("noscript"));
+    this._forEachNode(noscripts, function (noscript) {
+      // Parse content of noscript and make sure it only contains image
+      if (!this._isSingleImage(noscript)) {
+        return;
+      }
+      var tmp = doc.createElement("div");
+      // We're running in the document context, and using unmodified
+      // document contents, so doing this should be safe.
+      // (Also we heavily discourage people from allowing script to
+      // run at all in this document...)
+      // eslint-disable-next-line no-unsanitized/property
+      tmp.innerHTML = noscript.innerHTML;
+
+      // If noscript has previous sibling and it only contains image,
+      // replace it with noscript content. However we also keep old
+      // attributes that might contains image.
+      var prevElement = noscript.previousElementSibling;
+      if (prevElement && this._isSingleImage(prevElement)) {
+        var prevImg = prevElement;
+        if (prevImg.tagName !== "IMG") {
+          prevImg = prevElement.getElementsByTagName("img")[0];
+        }
+
+        var newImg = tmp.getElementsByTagName("img")[0];
+        for (var i = 0; i < prevImg.attributes.length; i++) {
+          var attr = prevImg.attributes[i];
+          if (attr.value === "") {
+            continue;
+          }
+
+          if (
+            attr.name === "src" ||
+            attr.name === "srcset" ||
+            /\.(jpg|jpeg|png|webp)/i.test(attr.value)
+          ) {
+            if (newImg.getAttribute(attr.name) === attr.value) {
+              continue;
+            }
+
+            var attrName = attr.name;
+            if (newImg.hasAttribute(attrName)) {
+              attrName = "data-old-" + attrName;
+            }
+
+            newImg.setAttribute(attrName, attr.value);
+          }
+        }
+
+        noscript.parentNode.replaceChild(tmp.firstElementChild, prevElement);
+      }
+    });
+  },
+
+  /**
+   * Removes script tags from the document.
+   *
+   * @param Element
+   **/
+  _removeScripts(doc) {
+    this._removeNodes(this._getAllNodesWithTag(doc, ["script", "noscript"]));
+  },
+
+  /**
+   * Check if this node has only whitespace and a single element with given tag
+   * Returns false if the DIV node contains non-empty text nodes
+   * or if it contains no element with given tag or more than 1 element.
+   *
+   * @param Element
+   * @param string tag of child element
+   **/
+  _hasSingleTagInsideElement(element, tag) {
+    // There should be exactly 1 element child with given tag
+    if (element.children.length != 1 || element.children[0].tagName !== tag) {
+      return false;
+    }
+
+    // And there should be no text nodes with real content
+    return !this._someNode(element.childNodes, function (node) {
+      return (
+        node.nodeType === this.TEXT_NODE &&
+        this.REGEXPS.hasContent.test(node.textContent)
+      );
+    });
+  },
+
+  _isElementWithoutContent(node) {
+    return (
+      node.nodeType === this.ELEMENT_NODE &&
+      !node.textContent.trim().length &&
+      (!node.children.length ||
+        node.children.length ==
+          node.getElementsByTagName("br").length +
+            node.getElementsByTagName("hr").length)
+    );
+  },
+
+  /**
+   * Determine whether element has any children block level elements.
+   *
+   * @param Element
+   */
+  _hasChildBlockElement(element) {
+    return this._someNode(element.childNodes, function (node) {
+      return (
+        this.DIV_TO_P_ELEMS.has(node.tagName) ||
+        this._hasChildBlockElement(node)
+      );
+    });
+  },
+
+  /***
+   * Determine if a node qualifies as phrasing content.
+   * https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Phrasing_content
+   **/
+  _isPhrasingContent(node) {
+    return (
+      node.nodeType === this.TEXT_NODE ||
+      this.PHRASING_ELEMS.includes(node.tagName) ||
+      ((node.tagName === "A" ||
+        node.tagName === "DEL" ||
+        node.tagName === "INS") &&
+        this._everyNode(node.childNodes, this._isPhrasingContent))
+    );
+  },
+
+  _isWhitespace(node) {
+    return (
+      (node.nodeType === this.TEXT_NODE &&
+        node.textContent.trim().length === 0) ||
+      (node.nodeType === this.ELEMENT_NODE && node.tagName === "BR")
+    );
+  },
+
+  /**
+   * Get the inner text of a node - cross browser compatibly.
+   * This also strips out any excess whitespace to be found.
+   *
+   * @param Element
+   * @param Boolean normalizeSpaces (default: true)
+   * @return string
+   **/
+  _getInnerText(e, normalizeSpaces) {
+    normalizeSpaces =
+      typeof normalizeSpaces === "undefined" ? true : normalizeSpaces;
+    var textContent = e.textContent.trim();
+
+    if (normalizeSpaces) {
+      return textContent.replace(this.REGEXPS.normalize, " ");
+    }
+    return textContent;
+  },
+
+  /**
+   * Get the number of times a string s appears in the node e.
+   *
+   * @param Element
+   * @param string - what to split on. Default is ","
+   * @return number (integer)
+   **/
+  _getCharCount(e, s) {
+    s = s || ",";
+    return this._getInnerText(e).split(s).length - 1;
+  },
+
+  /**
+   * Remove the style attribute on every e and under.
+   * TODO: Test if getElementsByTagName(*) is faster.
+   *
+   * @param Element
+   * @return void
+   **/
+  _cleanStyles(e) {
+    if (!e || e.tagName.toLowerCase() === "svg") {
+      return;
+    }
+
+    // Remove `style` and deprecated presentational attributes
+    for (var i = 0; i < this.PRESENTATIONAL_ATTRIBUTES.length; i++) {
+      e.removeAttribute(this.PRESENTATIONAL_ATTRIBUTES[i]);
+    }
+
+    if (this.DEPRECATED_SIZE_ATTRIBUTE_ELEMS.includes(e.tagName)) {
+      e.removeAttribute("width");
+      e.removeAttribute("height");
+    }
+
+    var cur = e.firstElementChild;
+    while (cur !== null) {
+      this._cleanStyles(cur);
+      cur = cur.nextElementSibling;
+    }
+  },
+
+  /**
+   * Get the density of links as a percentage of the content
+   * This is the amount of text that is inside a link divided by the total text in the node.
+   *
+   * @param Element
+   * @return number (float)
+   **/
+  _getLinkDensity(element) {
+    var textLength = this._getInnerText(element).length;
+    if (textLength === 0) {
+      return 0;
+    }
+
+    var linkLength = 0;
+
+    // XXX implement _reduceNodeList?
+    this._forEachNode(element.getElementsByTagName("a"), function (linkNode) {
+      var href = linkNode.getAttribute("href");
+      var coefficient = href && this.REGEXPS.hashUrl.test(href) ? 0.3 : 1;
+      linkLength += this._getInnerText(linkNode).length * coefficient;
+    });
+
+    return linkLength / textLength;
+  },
+
+  /**
+   * Get an elements class/id weight. Uses regular expressions to tell if this
+   * element looks good or bad.
+   *
+   * @param Element
+   * @return number (Integer)
+   **/
+  _getClassWeight(e) {
+    if (!this._flagIsActive(this.FLAG_WEIGHT_CLASSES)) {
+      return 0;
+    }
+
+    var weight = 0;
+
+    // Look for a special classname
+    if (typeof e.className === "string" && e.className !== "") {
+      if (this.REGEXPS.negative.test(e.className)) {
+        weight -= 25;
+      }
+
+      if (this.REGEXPS.positive.test(e.className)) {
+        weight += 25;
+      }
+    }
+
+    // Look for a special ID
+    if (typeof e.id === "string" && e.id !== "") {
+      if (this.REGEXPS.negative.test(e.id)) {
+        weight -= 25;
+      }
+
+      if (this.REGEXPS.positive.test(e.id)) {
+        weight += 25;
+      }
+    }
+
+    return weight;
+  },
+
+  /**
+   * Clean a node of all elements of type "tag".
+   * (Unless it's a youtube/vimeo video. People love movies.)
+   *
+   * @param Element
+   * @param string tag to clean
+   * @return void
+   **/
+  _clean(e, tag) {
+    var isEmbed = ["object", "embed", "iframe"].includes(tag);
+
+    this._removeNodes(this._getAllNodesWithTag(e, [tag]), function (element) {
+      // Allow youtube and vimeo videos through as people usually want to see those.
+      if (isEmbed) {
+        // First, check the elements attributes to see if any of them contain youtube or vimeo
+        for (var i = 0; i < element.attributes.length; i++) {
+          if (this._allowedVideoRegex.test(element.attributes[i].value)) {
+            return false;
+          }
+        }
+
+        // For embed with <object> tag, check inner HTML as well.
+        if (
+          element.tagName === "object" &&
+          this._allowedVideoRegex.test(element.innerHTML)
+        ) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  },
+
+  /**
+   * Check if a given node has one of its ancestor tag name matching the
+   * provided one.
+   * @param  HTMLElement node
+   * @param  String      tagName
+   * @param  Number      maxDepth
+   * @param  Function    filterFn a filter to invoke to determine whether this node 'counts'
+   * @return Boolean
+   */
+  _hasAncestorTag(node, tagName, maxDepth, filterFn) {
+    maxDepth = maxDepth || 3;
+    tagName = tagName.toUpperCase();
+    var depth = 0;
+    while (node.parentNode) {
+      if (maxDepth > 0 && depth > maxDepth) {
+        return false;
+      }
+      if (
+        node.parentNode.tagName === tagName &&
+        (!filterFn || filterFn(node.parentNode))
+      ) {
+        return true;
+      }
+      node = node.parentNode;
+      depth++;
+    }
+    return false;
+  },
+
+  /**
+   * Return an object indicating how many rows and columns this table has.
+   */
+  _getRowAndColumnCount(table) {
+    var rows = 0;
+    var columns = 0;
+    var trs = table.getElementsByTagName("tr");
+    for (var i = 0; i < trs.length; i++) {
+      var rowspan = trs[i].getAttribute("rowspan") || 0;
+      if (rowspan) {
+        rowspan = parseInt(rowspan, 10);
+      }
+      rows += rowspan || 1;
+
+      // Now look for column-related info
+      var columnsInThisRow = 0;
+      var cells = trs[i].getElementsByTagName("td");
+      for (var j = 0; j < cells.length; j++) {
+        var colspan = cells[j].getAttribute("colspan") || 0;
+        if (colspan) {
+          colspan = parseInt(colspan, 10);
+        }
+        columnsInThisRow += colspan || 1;
+      }
+      columns = Math.max(columns, columnsInThisRow);
+    }
+    return { rows, columns };
+  },
+
+  /**
+   * Look for 'data' (as opposed to 'layout') tables, for which we use
+   * similar checks as
+   * https://searchfox.org/mozilla-central/rev/f82d5c549f046cb64ce5602bfd894b7ae807c8f8/accessible/generic/TableAccessible.cpp#19
+   */
+  _markDataTables(root) {
+    var tables = root.getElementsByTagName("table");
+    for (var i = 0; i < tables.length; i++) {
+      var table = tables[i];
+      var role = table.getAttribute("role");
+      if (role == "presentation") {
+        table._readabilityDataTable = false;
+        continue;
+      }
+      var datatable = table.getAttribute("datatable");
+      if (datatable == "0") {
+        table._readabilityDataTable = false;
+        continue;
+      }
+      var summary = table.getAttribute("summary");
+      if (summary) {
+        table._readabilityDataTable = true;
+        continue;
+      }
+
+      var caption = table.getElementsByTagName("caption")[0];
+      if (caption && caption.childNodes.length) {
+        table._readabilityDataTable = true;
+        continue;
+      }
+
+      // If the table has a descendant with any of these tags, consider a data table:
+      var dataTableDescendants = ["col", "colgroup", "tfoot", "thead", "th"];
+      var descendantExists = function (tag) {
+        return !!table.getElementsByTagName(tag)[0];
+      };
+      if (dataTableDescendants.some(descendantExists)) {
+        this.log("Data table because found data-y descendant");
+        table._readabilityDataTable = true;
+        continue;
+      }
+
+      // Nested tables indicate a layout table:
+      if (table.getElementsByTagName("table")[0]) {
+        table._readabilityDataTable = false;
+        continue;
+      }
+
+      var sizeInfo = this._getRowAndColumnCount(table);
+
+      if (sizeInfo.columns == 1 || sizeInfo.rows == 1) {
+        // single colum/row tables are commonly used for page layout purposes.
+        table._readabilityDataTable = false;
+        continue;
+      }
+
+      if (sizeInfo.rows >= 10 || sizeInfo.columns > 4) {
+        table._readabilityDataTable = true;
+        continue;
+      }
+      // Now just go by size entirely:
+      table._readabilityDataTable = sizeInfo.rows * sizeInfo.columns > 10;
+    }
+  },
+
+  /* convert images and figures that have properties like data-src into images that can be loaded without JS */
+  _fixLazyImages(root) {
+    this._forEachNode(
+      this._getAllNodesWithTag(root, ["img", "picture", "figure"]),
+      function (elem) {
+        // In some sites (e.g. Kotaku), they put 1px square image as base64 data uri in the src attribute.
+        // So, here we check if the data uri is too short, just might as well remove it.
+        if (elem.src && this.REGEXPS.b64DataUrl.test(elem.src)) {
+          // Make sure it's not SVG, because SVG can have a meaningful image in under 133 bytes.
+          var parts = this.REGEXPS.b64DataUrl.exec(elem.src);
+          if (parts[1] === "image/svg+xml") {
+            return;
+          }
+
+          // Make sure this element has other attributes which contains image.
+          // If it doesn't, then this src is important and shouldn't be removed.
+          var srcCouldBeRemoved = false;
+          for (var i = 0; i < elem.attributes.length; i++) {
+            var attr = elem.attributes[i];
+            if (attr.name === "src") {
+              continue;
+            }
+
+            if (/\.(jpg|jpeg|png|webp)/i.test(attr.value)) {
+              srcCouldBeRemoved = true;
+              break;
+            }
+          }
+
+          // Here we assume if image is less than 100 bytes (or 133 after encoded to base64)
+          // it will be too small, therefore it might be placeholder image.
+          if (srcCouldBeRemoved) {
+            var b64starts = parts[0].length;
+            var b64length = elem.src.length - b64starts;
+            if (b64length < 133) {
+              elem.removeAttribute("src");
+            }
+          }
+        }
+
+        // also check for "null" to work around https://github.com/jsdom/jsdom/issues/2580
+        if (
+          (elem.src || (elem.srcset && elem.srcset != "null")) &&
+          !elem.className.toLowerCase().includes("lazy")
+        ) {
+          return;
+        }
+
+        for (var j = 0; j < elem.attributes.length; j++) {
+          attr = elem.attributes[j];
+          if (
+            attr.name === "src" ||
+            attr.name === "srcset" ||
+            attr.name === "alt"
+          ) {
+            continue;
+          }
+          var copyTo = null;
+          if (/\.(jpg|jpeg|png|webp)\s+\d/.test(attr.value)) {
+            copyTo = "srcset";
+          } else if (/^\s*\S+\.(jpg|jpeg|png|webp)\S*\s*$/.test(attr.value)) {
+            copyTo = "src";
+          }
+          if (copyTo) {
+            //if this is an img or picture, set the attribute directly
+            if (elem.tagName === "IMG" || elem.tagName === "PICTURE") {
+              elem.setAttribute(copyTo, attr.value);
+            } else if (
+              elem.tagName === "FIGURE" &&
+              !this._getAllNodesWithTag(elem, ["img", "picture"]).length
+            ) {
+              //if the item is a <figure> that does not contain an image or picture, create one and place it inside the figure
+              //see the nytimes-3 testcase for an example
+              var img = this._doc.createElement("img");
+              img.setAttribute(copyTo, attr.value);
+              elem.appendChild(img);
+            }
+          }
+        }
+      }
+    );
+  },
+
+  _getTextDensity(e, tags) {
+    var textLength = this._getInnerText(e, true).length;
+    if (textLength === 0) {
+      return 0;
+    }
+    var childrenLength = 0;
+    var children = this._getAllNodesWithTag(e, tags);
+    this._forEachNode(
+      children,
+      child => (childrenLength += this._getInnerText(child, true).length)
+    );
+    return childrenLength / textLength;
+  },
+
+  /**
+   * Clean an element of all tags of type "tag" if they look fishy.
+   * "Fishy" is an algorithm based on content length, classnames, link density, number of images & embeds, etc.
+   *
+   * @return void
+   **/
+  _cleanConditionally(e, tag) {
+    if (!this._flagIsActive(this.FLAG_CLEAN_CONDITIONALLY)) {
+      return;
+    }
+
+    // Gather counts for other typical elements embedded within.
+    // Traverse backwards so we can remove nodes at the same time
+    // without effecting the traversal.
+    //
+    // TODO: Consider taking into account original contentScore here.
+    this._removeNodes(this._getAllNodesWithTag(e, [tag]), function (node) {
+      // First check if this node IS data table, in which case don't remove it.
+      var isDataTable = function (t) {
+        return t._readabilityDataTable;
+      };
+
+      var isList = tag === "ul" || tag === "ol";
+      if (!isList) {
+        var listLength = 0;
+        var listNodes = this._getAllNodesWithTag(node, ["ul", "ol"]);
+        this._forEachNode(
+          listNodes,
+          list => (listLength += this._getInnerText(list).length)
+        );
+        isList = listLength / this._getInnerText(node).length > 0.9;
+      }
+
+      if (tag === "table" && isDataTable(node)) {
+        return false;
+      }
+
+      // Next check if we're inside a data table, in which case don't remove it as well.
+      if (this._hasAncestorTag(node, "table", -1, isDataTable)) {
+        return false;
+      }
+
+      if (this._hasAncestorTag(node, "code")) {
+        return false;
+      }
+
+      // keep element if it has a data tables
+      if (
+        [...node.getElementsByTagName("table")].some(
+          tbl => tbl._readabilityDataTable
+        )
+      ) {
+        return false;
+      }
+
+      var weight = this._getClassWeight(node);
+
+      this.log("Cleaning Conditionally", node);
+
+      var contentScore = 0;
+
+      if (weight + contentScore < 0) {
+        return true;
+      }
+
+      if (this._getCharCount(node, ",") < 10) {
+        // If there are not very many commas, and the number of
+        // non-paragraph elements is more than paragraphs or other
+        // ominous signs, remove the element.
+        var p = node.getElementsByTagName("p").length;
+        var img = node.getElementsByTagName("img").length;
+        var li = node.getElementsByTagName("li").length - 100;
+        var input = node.getElementsByTagName("input").length;
+        var headingDensity = this._getTextDensity(node, [
+          "h1",
+          "h2",
+          "h3",
+          "h4",
+          "h5",
+          "h6",
+        ]);
+
+        var embedCount = 0;
+        var embeds = this._getAllNodesWithTag(node, [
+          "object",
+          "embed",
+          "iframe",
+        ]);
+
+        for (var i = 0; i < embeds.length; i++) {
+          // If this embed has attribute that matches video regex, don't delete it.
+          for (var j = 0; j < embeds[i].attributes.length; j++) {
+            if (this._allowedVideoRegex.test(embeds[i].attributes[j].value)) {
+              return false;
+            }
+          }
+
+          // For embed with <object> tag, check inner HTML as well.
+          if (
+            embeds[i].tagName === "object" &&
+            this._allowedVideoRegex.test(embeds[i].innerHTML)
+          ) {
+            return false;
+          }
+
+          embedCount++;
+        }
+
+        var innerText = this._getInnerText(node);
+
+        // toss any node whose inner text contains nothing but suspicious words
+        if (
+          this.REGEXPS.adWords.test(innerText) ||
+          this.REGEXPS.loadingWords.test(innerText)
+        ) {
+          return true;
+        }
+
+        var contentLength = innerText.length;
+        var linkDensity = this._getLinkDensity(node);
+        var textishTags = ["SPAN", "LI", "TD"].concat(
+          Array.from(this.DIV_TO_P_ELEMS)
+        );
+        var textDensity = this._getTextDensity(node, textishTags);
+        var isFigureChild = this._hasAncestorTag(node, "figure");
+
+        // apply shadiness checks, then check for exceptions
+        const shouldRemoveNode = () => {
+          const errs = [];
+          if (!isFigureChild && img > 1 && p / img < 0.5) {
+            errs.push(`Bad p to img ratio (img=${img}, p=${p})`);
+          }
+          if (!isList && li > p) {
+            errs.push(`Too many li's outside of a list. (li=${li} > p=${p})`);
+          }
+          if (input > Math.floor(p / 3)) {
+            errs.push(`Too many inputs per p. (input=${input}, p=${p})`);
+          }
+          if (
+            !isList &&
+            !isFigureChild &&
+            headingDensity < 0.9 &&
+            contentLength < 25 &&
+            (img === 0 || img > 2) &&
+            linkDensity > 0
+          ) {
+            errs.push(
+              `Suspiciously short. (headingDensity=${headingDensity}, img=${img}, linkDensity=${linkDensity})`
+            );
+          }
+          if (
+            !isList &&
+            weight < 25 &&
+            linkDensity > 0.2 + this._linkDensityModifier
+          ) {
+            errs.push(
+              `Low weight and a little linky. (linkDensity=${linkDensity})`
+            );
+          }
+          if (weight >= 25 && linkDensity > 0.5 + this._linkDensityModifier) {
+            errs.push(
+              `High weight and mostly links. (linkDensity=${linkDensity})`
+            );
+          }
+          if ((embedCount === 1 && contentLength < 75) || embedCount > 1) {
+            errs.push(
+              `Suspicious embed. (embedCount=${embedCount}, contentLength=${contentLength})`
+            );
+          }
+          if (img === 0 && textDensity === 0) {
+            errs.push(
+              `No useful content. (img=${img}, textDensity=${textDensity})`
+            );
+          }
+
+          if (errs.length) {
+            this.log("Checks failed", errs);
+            return true;
+          }
+
+          return false;
+        };
+
+        var haveToRemove = shouldRemoveNode();
+
+        // Allow simple lists of images to remain in pages
+        if (isList && haveToRemove) {
+          for (var x = 0; x < node.children.length; x++) {
+            let child = node.children[x];
+            // Don't filter in lists with li's that contain more than one child
+            if (child.children.length > 1) {
+              return haveToRemove;
+            }
+          }
+          let li_count = node.getElementsByTagName("li").length;
+          // Only allow the list to remain if every li contains an image
+          if (img == li_count) {
+            return false;
+          }
+        }
+        return haveToRemove;
+      }
+      return false;
+    });
+  },
+
+  /**
+   * Clean out elements that match the specified conditions
+   *
+   * @param Element
+   * @param Function determines whether a node should be removed
+   * @return void
+   **/
+  _cleanMatchedNodes(e, filter) {
+    var endOfSearchMarkerNode = this._getNextNode(e, true);
+    var next = this._getNextNode(e);
+    while (next && next != endOfSearchMarkerNode) {
+      if (filter.call(this, next, next.className + " " + next.id)) {
+        next = this._removeAndGetNext(next);
+      } else {
+        next = this._getNextNode(next);
+      }
+    }
+  },
+
+  /**
+   * Clean out spurious headers from an Element.
+   *
+   * @param Element
+   * @return void
+   **/
+  _cleanHeaders(e) {
+    let headingNodes = this._getAllNodesWithTag(e, ["h1", "h2"]);
+    this._removeNodes(headingNodes, function (node) {
+      let shouldRemove = this._getClassWeight(node) < 0;
+      if (shouldRemove) {
+        this.log("Removing header with low class weight:", node);
+      }
+      return shouldRemove;
+    });
+  },
+
+  /**
+   * Check if this node is an H1 or H2 element whose content is mostly
+   * the same as the article title.
+   *
+   * @param Element  the node to check.
+   * @return boolean indicating whether this is a title-like header.
+   */
+  _headerDuplicatesTitle(node) {
+    if (node.tagName != "H1" && node.tagName != "H2") {
+      return false;
+    }
+    var heading = this._getInnerText(node, false);
+    this.log("Evaluating similarity of header:", heading, this._articleTitle);
+    return this._textSimilarity(this._articleTitle, heading) > 0.75;
+  },
+
+  _flagIsActive(flag) {
+    return (this._flags & flag) > 0;
+  },
+
+  _removeFlag(flag) {
+    this._flags = this._flags & ~flag;
+  },
+
+  _isProbablyVisible(node) {
+    // Have to null-check node.style and node.className.includes to deal with SVG and MathML nodes.
+    return (
+      (!node.style || node.style.display != "none") &&
+      (!node.style || node.style.visibility != "hidden") &&
+      !node.hasAttribute("hidden") &&
+      //check for "fallback-image" so that wikimedia math images are displayed
+      (!node.hasAttribute("aria-hidden") ||
+        node.getAttribute("aria-hidden") != "true" ||
+        (node.className &&
+          node.className.includes &&
+          node.className.includes("fallback-image")))
+    );
+  },
+
+  /**
+   * Runs readability.
+   *
+   * Workflow:
+   *  1. Prep the document by removing script tags, css, etc.
+   *  2. Build readability's DOM tree.
+   *  3. Grab the article content from the current dom tree.
+   *  4. Replace the current DOM tree with the new one.
+   *  5. Read peacefully.
+   *
+   * @return void
+   **/
+  parse() {
+    // Avoid parsing too large documents, as per configuration option
+    if (this._maxElemsToParse > 0) {
+      var numTags = this._doc.getElementsByTagName("*").length;
+      if (numTags > this._maxElemsToParse) {
+        throw new Error(
+          "Aborting parsing document; " + numTags + " elements found"
+        );
+      }
+    }
+
+    // Unwrap image from noscript
+    this._unwrapNoscriptImages(this._doc);
+
+    // Extract JSON-LD metadata before removing scripts
+    var jsonLd = this._disableJSONLD ? {} : this._getJSONLD(this._doc);
+
+    // Remove script tags from the document.
+    this._removeScripts(this._doc);
+
+    this._prepDocument();
+
+    var metadata = this._getArticleMetadata(jsonLd);
+    this._metadata = metadata;
+    this._articleTitle = metadata.title;
+
+    var articleContent = this._grabArticle();
+    if (!articleContent) {
+      return null;
+    }
+
+    this.log("Grabbed: " + articleContent.innerHTML);
+
+    this._postProcessContent(articleContent);
+
+    // If we haven't found an excerpt in the article's metadata, use the article's
+    // first paragraph as the excerpt. This is used for displaying a preview of
+    // the article's content.
+    if (!metadata.excerpt) {
+      var paragraphs = articleContent.getElementsByTagName("p");
+      if (paragraphs.length) {
+        metadata.excerpt = paragraphs[0].textContent.trim();
+      }
+    }
+
+    var textContent = articleContent.textContent;
+    return {
+      title: this._articleTitle,
+      byline: metadata.byline || this._articleByline,
+      dir: this._articleDir,
+      lang: this._articleLang,
+      content: this._serializer(articleContent),
+      textContent,
+      length: textContent.length,
+      excerpt: metadata.excerpt,
+      siteName: metadata.siteName || this._articleSiteName,
+      publishedTime: metadata.publishedTime,
+    };
+  },
+};
+
+if (typeof module === "object") {
+  /* eslint-disable-next-line no-redeclare */
+  /* global module */
+  module.exports = Readability;
+}
+
+// peerd vendoring note: upstream file is byte-identical above this line; the
+// ES-module export below is the only addition (see SOURCE.txt).
+export default Readability;

--- a/extension/vendor/readability/SOURCE.txt
+++ b/extension/vendor/readability/SOURCE.txt
@@ -1,0 +1,70 @@
+@mozilla/readability — vendored
+===============================
+Upstream:   https://github.com/mozilla/readability
+Package:    https://www.npmjs.com/package/@mozilla/readability
+Version:    0.6.0
+Source URL: https://registry.npmjs.org/@mozilla/readability/-/readability-0.6.0.tgz
+Tarball SHA-256: 6d3c3cc50dad51b543925deadc66d5b58cd2262d1d585f2ae0a44975627ad919
+Reviewed:   2026-07-07
+License:    Apache-2.0 (in-file header retained; see LICENSE.md in the upstream package)
+
+Why vendored
+------------
+peerd's fetch_url returns raw HTML today — boilerplate eats the 16k token
+budget. Readability is Firefox Reader View's article extractor: given a
+parsed Document it returns the main content (title, byline, content HTML),
+dropping nav/ads/footers. Extraction runs in the OFFSCREEN document
+(offscreen/web-extract.js) — Readability needs a DOM Document, and
+DOMParser is unavailable in the service worker. Client-side extraction is
+peerd's substitute for the hosted "clean content" APIs other agents use
+(BYOK/no-backend forbids those).
+
+Files committed (upstream source, unminified — no minified build is published)
+-------------------------------------------------------------------------------
+  Readability.js             — the extractor (new Readability(doc).parse())
+  Readability-readerable.js  — isProbablyReaderable(doc) pre-check (cheap
+                               heuristic: skip extraction on dashboards /
+                               listings and fall back to raw text)
+
+JSDOMParser.js is deliberately OMITTED: the offscreen document has native
+DOMParser, and JSDOMParser's sloppy-mode IIFE breaks under ES-module strict
+mode. index.js (the CJS entry) is also omitted — we import the two files
+directly.
+
+Modification (the append-export ESM conversion; browser-polyfill pattern)
+--------------------------------------------------------------------------
+Upstream files are committed BYTE-IDENTICAL, then an ES-module export tail
+is APPENDED (a comment + one line each):
+  Readability.js             + `export default Readability;`
+  Readability-readerable.js  + `export default isProbablyReaderable;`
+The upstream `module.exports` tails remain; `typeof module === "object"`
+is false in an ES module, so they are inert.
+
+SHA-256
+-------
+Upstream (pre-append, == bytes in the tarball):
+  Readability.js             34dcab3d0832d0019f02990eed6b6124e029e8c32b9f0c6f2550544ff8dff174
+  Readability-readerable.js  a98d28805804c1986ceed470678a3f409f150ee7f1d227f8c8239c005d21de65
+As committed (with the appended export tail):
+  Readability.js             66abf753559cf89baacf516115a3259a98825399ebc159255cf0065b3b9a899a
+  Readability-readerable.js  5a8fc32e70171edc4fd27a31c614874df9d7d7cc8becfd7920ecff6a149c5819
+
+Subresource Integrity (SHA-384, as committed)
+---------------------------------------------
+  Readability.js             sha384-wYsdgtVvqt67z9W0fz4h8tZis/eKD5WxxaNiHF4FKWVvLe6mcIYrEnhKerwYNscY
+  Readability-readerable.js  sha384-Bgk2SspfpHdSC60nxajfX+ziuQqUn/lFuLX1Y38KgPaUL01YYxZzMYOK4e9CEh0i
+
+Usage notes (why-comments for the integration)
+----------------------------------------------
+- Readability MUTATES the document it parses — always hand it a FRESH
+  DOMParser document per extraction, never a reused one.
+- DOMParser gives the parsed doc the offscreen page's baseURI; inject
+  `<base href="<fetched page URL>">` into the head before parsing so
+  relative links resolve against the fetched origin, not the extension.
+
+Update procedure
+----------------
+1. curl -sL -o r.tgz https://registry.npmjs.org/@mozilla/readability/-/readability-<ver>.tgz
+2. shasum -a 256 r.tgz — record the tarball hash above.
+3. tar xzf r.tgz; copy package/Readability.js + package/Readability-readerable.js.
+4. Re-append the two export tails exactly as above; recompute both hash sets.

--- a/extension/vendor/turndown/SOURCE.txt
+++ b/extension/vendor/turndown/SOURCE.txt
@@ -1,0 +1,46 @@
+turndown — vendored
+===================
+Upstream:   https://github.com/mixmark-io/turndown
+Package:    https://www.npmjs.com/package/turndown
+Version:    7.2.4
+Source URL: https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz
+Tarball SHA-256: 05f61bc3f0aeca5e5cd7f1b5492e26b9040bb00708cd41fb1b0f7b216e296fa0
+Reviewed:   2026-07-07
+License:    MIT (see LICENSE in the upstream package; the build ships no in-file header)
+
+Why vendored
+------------
+The HTML→Markdown half of fetch_url's clean-content extraction
+(offscreen/web-extract.js): Readability isolates the article HTML, Turndown
+converts it to markdown — the dense representation the model actually
+reads. Runs only in the offscreen document.
+
+Files committed
+---------------
+  turndown.browser.es.js — the BROWSER ES-module build, VERBATIM (zero
+                           imports, `export { TurndownService as default }`).
+
+Why exactly this build: the package ships six builds; lib/turndown.es.js
+(the node ESM build) statically imports '@mixmark-io/domino' — a bare
+specifier that 404s in a browser with no build step. The .browser.* builds
+inline a native-DOMParser probe instead (canParseHTMLNatively) and carry no
+imports. NOTE: that probe reads root.DOMParser AT IMPORT TIME — import this
+module only in a DOM context (the offscreen document), never the SW.
+
+Modification
+------------
+None — committed byte-identical to lib/turndown.browser.es.js.
+
+SHA-256 (as committed == upstream)
+----------------------------------
+  turndown.browser.es.js  3bcd2dd53d6eb3f7a8ed2363404c8869d92cfcaae7a76dca2d556e7ec4cb1f42
+
+Subresource Integrity (SHA-384, as committed)
+---------------------------------------------
+  turndown.browser.es.js  sha384-joNqBZlR4vEHMm33ui4gI1esOUAwdIUwHYHuHRUOgViyAkfVW+gsZVcxt5vEBYN/
+
+Update procedure
+----------------
+1. curl -sL -o t.tgz https://registry.npmjs.org/turndown/-/turndown-<ver>.tgz
+2. shasum -a 256 t.tgz — record the tarball hash above.
+3. tar xzf t.tgz; copy package/lib/turndown.browser.es.js verbatim; recompute hashes.

--- a/extension/vendor/turndown/turndown.browser.es.js
+++ b/extension/vendor/turndown/turndown.browser.es.js
@@ -1,0 +1,795 @@
+function extend(destination) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i];
+    for (var key in source) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) destination[key] = source[key];
+    }
+  }
+  return destination;
+}
+function repeat(character, count) {
+  return Array(count + 1).join(character);
+}
+function trimLeadingNewlines(string) {
+  return string.replace(/^\n*/, '');
+}
+function trimTrailingNewlines(string) {
+  // avoid match-at-end regexp bottleneck, see #370
+  var indexEnd = string.length;
+  while (indexEnd > 0 && string[indexEnd - 1] === '\n') indexEnd--;
+  return string.substring(0, indexEnd);
+}
+function trimNewlines(string) {
+  return trimTrailingNewlines(trimLeadingNewlines(string));
+}
+var blockElements = ['ADDRESS', 'ARTICLE', 'ASIDE', 'AUDIO', 'BLOCKQUOTE', 'BODY', 'CANVAS', 'CENTER', 'DD', 'DIR', 'DIV', 'DL', 'DT', 'FIELDSET', 'FIGCAPTION', 'FIGURE', 'FOOTER', 'FORM', 'FRAMESET', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'HEADER', 'HGROUP', 'HR', 'HTML', 'ISINDEX', 'LI', 'MAIN', 'MENU', 'NAV', 'NOFRAMES', 'NOSCRIPT', 'OL', 'OUTPUT', 'P', 'PRE', 'SECTION', 'TABLE', 'TBODY', 'TD', 'TFOOT', 'TH', 'THEAD', 'TR', 'UL'];
+function isBlock(node) {
+  return is(node, blockElements);
+}
+var voidElements = ['AREA', 'BASE', 'BR', 'COL', 'COMMAND', 'EMBED', 'HR', 'IMG', 'INPUT', 'KEYGEN', 'LINK', 'META', 'PARAM', 'SOURCE', 'TRACK', 'WBR'];
+function isVoid(node) {
+  return is(node, voidElements);
+}
+function hasVoid(node) {
+  return has(node, voidElements);
+}
+var meaningfulWhenBlankElements = ['A', 'TABLE', 'THEAD', 'TBODY', 'TFOOT', 'TH', 'TD', 'IFRAME', 'SCRIPT', 'AUDIO', 'VIDEO'];
+function isMeaningfulWhenBlank(node) {
+  return is(node, meaningfulWhenBlankElements);
+}
+function hasMeaningfulWhenBlank(node) {
+  return has(node, meaningfulWhenBlankElements);
+}
+function is(node, tagNames) {
+  return tagNames.indexOf(node.nodeName) >= 0;
+}
+function has(node, tagNames) {
+  return node.getElementsByTagName && tagNames.some(function (tagName) {
+    return node.getElementsByTagName(tagName).length;
+  });
+}
+var markdownEscapes = [[/\\/g, '\\\\'], [/\*/g, '\\*'], [/^-/g, '\\-'], [/^\+ /g, '\\+ '], [/^(=+)/g, '\\$1'], [/^(#{1,6}) /g, '\\$1 '], [/`/g, '\\`'], [/^~~~/g, '\\~~~'], [/\[/g, '\\['], [/\]/g, '\\]'], [/^>/g, '\\>'], [/_/g, '\\_'], [/^(\d+)\. /g, '$1\\. ']];
+function escapeMarkdown(string) {
+  return markdownEscapes.reduce(function (accumulator, escape) {
+    return accumulator.replace(escape[0], escape[1]);
+  }, string);
+}
+
+var rules = {};
+rules.paragraph = {
+  filter: 'p',
+  replacement: function (content) {
+    return '\n\n' + content + '\n\n';
+  }
+};
+rules.lineBreak = {
+  filter: 'br',
+  replacement: function (content, node, options) {
+    return options.br + '\n';
+  }
+};
+rules.heading = {
+  filter: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
+  replacement: function (content, node, options) {
+    var hLevel = Number(node.nodeName.charAt(1));
+    if (options.headingStyle === 'setext' && hLevel < 3) {
+      var underline = repeat(hLevel === 1 ? '=' : '-', content.length);
+      return '\n\n' + content + '\n' + underline + '\n\n';
+    } else {
+      return '\n\n' + repeat('#', hLevel) + ' ' + content + '\n\n';
+    }
+  }
+};
+rules.blockquote = {
+  filter: 'blockquote',
+  replacement: function (content) {
+    content = trimNewlines(content).replace(/^/gm, '> ');
+    return '\n\n' + content + '\n\n';
+  }
+};
+rules.list = {
+  filter: ['ul', 'ol'],
+  replacement: function (content, node) {
+    var parent = node.parentNode;
+    if (parent.nodeName === 'LI' && parent.lastElementChild === node) {
+      return '\n' + content;
+    } else {
+      return '\n\n' + content + '\n\n';
+    }
+  }
+};
+rules.listItem = {
+  filter: 'li',
+  replacement: function (content, node, options) {
+    var prefix = options.bulletListMarker + '   ';
+    var parent = node.parentNode;
+    if (parent.nodeName === 'OL') {
+      var start = parent.getAttribute('start');
+      var index = Array.prototype.indexOf.call(parent.children, node);
+      prefix = (start ? Number(start) + index : index + 1) + '.  ';
+    }
+    var isParagraph = /\n$/.test(content);
+    content = trimNewlines(content) + (isParagraph ? '\n' : '');
+    content = content.replace(/\n/gm, '\n' + ' '.repeat(prefix.length)); // indent
+    return prefix + content + (node.nextSibling ? '\n' : '');
+  }
+};
+rules.indentedCodeBlock = {
+  filter: function (node, options) {
+    return options.codeBlockStyle === 'indented' && node.nodeName === 'PRE' && node.firstChild && node.firstChild.nodeName === 'CODE';
+  },
+  replacement: function (content, node, options) {
+    return '\n\n    ' + node.firstChild.textContent.replace(/\n/g, '\n    ') + '\n\n';
+  }
+};
+rules.fencedCodeBlock = {
+  filter: function (node, options) {
+    return options.codeBlockStyle === 'fenced' && node.nodeName === 'PRE' && node.firstChild && node.firstChild.nodeName === 'CODE';
+  },
+  replacement: function (content, node, options) {
+    var className = node.firstChild.getAttribute('class') || '';
+    var language = (className.match(/language-(\S+)/) || [null, ''])[1];
+    var code = node.firstChild.textContent;
+    var fenceChar = options.fence.charAt(0);
+    var fenceSize = 3;
+    var fenceInCodeRegex = new RegExp('^' + fenceChar + '{3,}', 'gm');
+    var match;
+    while (match = fenceInCodeRegex.exec(code)) {
+      if (match[0].length >= fenceSize) {
+        fenceSize = match[0].length + 1;
+      }
+    }
+    var fence = repeat(fenceChar, fenceSize);
+    return '\n\n' + fence + language + '\n' + code.replace(/\n$/, '') + '\n' + fence + '\n\n';
+  }
+};
+rules.horizontalRule = {
+  filter: 'hr',
+  replacement: function (content, node, options) {
+    return '\n\n' + options.hr + '\n\n';
+  }
+};
+rules.inlineLink = {
+  filter: function (node, options) {
+    return options.linkStyle === 'inlined' && node.nodeName === 'A' && node.getAttribute('href');
+  },
+  replacement: function (content, node) {
+    var href = escapeLinkDestination(node.getAttribute('href'));
+    var title = escapeLinkTitle(cleanAttribute(node.getAttribute('title')));
+    var titlePart = title ? ' "' + title + '"' : '';
+    return '[' + content + '](' + href + titlePart + ')';
+  }
+};
+rules.referenceLink = {
+  filter: function (node, options) {
+    return options.linkStyle === 'referenced' && node.nodeName === 'A' && node.getAttribute('href');
+  },
+  replacement: function (content, node, options) {
+    var href = escapeLinkDestination(node.getAttribute('href'));
+    var title = cleanAttribute(node.getAttribute('title'));
+    if (title) title = ' "' + escapeLinkTitle(title) + '"';
+    var replacement;
+    var reference;
+    switch (options.linkReferenceStyle) {
+      case 'collapsed':
+        replacement = '[' + content + '][]';
+        reference = '[' + content + ']: ' + href + title;
+        break;
+      case 'shortcut':
+        replacement = '[' + content + ']';
+        reference = '[' + content + ']: ' + href + title;
+        break;
+      default:
+        var id = this.references.length + 1;
+        replacement = '[' + content + '][' + id + ']';
+        reference = '[' + id + ']: ' + href + title;
+    }
+    this.references.push(reference);
+    return replacement;
+  },
+  references: [],
+  append: function (options) {
+    var references = '';
+    if (this.references.length) {
+      references = '\n\n' + this.references.join('\n') + '\n\n';
+      this.references = []; // Reset references
+    }
+    return references;
+  }
+};
+rules.emphasis = {
+  filter: ['em', 'i'],
+  replacement: function (content, node, options) {
+    if (!content.trim()) return '';
+    return options.emDelimiter + content + options.emDelimiter;
+  }
+};
+rules.strong = {
+  filter: ['strong', 'b'],
+  replacement: function (content, node, options) {
+    if (!content.trim()) return '';
+    return options.strongDelimiter + content + options.strongDelimiter;
+  }
+};
+rules.code = {
+  filter: function (node) {
+    var hasSiblings = node.previousSibling || node.nextSibling;
+    var isCodeBlock = node.parentNode.nodeName === 'PRE' && !hasSiblings;
+    return node.nodeName === 'CODE' && !isCodeBlock;
+  },
+  replacement: function (content) {
+    if (!content) return '';
+    content = content.replace(/\r?\n|\r/g, ' ');
+    var extraSpace = /^`|^ .*?[^ ].* $|`$/.test(content) ? ' ' : '';
+    var delimiter = '`';
+    var matches = content.match(/`+/gm) || [];
+    while (matches.indexOf(delimiter) !== -1) delimiter = delimiter + '`';
+    return delimiter + extraSpace + content + extraSpace + delimiter;
+  }
+};
+rules.image = {
+  filter: 'img',
+  replacement: function (content, node) {
+    var alt = escapeMarkdown(cleanAttribute(node.getAttribute('alt')));
+    var src = escapeLinkDestination(node.getAttribute('src') || '');
+    var title = cleanAttribute(node.getAttribute('title'));
+    var titlePart = title ? ' "' + escapeLinkTitle(title) + '"' : '';
+    return src ? '![' + alt + ']' + '(' + src + titlePart + ')' : '';
+  }
+};
+function cleanAttribute(attribute) {
+  return attribute ? attribute.replace(/(\n+\s*)+/g, '\n') : '';
+}
+function escapeLinkDestination(destination) {
+  var escaped = destination.replace(/([<>()])/g, '\\$1');
+  return escaped.indexOf(' ') >= 0 ? '<' + escaped + '>' : escaped;
+}
+function escapeLinkTitle(title) {
+  return title.replace(/"/g, '\\"');
+}
+
+/**
+ * Manages a collection of rules used to convert HTML to Markdown
+ */
+
+function Rules(options) {
+  this.options = options;
+  this._keep = [];
+  this._remove = [];
+  this.blankRule = {
+    replacement: options.blankReplacement
+  };
+  this.keepReplacement = options.keepReplacement;
+  this.defaultRule = {
+    replacement: options.defaultReplacement
+  };
+  this.array = [];
+  for (var key in options.rules) this.array.push(options.rules[key]);
+}
+Rules.prototype = {
+  add: function (key, rule) {
+    this.array.unshift(rule);
+  },
+  keep: function (filter) {
+    this._keep.unshift({
+      filter: filter,
+      replacement: this.keepReplacement
+    });
+  },
+  remove: function (filter) {
+    this._remove.unshift({
+      filter: filter,
+      replacement: function () {
+        return '';
+      }
+    });
+  },
+  forNode: function (node) {
+    if (node.isBlank) return this.blankRule;
+    var rule;
+    if (rule = findRule(this.array, node, this.options)) return rule;
+    if (rule = findRule(this._keep, node, this.options)) return rule;
+    if (rule = findRule(this._remove, node, this.options)) return rule;
+    return this.defaultRule;
+  },
+  forEach: function (fn) {
+    for (var i = 0; i < this.array.length; i++) fn(this.array[i], i);
+  }
+};
+function findRule(rules, node, options) {
+  for (var i = 0; i < rules.length; i++) {
+    var rule = rules[i];
+    if (filterValue(rule, node, options)) return rule;
+  }
+  return undefined;
+}
+function filterValue(rule, node, options) {
+  var filter = rule.filter;
+  if (typeof filter === 'string') {
+    if (filter === node.nodeName.toLowerCase()) return true;
+  } else if (Array.isArray(filter)) {
+    if (filter.indexOf(node.nodeName.toLowerCase()) > -1) return true;
+  } else if (typeof filter === 'function') {
+    if (filter.call(rule, node, options)) return true;
+  } else {
+    throw new TypeError('`filter` needs to be a string, array, or function');
+  }
+}
+
+/**
+ * The collapseWhitespace function is adapted from collapse-whitespace
+ * by Luc Thevenard.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Luc Thevenard <lucthevenard@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * collapseWhitespace(options) removes extraneous whitespace from an the given element.
+ *
+ * @param {Object} options
+ */
+function collapseWhitespace(options) {
+  var element = options.element;
+  var isBlock = options.isBlock;
+  var isVoid = options.isVoid;
+  var isPre = options.isPre || function (node) {
+    return node.nodeName === 'PRE';
+  };
+  if (!element.firstChild || isPre(element)) return;
+  var prevText = null;
+  var keepLeadingWs = false;
+  var prev = null;
+  var node = next(prev, element, isPre);
+  while (node !== element) {
+    if (node.nodeType === 3 || node.nodeType === 4) {
+      // Node.TEXT_NODE or Node.CDATA_SECTION_NODE
+      var text = node.data.replace(/[ \r\n\t]+/g, ' ');
+      if ((!prevText || / $/.test(prevText.data)) && !keepLeadingWs && text[0] === ' ') {
+        text = text.substr(1);
+      }
+
+      // `text` might be empty at this point.
+      if (!text) {
+        node = remove(node);
+        continue;
+      }
+      node.data = text;
+      prevText = node;
+    } else if (node.nodeType === 1) {
+      // Node.ELEMENT_NODE
+      if (isBlock(node) || node.nodeName === 'BR') {
+        if (prevText) {
+          prevText.data = prevText.data.replace(/ $/, '');
+        }
+        prevText = null;
+        keepLeadingWs = false;
+      } else if (isVoid(node) || isPre(node)) {
+        // Avoid trimming space around non-block, non-BR void elements and inline PRE.
+        prevText = null;
+        keepLeadingWs = true;
+      } else if (prevText) {
+        // Drop protection if set previously.
+        keepLeadingWs = false;
+      }
+    } else {
+      node = remove(node);
+      continue;
+    }
+    var nextNode = next(prev, node, isPre);
+    prev = node;
+    node = nextNode;
+  }
+  if (prevText) {
+    prevText.data = prevText.data.replace(/ $/, '');
+    if (!prevText.data) {
+      remove(prevText);
+    }
+  }
+}
+
+/**
+ * remove(node) removes the given node from the DOM and returns the
+ * next node in the sequence.
+ *
+ * @param {Node} node
+ * @return {Node} node
+ */
+function remove(node) {
+  var next = node.nextSibling || node.parentNode;
+  node.parentNode.removeChild(node);
+  return next;
+}
+
+/**
+ * next(prev, current, isPre) returns the next node in the sequence, given the
+ * current and previous nodes.
+ *
+ * @param {Node} prev
+ * @param {Node} current
+ * @param {Function} isPre
+ * @return {Node}
+ */
+function next(prev, current, isPre) {
+  if (prev && prev.parentNode === current || isPre(current)) {
+    return current.nextSibling || current.parentNode;
+  }
+  return current.firstChild || current.nextSibling || current.parentNode;
+}
+
+/*
+ * Set up window for Node.js
+ */
+
+var root = typeof window !== 'undefined' ? window : {};
+
+/*
+ * Parsing HTML strings
+ */
+
+function canParseHTMLNatively() {
+  var Parser = root.DOMParser;
+  var canParse = false;
+
+  // Adapted from https://gist.github.com/1129031
+  // Firefox/Opera/IE throw errors on unsupported types
+  try {
+    // WebKit returns null on unsupported types
+    if (new Parser().parseFromString('', 'text/html')) {
+      canParse = true;
+    }
+  } catch (e) {}
+  return canParse;
+}
+function createHTMLParser() {
+  var Parser = function () {};
+  {
+    if (shouldUseActiveX()) {
+      Parser.prototype.parseFromString = function (string) {
+        var doc = new window.ActiveXObject('htmlfile');
+        doc.designMode = 'on'; // disable on-page scripts
+        doc.open();
+        doc.write(string);
+        doc.close();
+        return doc;
+      };
+    } else {
+      Parser.prototype.parseFromString = function (string) {
+        var doc = document.implementation.createHTMLDocument('');
+        doc.open();
+        doc.write(string);
+        doc.close();
+        return doc;
+      };
+    }
+  }
+  return Parser;
+}
+function shouldUseActiveX() {
+  var useActiveX = false;
+  try {
+    document.implementation.createHTMLDocument('').open();
+  } catch (e) {
+    if (root.ActiveXObject) useActiveX = true;
+  }
+  return useActiveX;
+}
+var HTMLParser = canParseHTMLNatively() ? root.DOMParser : createHTMLParser();
+
+function RootNode(input, options) {
+  var root;
+  if (typeof input === 'string') {
+    var doc = htmlParser().parseFromString(
+    // DOM parsers arrange elements in the <head> and <body>.
+    // Wrapping in a custom element ensures elements are reliably arranged in
+    // a single element.
+    '<x-turndown id="turndown-root">' + input + '</x-turndown>', 'text/html');
+    root = doc.getElementById('turndown-root');
+  } else {
+    root = input.cloneNode(true);
+  }
+  collapseWhitespace({
+    element: root,
+    isBlock: isBlock,
+    isVoid: isVoid,
+    isPre: options.preformattedCode ? isPreOrCode : null
+  });
+  return root;
+}
+var _htmlParser;
+function htmlParser() {
+  _htmlParser = _htmlParser || new HTMLParser();
+  return _htmlParser;
+}
+function isPreOrCode(node) {
+  return node.nodeName === 'PRE' || node.nodeName === 'CODE';
+}
+
+function Node(node, options) {
+  node.isBlock = isBlock(node);
+  node.isCode = node.nodeName === 'CODE' || node.parentNode.isCode;
+  node.isBlank = isBlank(node);
+  node.flankingWhitespace = flankingWhitespace(node, options);
+  return node;
+}
+function isBlank(node) {
+  return !isVoid(node) && !isMeaningfulWhenBlank(node) && /^\s*$/i.test(node.textContent) && !hasVoid(node) && !hasMeaningfulWhenBlank(node);
+}
+function flankingWhitespace(node, options) {
+  if (node.isBlock || options.preformattedCode && node.isCode) {
+    return {
+      leading: '',
+      trailing: ''
+    };
+  }
+  var edges = edgeWhitespace(node.textContent);
+
+  // abandon leading ASCII WS if left-flanked by ASCII WS
+  if (edges.leadingAscii && isFlankedByWhitespace('left', node, options)) {
+    edges.leading = edges.leadingNonAscii;
+  }
+
+  // abandon trailing ASCII WS if right-flanked by ASCII WS
+  if (edges.trailingAscii && isFlankedByWhitespace('right', node, options)) {
+    edges.trailing = edges.trailingNonAscii;
+  }
+  return {
+    leading: edges.leading,
+    trailing: edges.trailing
+  };
+}
+function edgeWhitespace(string) {
+  var m = string.match(/^(([ \t\r\n]*)(\s*))(?:(?=\S)[\s\S]*\S)?((\s*?)([ \t\r\n]*))$/);
+  return {
+    leading: m[1],
+    // whole string for whitespace-only strings
+    leadingAscii: m[2],
+    leadingNonAscii: m[3],
+    trailing: m[4],
+    // empty for whitespace-only strings
+    trailingNonAscii: m[5],
+    trailingAscii: m[6]
+  };
+}
+function isFlankedByWhitespace(side, node, options) {
+  var sibling;
+  var regExp;
+  var isFlanked;
+  if (side === 'left') {
+    sibling = node.previousSibling;
+    regExp = / $/;
+  } else {
+    sibling = node.nextSibling;
+    regExp = /^ /;
+  }
+  if (sibling) {
+    if (sibling.nodeType === 3) {
+      isFlanked = regExp.test(sibling.nodeValue);
+    } else if (options.preformattedCode && sibling.nodeName === 'CODE') {
+      isFlanked = false;
+    } else if (sibling.nodeType === 1 && !isBlock(sibling)) {
+      isFlanked = regExp.test(sibling.textContent);
+    }
+  }
+  return isFlanked;
+}
+
+var reduce = Array.prototype.reduce;
+function TurndownService(options) {
+  if (!(this instanceof TurndownService)) return new TurndownService(options);
+  var defaults = {
+    rules: rules,
+    headingStyle: 'setext',
+    hr: '* * *',
+    bulletListMarker: '*',
+    codeBlockStyle: 'indented',
+    fence: '```',
+    emDelimiter: '_',
+    strongDelimiter: '**',
+    linkStyle: 'inlined',
+    linkReferenceStyle: 'full',
+    br: '  ',
+    preformattedCode: false,
+    blankReplacement: function (content, node) {
+      return node.isBlock ? '\n\n' : '';
+    },
+    keepReplacement: function (content, node) {
+      return node.isBlock ? '\n\n' + node.outerHTML + '\n\n' : node.outerHTML;
+    },
+    defaultReplacement: function (content, node) {
+      return node.isBlock ? '\n\n' + content + '\n\n' : content;
+    }
+  };
+  this.options = extend({}, defaults, options);
+  this.rules = new Rules(this.options);
+}
+TurndownService.prototype = {
+  /**
+   * The entry point for converting a string or DOM node to Markdown
+   * @public
+   * @param {String|HTMLElement} input The string or DOM node to convert
+   * @returns A Markdown representation of the input
+   * @type String
+   */
+
+  turndown: function (input) {
+    if (!canConvert(input)) {
+      throw new TypeError(input + ' is not a string, or an element/document/fragment node.');
+    }
+    if (input === '') return '';
+    var output = process.call(this, new RootNode(input, this.options));
+    return postProcess.call(this, output);
+  },
+  /**
+   * Add one or more plugins
+   * @public
+   * @param {Function|Array} plugin The plugin or array of plugins to add
+   * @returns The Turndown instance for chaining
+   * @type Object
+   */
+
+  use: function (plugin) {
+    if (Array.isArray(plugin)) {
+      for (var i = 0; i < plugin.length; i++) this.use(plugin[i]);
+    } else if (typeof plugin === 'function') {
+      plugin(this);
+    } else {
+      throw new TypeError('plugin must be a Function or an Array of Functions');
+    }
+    return this;
+  },
+  /**
+   * Adds a rule
+   * @public
+   * @param {String} key The unique key of the rule
+   * @param {Object} rule The rule
+   * @returns The Turndown instance for chaining
+   * @type Object
+   */
+
+  addRule: function (key, rule) {
+    this.rules.add(key, rule);
+    return this;
+  },
+  /**
+   * Keep a node (as HTML) that matches the filter
+   * @public
+   * @param {String|Array|Function} filter The unique key of the rule
+   * @returns The Turndown instance for chaining
+   * @type Object
+   */
+
+  keep: function (filter) {
+    this.rules.keep(filter);
+    return this;
+  },
+  /**
+   * Remove a node that matches the filter
+   * @public
+   * @param {String|Array|Function} filter The unique key of the rule
+   * @returns The Turndown instance for chaining
+   * @type Object
+   */
+
+  remove: function (filter) {
+    this.rules.remove(filter);
+    return this;
+  },
+  /**
+   * Escapes Markdown syntax
+   * @public
+   * @param {String} string The string to escape
+   * @returns A string with Markdown syntax escaped
+   * @type String
+   */
+
+  escape: function (string) {
+    return escapeMarkdown(string);
+  }
+};
+
+/**
+ * Reduces a DOM node down to its Markdown string equivalent
+ * @private
+ * @param {HTMLElement} parentNode The node to convert
+ * @returns A Markdown representation of the node
+ * @type String
+ */
+
+function process(parentNode) {
+  var self = this;
+  return reduce.call(parentNode.childNodes, function (output, node) {
+    node = new Node(node, self.options);
+    var replacement = '';
+    if (node.nodeType === 3) {
+      replacement = node.isCode ? node.nodeValue : self.escape(node.nodeValue);
+    } else if (node.nodeType === 1) {
+      replacement = replacementForNode.call(self, node);
+    }
+    return join(output, replacement);
+  }, '');
+}
+
+/**
+ * Appends strings as each rule requires and trims the output
+ * @private
+ * @param {String} output The conversion output
+ * @returns A trimmed version of the ouput
+ * @type String
+ */
+
+function postProcess(output) {
+  var self = this;
+  this.rules.forEach(function (rule) {
+    if (typeof rule.append === 'function') {
+      output = join(output, rule.append(self.options));
+    }
+  });
+  return output.replace(/^[\t\r\n]+/, '').replace(/[\t\r\n\s]+$/, '');
+}
+
+/**
+ * Converts an element node to its Markdown equivalent
+ * @private
+ * @param {HTMLElement} node The node to convert
+ * @returns A Markdown representation of the node
+ * @type String
+ */
+
+function replacementForNode(node) {
+  var rule = this.rules.forNode(node);
+  var content = process.call(this, node);
+  var whitespace = node.flankingWhitespace;
+  if (whitespace.leading || whitespace.trailing) content = content.trim();
+  return whitespace.leading + rule.replacement(content, node, this.options) + whitespace.trailing;
+}
+
+/**
+ * Joins replacement to the current output with appropriate number of new lines
+ * @private
+ * @param {String} output The current conversion output
+ * @param {String} replacement The string to append to the output
+ * @returns Joined output
+ * @type String
+ */
+
+function join(output, replacement) {
+  var s1 = trimTrailingNewlines(output);
+  var s2 = trimLeadingNewlines(replacement);
+  var nls = Math.max(output.length - s1.length, replacement.length - s2.length);
+  var separator = '\n\n'.substring(0, nls);
+  return s1 + separator + s2;
+}
+
+/**
+ * Determines whether an input can be converted
+ * @private
+ * @param {String|HTMLElement} input Describe this parameter
+ * @returns Describe what it returns
+ * @type String|Object|Array|Boolean|Number
+ */
+
+function canConvert(input) {
+  return input != null && (typeof input === 'string' || input.nodeType && (input.nodeType === 1 || input.nodeType === 9 || input.nodeType === 11));
+}
+
+export { TurndownService as default };

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -76,7 +76,10 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // 498 → 499: standing peer conversations add subagent/conversation-registry.js
 // (the pure convId → turns thread store).
 // 499 → 500: the OpenAI provider adapter adds peerd-provider/adapters/openai.js.
-const COVERED_FLOOR = 501;
+// 501 → 505: the fetch_url content pipeline adds offscreen/web-extract.js,
+// background/offscreen-web-client.js, tools/web/spill.js, and
+// tools/defs/read-web-cache.js (vendor/ is exempt from the scan).
+const COVERED_FLOOR = 505;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/scripts/cdp/diagnose-actor-spend.mjs
+++ b/scripts/cdp/diagnose-actor-spend.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env bun
+// scripts/cdp/diagnose-actor-spend.mjs — $0 proof that a delegated (web-actor)
+// task's spend reaches the eval scorecard's ACTOR bucket.
+//
+// why this exists: the fetch-suite measurement was blind twice for the same
+// class of reason — the actor's activity/cost events never reached the eval
+// page (first the async ack-scoring, then turn/actor-cost carrying only USD).
+// This probe drives ONE delegated task with a wire-fake model (the fake SSE
+// carries usage: prompt 1 / completion 2 per call) and asserts the scorecard's
+// runner (ACTOR) tokens are non-zero. No key, no cost, ~30s.
+//
+// Run: bun scripts/cdp/diagnose-actor-spend.mjs   (exit 0 = proven)
+
+import { launchPeerd, openExtPage, rpc, evalIn, waitFor, log, PASSPHRASE, sseText, sseToolCall } from './e2e-harness.mjs';
+
+let orchDelegated = false;
+let actorTurn = 0;
+const modelResponder = (_i, request) => {
+  const body = (request && request.postData) || '';
+  if (body.includes('<actor_agent>')) {
+    const t = actorTurn++;
+    if (t === 0) return { sse: sseToolCall('navigate', { url: 'https://example.com/' }) };
+    return { sse: sseText('The page says it is for use in illustrative examples in documents.') };
+  }
+  if (!orchDelegated) { orchDelegated = true; return { sse: sseToolCall('message_actor', { to: 'web', message: 'fetch example.com and report what the domain is for' }) }; }
+  return { sse: sseText('The domain is for use in illustrative examples in documents.') };
+};
+
+const ctx = await launchPeerd({ modelResponder });
+try {
+  const vault = await rpc(ctx.page, { type: 'vault/initialize', passphrase: PASSPHRASE });
+  if (!vault?.ok) throw new Error(`vault/initialize failed: ${JSON.stringify(vault)}`);
+  await rpc(ctx.page, { type: 'onboarding/complete', peerName: 'peerd', facts: null });
+  await rpc(ctx.page, { type: 'settings/update', patch: { providerName: 'ollama' } });
+
+  const evalPage = await openExtPage(ctx, 'eval/runner.html');
+  if (!await waitFor(() => evalIn(evalPage, `!!(window.__peerdEval && window.__peerdEval.ready)`), { budgetMs: 30_000 })) {
+    throw new Error('eval/runner.html never exposed __peerdEval');
+  }
+  // One delegated task from the fetch suite; the wire fake stands in for the
+  // model, so only the DELEGATION MACHINERY (and its cost events) is under test.
+  await evalIn(evalPage, `(() => { window.__peerdEval.run({ suite: 'fetch', taskIds: ['fetch-nonarticle-fallback'] }); return true; })()`);
+  const card = await waitFor(async () => {
+    const err = await evalIn(evalPage, `window.__peerdEval.lastError`);
+    if (err) throw new Error(`in-page: ${err}`);
+    return evalIn(evalPage, `window.__peerdEval.lastCard`);
+  }, { budgetMs: 120_000, pollMs: 2_000 });
+  if (!card) throw new Error('no scorecard within budget');
+
+  log(`avgRunnerTokens=${card.avgRunnerTokens}  avgRunnerCostUsd=${card.avgRunnerCostUsd}  passRate=${card.passRate}%`);
+  if (!(card.avgRunnerTokens > 0)) {
+    log('✗ ACTOR bucket is EMPTY — the actor\'s spend never reached the eval page.');
+    ctx.close();
+    process.exit(1);
+  }
+  log('✓ ACTOR spend reaches the scorecard — the fetch-suite measurement can see delegated work.');
+  ctx.close();
+  process.exit(0);
+} catch (e) {
+  console.error('[diagnose-actor-spend]', e?.message || e);
+  try { ctx.close(); } catch { /* */ }
+  process.exit(1);
+}

--- a/scripts/cdp/run-eval-bench.mjs
+++ b/scripts/cdp/run-eval-bench.mjs
@@ -173,13 +173,17 @@ async function main() {
 function printCard(card) {
   log('=== SCORECARD ===');
   log(`passRate ${card.passRate}% (${card.passed}/${card.total})  ·  avg ${card.avgSteps} steps  ·  MAIN ${card.avgFreshTokens} fresh + ${card.avgCacheReadTokens} cache  ·  $${card.avgCostUsd}/task  ·  ${(card.avgDurationMs / 1000).toFixed(1)}s`);
+  // The ACTOR's spend — where delegated web work (fetch_url bodies, page reads)
+  // actually lands. THE number a content-pipeline change moves; the MAIN
+  // buckets above barely see it.
+  log(`ACTOR ${card.avgRunnerTokens} tok/task ($${card.avgRunnerCostUsd}/task)`);
   if (card.failures?.length) log(`failures (${card.failures.length}): ${card.failures.map((f) => f.id).join(', ')}`);
 }
 
 function printDelta(d) {
   log('=== Δ vs baseline ===');
   const s = (n) => (n >= 0 ? `+${n}` : `${n}`);
-  log(`passRate ${s(d.passRateDelta)}%  ·  fresh ${s(d.freshTokensDelta)} tok  ·  $/task ${s(d.costUsdDelta)}  ·  steps ${s(d.stepsDelta)}`);
+  log(`passRate ${s(d.passRateDelta)}%  ·  fresh ${s(d.freshTokensDelta)} tok  ·  ACTOR ${s(d.runnerTokensDelta)} tok  ·  $/task ${s(d.costUsdDelta)}  ·  steps ${s(d.stepsDelta)}`);
   if (d.regressions.length) log(`⚠ REGRESSIONS (${d.regressions.length}): ${d.regressions.join(', ')}`);
   else log(`✓ no regressions${d.fixes.length ? `  ·  fixed: ${d.fixes.join(', ')}` : ''}`);
 }

--- a/tests/peerd-provider/to-anthropic.test.ts
+++ b/tests/peerd-provider/to-anthropic.test.ts
@@ -97,12 +97,28 @@ describe('toAnthropicBody — output ceiling + effort', () => {
     expect(body.max_tokens).toBe(2000);
   });
 
-  test('reasoning.effort passes through as output_config.effort', () => {
+  test('reasoning.effort passes through as output_config.effort (adaptive models)', () => {
     const body = toAnthropicBody({
       model: 'claude-opus-4-8', system: 's', messages: [userMsg('hi')],
       reasoning: { enabled: true, effort: 'medium' },
     });
     expect(body.output_config).toEqual({ effort: 'medium' });
+  });
+
+  test('effort is OMITTED on pre-4.6 models — they 400 on output_config.effort', () => {
+    // Regression: peerd sent output_config.effort to EVERY model, and Haiku 4.5
+    // (pre-4.6) rejects it ("This model does not support the effort parameter"),
+    // which failed every request with the default reasoningEffort='medium'. The
+    // effort knob rides ONLY the adaptive shape (usesAdaptiveThinking).
+    for (const model of ['claude-haiku-4-5', 'claude-haiku-4-5-20251001', 'claude-sonnet-4-5', 'claude-3-5-sonnet']) {
+      const body = toAnthropicBody({
+        model, system: 's', messages: [userMsg('hi')],
+        reasoning: { enabled: true, effort: 'medium' },
+      });
+      expect('output_config' in body).toBe(false);
+      // ...and it still gets the legacy enabled+budget thinking shape.
+      expect(body.thinking).toEqual({ type: 'enabled', budget_tokens: 2048 });
+    }
   });
 
   test('no output_config when effort is absent (platform default = high)', () => {

--- a/tests/peerd-runtime/exposure.test.ts
+++ b/tests/peerd-runtime/exposure.test.ts
@@ -281,18 +281,23 @@ describe('DESIGN-17 web actor — the fourth kind (DOM toolset + tab pin)', () =
     // call_api stays OUT — the web actor's open-web read is fetch_url (sessionless),
     // not the credential-capable call_api.
     expect(isAllowedForActorType('call_api', 'web')).toBe(false);
-    // == DOM toolset + the one fetch_url addition (drift: bump if the set grows).
-    expect(actorAllowedTools('web').size).toBe(WEB_ACTOR_DOM_TOOLS.length + 1);
+    // == DOM toolset + fetch_url + read_web_cache (drift: bump if the set grows).
+    expect(actorAllowedTools('web').size).toBe(WEB_ACTOR_DOM_TOOLS.length + 2);
+    // read_web_cache pages a spilled fetch_url body — same tier as the fetch.
+    expect(isAllowedForActorType('read_web_cache', 'web')).toBe(true);
+    expect(isAllowedForActorType('read_web_cache', 'app')).toBe(false);
   });
 
   test('DESIGN-18: an API backing (web actor, no tab) is fetch_url-ONLY', () => {
     // fetch_url is in; the whole DOM toolset is OUT (it needs a tab the API actor
     // never has). The gate refuses a DOM tool for backing:'api' at the gate.
     expect(isAllowedForActor('fetch_url', 'web', 'api')).toBe(true);
+    // ...and its paging read side — an API actor that overflows must page too.
+    expect(isAllowedForActor('read_web_cache', 'web', 'api')).toBe(true);
     for (const n of ['click', 'type', 'navigate', 'snapshot', 'read_page', 'query_dom', 'read_pdf']) {
       expect(isAllowedForActor(n, 'web', 'api')).toBe(false);
     }
-    expect(actorAllowedToolsFor('web', 'api').size).toBe(1);   // fetch_url only
+    expect(actorAllowedToolsFor('web', 'api').size).toBe(2);   // fetch_url + read_web_cache
     // A tab backing (and an absent backing — the DESIGN-17 default) keeps the FULL set.
     expect(isAllowedForActor('click', 'web', 'tab')).toBe(true);
     expect(isAllowedForActor('click', 'web', undefined)).toBe(true);

--- a/tests/peerd-runtime/tools/fetch-url.test.ts
+++ b/tests/peerd-runtime/tools/fetch-url.test.ts
@@ -123,3 +123,129 @@ describe('fetch_url — sessionless secure fetch', () => {
     expect(r.error).toMatch(/redirect/i);
   });
 });
+
+// --- the content pipeline: HTML→markdown extraction + spill-and-page ---------
+// The extraction is FAIL-OPEN (a non-article page, a missing client, or an
+// extraction error all keep the raw behavior); the spill turns the old silent
+// head-only slice into a windowed body + a trusted paging footer OUTSIDE the
+// fence.
+
+const HTML_HEADERS = { 'content-type': 'text/html; charset=utf-8' };
+const htmlCtx = (over: any = {}) => recordingCtx({
+  webFetch: async () => mockResponse({ body: '<html><body><p>raw page</p></body></html>', headers: HTML_HEADERS, url: 'https://site.example/a' }),
+  ...over,
+}).ctx;
+
+describe('fetch_url — markdown extraction (fail-open)', () => {
+  test('an HTML response routes through the extraction client and comes back as markdown', async () => {
+    const ctx = htmlCtx({
+      webOffscreenClient: {
+        extractMarkdown: async ({ html, url }: any) => {
+          expect(html).toContain('raw page');
+          expect(url).toBe('https://site.example/a');
+          return { readerable: true, markdown: '# Title\n\nclean body', title: 'Title', htmlTruncated: false };
+        },
+      },
+    });
+    const r = await fetchUrlTool.execute({ url: 'https://site.example/a' }, ctx);
+    if (!r.ok) throw new Error('expected ok');
+    const body = unwrap(r.content!);
+    expect(body.format).toBe('markdown');
+    expect(body.title).toBe('Title');
+    expect(body.body).toContain('clean body');
+  });
+
+  test('raw:true bypasses extraction entirely', async () => {
+    let called = false;
+    const ctx = htmlCtx({ webOffscreenClient: { extractMarkdown: async () => { called = true; return { readerable: true, markdown: 'x' }; } } });
+    const r = await fetchUrlTool.execute({ url: 'https://site.example/a', raw: true }, ctx);
+    if (!r.ok) throw new Error('expected ok');
+    expect(called).toBe(false);
+    expect(unwrap(r.content!).format).toBe('raw');
+  });
+
+  test('a non-readerable page and an extraction error both fall back to raw', async () => {
+    for (const client of [
+      { extractMarkdown: async () => ({ readerable: false, htmlTruncated: false }) },
+      { extractMarkdown: async () => { throw new Error('boom'); } },
+    ]) {
+      const r = await fetchUrlTool.execute({ url: 'https://site.example/a' }, htmlCtx({ webOffscreenClient: client }));
+      if (!r.ok) throw new Error('expected ok');
+      const body = unwrap(r.content!);
+      expect(body.format).toBe('raw');
+      expect(body.body).toContain('raw page');
+    }
+  });
+
+  test('a missing client (Firefox: no offscreen doc) keeps the raw behavior', async () => {
+    const r = await fetchUrlTool.execute({ url: 'https://site.example/a' }, htmlCtx());
+    if (!r.ok) throw new Error('expected ok');
+    expect(unwrap(r.content!).format).toBe('raw');
+  });
+
+  test('non-HTML content types never touch the extraction client', async () => {
+    let called = false;
+    const { ctx } = recordingCtx({
+      webFetch: async () => mockResponse({ body: '{"a":1}', headers: { 'content-type': 'application/json' }, url: 'https://api.example/x' }),
+      webOffscreenClient: { extractMarkdown: async () => { called = true; return { readerable: true, markdown: 'x' }; } },
+    });
+    const r = await fetchUrlTool.execute({ url: 'https://api.example/x' }, ctx);
+    if (!r.ok) throw new Error('expected ok');
+    expect(called).toBe(false);
+    expect(unwrap(r.content!).json).toEqual({ a: 1 });
+  });
+});
+
+describe('fetch_url — spill-and-page for an oversized body', () => {
+  const BIG = 'H'.repeat(15_000) + 'M'.repeat(30_000) + 'T'.repeat(15_000);   // 60k chars
+
+  test('spills the full text, shows head+tail, and appends the paging footer OUTSIDE the fence', async () => {
+    const stored: any[] = [];
+    const { ctx } = recordingCtx({
+      webFetch: async () => mockResponse({ body: BIG, headers: { 'content-type': 'text/plain' }, url: 'https://site.example/big' }),
+      webCache: { key: () => 'wc-test-1', put: async (rec: any) => { stored.push(rec); } },
+    });
+    const r = await fetchUrlTool.execute({ url: 'https://site.example/big' }, ctx);
+    if (!r.ok) throw new Error('expected ok');
+    // The FULL text was spilled.
+    expect(stored).toHaveLength(1);
+    expect(stored[0].key).toBe('wc-test-1');
+    expect(stored[0].text.length).toBe(60_000);
+    // The fenced body is the head+tail window with the elision marker.
+    const afterFence = r.content!.split('</untrusted_web_content>')[1];
+    expect(afterFence).toContain('read_web_cache');
+    expect(afterFence).toContain('"key": "wc-test-1"');
+    // unwrap() anchors the close tag at $ — with a footer after the fence,
+    // parse the fenced JSON by splitting at the tags instead.
+    const body = JSON.parse(r.content!.split(/<untrusted_web_content [^>]*>\n/)[1].split('\n</untrusted_web_content>')[0]);
+    expect(body.truncated).toBe(true);
+    expect(body.body).toContain('characters elided');
+    expect(body.body.startsWith('H'.repeat(100))).toBe(true);
+    expect(body.body.endsWith('T'.repeat(100))).toBe(true);
+  });
+
+  test('no webCache capability → the pre-spill head-only slice, no footer', async () => {
+    const { ctx } = recordingCtx({
+      webFetch: async () => mockResponse({ body: BIG, headers: { 'content-type': 'text/plain' }, url: 'https://site.example/big' }),
+    });
+    const r = await fetchUrlTool.execute({ url: 'https://site.example/big' }, ctx);
+    if (!r.ok) throw new Error('expected ok');
+    expect(r.content).not.toContain('read_web_cache');
+    const body = unwrap(r.content!);
+    expect(body.truncated).toBe(true);
+    expect(body.body.length).toBe(16_000);
+    expect(body.body.endsWith('M'.repeat(100))).toBe(true);   // head-only: ends mid-middle
+  });
+
+  test('a small body is untouched: no spill, no footer, truncated:false', async () => {
+    const stored: any[] = [];
+    const { ctx } = recordingCtx({
+      webCache: { key: () => 'wc-x', put: async (rec: any) => { stored.push(rec); } },
+    });
+    const r = await fetchUrlTool.execute({ url: 'https://x.com/' }, ctx);
+    if (!r.ok) throw new Error('expected ok');
+    expect(stored).toHaveLength(0);
+    expect(r.content).not.toContain('[paging]');
+    expect(unwrap(r.content!).truncated).toBe(false);
+  });
+});

--- a/tests/peerd-runtime/tools/read-web-cache.test.ts
+++ b/tests/peerd-runtime/tools/read-web-cache.test.ts
@@ -1,0 +1,62 @@
+// read_web_cache — the paging read side of fetch_url's spill. The invariants:
+// the slice comes back FENCED (it is fetched page content), the paging status
+// is tool-authored and rides OUTSIDE the fence, bounds are clamped, and a
+// missing capability / evicted key fails closed with an actionable error.
+
+import { describe, test, expect } from 'bun:test';
+import { readWebCacheTool } from '../../../extension/peerd-runtime/tools/defs/read-web-cache.js';
+
+const TAG_OPEN = /<untrusted_web_content origin="[^"]*" tool="([^"]*)" retrieved_at="[^"]*">\n/;
+const TAG_CLOSE = /\n<\/untrusted_web_content>/;
+const unwrap = (content: string) => {
+  expect(content).toMatch(TAG_OPEN);
+  expect(content).toMatch(TAG_CLOSE);
+  const inner = content.split(TAG_OPEN).pop()!.split(TAG_CLOSE)[0];
+  return JSON.parse(inner);
+};
+
+const ctxWith = (records: Record<string, any>) => ({
+  webCache: { get: async (key: string) => records[key] },
+});
+
+describe('read_web_cache', () => {
+  const REC = { key: 'wc-1', url: 'https://site.example/article', format: 'markdown', text: 'x'.repeat(100) };
+
+  test('slices the stored text, fenced, with the paging status OUTSIDE the fence', async () => {
+    const r = await readWebCacheTool.execute({ key: 'wc-1', offset: 10, limit: 20 }, ctxWith({ 'wc-1': REC }) as any);
+    expect(r.ok).toBe(true);
+    if (!r.ok) throw new Error('expected ok');
+    const body = unwrap(r.content!);
+    expect(body.body).toBe('x'.repeat(20));
+    expect(body).toMatchObject({ key: 'wc-1', offset: 10, end: 30, total: 100, format: 'markdown' });
+    // The tool-authored status is AFTER the close tag — outside the fence.
+    const afterFence = r.content!.split('</untrusted_web_content>')[1];
+    expect(afterFence).toContain('[paging]');
+    expect(afterFence).toContain('"offset": 30');   // the next-call hint continues where this slice ended
+  });
+
+  test('the final slice says end-of-text instead of a next-call hint', async () => {
+    const r = await readWebCacheTool.execute({ key: 'wc-1', offset: 90, limit: 50 }, ctxWith({ 'wc-1': REC }) as any);
+    if (!r.ok) throw new Error('expected ok');
+    const afterFence = r.content!.split('</untrusted_web_content>')[1];
+    expect(afterFence).toContain('end of stored text');
+    expect(afterFence).not.toContain('next:');
+  });
+
+  test('caps the limit at 16k even when asked for more', async () => {
+    const big = { key: 'wc-2', text: 'y'.repeat(40_000) };
+    const r = await readWebCacheTool.execute({ key: 'wc-2', limit: 999_999 }, ctxWith({ 'wc-2': big }) as any);
+    if (!r.ok) throw new Error('expected ok');
+    expect(unwrap(r.content!).body.length).toBe(16_000);
+  });
+
+  test('fails closed: missing key, evicted entry, absent capability', async () => {
+    expect((await readWebCacheTool.execute({}, ctxWith({}) as any)).ok).toBe(false);
+    const gone = await readWebCacheTool.execute({ key: 'wc-gone' }, ctxWith({}) as any);
+    expect(gone.ok).toBe(false);
+    if (!gone.ok) expect(gone.error).toContain('re-fetch');
+    const noCap = await readWebCacheTool.execute({ key: 'wc-1' }, {} as any);
+    expect(noCap.ok).toBe(false);
+    if (!noCap.ok) expect(noCap.error).toBe('web_cache_unavailable');
+  });
+});

--- a/tests/peerd-runtime/tools/web-spill.test.ts
+++ b/tests/peerd-runtime/tools/web-spill.test.ts
@@ -1,0 +1,57 @@
+// The spill-and-page pure core (tools/web/spill.js): head+tail windowing for an
+// oversized fetched body, the trusted paging footer, and the offset/limit
+// slicer read_web_cache serves. Pure functions — the invariants that keep the
+// paging contract honest live here.
+
+import { describe, test, expect } from 'bun:test';
+import { windowText, pagingFooter, pageSlice } from '../../../extension/peerd-runtime/tools/web/spill.js';
+
+describe('windowText', () => {
+  test('text at or under the budget passes through whole', () => {
+    const r = windowText('short body', 100);
+    expect(r.windowed).toBe(false);
+    expect(r.window).toBe('short body');
+    expect(r.total).toBe(10);
+  });
+
+  test('oversized text becomes head(75%) + elision marker + tail(25%)', () => {
+    const text = 'H'.repeat(500) + 'M'.repeat(500) + 'T'.repeat(500);
+    const r = windowText(text, 400);
+    expect(r.windowed).toBe(true);
+    expect(r.headChars).toBe(300);
+    expect(r.tailChars).toBe(100);
+    expect(r.window.startsWith('H'.repeat(300))).toBe(true);
+    expect(r.window.endsWith('T'.repeat(100))).toBe(true);
+    // The marker names HOW MUCH was elided — the model must see content is missing.
+    expect(r.window).toContain(`${1500 - 400} characters elided`);
+    expect(r.total).toBe(1500);
+  });
+});
+
+describe('pagingFooter', () => {
+  test('names the exact read_web_cache call with the caller-computed values only', () => {
+    const f = pagingFooter({ key: 'wc-abc-1', total: 90_000, headChars: 12_000, tailChars: 4_000 });
+    expect(f).toContain('read_web_cache');
+    expect(f).toContain('"key": "wc-abc-1"');
+    expect(f).toContain('90000 chars');
+    // The continuation offset the model should use = where the head stopped.
+    expect(f).toContain('offset 12000');
+  });
+});
+
+describe('pageSlice', () => {
+  const text = 'abcdefghij';   // 10 chars
+
+  test('slices offset/limit and reports what remains', () => {
+    const r = pageSlice(text, 2, 3);
+    expect(r.slice).toBe('cde');
+    expect(r).toMatchObject({ offset: 2, end: 5, total: 10, remaining: 5 });
+  });
+
+  test('clamps out-of-range offsets and limits instead of throwing', () => {
+    expect(pageSlice(text, -5, 3).slice).toBe('abc');        // negative offset → 0
+    expect(pageSlice(text, 8, 100).slice).toBe('ij');        // limit past the end → to end
+    expect(pageSlice(text, 99, 3)).toMatchObject({ slice: '', remaining: 0 });  // offset past end
+    expect(pageSlice(text, 0, 0).slice).toBe('a');           // degenerate limit → at least 1 char
+  });
+});


### PR DESCRIPTION
## What

The web thread's next lever after the OM2W baseline (26.7%, failure taxonomy dominated by budget exhaustion): make every `fetch_url` byte count.

1. **HTML → clean markdown by default** (`raw:true` opts out). Vendored Readability 0.6.0 + Turndown 7.2.4 (pinned, hashed, SOURCE.txt each) running in the **offscreen document** (the SW has no DOMParser), mirroring the pdf-extract pattern end to end. Fail-open: a non-article page (`isProbablyReaderable` pre-check), a missing client (Firefox), or an extraction error all keep today's raw behavior. Client-side extraction is the BYOK/no-backend substitute for the hosted clean-content APIs other agents use — no third party sees the URL.
2. **Spill-and-page for oversized bodies.** The old silent head-only 16k slice lost the tail without saying so. Now the full text spills to a new `web_extract_cache` IDB store (v11; vm_http_cache posture) and the model sees a head(75%)+tail(25%) window with an elision marker plus a footer naming the exact `read_web_cache {key, offset, limit}` call. New `read_web_cache` tool, same exposure tier as `fetch_url` (web actor only).
3. **Measurement infra first** (separate commit, so the before-baseline is capturable): a 5-task `fetch` eval suite + `avgRunnerTokens` (the actor's spend — where fetched bytes land) surfaced on the bench stdout and baseline delta.

## Security posture

- Extraction adds **zero authority**: same fetch, same egress chain; the transform runs on already-fetched bytes.
- The paging footer is **tool-authored** (caller-computed values only, never fetched bytes) and rides **outside** the `<untrusted_web_content>` fence — page content cannot forge or suppress it. Cached text re-enters fenced on every read.
- `ctx.webCache` is stripped to exactly `fetch_url` + `read_web_cache` (spawn.js CAPABILITY_CONSUMERS).
- **Owner sign-off wanted**: spilled page text persists unencrypted in extension-scoped IDB (the existing vm_http_cache posture — fetched public bytes, newest-40 eviction, safe to clear). Flag if you want TTL or session scoping instead.

## Measurement plan (next)

```
# BEFORE (on the eval-infra commit), then AFTER (on HEAD):
PEERD_BENCH_KEY=... bun run eval:bench --provider=anthropic --model=claude-haiku-4-5 --suite=fetch
PEERD_BENCH_KEY=... bun run eval:bench --provider=anthropic --model=claude-haiku-4-5 --suite=fetch --baseline=<before.json>
```
Read `ACTOR tok/task` + the baseline delta. Target: the ~3-5x token cut on article pages, pass-rate flat.

Gates: 2738 bun tests, strict typecheck, eslint, tscheck floor 505/505, no gen drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)