### PR TITLE
fix: post-merge review-swarm findings on #170/#187/#188/#189

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Each maps to one letter and color in the brand wordmark:
 
 | Letter | Color | Module | Role |
 |---|---|---|---|
-| `p` | cyan    | `peerd-provider/`     | Model adapters (Anthropic + OpenRouter + Ollama shipped; OpenAI later; local WebGPU deferred) |
+| `p` | cyan    | `peerd-provider/`     | Model adapters (Anthropic, OpenRouter, OpenAI, Z.ai GLM, and keyless Ollama shipped; local WebGPU gated on the resident engine — `registry.js` is the live list) |
 | `e` | red     | `peerd-egress/`       | Security: vault, allowlist (`safeFetch`), denylist, audit |
 | `e` | amber   | `peerd-engine/`       | Execution instances — Sandboxes. Three kinds run in their own visible tab: WebVMs (CheerpX Linux), Notebooks (sealed JS worker + OPFS), Apps (opaque-origin iframe). A fourth, the **headless worker** (`script`), runs the Notebook's sealed worker offscreen with no tab — the agent's own quick compute. The sandbox is the isolate; a tab is one way to host it (taxonomy in the `peerd-engine/` code). |
 | `r` | green   | `peerd-runtime/`      | Agent loop, tools + per-environment actors (`message_actor`), sessions, profiles, skills, memory, permissions (Plan/Act), review, goal mode (autonomous loop), composer, cost, transfer, voice, clock, web tool policy |
@@ -260,9 +260,11 @@ gotchas to know going in:
 - Anthropic provider with streaming, adaptive extended thinking on newer
   models, prompt-cache breakpoints, retry on transient/overload statuses,
   and the `anthropic-dangerous-direct-browser-access` ack — plus an
-  OpenRouter adapter (OpenAI-compatible gateway) and a keyless Ollama
-  adapter (local inference; live `/api/tags` model inventory; GPU-fit
-  model recommendation in Settings) (`peerd-provider/`).
+  OpenRouter adapter (OpenAI-compatible gateway), a direct OpenAI adapter,
+  a Z.ai GLM adapter (OpenAI-compatible direct endpoint), and a keyless
+  Ollama adapter (local inference; live `/api/tags` model inventory; GPU-fit
+  model recommendation in Settings) (`peerd-provider/`). The shipped set is
+  whatever `registry.js` registers — don't take this list as authoritative.
 - Vault with passphrase unlock AND WebAuthn PRF (Touch ID / Windows
   Hello) — same DK from either path (`peerd-egress/vault/`). Idle
   auto-lock ON by default (user-settable); manual Lock button
@@ -406,13 +408,13 @@ land with deliberate design work):
   actors are already trimmed to tight per-kind allow-lists by
   construction (`tools/exposure.js` `actorAllowedTools`, enforced at
   dispatch in `gates.js`) — an actor never sees the full surface.
