### PR TITLE
read_page mode:'content' — rendered pages through the extraction pipeline

### DIFF
--- a/extension/peerd-runtime/actor/spawn.js
+++ b/extension/peerd-runtime/actor/spawn.js
@@ -126,7 +126,7 @@ export const CAPABILITY_CONSUMERS = Object.freeze({
   getSecret:          [],
   safeFetch:          [],
   webFetch:           ['vm_import', 'fetch_url'],
-  webCache:           ['fetch_url', 'read_web_cache'],
+  webCache:           ['fetch_url', 'read_web_cache', 'read_page'],
   memory:             ['read_memory', 'remember'],
   kv:                 ['inspect'],
   idb:                ['inspect'],

--- a/extension/peerd-runtime/tools/defs/read-page.js
+++ b/extension/peerd-runtime/tools/defs/read-page.js
@@ -14,18 +14,24 @@
 
 import { wrapUntrusted } from '../prompt-wrap.js';
 import { resolveTargetTab, originOfUrl } from './dom-helpers.js';
+import { windowText, pagingFooter } from '../web/spill.js';
+
+// Content mode shares fetch_url's body budget — one read costs like one fetch.
+const CONTENT_BODY_CHARS = 16_000;
 
 /** @type {import('/shared/tool-types.js').Tool} */
 export const readPageTool = {
   name: 'read_page',
   primitive: 'tab',
   description: [
-    'Read the DOM of a tab. Returns title, URL, visible body text',
+    'Read the DOM of a tab. Default mode returns title, URL, visible body text',
     '(truncated to ~4000 chars), and a list of interactable elements',
     '(inputs, buttons, links) with CSS selectors you can pass to click()',
-    'and type(). By default reads the active tab. The text cap is',
-    'conservative — if you need to see more, call read_page again after',
-    'scrolling or navigating to a more focused page.',
+    "and type(). mode:'content' instead extracts the page's READABLE CORE as",
+    'markdown (boilerplate stripped, capped 16k, with paging for the overflow) —',
+    'far denser for articles/docs/reference pages you are READING rather than',
+    'operating; it returns no interactables, so use the default when you need',
+    'to act on the page. By default reads the active tab.',
   ].join(' '),
   schema: {
     type: 'object',
@@ -33,6 +39,11 @@ export const readPageTool = {
       tabId: {
         type: 'integer',
         description: 'Optional tab id; defaults to the active tab.',
+      },
+      mode: {
+        type: 'string',
+        enum: ['snapshot', 'content'],
+        description: "snapshot (default): text + interactables for OPERATING the page. content: the readable core as markdown for READING it.",
       },
     },
   },
@@ -46,6 +57,54 @@ export const readPageTool = {
     // why: ToolContext types `scripting` as the opaque chrome.scripting slot;
     // narrow it to the typed API surface for the executeScript call.
     const scripting = /** @type {typeof chrome.scripting} */ (ctx.scripting);
+
+    // mode:'content' — the RENDERED page's readable core as markdown. Grabs the
+    // live DOM's outerHTML (post-JS, unlike fetch_url which sees served bytes)
+    // and routes it through the SAME offscreen Readability+Turndown extractor
+    // and the SAME spill-and-page machinery fetch_url uses. FAIL-OPEN: a
+    // non-readerable page, a missing extractor (Firefox), or an extraction
+    // error all fall through to the default snapshot below — content mode is
+    // an optimization, never a gate on reading the page.
+    if (args?.mode === 'content') {
+      const webClient = /** @type {{ extractMarkdown?: (s: { html: string, url?: string }) => Promise<{ readerable: boolean, markdown?: string, title?: string | null }> } | undefined} */ (
+        /** @type {any} */ (ctx).webOffscreenClient);
+      if (webClient?.extractMarkdown) {
+        try {
+          const grabbed = (await scripting.executeScript({ target: { tabId: tab.id }, func: readOuterHtmlInjected }))[0]?.result;
+          if (grabbed?.html) {
+            const ex = await webClient.extractMarkdown({ html: grabbed.html, url: grabbed.url || tab.url });
+            if (ex.readerable && typeof ex.markdown === 'string' && ex.markdown.trim()) {
+              const origin = originOfUrl(grabbed.url || tab.url);
+              const webCache = /** @type {{ key?: () => string, put?: (r: object) => Promise<void> } | undefined} */ (
+                /** @type {any} */ (ctx).webCache);
+              const win = windowText(ex.markdown, CONTENT_BODY_CHARS);
+              let text = win.window;
+              /** @type {string | null} */
+              let footer = null;
+              if (win.windowed && webCache?.key && webCache?.put) {
+                const cacheKey = webCache.key();
+                try {
+                  await webCache.put({ key: cacheKey, url: grabbed.url || tab.url, format: 'markdown', text: ex.markdown });
+                  footer = pagingFooter({ key: cacheKey, total: win.total, headChars: win.headChars, tailChars: win.tailChars });
+                } catch { /* spill failed — the window (with its elision marker) still ships */ }
+              } else if (win.windowed && !webCache) {
+                text = ex.markdown.slice(0, CONTENT_BODY_CHARS);
+              }
+              const fenced = wrapUntrusted({
+                origin, tool: 'read_page',
+                body: JSON.stringify({
+                  mode: 'content', url: grabbed.url || tab.url,
+                  ...(ex.title ? { title: ex.title } : {}),
+                  format: 'markdown', truncated: win.windowed, body: text,
+                }, null, 2),
+              });
+              return { ok: true, content: footer ? `${fenced}\n${footer}` : fenced };
+            }
+          }
+        } catch { /* fail-open to the snapshot below */ }
+      }
+    }
+
     let scriptResult;
     try {
       const results = await scripting.executeScript({
@@ -115,8 +174,25 @@ const formatPageBody = (snap) => {
 };
 
 // ───────────────────────────────────────────────────────────────────────
-// Injected function — runs in the page world. Self-contained.
+// Injected functions — run in the page world. Self-contained.
 // ───────────────────────────────────────────────────────────────────────
+// content mode's grabber: the rendered DOM, serialized. Capped so a pathological
+// page doesn't blow the executeScript result channel (the offscreen extractor
+// caps again).
+function readOuterHtmlInjected() {
+  // why: serialized by chrome.scripting.executeScript and re-evaluated in the
+  // page's classic-script world; the calling module's strict mode doesn't
+  // carry across. Opt in here (same note as readPageInjected below).
+  'use strict';
+  const MAX = 2_000_000;
+  const html = document.documentElement ? document.documentElement.outerHTML : '';
+  return {
+    html: html.length > MAX ? html.slice(0, MAX) : html,
+    url: location.href,
+    title: document.title || '',
+  };
+}
+
 function readPageInjected() {
   // why: serialized by chrome.scripting.executeScript and re-evaluated
   // in the page's classic-script world; the calling module's strict

--- a/extension/peerd-runtime/tools/defs/read-web-cache.js
+++ b/extension/peerd-runtime/tools/defs/read-web-cache.js
@@ -25,10 +25,12 @@ export const readWebCacheTool = {
   name: 'read_web_cache',
   primitive: 'web',
   description: [
-    'Read a slice of a spilled fetch_url body. When a fetch overflows its budget the',
-    'full text is stored locally and the result names the cache key — page through it',
-    'here with { key, offset, limit }. Offsets are character positions into the stored',
-    'text; the result reports what remains after the slice.',
+    'Read a slice of a spilled fetch_url / read_page body. When a read overflows its',
+    'budget the full text is stored locally and the result names the cache key — page',
+    'through it here with { key, offset, limit }. Offsets are character positions into',
+    'the stored text; the result reports what remains after the slice. Page',
+    'DELIBERATELY: the head+tail window you already saw usually carries the answer —',
+    'one or two targeted slices should settle it. Do not walk the whole document.',
   ].join(' '),
   schema: {
     type: 'object',

--- a/tests/peerd-runtime/tools/read-page-content.test.ts
+++ b/tests/peerd-runtime/tools/read-page-content.test.ts
@@ -1,0 +1,89 @@
+// read_page mode:'content' — the rendered DOM's readable core as markdown,
+// via the same offscreen extractor + spill-and-page fetch_url uses. The
+// invariants: content mode is FAIL-OPEN (non-readerable page, missing
+// extractor, extraction error, script failure all fall through to the default
+// snapshot), overflow spills with a paging footer OUTSIDE the fence, and the
+// default snapshot mode is untouched.
+
+import { describe, test, expect } from 'bun:test';
+import { readPageTool } from '../../../extension/peerd-runtime/tools/defs/read-page.js';
+
+const fencedBody = (content: string) =>
+  JSON.parse(content.split(/<untrusted_web_content [^>]*>\n/)[1].split('\n</untrusted_web_content>')[0]);
+
+// A ctx whose injected scripts return canned results: the content grabber
+// (detected by function name) gets HTML; the snapshot function gets a snapshot.
+const ctxWith = (over: any = {}) => ({
+  activeTab: { id: 7, url: 'https://site.example/article', origin: 'https://site.example' },
+  tabs: { get: async (id: number) => ({ id, url: 'https://site.example/article' }) },
+  scripting: {
+    executeScript: async ({ func }: any) => {
+      if (String(func.name) === 'readOuterHtmlInjected') {
+        return [{ result: { html: '<html><body><article>rendered body</article></body></html>', url: 'https://site.example/article', title: 'T' } }];
+      }
+      return [{ result: { title: 'T', url: 'https://site.example/article', text: 'snapshot text', interactables: [] } }];
+    },
+  },
+  ...over,
+});
+
+describe('read_page mode:content', () => {
+  test('extracts the rendered DOM to markdown via the offscreen client', async () => {
+    let sawHtml = '';
+    const ctx = ctxWith({
+      webOffscreenClient: {
+        extractMarkdown: async ({ html, url }: any) => {
+          sawHtml = html;
+          expect(url).toBe('https://site.example/article');
+          return { readerable: true, markdown: '# T\n\nrendered body as markdown', title: 'T' };
+        },
+      },
+    });
+    const r = await readPageTool.execute({ mode: 'content' }, ctx as any);
+    expect(r.ok).toBe(true);
+    if (!r.ok) throw new Error('expected ok');
+    expect(sawHtml).toContain('rendered body');
+    const body = fencedBody(r.content!);
+    expect(body.mode).toBe('content');
+    expect(body.format).toBe('markdown');
+    expect(body.body).toContain('rendered body as markdown');
+  });
+
+  test('overflow spills to the cache with the paging footer OUTSIDE the fence', async () => {
+    const stored: any[] = [];
+    const big = 'M'.repeat(40_000);
+    const ctx = ctxWith({
+      webOffscreenClient: { extractMarkdown: async () => ({ readerable: true, markdown: big, title: 'Big' }) },
+      webCache: { key: () => 'wc-rp-1', put: async (rec: any) => { stored.push(rec); } },
+    });
+    const r = await readPageTool.execute({ mode: 'content' }, ctx as any);
+    if (!r.ok) throw new Error('expected ok');
+    expect(stored).toHaveLength(1);
+    expect(stored[0].text.length).toBe(40_000);
+    const afterFence = r.content!.split('</untrusted_web_content>')[1];
+    expect(afterFence).toContain('read_web_cache');
+    expect(afterFence).toContain('"key": "wc-rp-1"');
+    expect(fencedBody(r.content!).truncated).toBe(true);
+  });
+
+  test('fail-open: non-readerable, extractor error, and missing client all yield the SNAPSHOT', async () => {
+    for (const client of [
+      { extractMarkdown: async () => ({ readerable: false }) },
+      { extractMarkdown: async () => { throw new Error('boom'); } },
+      undefined,
+    ]) {
+      const r = await readPageTool.execute({ mode: 'content' }, ctxWith({ webOffscreenClient: client }) as any);
+      if (!r.ok) throw new Error('expected ok');
+      expect(r.content).toContain('snapshot text');   // the default path's body
+    }
+  });
+
+  test('the default mode is untouched (no extractor call)', async () => {
+    let called = false;
+    const ctx = ctxWith({ webOffscreenClient: { extractMarkdown: async () => { called = true; return { readerable: true, markdown: 'x' }; } } });
+    const r = await readPageTool.execute({}, ctx as any);
+    if (!r.ok) throw new Error('expected ok');
+    expect(called).toBe(false);
+    expect(r.content).toContain('snapshot text');
+  });
+});


### PR DESCRIPTION
Follow-on to #187, aimed at the OM2W failure taxonomy (budget exhaustion on tab-driven tasks — the dominant fixable bucket at the 26.7% baseline).

- **`read_page` gains `mode:'content'`**: grabs the rendered DOM's `outerHTML` (post-JS — pages `fetch_url` can't see) and routes it through the **same** offscreen Readability+Turndown extractor and the **same** spill-and-page machinery #187 shipped. One new tiny injected grabber; no new vendoring, no page-world library injection, same untrusted fence. Fail-open to the default snapshot everywhere (non-readerable / Firefox / extraction error / grab failure).
- **Default snapshot mode untouched** (content mode returns no interactables; the tool description teaches READ vs OPERATE).
- **Paging-loop counter-pressure**: the #187 measurement caught one task walking a whole spilled document (465k actor tokens); `read_web_cache` now teaches deliberate paging.

Zero added authority: same gated dispatch, same fence, the markdown transform runs on bytes the actor could already read.

Tests: content-mode suite (extraction, spill+footer-outside-fence, all fail-open paths, default-mode untouched). Full battery green (2747 bun tests, strict typecheck, eslint, tscheck floor, no gen drift).

Measurement: the `fetch` suite covers the fetch path; a rendered-page before/after needs a tab-heavy task set — proposed as the same before/after protocol on the `web-actor` suite once #119 (which carries it) merges, then an OM2W-30 re-run to see if the baseline moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)