### PR TITLE
chore: drop the DCO sign-off checkbox from the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,6 @@ Closes #
 ## Checklist
 
 - [ ] `bun run preflight` passes (tests, typecheck, lint, in-browser, dweb-boundary, no manifest drift)
-- [ ] Commits are signed off — `git commit -s` (we use the DCO)
 - [ ] Only original or permissively-licensed code — **no GPL / AGPL / copyleft**
 - [ ] Tests added or updated (or N/A)
 - [ ] No hand-edited generated files (`manifest.json`, `shared/channel-config.js`)


### PR DESCRIPTION
## What & why

Removes the "Commits are signed off — `git commit -s` (we use the DCO)" checkbox from `.github/pull_request_template.md`.

The convention was never actually enforced — there is no DCO check in CI, `CONTRIBUTING.md` doesn't mention it, and the merged history doesn't follow it (the large majority of commits on main carry no `Signed-off-by` trailer). In practice the checkbox only produced false review blocks on external PRs (#170, #188, #189) while providing no real provenance guarantee. Apache-2.0 §5 already gives the inbound=outbound license grant for submitted contributions.

Closes # — (no issue; owner-directed cleanup)

## Checklist

- [x] `bun run preflight` passes — N/A, template-only change, no code paths touched
- [x] Only original or permissively-licensed code — **no GPL / AGPL / copyleft**
- [x] Tests added or updated (or N/A) — N/A
- [x] No hand-edited generated files (`manifest.json`, `shared/channel-config.js`)
- [x] Called out below if this touches a **danger zone** — it doesn't (template prose only)

## Notes for reviewers

If DCO enforcement is ever genuinely wanted, the right shape is the DCO GitHub App as a required check — mechanical from day one — rather than an honor-system checkbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8EYHtUpzTX6YGfEXPRPKF

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8EYHtUpzTX6YGfEXPRPKF)_