-- OpenAI provider adapter — the file doesn't exist yet (OpenRouter
-  covers most vendors meanwhile; Ollama shipped 2026-06-12 with its
-  `http://localhost:11434` CSP connect-src entry restored in
-  `manifests/base.json`). The manifest still does NOT pre-declare
-  hosts for unshipped adapters (store policy: never request what the
-  shipped version doesn't use); `<all_urls>` already covers HTTPS API
-  hosts.
+- New provider adapters — the shipped set (Anthropic, OpenRouter, OpenAI,
+  Z.ai GLM, Ollama) lives in `peerd-provider/adapters/`; adding one is a
+  registry entry, not chassis wiring. The manifest still does NOT pre-declare
+  hosts for adapters a given package doesn't ship (store policy: never request
+  what the shipped version doesn't use); `<all_urls>` already covers HTTPS API
+  hosts, and a loopback provider like Ollama needs its own CSP connect-src
+  entry (`manifests/base.json`).
 - The dweb's next reach — A2A's first hop shipped (the `a2a_run` code
   surface above); still ahead is what rides it: standing multi-turn peer
   conversations beyond a single run, richer dwapps, and global discovery

--- a/README.md
+++ b/README.md
@@ -129,8 +129,10 @@ Preview package install paths (Firefox is the smoother of the two):
 peerd has **no build step**: you load the `extension/` folder straight
 into Chrome as it is on disk. You need a Chromium-based browser (Chrome,
 Edge, Brave, Arc, …) and a model to talk to: a key from
-[Anthropic](https://console.anthropic.com/) and/or
-[OpenRouter](https://openrouter.ai/keys), or a local
+[Anthropic](https://console.anthropic.com/),
+[OpenRouter](https://openrouter.ai/keys),
+[OpenAI](https://platform.openai.com/api-keys), or
+[Z.ai](https://z.ai/) (GLM) — or a local
 [Ollama](https://ollama.com/) (keyless, no bill, nothing leaves your
 machine). BYOK: any key lives encrypted in a local vault and is only
 ever sent to that provider.
@@ -164,8 +166,9 @@ to your model provider.
 **4. Add your API key(s)**
 
 Open **Settings** (gear icon) → **API keys**. Paste a key for
-**Anthropic** (`sk-ant-…`) and/or **OpenRouter** (`sk-or-…`). You can set
-both at once, each stored independently. Choose a default under
+**Anthropic** (`sk-ant-…`), **OpenRouter** (`sk-or-…`), **OpenAI**
+(`sk-…`), or **Z.ai** (GLM) — set as many as you like, each stored
+independently. Choose a default under
 *Default model for new chats*, and switch the model per chat from the
 picker above the message box.
 
@@ -225,7 +228,7 @@ one top-level module, each owning its public API through `index.js`:
 
 | | Module | Role |
 |---|---|---|
-| **`p`** · cyan | [`peerd-provider`](extension/peerd-provider/) | Model adapters — Anthropic, OpenRouter, Ollama (streaming, caching, cost, retries) |
+| **`p`** · cyan | [`peerd-provider`](extension/peerd-provider/) | Model adapters — Anthropic, OpenRouter, OpenAI, Z.ai GLM, Ollama (streaming, caching, cost, retries) |
 | **`e`** · red | [`peerd-egress`](extension/peerd-egress/) | Security — the vault, the egress chokepoint, the denylist, the audit log |
 | **`e`** · amber | [`peerd-engine`](extension/peerd-engine/) | Sandboxes — WebVMs, Notebooks, Apps, and the headless worker |
 | **`r`** · green | [`peerd-runtime`](extension/peerd-runtime/) | The orchestrator — agent loop, tools, the `message_actor` delegation channel, actors, sessions, memory, skills, review, goal mode, voice |
@@ -285,7 +288,7 @@ detail). Each colored letter maps to a top-level module:
 peerd/
 ├── extension/                # the extension itself — load this dir unpacked
 │   ├── manifest.json
-│   ├── peerd-provider/       # p · cyan    — model adapters (Anthropic, OpenRouter, Ollama; OpenAI later)
+│   ├── peerd-provider/       # p · cyan    — model adapters (Anthropic, OpenRouter, OpenAI, Z.ai GLM, Ollama)
 │   ├── peerd-egress/         # e · red     — vault, allowlist, denylist, confirm, audit
 │   ├── peerd-engine/         # e · amber   — execution-instance registries (WebVM, Notebook, App). Tab runtimes in <kind>-tab/; the headless script worker in offscreen/.
 │   ├── peerd-runtime/        # r · green   — agent loop, tools + message_actor delegation, actors + actors, sessions, permissions, composer, skills, memory, review, goal mode, cost, transfer, voice, clock, dom, edit

--- a/docs/benchmarks/2026-07-web-thread.md
+++ b/docs/benchmarks/2026-07-web-thread.md
@@ -27,12 +27,15 @@ purpose-built hosted agents report ~88%. A 30-task subset carries roughly ±8pp 
 honest positioning is not "we beat everyone" — it's *the first extension-native number on
 this benchmark, with the failure taxonomy that says exactly where the next points are*:
 
-| Failure mode (of 22 fails) | Count | Meaning |
+| Failure mode (22 fails; categories overlap) | Count | Meaning |
 |---|---|---|
 | Hit the 25-step cap mid-task | 6 | step-inefficiency, not capability |
 | Near-cap thrash (20–25 steps) | 3 | same |
 | Incomplete final action | 9 | found the info, skipped add-to-cart / a filter |
 | Wrong/other | 7 | genuine misses |
+
+Categories are **non-exclusive** — a task that ran to the cap *and* skipped its final action
+is counted under both, so the column sums above the 22 fails rather than partitioning them.
 
 Budget exhaustion dominates. **Efficiency is the lever**, which drove both experiments below.
 
@@ -47,10 +50,13 @@ identically:
 
 | | tool-call | code-REPL |
 |---|---|---|
-| Pass rate | **26.7%** (8/30) | 20.7% (6/29) |
+| Pass rate | **26.7%** (8/30) | 20.7% (6/29)† |
 | Median steps/task | 11 | 14 |
 | 25-step-cap deaths | 6 | 8 |
 | Tasks won that the other arm lost | 2 | **0** |
+
+† One code-arm run did not complete scoring (harness hang, see §4), so 29 of the 30 tasks
+were scored in that arm; the tool-call arm scored all 30.
 
 **Verdict: the code arm loses on live sites.** Long blind scripts drift when pages change
 under them; the write-code-then-look loop costs more round-trips than it saves. The code

--- a/extension/peerd-egress/storage/idb.js
+++ b/extension/peerd-egress/storage/idb.js
@@ -65,12 +65,16 @@ const DB_NAME = 'peerd';
 // v10 — audit_meta: the audit log's hash-chain head record (R4 tamper
 // evidence). One tiny record ({ key: 'audit_chain_head', id, chain })
 // pinning the newest entry so tail truncation is detectable.
-// v11 — web_extract_cache: fetch_url's spill-and-page store. When a fetched
-// body overflows the tool budget, the FULL text is spilled here (records
-// { key, url, format, text, storedAt }) and the model gets a head+tail window
-// plus the exact read_web_cache paging call — instead of silently losing the
-// middle. Same posture as vm_http_cache: fetched public bytes, unencrypted
-// extension-scoped disk, best-effort, safe to clear at any time.
+// v11 — web_extract_cache: the spill-and-page store for fetch_url AND
+// read_page mode:'content'. When a read overflows the tool budget, the FULL
+// text is spilled here (records { key, url, format, text, storedAt }) and the
+// model gets a head+tail window plus the exact read_web_cache paging call —
+// instead of silently losing the middle. Unencrypted extension-scoped disk,
+// best-effort, safe to clear at any time. NOTE: unlike vm_http_cache's fetched
+// public bytes, read_page content is the RENDERED DOM of a tab the user may be
+// logged into, so an entry can hold authenticated page text; it is not purged
+// on vault lock (same at-rest posture as session_messages/memory, which also
+// persist plaintext here).
 const DB_VERSION = 11;
 
 /**

--- a/extension/peerd-provider/adapters/openai.js
+++ b/extension/peerd-provider/adapters/openai.js
@@ -105,7 +105,7 @@ export async function* callOpenAi(args) {
       if (!res.body) {
         throw new ProviderError('openai', 'response has no body (streaming requires it)');
       }
-      yield* fromOpenAiStream(res.body);
+      yield* fromOpenAiStream(res.body, { provider: 'openai' });
       return;
     }
     // Non-2xx: read the body ONCE (drains the socket for reuse), then classify

--- a/extension/peerd-provider/error-classify.js
+++ b/extension/peerd-provider/error-classify.js
@@ -15,13 +15,19 @@
 // Deliberately NARROW — 'rate limit' / 'per-minute' / 'overloaded' are
 // EXCLUDED so a genuine transient 429 still rides the retry path. Anthropic's
 // monthly-spend stop ("…would exceed your monthly spend limit") and
-// OpenRouter's insufficient-credits 402 both land here.
+// OpenRouter's insufficient-credits 402 both land here. Z.ai signals an
+// out-of-credit account as error 1113 "Insufficient balance or no resource
+// package. Please recharge." on HTTP 429 (NOT 402), so 'insufficient balance'
+// and 'recharge' are needed or a spent GLM account gets 3 pointless retries
+// then a misleading generic 429 with no failover.
 const HARD_LIMIT_NEEDLES = Object.freeze([
   'credit balance',
   'out of credit',
   'insufficient credit',
+  'insufficient balance',
   'insufficient_quota',
   'insufficient funds',
+  'recharge',
   'billing',
   'payment required',
   'spending limit',

--- a/extension/peerd-provider/format/from-openai.js
+++ b/extension/peerd-provider/format/from-openai.js
@@ -81,7 +81,8 @@ const mapStopReason = (finish) => {
  * @param {ReadableStream<Uint8Array>} body
  * @param {{ provider?: string }} [opts]
  *   `provider` labels in-stream error events so the UI names the right
- *   source (this parser is shared by OpenRouter AND Ollama).
+ *   source (this parser is shared by OpenRouter, OpenAI, Z.ai GLM, and
+ *   Ollama — each passes its own name; the default is only a fallback).
  * @returns {AsyncGenerator<ProviderEvent>}
  */
 export async function* fromOpenAiStream(body, { provider = 'openrouter' } = {}) {

--- a/extension/peerd-provider/index.js
+++ b/extension/peerd-provider/index.js
@@ -7,8 +7,9 @@
 // and never imports adapter modules directly — that keeps runtime
 // agnostic to which providers exist.
 //
-// Shipped: Anthropic + OpenRouter (cloud) and Ollama (local, keyless).
-// Later: OpenAI adapter, local WebGPU inference.
+// Shipped (cloud, BYOK): Anthropic, OpenRouter, OpenAI, Z.ai GLM.
+// Local (keyless): Ollama, plus the WebGPU on-device runner (gated on the
+// resident engine). The registry is the source of truth — see registry.js.
 
 export {
   callModel,

--- a/extension/peerd-provider/pricing.js
+++ b/extension/peerd-provider/pricing.js
@@ -81,12 +81,16 @@ export const DEFAULT_PRICING = Object.freeze({
 
   // ---- Z.ai GLM (native adapter; bare model ids) ----
   // Source: docs.z.ai/guides/overview/pricing (2026-07 snapshot, USD / 1M tokens).
-  // GLM-5.2 flagship tier; cacheRead is the cached-input rate. Z.ai reports no
-  // separate cache-write line (0). GLM-4.5-Air (the web-actor runner) is
-  // intentionally absent — its lower tier is left to user override rather than
-  // a guessed number; an unknown id degrades to an honest "estimate unavailable".
-  'glm-5.2': Object.freeze({ input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 }),
-  'glm-4.6': Object.freeze({ input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 }),
+  // Each tier is priced from its own published rate — GLM-4.6 is a distinctly
+  // cheaper tier than the 5.2 flagship, NOT the same rate card. Z.ai reports no
+  // separate cache-write line (0); cacheRead is the published cached-input rate
+  // (GLM-4.6 has no published cached rate, so it carries the 5.2 tier's ~0.19x
+  // ratio applied to its input — an estimate, still far closer than the
+  // flagship's number). GLM-4.5-Air (the web-actor runner) is intentionally
+  // absent — its lower tier is left to user override rather than a guessed
+  // number; an unknown id degrades to an honest "estimate unavailable".
+  'glm-5.2': Object.freeze({ input: 1.4,  output: 4.4,  cacheRead: 0.26, cacheWrite: 0 }),
+  'glm-4.6': Object.freeze({ input: 0.43, output: 1.74, cacheRead: 0.08, cacheWrite: 0 }),
 
   // ---- Ollama (local inference — $0 by construction) ----
   // why: the CostChip prices by model id; without entries the curated

--- a/extension/peerd-runtime/tools/defs/read-page.js
+++ b/extension/peerd-runtime/tools/defs/read-page.js
@@ -96,6 +96,10 @@ export const readPageTool = {
                   mode: 'content', url: grabbed.url || tab.url,
                   ...(ex.title ? { title: ex.title } : {}),
                   format: 'markdown', truncated: win.windowed, body: text,
+                  // the RAW DOM was clipped at 2MB before extraction — the
+                  // readable core may be missing its tail (distinct from
+                  // `truncated`, which only means the markdown was windowed).
+                  ...(grabbed.htmlTruncated ? { htmlTruncated: true } : {}),
                 }, null, 2),
               });
               return { ok: true, content: footer ? `${fenced}\n${footer}` : fenced };
@@ -185,9 +189,14 @@ function readOuterHtmlInjected() {
   // carry across. Opt in here (same note as readPageInjected below).
   'use strict';
   const MAX = 2_000_000;
-  const html = document.documentElement ? document.documentElement.outerHTML : '';
+  const raw = document.documentElement ? document.documentElement.outerHTML : '';
+  const clipped = raw.length > MAX;
   return {
-    html: html.length > MAX ? html.slice(0, MAX) : html,
+    html: clipped ? raw.slice(0, MAX) : raw,
+    // why: flag the clip so the caller never reports a complete read when the
+    // raw DOM's tail was dropped here — before the extractor ever saw it, so no
+    // downstream truncation signal would otherwise fire.
+    htmlTruncated: clipped,
     url: location.href,
     title: document.title || '',
   };

--- a/extension/peerd-runtime/tools/defs/read-web-cache.js
+++ b/extension/peerd-runtime/tools/defs/read-web-cache.js
@@ -51,7 +51,7 @@ export const readWebCacheTool = {
     if (!webCache?.get) return { ok: false, error: 'web_cache_unavailable' };
     const rec = await webCache.get(args.key).catch(() => undefined);
     if (!rec || typeof rec.text !== 'string') {
-      return { ok: false, error: `no_such_key: ${args.key} — the cache entry may have been evicted; re-fetch the URL.` };
+      return { ok: false, error: `no_such_key: ${args.key} — the cache entry may have been evicted; re-run the read that produced it (fetch_url, or read_page mode:'content' for a tab you've already rendered — don't fetch_url a page you can still see).` };
     }
     const limit = Math.min(typeof args.limit === 'number' && args.limit > 0 ? args.limit : MAX_SLICE_CHARS, MAX_SLICE_CHARS);
     const page = pageSlice(rec.text, typeof args.offset === 'number' ? args.offset : 0, limit);

--- a/extension/peerd-runtime/tools/manifests.js
+++ b/extension/peerd-runtime/tools/manifests.js
@@ -43,7 +43,12 @@ export const TOOL_MANIFEST_PRESETS = Object.freeze({
       // web_search/call_api/read_article/submit_form were all removed — the web
       // actor searches by navigating to an engine + reading results, and reads via
       // fetch_url or its drive-a-tab DOM tools.
-      'fetch_url', 'capture',
+      // read_web_cache MUST ride along with any spill producer (fetch_url /
+      // read_page mode:'content'): an overflowing read spills to the cache and
+      // emits a trusted footer instructing read_web_cache — omit it and the
+      // pager the model is told to call is refused by the manifest gate, the
+      // spilled tail is unreachable, and turns burn on guaranteed-refused calls.
+      'fetch_url', 'read_web_cache', 'capture',
       // the main agent's browser surface: enumerate actors (instances/tabs/
       // integrations) + open a tab + message a tab's web actor to read or act.
       'actor_list', 'open_tab', 'message_actor',
@@ -68,8 +73,11 @@ export const TOOL_MANIFEST_PRESETS = Object.freeze({
       'actor_list', 'open_tab', 'navigate', 'message_actor',
       // read-only DOM subset (observe, never mutate) — inherited by the web actor.
       'snapshot', 'read_page', 'read_state', 'query_dom', 'read_pdf', 'view',
-      // web reads: fetch_url (the web actor's sessionless fetch)
-      'fetch_url',
+      // web reads: fetch_url (the web actor's sessionless fetch) + its pager.
+      // read_web_cache pages a spilled fetch_url / read_page body — it must be
+      // present wherever a spill producer is, or the trusted paging footer names
+      // a tool this manifest refuses (read-only, local cache, no new authority).
+      'fetch_url', 'read_web_cache',
       // temporal grounding (reads)
       'now',
     ]),

--- a/extension/sidepanel/error-display.js
+++ b/extension/sidepanel/error-display.js
@@ -29,7 +29,7 @@ export const mapError = (e) => {
   if (e.startsWith('provider-usage-limit')) {
     const detail = e.slice('provider-usage-limit'.length).replace(/^[:\s]+/, '').trim();
     const suffix = detail ? ` (${detail})` : '';
-    return `Usage/credit limit reached — your provider account is out of credit or over a spend/usage cap. Check your Anthropic / OpenRouter billing & limits, then retry.${suffix}`;
+    return `Usage/credit limit reached — your provider account is out of credit or over a spend/usage cap. Check your provider's billing & limits, then retry.${suffix}`;
   }
 
   const s = e.toLowerCase();
@@ -42,7 +42,7 @@ export const mapError = (e) => {
   // Account/credit/quota limits often arrive as 400/403 with a message,
   // not 429 — catch them by content before the generic HTTP fallback.
   if (has('credit balance', 'billing', 'quota', 'insufficient_quota', 'usage limit', 'plan limit')) {
-    return 'Provider account limit — out of credit or over a usage cap. Check your Anthropic / OpenRouter billing, then retry.';
+    return "Provider account limit — out of credit or over a usage cap. Check your provider's billing, then retry.";
   }
   if (e.startsWith('provider-http-429') || has('http 429', 'rate_limit', 'rate limit')) {
     return 'Rate limited (429) — your provider is throttling, or your account hit a usage/credit limit. Wait a moment and retry; if it persists, check your provider account.';

--- a/tests/peerd-provider/pricing.test.ts
+++ b/tests/peerd-provider/pricing.test.ts
@@ -66,4 +66,17 @@ describe('DEFAULT_PRICING ↔ MODEL_CATALOG parity', () => {
     expect(DEFAULT_PRICING['claude-haiku-4-5-20251001']).toEqual(
       { input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25 });
   });
+
+  test('Z.ai GLM rates are per-tier, not the flagship copied down', () => {
+    // Regression guard: glm-4.6 shipped priced identically to the glm-5.2
+    // flagship ($1.4/$4.4), a ~3x overestimate that inflated the CostChip and
+    // tripped spend limits early. GLM-4.6 is a distinctly cheaper tier.
+    // Source: docs.z.ai/guides/overview/pricing (2026-07, USD / MTok).
+    expect(DEFAULT_PRICING['glm-5.2']).toEqual(
+      { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 });
+    expect(DEFAULT_PRICING['glm-4.6']).toEqual(
+      { input: 0.43, output: 1.74, cacheRead: 0.08, cacheWrite: 0 });
+    // the two tiers must NOT share a rate card
+    expect(DEFAULT_PRICING['glm-4.6'].input).not.toBe(DEFAULT_PRICING['glm-5.2'].input);
+  });
 });

--- a/tests/peerd-provider/usage-limit.test.ts
+++ b/tests/peerd-provider/usage-limit.test.ts
@@ -8,6 +8,7 @@
 import { describe, test, expect } from 'bun:test';
 import { callAnthropic } from '../../extension/peerd-provider/adapters/anthropic.js';
 import { callOpenRouter } from '../../extension/peerd-provider/adapters/openrouter.js';
+import { callGlm } from '../../extension/peerd-provider/adapters/glm.js';
 import { ProviderUsageLimitError } from '../../extension/peerd-provider/errors.js';
 
 const stubResponse = (status: number, bodyText = '', headers: Record<string, string> = {}) => ({
@@ -78,5 +79,40 @@ describe('callOpenRouter — hard usage/credit limit', () => {
     expect(calls).toBe(1);
     expect(thrown).toBeInstanceOf(ProviderUsageLimitError);
     expect(thrown.status).toBe(402);
+  });
+});
+
+describe('callGlm — hard usage/credit limit', () => {
+  // Z.ai signals an out-of-credit account as error 1113 on HTTP 429 (not 402):
+  // "Insufficient balance or no resource package. Please recharge." Without the
+  // 'insufficient balance' / 'recharge' needles this classified as a transient
+  // 429 → 3 pointless retries → a misleading generic error with no failover.
+  test('a 429 "insufficient balance … recharge" body fails fast (no retries)', async () => {
+    let calls = 0;
+    const safeFetch = async () => {
+      calls++;
+      return stubResponse(429, '{"error":{"code":"1113","message":"Insufficient balance or no resource package. Please recharge."}}');
+    };
+    let thrown: any;
+    try { await drain(callGlm(baseArgs(safeFetch) as any)); }
+    catch (e) { thrown = e; }
+    expect(calls).toBe(1);                       // NOT retried
+    expect(thrown).toBeInstanceOf(ProviderUsageLimitError);
+    expect(thrown.detail).toContain('recharge');
+  });
+
+  test('a transient 429 (no billing needle) still retries (regression guard)', async () => {
+    let calls = 0;
+    const safeFetch = async () => {
+      calls++;
+      if (calls === 1) return stubResponse(429, '{"error":{"message":"rate limit exceeded"}}', { 'retry-after': '0' });
+      const body = new ReadableStream<Uint8Array>({
+        start(c) { c.enqueue(new TextEncoder().encode('data: [DONE]\n\n')); c.close(); },
+      });
+      return { ok: true, status: 200, headers: new Headers(), body, text: async () => '' };
+    };
+    const events = await drain(callGlm(baseArgs(safeFetch) as any));
+    expect(calls).toBe(2);
+    expect(events[0].type).toBe('rate-limit-pause');
   });
 });

--- a/tests/peerd-runtime/spawn.test.ts
+++ b/tests/peerd-runtime/spawn.test.ts
@@ -63,6 +63,7 @@ describe('restrictCtxCapabilities', () => {
     getSecret: () => 'KEY',
     safeFetch: () => {},
     webFetch: () => {},
+    webCache: { get: () => {}, put: () => {}, key: () => 'k' },
     memory: { read: () => {} },
     kv: { get: () => {} },
     idb: { getAll: () => {} },
@@ -86,7 +87,11 @@ describe('restrictCtxCapabilities', () => {
   const CAP_KEYS = Object.keys(CAPABILITY_CONSUMERS);
 
   test("a DOM-only runner toolset strips EVERY capability — no path to secrets/egress/spawn", () => {
-    const allowed = new Set(['snapshot', 'read_page', 'click', 'type', 'navigate', 'query_dom']);
+    // read_page is deliberately EXCLUDED here: it consumes webCache (its
+    // mode:'content' spill pager), so it is not a no-capability DOM tool — the
+    // read_page→webCache grant is asserted on its own below. The rest of the
+    // DOM toolset consumes nothing, so this set must strip every capability.
+    const allowed = new Set(['snapshot', 'click', 'type', 'navigate', 'query_dom']);
     const out = restrictCtxCapabilities(fullCtx(), allowed);
     for (const cap of CAP_KEYS) expect(out[cap as keyof typeof out]).toBeUndefined();
     // the high-value ones, called out explicitly
@@ -104,6 +109,10 @@ describe('restrictCtxCapabilities', () => {
   test('a capability is KEPT when a granted tool consumes it', () => {
     expect('webFetch' in restrictCtxCapabilities(fullCtx(), new Set(['fetch_url']))).toBe(true);
     expect('webFetch' in restrictCtxCapabilities(fullCtx(), new Set(['vm_import']))).toBe(true);
+    // read_page mode:'content' pages its overflow through webCache — the grant
+    // that #189 added to CAPABILITY_CONSUMERS.webCache must survive narrowing.
+    expect('webCache' in restrictCtxCapabilities(fullCtx(), new Set(['read_page']))).toBe(true);
+    expect('webCache' in restrictCtxCapabilities(fullCtx(), new Set(['read_web_cache']))).toBe(true);
     expect('memory' in restrictCtxCapabilities(fullCtx(), new Set(['remember']))).toBe(true);
     expect('requestReview' in restrictCtxCapabilities(fullCtx(), new Set(['request_review']))).toBe(true);
     // sandbox_create keeps the dweb closure (its app arm reads ctx.dweb for the dwapp flag)

--- a/tests/peerd-runtime/tools/read-page-content.test.ts
+++ b/tests/peerd-runtime/tools/read-page-content.test.ts
@@ -78,6 +78,45 @@ describe('read_page mode:content', () => {
     }
   });
 
+  test('fail-open: a grab-script failure (executeScript throws) falls through to the SNAPSHOT', async () => {
+    // the extractor is present and healthy — only the outerHTML grab throws, so
+    // this exercises the fourth fail-open path the header names but the loop above
+    // (which only varies the client) never reaches.
+    const ctx = ctxWith({
+      webOffscreenClient: { extractMarkdown: async () => ({ readerable: true, markdown: 'unreached', title: 'T' }) },
+      scripting: {
+        executeScript: async ({ func }: any) => {
+          if (String(func.name) === 'readOuterHtmlInjected') throw new Error('grab boom');
+          return [{ result: { title: 'T', url: 'https://site.example/article', text: 'snapshot text', interactables: [] } }];
+        },
+      },
+    });
+    const r = await readPageTool.execute({ mode: 'content' }, ctx as any);
+    if (!r.ok) throw new Error('expected ok');
+    expect(r.content).toContain('snapshot text');
+  });
+
+  test('a 2MB-clipped raw DOM surfaces htmlTruncated (distinct from paging truncation)', async () => {
+    const ctx = ctxWith({
+      webOffscreenClient: { extractMarkdown: async () => ({ readerable: true, markdown: '# T\n\nhead only', title: 'T' }) },
+      scripting: {
+        executeScript: async ({ func }: any) => {
+          if (String(func.name) === 'readOuterHtmlInjected') {
+            return [{ result: { html: '<html><body>clipped</body></html>', htmlTruncated: true, url: 'https://site.example/article', title: 'T' } }];
+          }
+          return [{ result: { title: 'T', url: 'https://site.example/article', text: 'snapshot text', interactables: [] } }];
+        },
+      },
+    });
+    const r = await readPageTool.execute({ mode: 'content' }, ctx as any);
+    if (!r.ok) throw new Error('expected ok');
+    const body = fencedBody(r.content!);
+    expect(body.htmlTruncated).toBe(true);
+    // the markdown fit the window, so paging truncation is false — the two signals
+    // are independent, which is the point of the separate field.
+    expect(body.truncated).toBe(false);
+  });
+
   test('the default mode is untouched (no extractor call)', async () => {
     let called = false;
     const ctx = ctxWith({ webOffscreenClient: { extractMarkdown: async () => { called = true; return { readerable: true, markdown: 'x' }; } } });

--- a/tests/peerd-runtime/tools/read-web-cache.test.ts
+++ b/tests/peerd-runtime/tools/read-web-cache.test.ts
@@ -54,7 +54,9 @@ describe('read_web_cache', () => {
     expect((await readWebCacheTool.execute({}, ctxWith({}) as any)).ok).toBe(false);
     const gone = await readWebCacheTool.execute({ key: 'wc-gone' }, ctxWith({}) as any);
     expect(gone.ok).toBe(false);
-    if (!gone.ok) expect(gone.error).toContain('re-fetch');
+    // the recovery hint is source-aware now (a read_page spill must NOT be told
+    // to fetch_url the rendered page it came from) — it says "re-run the read".
+    if (!gone.ok) expect(gone.error).toContain('re-run the read');
     const noCap = await readWebCacheTool.execute({ key: 'wc-1' }, {} as any);
     expect(noCap.ok).toBe(false);
     if (!noCap.ok) expect(noCap.error).toBe('web_cache_unavailable');


### PR DESCRIPTION
## What & why

A skeptical, adversarially-verified review swarm over the four just-merged PRs (#170 Z.ai GLM, #187/#189 read_page content pipeline, #188 benchmark doc) surfaced a set of correctness, integration, doc, and test-hygiene defects. Every fix below survived a 2–3 vote adversarial verification pass; the two external-data claims (Z.ai's error-1113 wording and GLM-4.6's real rate card) were confirmed against Z.ai's published docs.

Closes # — (no issue; follow-up to the merges above)

**Correctness**
- **`manifests.js`** — the `research` / `browse-only` presets allowed a spill producer (`fetch_url`, `read_page mode:'content'`) but omitted `read_web_cache`, so a spilled body's trusted paging footer instructed a tool the manifest gate then refused: the spilled tail unreachable, turns burned on guaranteed-refused calls (the exact budget-exhaustion mode #189 set out to fix). Added `read_web_cache` to both presets — read-only, local cache, no new authority.
- **`read-page.js`** — `mode:'content'` clipped the raw DOM at 2 MB but reported `truncated:false`, silently dropping the tail. Now surfaces an explicit `htmlTruncated` signal, distinct from the paging `truncated` flag.
- **`read-web-cache.js`** — the evicted-entry hint said "re-fetch the URL", which for a `read_page` spill steers the actor to `fetch_url` a page it already rendered (losing the post-JS DOM). Made the recovery hint source-aware.

**Provider integration (#170 rebase + adjacent)**
- **`error-classify.js`** — Z.ai signals out-of-credit as error 1113 "Insufficient balance … Please recharge." on HTTP 429; the needle list missed it, so a spent GLM account got 3 pointless retries and no failover. Added the needles.
- **`pricing.js`** — `glm-4.6` shipped priced identically to the `glm-5.2` flagship ($1.4/$4.4), a ~3× overestimate that inflated the CostChip and tripped spend limits early. Corrected to its published tier ($0.43/$1.74).
- **`openai.js`** — the stream parser was called without a provider label, so in-stream errors on OpenAI chats were attributed to "openrouter". Now passes `{ provider: 'openai' }`.

**Docs / classification**
- **`CLAUDE.md`, `README.md`, `peerd-provider/index.js`** — the provider inventory said OpenAI "doesn't exist yet" and omitted OpenAI + Z.ai GLM; both ship. Updated, deferring to `registry.js` per the no-hard-coded-inventories rule.
- **`idb.js`** — `web_extract_cache` was labeled "fetched public bytes"; `read_page` content mode can store a logged-in tab's rendered DOM. Corrected the classification comment.
- **`error-display.js`** — usage-limit copy hard-coded "Anthropic / OpenRouter billing"; genericized (the error already names the provider dynamically).
- **`docs/benchmarks/2026-07-web-thread.md`** — reconciled the failure-taxonomy count (categories overlap) and the 6/29 code-arm denominator (one run did not complete scoring).

## Checklist

- [x] `bun run preflight` passes — locally: typecheck, lint, tscheck floor (511/511), dweb-boundary, docpaths, packaged page-boot (both channels), **2827 bun tests pass**, no generated-file drift.
- [x] Only original or permissively-licensed code.
- [x] Tests added or updated — GLM hard-limit classification + retry regression, GLM per-tier pricing regression, `read_page` grab-failure fail-open + `htmlTruncated`, `spawn.test` fixture completion + `read_page`→`webCache` assertion.
- [x] No hand-edited generated files (`manifest.json`, `channel-config.js` regenerate clean).
- [x] Danger zone: touches egress-adjacent (`error-classify`, `idb` cache comment) and gate-adjacent (`manifests` presets) code — all reviewed; no behavior widened. The manifest change only *adds* a read-only tool the web actor is already allowed; no authority is granted.

## Notes for reviewers

**Deliberately NOT fixed here — flagged for a follow-up.** The review also confirmed a **medium** finding: unpriced runner models (`glm-4.5-air`, OpenRouter's default `anthropic/claude-haiku-4.5`) render as `$0.00` and **bypass the spend limit** (`0 > limit` never trips), so the web-actor session's spend is uncapped by default on those providers. The correct fix is a cost-path change — thread `costOf`'s `estimated` flag through the tally, render "—" instead of `$0.00`, and fail-closed on an unpriced model when a `spendLimitUsd` is set — which touches core cost/limit logic and affects multiple providers. That's a deliberate design change, not an obvious one-liner, so it belongs in its own PR rather than riding this cleanup. Happy to take it next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8EYHtUpzTX6YGfEXPRPKF

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8EYHtUpzTX6YGfEXPRPKF)_