### PR TITLE
feat(web): BM25 query-relevant excerpting for oversized fetched pages

### DIFF
--- a/extension/peerd-runtime/loop/system-prompt.js
+++ b/extension/peerd-runtime/loop/system-prompt.js
@@ -352,6 +352,9 @@ data looks API-reachable; render if it's gated, needs auth, or comes back empty
 (fetch_url returns served html/json, not what JS builds).
 RENDER, don't re-fetch: once a page is in your tab, its content is the DOM — READ it
 (snapshot/read_page). Never call fetch_url for something already on the page you're on.
+LONG page, SPECIFIC fact: pass a query (a few keywords for what you're after) to fetch_url
+or read_page — you get the passages that MATCH it, not a blind head+tail window, so an
+answer buried mid-page isn't missed. Skip it when you want the whole page.
 And a fetch_url "blocked: private/loopback host" (localhost, 127.0.0.1, 192.168.*, a local
 dev server) is an SSRF refusal of the DIRECT fetch — NOT "the site is unreachable": navigate
 to it and read the rendered DOM. Don't give up (or ask the user) on a page you can just open.

--- a/extension/peerd-runtime/tools/defs/fetch-url.js
+++ b/extension/peerd-runtime/tools/defs/fetch-url.js
@@ -19,7 +19,7 @@
 import { fetchUrl } from '../web/primitives.js';
 import { originOfUrl } from './dom-helpers.js';
 import { wrapUntrusted } from '../prompt-wrap.js';
-import { windowText, pagingFooter } from '../web/spill.js';
+import { windowText, pagingFooter, excerptRelevant, excerptFooter } from '../web/spill.js';
 import { needsWebWriteConfirm } from '/peerd-engine/index.js';
 
 const MAX_BODY_CHARS = 16_000;   // hard cap to avoid context-blast on huge payloads
@@ -64,6 +64,7 @@ export const fetchUrlTool = {
       url: { type: 'string', description: 'Absolute URL (must include an http(s) scheme).' },
       method: { type: 'string', enum: ['GET', 'POST'], description: 'HTTP method. Default GET.' },
       raw: { type: 'boolean', description: 'HTML responses are extracted to clean markdown by default (boilerplate stripped). Pass true to get the raw HTML instead — e.g. when you need markup, attributes, or embedded script/JSON the extraction would drop.' },
+      query: { type: 'string', description: 'What you are looking for on this page (a few keywords). When the page is too long to show whole, the most relevant passages are surfaced (BM25) instead of a blind head+tail window — so a mid-page answer is not missed. Omit to get the head+tail window.' },
       headers: {
         type: 'object',
         description: 'Request headers. Tool-supplied Cookie / Authorization are always stripped (you cannot inject a credential). Content-Type is set automatically for JSON bodies.',
@@ -148,18 +149,29 @@ export const fetchUrlTool = {
       // the cache capability is absent (a ctx without webCache).
       const webCache = /** @type {{ key?: () => string, put?: (r: object) => Promise<void> } | undefined} */ (
         /** @type {any} */ (ctx).webCache);
-      const win = windowText(workingBody, MAX_BODY_CHARS);
-      let text = win.window;
-      const truncated = win.windowed;
+      // When the caller named a query AND the body is prose (not JSON — BM25 is
+      // for paragraphs, not object trees), surface the most-relevant PASSAGES
+      // instead of a blind head+tail window: a long page's answer usually sits
+      // mid-document. excerptRelevant returns null (no query / no match / too
+      // few passages) → fall back to windowText. Either way the FULL text is
+      // stored and pageable; this only picks a better first window.
+      const query = typeof args.query === 'string' ? args.query.trim() : '';
+      const ex = (query && !/(json|graphql)/i.test(ct))
+        ? excerptRelevant(workingBody, query, MAX_BODY_CHARS) : null;
+      const win = windowText(workingBody, MAX_BODY_CHARS);   // always computed (cheap) — the fallback path
+      let text = ex ? ex.excerpt : win.window;
+      const truncated = ex ? ex.excerpted : win.windowed;
       /** @type {string | null} */
       let footer = null;
-      if (win.windowed && webCache?.key && webCache?.put) {
+      if (truncated && webCache?.key && webCache?.put) {
         const cacheKey = webCache.key();
         try {
           await webCache.put({ key: cacheKey, url: res.finalUrl || args.url, format, text: workingBody });
-          footer = pagingFooter({ key: cacheKey, total: win.total, headChars: win.headChars, tailChars: win.tailChars });
-        } catch { /* spill failed — the window (with its elision marker) still ships */ }
-      } else if (win.windowed && !webCache) {
+          footer = ex
+            ? excerptFooter({ key: cacheKey, total: ex.total, passagesShown: ex.passagesShown, passagesTotal: ex.passagesTotal, query })
+            : pagingFooter({ key: cacheKey, total: win.total, headChars: win.headChars, tailChars: win.tailChars });
+        } catch { /* spill failed — the window/excerpt (with its elision markers) still ships */ }
+      } else if (truncated && !webCache) {
         // No cache capability → the pre-spill behavior (head-only slice).
         text = workingBody.slice(0, MAX_BODY_CHARS);
       }

--- a/extension/peerd-runtime/tools/defs/read-page.js
+++ b/extension/peerd-runtime/tools/defs/read-page.js
@@ -14,7 +14,7 @@
 
 import { wrapUntrusted } from '../prompt-wrap.js';
 import { resolveTargetTab, originOfUrl } from './dom-helpers.js';
-import { windowText, pagingFooter } from '../web/spill.js';
+import { windowText, pagingFooter, excerptRelevant, excerptFooter } from '../web/spill.js';
 
 // Content mode shares fetch_url's body budget — one read costs like one fetch.
 const CONTENT_BODY_CHARS = 16_000;
@@ -45,6 +45,7 @@ export const readPageTool = {
         enum: ['snapshot', 'content'],
         description: "snapshot (default): text + interactables for OPERATING the page. content: the readable core as markdown for READING it.",
       },
+      query: { type: 'string', description: "content mode only: what you're looking for (a few keywords). When the page is too long to show whole, the most relevant passages are surfaced (BM25) instead of a blind head+tail window. Omit for the head+tail window." },
     },
   },
   sideEffect: 'read',
@@ -77,17 +78,25 @@ export const readPageTool = {
               const origin = originOfUrl(grabbed.url || tab.url);
               const webCache = /** @type {{ key?: () => string, put?: (r: object) => Promise<void> } | undefined} */ (
                 /** @type {any} */ (ctx).webCache);
+              // Query-relevant excerpt when the caller named what it's after
+              // (markdown is always prose here); else the head+tail window. Same
+              // spill contract — full markdown stored + pageable either way.
+              const query = typeof args.query === 'string' ? args.query.trim() : '';
+              const excerpt = query ? excerptRelevant(ex.markdown, query, CONTENT_BODY_CHARS) : null;
               const win = windowText(ex.markdown, CONTENT_BODY_CHARS);
-              let text = win.window;
+              let text = excerpt ? excerpt.excerpt : win.window;
+              const truncated = excerpt ? excerpt.excerpted : win.windowed;
               /** @type {string | null} */
               let footer = null;
-              if (win.windowed && webCache?.key && webCache?.put) {
+              if (truncated && webCache?.key && webCache?.put) {
                 const cacheKey = webCache.key();
                 try {
                   await webCache.put({ key: cacheKey, url: grabbed.url || tab.url, format: 'markdown', text: ex.markdown });
-                  footer = pagingFooter({ key: cacheKey, total: win.total, headChars: win.headChars, tailChars: win.tailChars });
-                } catch { /* spill failed — the window (with its elision marker) still ships */ }
-              } else if (win.windowed && !webCache) {
+                  footer = excerpt
+                    ? excerptFooter({ key: cacheKey, total: excerpt.total, passagesShown: excerpt.passagesShown, passagesTotal: excerpt.passagesTotal, query })
+                    : pagingFooter({ key: cacheKey, total: win.total, headChars: win.headChars, tailChars: win.tailChars });
+                } catch { /* spill failed — the window/excerpt (with its elision markers) still ships */ }
+              } else if (truncated && !webCache) {
                 text = ex.markdown.slice(0, CONTENT_BODY_CHARS);
               }
               const fenced = wrapUntrusted({
@@ -95,7 +104,7 @@ export const readPageTool = {
                 body: JSON.stringify({
                   mode: 'content', url: grabbed.url || tab.url,
                   ...(ex.title ? { title: ex.title } : {}),
-                  format: 'markdown', truncated: win.windowed, body: text,
+                  format: 'markdown', truncated, body: text,
                   // the RAW DOM was clipped at 2MB before extraction — the
                   // readable core may be missing its tail (distinct from
                   // `truncated`, which only means the markdown was windowed).

--- a/extension/peerd-runtime/tools/web/spill.js
+++ b/extension/peerd-runtime/tools/web/spill.js
@@ -68,3 +68,173 @@ export const pageSlice = (text, offset, limit) => {
   const end = Math.min(start + Math.max(1, Math.floor(limit) || 1), total);
   return { slice: text.slice(start, end), offset: start, end, total, remaining: total - end };
 };
+
+// ── Query-relevant excerpting (BM25) ────────────────────────────────────────
+// windowText's head+tail is query-BLIND: on a long page the answer is rarely in
+// the first 75% + last 25% — it's in the one paragraph that matches what you
+// asked. When the caller HAS a query (the subgoal it's reading the page for),
+// excerptRelevant returns the passages that best match it, ranked by BM25 and
+// reassembled in DOCUMENT order (so it still reads top-to-bottom) with elision
+// markers where passages were dropped. Same spill contract: the FULL text is
+// still stored and pageable — this just picks a better window to show first.
+// Pure, no IO. Returns null when there's no usable query signal so the caller
+// falls back to windowText.
+
+// A tiny English stoplist — enough to keep common function words from
+// dominating IDF on short queries. why not a big list: over-stemming/stopping
+// hurts recall on proper nouns and short queries more than it helps.
+const STOPWORDS = new Set([
+  'the', 'a', 'an', 'and', 'or', 'of', 'to', 'in', 'on', 'for', 'is', 'are',
+  'was', 'were', 'be', 'by', 'at', 'as', 'it', 'its', 'this', 'that', 'with',
+  'from', 'what', 'which', 'how', 'who', 'when', 'where', 'find', 'get', 'show',
+]);
+
+/** @param {string} s @returns {string[]} lowercased alphanumeric tokens, stopword/1-char stripped */
+const tokenize = (s) => (String(s).toLowerCase().match(/[a-z0-9]+/g) || [])
+  .filter((t) => t.length > 1 && !STOPWORDS.has(t));
+
+/**
+ * Split text into passage chunks on blank lines (markdown paragraphs), then
+ * hard-split any chunk longer than maxChunk so one giant blob can't dominate.
+ * Keeps the original order.
+ * @param {string} text @param {number} maxChunk
+ * @returns {string[]}
+ */
+const chunkPassages = (text, maxChunk) => {
+  /** @type {string[]} */
+  const out = [];
+  for (const para of text.split(/\n{2,}/)) {
+    const p = para.trim();
+    if (!p) continue;
+    if (p.length <= maxChunk) { out.push(p); continue; }
+    for (let i = 0; i < p.length; i += maxChunk) out.push(p.slice(i, i + maxChunk));
+  }
+  return out;
+};
+
+/**
+ * BM25 score of each chunk against the query terms (Robertson/Spärck-Jones).
+ * @param {string[][]} chunkTokens  pre-tokenized chunks
+ * @param {string[]} queryTerms
+ * @param {{ k1?: number, b?: number }} [opts]
+ * @returns {number[]} one score per chunk (0 = no query term present)
+ */
+const bm25Scores = (chunkTokens, queryTerms, { k1 = 1.5, b = 0.75 } = {}) => {
+  const N = chunkTokens.length;
+  const lengths = chunkTokens.map((t) => t.length);
+  const avgdl = lengths.reduce((s, l) => s + l, 0) / (N || 1) || 1;
+  const uniqQuery = [...new Set(queryTerms)];
+  // document frequency per query term
+  /** @type {Map<string, number>} */
+  const df = new Map();
+  for (const term of uniqQuery) {
+    let d = 0;
+    for (const toks of chunkTokens) if (toks.includes(term)) d++;
+    df.set(term, d);
+  }
+  // idf with the +1 floor so a term in every chunk still scores ≥ 0
+  /** @type {Map<string, number>} */
+  const idf = new Map();
+  for (const term of uniqQuery) {
+    const d = df.get(term) || 0;
+    idf.set(term, Math.log(1 + (N - d + 0.5) / (d + 0.5)));
+  }
+  return chunkTokens.map((toks, i) => {
+    if (!toks.length) return 0;
+    /** @type {Map<string, number>} */
+    const tf = new Map();
+    for (const t of toks) tf.set(t, (tf.get(t) || 0) + 1);
+    let score = 0;
+    for (const term of uniqQuery) {
+      const f = tf.get(term) || 0;
+      if (!f) continue;
+      const denom = f + k1 * (1 - b + (b * lengths[i]) / avgdl);
+      score += (idf.get(term) || 0) * (f * (k1 + 1)) / denom;
+    }
+    return score;
+  });
+};
+
+/**
+ * Query-relevant excerpt of an oversized text. Returns the highest-BM25 passages
+ * that fit the budget, reassembled in document order with elision markers.
+ * Text at/under budget passes through whole. Returns NULL — signalling the
+ * caller to fall back to windowText — when there is no usable query, fewer than
+ * two passages, or no passage matches the query (all scores 0).
+ *
+ * @param {string} text
+ * @param {string} query   what the caller is looking for on this page
+ * @param {number} budget  max chars to show
+ * @param {{ k1?: number, b?: number, maxChunk?: number }} [opts]
+ * @returns {{ excerpted: boolean, excerpt: string, passagesShown: number, passagesTotal: number, charsShown: number, total: number } | null}
+ */
+export const excerptRelevant = (text, query, budget, opts = {}) => {
+  const total = text.length;
+  const queryTerms = tokenize(query || '');
+  if (!queryTerms.length) return null;                       // no query → caller windows head/tail
+  if (total <= budget) {
+    return { excerpted: false, excerpt: text, passagesShown: 1, passagesTotal: 1, charsShown: total, total };
+  }
+  const maxChunk = Math.max(200, Math.min(opts.maxChunk ?? 1200, budget));
+  const chunks = chunkPassages(text, maxChunk);
+  if (chunks.length < 2) return null;                        // nothing to rank → fall back
+  const chunkTokens = chunks.map(tokenize);
+  const scores = bm25Scores(chunkTokens, queryTerms, opts);
+  if (!scores.some((s) => s > 0)) return null;               // query matches nothing → fall back
+
+  // Greedily take highest-scoring passages until the next won't fit; always
+  // take at least the top one. Ties broken by earlier document position.
+  const ranked = chunks
+    .map((t, i) => ({ i, t, score: scores[i] }))
+    .filter((c) => c.score > 0)
+    .sort((a, b) => (b.score - a.score) || (a.i - b.i));
+  const SEP = '\n\n';
+  /** @type {{ i: number, t: string }[]} */
+  const picked = [];
+  let used = 0;
+  for (const c of ranked) {
+    const add = c.t.length + (picked.length ? SEP.length : 0);
+    if (picked.length && used + add > budget) continue;      // skip; a later shorter one may still fit
+    picked.push(c); used += add;
+    if (used >= budget) break;
+  }
+  picked.sort((a, b) => a.i - b.i);                          // back into document order
+
+  // Assemble in order; mark where passages were dropped between kept ones.
+  const parts = [];
+  if (picked[0].i > 0) parts.push(`[… ${picked[0].i} earlier passage(s) …]`);
+  for (let k = 0; k < picked.length; k++) {
+    parts.push(picked[k].t);
+    const next = picked[k + 1];
+    if (next) {
+      const gap = next.i - picked[k].i - 1;
+      if (gap > 0) parts.push(`[… ${gap} passage(s) …]`);
+    }
+  }
+  const lastKept = picked[picked.length - 1].i;
+  const trailing = chunks.length - 1 - lastKept;
+  if (trailing > 0) parts.push(`[… ${trailing} later passage(s) …]`);
+
+  return {
+    excerpted: true,
+    excerpt: parts.join('\n\n'),
+    passagesShown: picked.length,
+    passagesTotal: chunks.length,
+    charsShown: used,
+    total,
+  };
+};
+
+/**
+ * The paging footer for an EXCERPTED body — same trust rules as pagingFooter
+ * (rides outside the untrusted fence, caller-computed values only). Tells the
+ * model it saw the most-relevant passages, not a contiguous slice, and how to
+ * read the rest.
+ *
+ * @param {{ key: string, total: number, passagesShown: number, passagesTotal: number, query: string }} p
+ * @returns {string}
+ */
+export const excerptFooter = ({ key, total, passagesShown, passagesTotal, query }) => [
+  `[paging] Showed the ${passagesShown} passage(s) most relevant to "${query}" (of ${passagesTotal}) from ${total} chars stored locally — NOT a contiguous slice.`,
+  `To read the surrounding text or other sections call read_web_cache with { "key": "${key}", "offset": <char offset>, "limit": <chars, max 16000> }.`,
+].join('\n');

--- a/tests/peerd-runtime/tools/web-spill.test.ts
+++ b/tests/peerd-runtime/tools/web-spill.test.ts
@@ -4,7 +4,7 @@
 // paging contract honest live here.
 
 import { describe, test, expect } from 'bun:test';
-import { windowText, pagingFooter, pageSlice } from '../../../extension/peerd-runtime/tools/web/spill.js';
+import { windowText, pagingFooter, pageSlice, excerptRelevant, excerptFooter } from '../../../extension/peerd-runtime/tools/web/spill.js';
 
 describe('windowText', () => {
   test('text at or under the budget passes through whole', () => {
@@ -53,5 +53,65 @@ describe('pageSlice', () => {
     expect(pageSlice(text, 8, 100).slice).toBe('ij');        // limit past the end → to end
     expect(pageSlice(text, 99, 3)).toMatchObject({ slice: '', remaining: 0 });  // offset past end
     expect(pageSlice(text, 0, 0).slice).toBe('a');           // degenerate limit → at least 1 char
+  });
+});
+
+describe('excerptRelevant (BM25 query-relevant excerpting)', () => {
+  // A long page: filler paragraphs surrounding one that actually answers the query.
+  const filler = (n: number) =>
+    Array.from({ length: n }, (_, i) => `Section ${i}. General background prose about unrelated topics, navigation, cookies, and boilerplate footer links repeated across the site.`);
+  const needle = 'Qatar Airways economy class checked baggage allowance is 30 kg per passenger on most routes.';
+  const page = [...filler(20), needle, ...filler(20)].join('\n\n');
+
+  test('no query → returns null so the caller falls back to head/tail windowing', () => {
+    expect(excerptRelevant(page, '', 400)).toBeNull();
+    expect(excerptRelevant(page, '   ', 400)).toBeNull();
+  });
+
+  test('text at or under budget passes through whole (not excerpted)', () => {
+    const r = excerptRelevant('a short body about baggage', 'baggage', 1000);
+    expect(r).not.toBeNull();
+    expect(r!.excerpted).toBe(false);
+    expect(r!.excerpt).toBe('a short body about baggage');
+  });
+
+  test('surfaces the passage that answers the query and drops the filler', () => {
+    const budget = 400;   // far smaller than the full page → must choose
+    const r = excerptRelevant(page, 'Qatar economy baggage allowance kg', budget);
+    expect(r).not.toBeNull();
+    expect(r!.excerpted).toBe(true);
+    // the answer is present even though it sat in the MIDDLE (a head+tail window would miss it)
+    expect(r!.excerpt).toContain('30 kg');
+    // it dropped most passages (chose a few relevant, not all 41)
+    expect(r!.passagesShown).toBeLessThan(r!.passagesTotal);
+    // and it flagged that passages were elided, so the model knows it isn't the whole page
+    expect(r!.excerpt).toMatch(/passage\(s\)/);
+    // budget respected
+    expect(r!.charsShown).toBeLessThanOrEqual(budget);
+  });
+
+  test('kept passages stay in document order', () => {
+    // two needles far apart; both should appear, first one before the second
+    const p = [needle, ...filler(30), 'Business class baggage allowance is 40 kg.'].join('\n\n');
+    const r = excerptRelevant(p, 'baggage allowance kg', 500);
+    expect(r).not.toBeNull();
+    const i30 = r!.excerpt.indexOf('30 kg');
+    const i40 = r!.excerpt.indexOf('40 kg');
+    if (i30 !== -1 && i40 !== -1) expect(i30).toBeLessThan(i40);   // document order preserved
+  });
+
+  test('query that matches nothing → null (fall back to windowing)', () => {
+    expect(excerptRelevant(page, 'xyzzyquux nonexistentterm', 400)).toBeNull();
+  });
+});
+
+describe('excerptFooter', () => {
+  test('names the passages shown, the query, and the read_web_cache call', () => {
+    const f = excerptFooter({ key: 'wc-abc-1', total: 90_000, passagesShown: 3, passagesTotal: 55, query: 'baggage allowance' });
+    expect(f).toContain('read_web_cache');
+    expect(f).toContain('"key": "wc-abc-1"');
+    expect(f).toContain('3 passage(s)');
+    expect(f).toContain('baggage allowance');
+    expect(f).toContain('NOT a contiguous slice');   // the honesty flag: it's relevance-ranked, not a window
   });
 });


### PR DESCRIPTION
The planned next step from the content pipeline (#187).

## The gap

`fetch_url` and `read_page(mode:'content')` already spill an oversized body: the full text is stored locally and the model sees a **head+tail window** plus the exact `read_web_cache` paging call. But head+tail is **query-blind** — a long page's answer usually sits *mid-document*, exactly the part the window elides. The model then has to page around blindly to find it (the "paging loop" rough edge flagged in #187).

## The change

When the caller names a **`query`** (what it's looking for on the page), surface the passages that best match it instead of a blind window — ranked by **BM25**, reassembled in **document order**, with elision markers where passages were dropped.

- **`spill.js`** gains `excerptRelevant(text, query, budget)` + `excerptFooter` — pure, no IO. Paragraph-chunk the text, BM25-score chunks against the query, greedily take the top ones that fit the budget, re-sort into document order. Returns **`null`** (→ caller falls back to the existing head+tail window) when there's no query, no match, or too few passages — so **behavior is unchanged without a query**.
- **`fetch_url` / `read_page`** take an optional `query` arg. On overflow *with* a query (and prose, not JSON — BM25 is for paragraphs), they excerpt-relevant and emit a footer that's explicit it's a *relevance ranking, not a contiguous slice*. Same spill contract: the **full text is still stored and pageable** via `read_web_cache`, so nothing is lost.

## Why it helps

A long page's answer is rarely in the first 75% + last 25%. Returning the BM25-relevant passages means the model sees the answer on the *first* read instead of paging to find it — fewer round-trips, fewer tokens, fewer step-cap deaths on long pages. It's a strict improvement over head+tail: same fallback when there's no query, better window when there is.

## Tests / gates

BM25 core is pure → fully unit-tested (extends `web-spill.test.ts`): a mid-page answer surfaces when a head+tail window would miss it; budget respected; document order preserved; and the no-query / no-match paths fall back to head+tail. `bun run typecheck`, `eslint`, and the full `bun test ./tests` (2833 pass) all green.

Fail-open and additive — the `query` arg is optional and the no-query path is byte-identical to today.