### PR TITLE
feat(actor): opt-in await for the orchestrator's web delegation (finish-and-report, orchestrator half)

### DIFF
--- a/extension/peerd-provider/system-prompt.txt
+++ b/extension/peerd-provider/system-prompt.txt
@@ -52,8 +52,9 @@ Tools grouped by primitive:
                        app, or a specific page's tabId: "install ffmpeg and transcode
                        /in.mov to /out.webm", "log into gmail and read the latest from
                        Mark". Fire it and don't wait; the reply lands a LATER turn
-                       as a fenced note. Need its answer to proceed? Same later reply —
-                       you just await it. Nothing to poll. (Pages: see browsing below.)
+                       as a fenced note. Nothing to poll. Need its answer to FINISH
+                       THIS turn's answer? Pass await:true and the reply resolves
+                       into this tool result instead. (Pages: see browsing below.)
 
   actor (spawn an EPHEMERAL ACTOR — a focused child agent, fire-once)
     actor_create           — run a child actor on one task (async: its result returns on a LATER turn; sync:true to wait this turn)
@@ -98,12 +99,20 @@ You reach the web by MESSAGING it with intent.
     actor_list shows the ones you've formed (type integration) + the ones the user has stored
     an API key for (detail "keyed": the key rides automatically, same-origin, you never see it).
 
-Delegation is async: message_actor hands the actor a goal and returns at once; its
-summary arrives on a LATER turn as a fenced note you handle then ("complete the
-checkout and report the order number"). When you need a value back to proceed ("read
-the cheapest price"), it's the same channel — you await that later reply. Either way
-nothing waits synchronously and nothing is polled: fire the message(s), keep working
-or end your turn, react to each reply when it lands.
+Delegation is async BY DEFAULT: message_actor hands the actor a goal and returns at
+once; its summary arrives on a LATER turn as a fenced note you handle then ("complete
+the checkout and report the order number"). Nothing is polled: fire the message(s),
+keep working or end your turn, react to each reply when it lands. Prefer this — it is
+the only shape that fans out, and it never parks the user waiting on you.
+
+The ONE exception is await:true, and the test is narrow: you need the actor's value to
+write THIS turn's answer, and deferring would make you end on "I'll report back" with
+nothing said. "Read the cheapest price and tell me" is that case. With await:true the
+fenced reply resolves into the tool result and you answer in the same turn. It BLOCKS,
+so use it for a single delegation you are about to speak from — never for fan-out, and
+never when you have other work you could be doing meanwhile. If the actor is slow the
+await returns "still working" after a few minutes and its real reply arrives on a later
+turn as usual, so nothing is ever lost.
 
 FAN-OUT IN CODE — the script tool's `actors` client. When a task needs SEVERAL
 delegations, or one actor's output feeds another, write ONE script instead of

--- a/extension/peerd-runtime/actor/actor-messaging.js
+++ b/extension/peerd-runtime/actor/actor-messaging.js
@@ -11,9 +11,13 @@
 // synthetic wake, and a per-sender runaway guard. Functional core / imperative shell:
 // every IO surface is injected, so the spawn → run → reply flow is unit-testable.
 //
-// ONE reply shape for EVERY kind (web included). The orchestrator NEVER blocks: it
-// hands a task to an actor and gets woken with the reply on a later turn via
-// deliver()/runWhenIdle — the actor model, uniformly. The actor's own turn slot
+// ONE reply shape for EVERY kind (web included). The orchestrator does not block BY
+// DEFAULT: it hands a task to an actor and gets woken with the reply on a later turn
+// via deliver()/runWhenIdle — the actor model, uniformly. The one exception is the
+// opt-in `await:true` (message_actor), which resolves the fenced reply into the tool
+// result so the orchestrator can answer in the SAME turn instead of deferring; it is
+// bounded by a wall-clock cap that degrades back to the later-turn wake, so even the
+// blocking shape cannot park a turn indefinitely or drop a reply. The actor's own turn slot
 // serializes its turns (one actor per tab/instance); deliver() wrapUntrusted-
 // fences the reply, so a web actor's page-derived reply is fenced like any other
 // untrusted content. (Web used to be a sync-await special case — collapsed into
@@ -60,6 +64,29 @@ import { ASYNC_ACTOR_ACTORS, mayMessageActor, messageProvenance } from './delega
 // Pure policy (no IO), imported directly like the other pure helpers here; the
 // FLAG that turns it on is injected (schemaValidatedReplies), SW-side.
 import { validateActorReply, renderValidatedReply, REPLY_VALIDATION_FAILED } from './reply-schema.js';
+import { ABORT_STEER } from '../loop/turn-slots.js';
+
+/**
+ * The reason a turn's abort signal carries, when it carries one.
+ *
+ * why a helper rather than reading `signal.reason` inline: awaitSignal is
+ * duck-typed — the real one is an AbortSignal, but spawn.js and the tests pass
+ * stubs that implement only `aborted` + the listener pair, where the property is
+ * absent entirely.
+ *
+ * Only an explicit ABORT_STEER opts into the degrade path. Everything else falls
+ * through to cancel: an untagged `abort()` (whose reason is the platform's own
+ * AbortError), ABORT_STOP, and a stub's undefined alike. That direction is the
+ * safe one — cancelling is what every abort meant before reasons existed, so a
+ * caller this file has not been taught about keeps the old semantics rather than
+ * silently leaving an actor running that the user meant to kill.
+ *
+ * @param {{ reason?: unknown } | null | undefined} signal
+ * @returns {unknown}
+ */
+const abortReasonOf = (signal) => {
+  try { return signal?.reason; } catch { return undefined; }
+};
 
 // The actor kinds whose reply is UNTRUSTED web content and so must cross the
 // deterministic schema boundary when it's enabled. Engine sandboxes (vm/notebook/
@@ -465,7 +492,7 @@ export const makeActorMessaging = (deps) => {
   };
 
   /**
-   * @param {{ to?: string, message?: string, senderSessionId?: string|null, inbound?: boolean, toolUseId?: string, oneShot?: boolean, awaitReply?: boolean, awaitCapMs?: number, degradeToAsync?: boolean, via?: string, bareReply?: boolean, awaitSignal?: { aborted: boolean, addEventListener: (t: string, fn: () => void, opts?: object) => void, removeEventListener?: (t: string, fn: () => void) => void } }} req
+   * @param {{ to?: string, message?: string, senderSessionId?: string|null, inbound?: boolean, toolUseId?: string, oneShot?: boolean, awaitReply?: boolean, awaitCapMs?: number, degradeToAsync?: boolean, via?: string, bareReply?: boolean, awaitSignal?: { aborted: boolean, reason?: unknown, addEventListener: (t: string, fn: () => void, opts?: object) => void, removeEventListener?: (t: string, fn: () => void) => void } }} req
    *   awaitReply — the ACTOR reply mode (PR #134): resolve the fenced reply
    *   into this call's result instead of a later-turn wake. Set by the
    *   message_actor tool for a `kind:'spawned'` sender.
@@ -597,8 +624,10 @@ export const makeActorMessaging = (deps) => {
     trackIntent(rootSessionId, intentK);
     appendAudit({ type: 'actor_message', details: { to: instanceId, kind, senderSessionId, rootSessionId, lineagePath: provenance.lineagePath, ...(typeof via === 'string' ? { via } : {}) } }).catch(() => {});
 
-    // ASYNC for EVERY long-lived sender — web included. The orchestrator never
-    // blocks: it hands a task to the actor and gets woken with the reply on a
+    // ASYNC for EVERY long-lived sender — web included — unless the caller opted
+    // into `await:true`, which takes the awaitReply branch below instead. On THIS
+    // path the orchestrator does not block: it hands a task
+    // to the actor and gets woken with the reply on a
     // later turn (the actor model, uniformly). Persist the correlation to the
     // durable mailbox FIRST (await the write so the record is on disk before any
     // actor side effect begins — closing the accept→persist window an SW death
@@ -656,6 +685,20 @@ export const makeActorMessaging = (deps) => {
         let capTimer = /** @type {ReturnType<typeof setTimeout> | null} */ (null);
         const onAbort = () => {
           if (done) return;                                 // stale abort after the reply → no-op
+          // A STEER is not a cancel. The turn slot aborts on Stop AND on a steer
+          // (a second message into the same chat supersedes the streaming turn),
+          // and both arrive on this one signal. Stop means "end the delegated
+          // work" — #134's semantics, kept. A steer means the user ADDED a
+          // message; they did not ask for the web actor mid-fetch to be thrown
+          // away, and before await:true existed that reply survived a steer and
+          // landed on a later turn. So a steer takes the SAME exit as the
+          // wall-clock cap: don't stop the actor, mark the correlation degraded,
+          // and let the reply wake the sender's next turn — which, on a steer,
+          // is the very turn the user just started. Only for a sender that HAS
+          // a later turn (degradeToAsync, i.e. the orchestrator opt-in); an
+          // ephemeral child has none, so degrading it would drop the reply and
+          // it keeps the cancel.
+          if (degradeToAsync === true && abortReasonOf(awaitSignal) === ABORT_STEER) { onCap(); return; }
           stopActorForAwait(correlationId, actor.actorSessionId);
           const notice = 'the request was aborted (timeout or cancel) before the actor replied.';
           finish({ text: bareReply === true ? notice : replyText(instanceId, kind, name, notice, true), failed: true });

--- a/extension/peerd-runtime/actor/actor-messaging.js
+++ b/extension/peerd-runtime/actor/actor-messaging.js
@@ -339,8 +339,8 @@ export const makeActorMessaging = (deps) => {
   //
   // Bookkeeping is keyed by rootSessionId (phase 4/5): the lineage root shares
   // one budget and one Stop generation, whoever in the tree actually sent.
-  /** @param {{ correlationId: string, senderSessionId: string, rootSessionId: string, actor: { instanceId: string, kind: string, actorSessionId: string, name?: string, tabId?: number }, message: string, parentToolUseId?: string, oneShot?: boolean, bare?: boolean, via?: string, onReply?: (text: string, failed: boolean) => void }} o */
-  const runEngineDelivery = ({ correlationId, senderSessionId, rootSessionId, actor, message, parentToolUseId, oneShot, bare, via, onReply }) => {
+  /** @param {{ correlationId: string, senderSessionId: string, rootSessionId: string, actor: { instanceId: string, kind: string, actorSessionId: string, name?: string, tabId?: number }, message: string, parentToolUseId?: string, oneShot?: boolean, bare?: boolean, via?: string, onReply?: (text: string, failed: boolean) => void, deliverInstead?: () => boolean }} o */
+  const runEngineDelivery = ({ correlationId, senderSessionId, rootSessionId, actor, message, parentToolUseId, oneShot, bare, via, onReply, deliverInstead }) => {
     const { instanceId, kind, actorSessionId, name, tabId } = actor;
     trackActor(rootSessionId, actorSessionId);
     // Keyed on actorSessionId, NOT instanceId — must match the live-path track
@@ -405,7 +405,17 @@ export const makeActorMessaging = (deps) => {
       // free-form/error bodies were previously clamped at the callsite — apply the
       // single RESULT_CHARS ceiling here for every path.
       outBody = outBody.slice(0, RESULT_CHARS);
-      if (onReply) { onReply(bare ? outBody : replyText(instanceId, kind, name, outBody, outFailed), outFailed); return; }
+      // deliverInstead() true = the awaiting caller already resolved by its
+      // wall-clock cap (degrade-to-async): the actor kept working, so its now-
+      // arrived reply must route to the sender's LATER turn (deliver) instead of
+      // an onReply the caller has stopped listening on — otherwise the reply is
+      // dropped. Only the orchestrator opt-in await sets this (it has a later
+      // turn); an ephemeral child never does (no later turn to wake).
+      //
+      // Ordering note (rebase onto #255): validation + the RESULT_CHARS clamp run
+      // FIRST, so a degraded reply that lands on the later turn is the same
+      // validated, bounded body the awaiting caller would have received.
+      if (onReply && !(deliverInstead && deliverInstead())) { onReply(bare ? outBody : replyText(instanceId, kind, name, outBody, outFailed), outFailed); return; }
       deliver(senderSessionId, instanceId, kind, name, outBody, outFailed, via);
     };
     // Serialize on the ACTOR's slot — runWhenIdle runs the turn the moment the
@@ -455,17 +465,23 @@ export const makeActorMessaging = (deps) => {
   };
 
   /**
-   * @param {{ to?: string, message?: string, senderSessionId?: string|null, inbound?: boolean, toolUseId?: string, oneShot?: boolean, awaitReply?: boolean, via?: string, bareReply?: boolean, awaitSignal?: { aborted: boolean, addEventListener: (t: string, fn: () => void, opts?: object) => void, removeEventListener?: (t: string, fn: () => void) => void } }} req
+   * @param {{ to?: string, message?: string, senderSessionId?: string|null, inbound?: boolean, toolUseId?: string, oneShot?: boolean, awaitReply?: boolean, awaitCapMs?: number, degradeToAsync?: boolean, via?: string, bareReply?: boolean, awaitSignal?: { aborted: boolean, addEventListener: (t: string, fn: () => void, opts?: object) => void, removeEventListener?: (t: string, fn: () => void) => void } }} req
    *   awaitReply — the ACTOR reply mode (PR #134): resolve the fenced reply
    *   into this call's result instead of a later-turn wake. Set by the
    *   message_actor tool for a `kind:'spawned'` sender.
+   *   degradeToAsync + awaitCapMs — the orchestrator opt-in await's wall-clock
+   *   cap. When degradeToAsync is true and the cap elapses before the reply, the
+   *   await resolves with a non-failed "still working" note WITHOUT cancelling the
+   *   actor, and the eventual reply routes to the sender's later turn (deliver).
+   *   Only a long-lived sender (has a later turn) sets these; an ephemeral child
+   *   never does (its awaitSignal is its own wall-clock, and it has no later turn).
    *   awaitSignal — the awaiting actor's AbortSignal (its wall-clock timeout
    *   / cancel). Only meaningful with awaitReply: the await races the reply
    *   against it so an aborted child unblocks instead of parking on a hung actor.
    * @returns {Promise<{ ok: boolean, content?: string, error?: string }>}
    */
   const messageActor = async (req) => {
-    const { to, message, senderSessionId, inbound, toolUseId, oneShot, awaitReply, awaitSignal, via, bareReply } = req;
+    const { to, message, senderSessionId, inbound, toolUseId, oneShot, awaitReply, awaitSignal, awaitCapMs, degradeToAsync, via, bareReply } = req;
     if (typeof to !== 'string' || !to.trim()) {
       return { ok: false, error: 'message_actor: `to` (a tab-hosted instance id) is required' };
     }
@@ -632,15 +648,36 @@ export const makeActorMessaging = (deps) => {
         // trackActor/clear bookkeeping stays symmetric even on abort (its onReply
         // just no-ops by then).
         let done = false;
+        // Set true when the wall-clock cap fires: the awaited turn keeps running
+        // (NOT cancelled), so its later reply must route to the sender's next turn
+        // via deliver() — settle() reads this getter. Only the orchestrator opt-in
+        // arms the cap (degradeToAsync), and only it HAS a later turn to wake.
+        let degraded = false;
+        let capTimer = /** @type {ReturnType<typeof setTimeout> | null} */ (null);
         const onAbort = () => {
           if (done) return;                                 // stale abort after the reply → no-op
           stopActorForAwait(correlationId, actor.actorSessionId);
           const notice = 'the request was aborted (timeout or cancel) before the actor replied.';
           finish({ text: bareReply === true ? notice : replyText(instanceId, kind, name, notice, true), failed: true });
         };
+        // The await wall-clock cap → DEGRADE TO ASYNC. why distinct from onAbort:
+        // Stop/cancel means "stop the work"; a too-slow reply does NOT — the actor
+        // is still making progress, so we DON'T stopActorForAwait. We unblock the
+        // orchestrator turn NOW with a truthful, non-failed note, flip `degraded`
+        // so the eventual reply lands as the sender's later-turn wake (deliver),
+        // and let the actor finish. This is the bound the orchestrator's turn
+        // signal lacks (no wall-clock — only Stop), the "parked forever" case the
+        // reviewer flagged; the reply is re-routed, never dropped.
+        const onCap = () => {
+          if (done) return;
+          degraded = true;
+          const notice = `the ${kind} actor is still working; its reply will arrive as a fenced note on a later turn.`;
+          finish({ text: bareReply === true ? notice : replyText(instanceId, kind, name, notice, false), failed: false });
+        };
         const finish = (/** @type {{ text: string, failed: boolean }} */ v) => {
           if (done) return;
           done = true;
+          if (capTimer) { clearTimeout(capTimer); capTimer = null; }
           try { awaitSignal?.removeEventListener?.('abort', onAbort); } catch { /* stub signal in tests */ }
           resolve(v);
         };
@@ -652,10 +689,17 @@ export const makeActorMessaging = (deps) => {
           correlationId, senderSessionId: sender, rootSessionId, actor, message,
           parentToolUseId: toolUseId, oneShot: oneShot === true, bare: bareReply === true,
           onReply: (text, failed) => finish({ text, failed }),
+          deliverInstead: () => degraded,
         });
         if (awaitSignal) {
           if (awaitSignal.aborted) onAbort();               // already aborted → resolve now
           else awaitSignal.addEventListener('abort', onAbort, { once: true });
+        }
+        // Arm the cap only for the orchestrator opt-in (degradeToAsync + a positive
+        // cap). An ephemeral child passes neither — its awaitSignal IS its wall-clock,
+        // and it has no later turn, so degrading it would DROP the reply.
+        if (degradeToAsync === true && typeof awaitCapMs === 'number' && awaitCapMs > 0 && !done) {
+          capTimer = setTimeout(onCap, awaitCapMs);
         }
       });
       return settled.failed

--- a/extension/peerd-runtime/loop/turn-driver.js
+++ b/extension/peerd-runtime/loop/turn-driver.js
@@ -290,6 +290,14 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
   const toolContext = await buildToolContext(isActor
     ? { exposure: EXPOSURE_ACTOR, sessionId, activeTabId, synthetic, trusted, actorInstanceId, actorType, actorBacking }
     : { exposure: 'main', sessionId, activeTabId, synthetic, trusted });
+  // why: thread THIS turn's abort signal onto the tool ctx so a tool that can
+  // block IN-BAND unwinds on Stop / the turn timeout instead of parking the
+  // turn — message_actor with await:true (which resolves the actor's reply into
+  // the tool result), and a headless script run. The offscreen actor path
+  // already gets its own signal; this closes the same gap for the orchestrator,
+  // whose awaited web delegation must stay cancellable. The controller aborts on
+  // Stop (turnSlots.claim → abortController.abort()).
+  toolContext.abortSignal = abortController.signal;
 
   // Recomputed PER STEP (the loop's refreshTools): the dweb-engagement and
   // goal cuts below change mid-turn, so the advertised list must follow.

--- a/extension/peerd-runtime/loop/turn-slots.js
+++ b/extension/peerd-runtime/loop/turn-slots.js
@@ -28,6 +28,18 @@
 // service worker is the imperative shell that binds these slots to the
 // agent loop, the side-panel port, and auto-memory's busy gate.
 
+// WHY the abort carries a REASON. Both paths below abort the same controller, but
+// they mean opposite things to work the turn had delegated: Stop means "end it", a
+// steer means "also do this" — the user added a message, they did not ask for the
+// web actor mid-fetch to be thrown away. A bare abort() is indistinguishable at the
+// listener, so an awaited delegation had to treat every abort as a cancel and
+// destroyed in-flight actor work on a steer. These reasons let a listener tell them
+// apart (actor-messaging.js routes a steer through degrade-to-async instead of
+// cancelling). Plain strings, compared by identity-free equality: the signal crosses
+// no worker boundary, but a string survives one and an Error subclass would not.
+export const ABORT_STOP = 'peerd:stop';
+export const ABORT_STEER = 'peerd:steer';
+
 /**
  * @returns {{
  *   claim: (sessionId: string) => { controller: AbortController, release: () => void },
@@ -95,7 +107,7 @@ export const makeTurnSlots = ({ onAbort, forceReleaseMs = 15_000 } = {}) => {
       // turn already streaming there. onAbort decline-settles the superseded
       // turn's pending confirm (if any) so it doesn't run the cancelled action.
       const superseded = slots.get(sessionId);
-      if (superseded) { superseded.abort(); onAbort?.(sessionId); }
+      if (superseded) { superseded.abort(ABORT_STEER); onAbort?.(sessionId); }
       const controller = new AbortController();
       slots.set(sessionId, controller);
       return {
@@ -114,7 +126,7 @@ export const makeTurnSlots = ({ onAbort, forceReleaseMs = 15_000 } = {}) => {
     stop(sessionId) {
       const controller = slots.get(sessionId);
       if (!controller) return false;
-      controller.abort();
+      controller.abort(ABORT_STOP);
       onAbort?.(sessionId); // decline any confirm this turn is parked on
       // A well-behaved turn observes the abort and release()s within ms; a
       // hung one never does — reap it so Stop actually frees the session.

--- a/extension/peerd-runtime/tools/defs/message-actor.js
+++ b/extension/peerd-runtime/tools/defs/message-actor.js
@@ -10,11 +10,22 @@
 // SW). The exposure gate refuses this tool on an actor session, so an actor
 // can't recursively message another actor.
 
+// why a wall-clock cap on the orchestrator's opt-in await: the orchestrator's
+// turn has NO timeout of its own (only user Stop), so a slow or hung web
+// delegation awaited in-band would block the turn indefinitely. At the cap the
+// await DEGRADES TO ASYNC — the actor is NOT cancelled, it keeps working and its
+// reply lands as the usual later-turn fenced note — so the user gets a prompt
+// "still working" answer instead of a frozen turn. A few minutes: long enough
+// that most primary web tasks resolve in-band, short enough to never read as
+// hung. Ephemeral children don't use this — their awaitSignal is their own
+// wall-clock cap, and they have no later turn to degrade to.
+const ORCHESTRATOR_AWAIT_CAP_MS = 3 * 60_000;
+
 /**
  * The ctx slot message_actor reads (an SW-injected extra, not on the base
  * ToolContext contract).
  * @typedef {Object} MessageActorCtx
- * @property {(req: { to: string, message: string, senderSessionId?: string|null, inbound?: boolean, toolUseId?: string, oneShot?: boolean, awaitReply?: boolean, awaitSignal?: any }) => Promise<{ ok: boolean, content?: string, error?: string }>} [messageActor]
+ * @property {(req: { to: string, message: string, senderSessionId?: string|null, inbound?: boolean, toolUseId?: string, oneShot?: boolean, awaitReply?: boolean, awaitSignal?: any, degradeToAsync?: boolean, awaitCapMs?: number }) => Promise<{ ok: boolean, content?: string, error?: string }>} [messageActor]
  * @property {{ sessionId?: string, kind?: string }} [session]
  * @property {boolean} [inbound]
  * @property {string} [toolUseId]
@@ -68,7 +79,7 @@ export const messageActorTool = {
       },
       await: {
         type: 'boolean',
-        description: 'WAIT for the actor\'s reply IN THIS turn and receive its summarized (fenced) substance as this tool\'s result, instead of the default fire-and-continue (reply on a LATER turn). Set true for ONE primary task whose answer you need now to respond to the user — so you reply with the substance, not an "I\'ll report back" deferral. Leave false (default) to fan out several actors in parallel, or when you will act on the reply on a later turn. Ignored for an ephemeral actor (whose reply always returns here) and for a sandbox oneShot.',
+        description: 'WAIT for the actor\'s reply IN THIS turn and receive its summarized (fenced) substance as this tool\'s result, instead of the default fire-and-continue (reply on a LATER turn). Set true for ONE primary task whose answer you need now to respond to the user — so you reply with the substance, not an "I\'ll report back" deferral. Leave false (default) to fan out several actors in parallel, or when you will act on the reply on a later turn. If the actor takes more than a few minutes, the wait ends with a "still working" note and its reply lands on a later turn instead (it is never dropped). An ephemeral actor\'s reply always returns here regardless of this flag.',
       },
     },
     required: ['to', 'message'],
@@ -112,6 +123,14 @@ export const messageActorTool = {
       // caller's wall-clock timeout / Stop / cancel, so a hung actor turn can't
       // park the await past its budget (#1/#3).
       awaitSignal: c.abortSignal,
+      // The orchestrator opt-in (await:true from a NON-ephemeral sender) gets a
+      // wall-clock cap that DEGRADES TO ASYNC — its turn signal has no timeout of
+      // its own, so without this a slow web delegation would block the turn until
+      // Stop. Gated to a long-lived sender: an ephemeral child (kind:'spawned')
+      // has no later turn to degrade to, so it keeps the abort-only semantics and
+      // relies on its own wall-clock awaitSignal.
+      degradeToAsync: args?.await === true && c.session?.kind !== 'spawned',
+      awaitCapMs: ORCHESTRATOR_AWAIT_CAP_MS,
     });
     // Narrow the orchestrator's {ok, content?, error?} into the ToolResult union.
     return res.ok

--- a/extension/peerd-runtime/tools/defs/message-actor.js
+++ b/extension/peerd-runtime/tools/defs/message-actor.js
@@ -34,10 +34,12 @@ export const messageActorTool = {
     'on a SPECIFIC already-open tab, address its tabId from actor_list / open_tab.) For',
     'a WebVM / Notebook / App, address the instance id from actor_list. Each actor is',
     'started on first message, holds that environment\'s tools, and does the work in',
-    'its own focused context. You SEND a goal and don\'t wait; the reply lands as a',
-    'fenced note on a LATER turn. When your next step',
-    'needs a value back ("read the price") it\'s a call — same later-turn reply, you',
-    'just await it. Nothing to poll either way. An actor is STATEFUL and handles one',
+    'its own focused context. By DEFAULT you send a goal and don\'t wait — the reply',
+    'lands as a fenced note on a LATER turn; fan out several actors this way and',
+    'synthesize as their replies land. But for a SINGLE primary task whose answer you',
+    'need NOW to answer the user ("find X and tell me"), set `await:true`: the actor\'s',
+    'substance comes straight back in THIS tool result and you reply with it, never an',
+    '"I\'ll report back" deferral. Nothing to poll either way. An actor is STATEFUL and handles one',
     'message at a time (its mailbox): reuse the same `to` for follow-up (no',
     're-orientation); message a DIFFERENT tab/instance for independent work — separate',
     'actors run in parallel. Your ONLY path to act on a page or mutate an instance.',
@@ -63,6 +65,10 @@ export const messageActorTool = {
       oneShot: {
         type: 'boolean',
         description: 'SANDBOX INSTANCES ONLY (a vm/notebook/app id — never "web", a tabId, an API origin, or "dweb"; those are refused). Set true when ONE round in your own sandbox settles it — a concrete command or read whose raw result IS the answer ("run `python3 …`", "cat the config"). The actor does the single action and hands its result straight back, skipping the extra turn it would otherwise spend re-summarizing — faster and cheaper. Leave false (default) for open-ended or multi-step work, and always for web/API/dweb targets (their replies are untrusted content and always return summarized). If the action errors, the actor recovers normally regardless.',
+      },
+      await: {
+        type: 'boolean',
+        description: 'WAIT for the actor\'s reply IN THIS turn and receive its summarized (fenced) substance as this tool\'s result, instead of the default fire-and-continue (reply on a LATER turn). Set true for ONE primary task whose answer you need now to respond to the user — so you reply with the substance, not an "I\'ll report back" deferral. Leave false (default) to fan out several actors in parallel, or when you will act on the reply on a later turn. Ignored for an ephemeral actor (whose reply always returns here) and for a sandbox oneShot.',
       },
     },
     required: ['to', 'message'],
@@ -93,14 +99,18 @@ export const messageActorTool = {
       // same thread actor_create uses) keys the actor's live display stream
       // to this card, so its work renders inline like an actor transcript.
       toolUseId: c.toolUseId,
-      // PR #134 — the actor reply mode. An ephemeral child has no later turn
-      // for the reply-wake to re-enter (and waking its session would rebuild it
-      // on the main exposure surface), so its reply resolves INTO this tool
-      // result — still wrapUntrusted-fenced. Long-lived senders keep the wake.
-      awaitReply: c.session?.kind === 'spawned',
-      // The child's own abort signal (spawn.js threads it onto ctx). Lets the
-      // awaited reply race the child's wall-clock timeout / cancel, so a hung
-      // actor turn doesn't park the actor past its budget (#1/#3).
+      // The actor reply mode. An ephemeral child ALWAYS awaits: it has no later
+      // turn for the reply-wake to re-enter (PR #134; waking its session would
+      // rebuild it on the main exposure surface). The orchestrator OPTS IN with
+      // await:true for a single primary task, so it answers the user with the
+      // substance THIS turn instead of a deferral — its awaited reply races the
+      // turn's abort signal (below) so Stop / the turn timeout unwinds it.
+      // Either way the reply resolves INTO this tool result, still wrapUntrusted-fenced.
+      awaitReply: c.session?.kind === 'spawned' || args?.await === true,
+      // The caller's abort signal: spawn.js threads the child's; the turn-driver
+      // threads the orchestrator's turn signal. Lets an awaited reply race the
+      // caller's wall-clock timeout / Stop / cancel, so a hung actor turn can't
+      // park the await past its budget (#1/#3).
       awaitSignal: c.abortSignal,
     });
     // Narrow the orchestrator's {ok, content?, error?} into the ToolResult union.

--- a/tests/peerd-runtime/actor-messaging.test.ts
+++ b/tests/peerd-runtime/actor-messaging.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { makeActorMessaging } from '../../extension/peerd-runtime/actor/actor-messaging.js';
+import { ABORT_STEER, ABORT_STOP } from '../../extension/peerd-runtime/loop/turn-slots.js';
 
 // A flush for the fire-and-forget runWhenIdle → runActorTurn → deliver chain.
 const tick = () => new Promise((r) => setTimeout(r, 0));
@@ -246,6 +247,99 @@ describe('message_actor — awaitReply (in-band reply mode)', () => {
     expect(r.error).toContain('aborted');
     await tick();
     expect(reentries.length).toBe(0);
+  });
+
+  test('a STEER mid-await degrades instead of cancelling — the actor keeps working and its reply lands on the later turn', async () => {
+    // The turn slot aborts on Stop AND on a steer (a second message into the same
+    // chat supersedes the streaming turn), on ONE signal. Before the abort carried
+    // a reason they were indistinguishable, so a user typing a follow-up while the
+    // orchestrator was parked on await:true destroyed the web actor's in-flight
+    // work with no notice to anyone — where pre-await that reply survived the steer
+    // and landed later. A steer must take the cap's exit, not the cancel's.
+    let stopArgs: unknown[] | null = null;
+    let resolveTurn: () => void = () => {};
+    const turnDone = new Promise<void>((res) => { resolveTurn = res; });
+    const { messageActor, reentries } = harness({
+      runActorTurn: async () => { await turnDone; return { result: 'the late price is $42' }; },
+      turnSlots: {
+        runWhenIdle: (_sid: string, fn: () => void) => { fn(); },
+        advanceQueue: () => {},
+        stop: (...a: unknown[]) => { stopArgs = a; return true; },
+      },
+    });
+    const ac = new AbortController();
+    const p = messageActor({
+      to: 'app-1', message: 'find the price', senderSessionId: 'chat-1',
+      awaitReply: true, degradeToAsync: true, awaitSignal: ac.signal,
+    });
+    await tick();                                                    // turn in flight
+    ac.abort(ABORT_STEER);                                           // the user typed a follow-up
+    const r = await p;
+    // The await unblocks NOW, non-failed, with the same note the cap gives.
+    expect(r.ok).toBe(true);
+    expect(r.content).toContain('still working');
+    // …and critically, the delegate was NOT slot-cancelled.
+    expect(stopArgs).toBeNull();
+    expect(reentries.length).toBe(0);
+    // Its reply then arrives as the ordinary later-turn wake — never dropped.
+    resolveTurn();
+    await tick(); await tick();
+    expect(reentries.length).toBe(1);
+    expect(reentries[0].userText).toContain('<u origin="app-1">the late price is $42</u>');
+  });
+
+  test('a STOP mid-await still cancels the delegate (a steer must not have widened Stop)', async () => {
+    // The other half of the reason gate, revert-proofed: routing EVERY abort to
+    // the degrade path would silently break #134's Stop semantics ("Stop ends
+    // delegated work"), and the steer test above would still pass.
+    let stopArgs: unknown[] | null = null;
+    const { messageActor, reentries } = harness({
+      runActorTurn: () => new Promise(() => {}),
+      turnSlots: {
+        runWhenIdle: (_sid: string, fn: () => void) => { fn(); },
+        advanceQueue: () => {},
+        stop: (...a: unknown[]) => { stopArgs = a; return true; },
+      },
+    });
+    const ac = new AbortController();
+    const p = messageActor({
+      to: 'app-1', message: 'find the price', senderSessionId: 'chat-1',
+      awaitReply: true, degradeToAsync: true, awaitSignal: ac.signal,
+    });
+    await tick();
+    ac.abort(ABORT_STOP);
+    const r = await p;
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('aborted');
+    expect(stopArgs).not.toBeNull();                                 // Stop still slot-cancels
+    await tick();
+    expect(reentries.length).toBe(0);
+  });
+
+  test('an UNTAGGED abort keeps the cancel path (fail-safe for stub signals)', async () => {
+    // awaitSignal is duck-typed and several callers pass stubs with no `reason`.
+    // A missing reason must read as "cancel" — the meaning every abort had before
+    // reasons existed — rather than silently degrading into a blocked-forever actor.
+    let stopArgs: unknown[] | null = null;
+    const { messageActor } = harness({
+      runActorTurn: () => new Promise(() => {}),
+      turnSlots: {
+        runWhenIdle: (_sid: string, fn: () => void) => { fn(); },
+        advanceQueue: () => {},
+        stop: (...a: unknown[]) => { stopArgs = a; return true; },
+      },
+    });
+    const ac = new AbortController();
+    const p = messageActor({
+      to: 'app-1', message: 'x', senderSessionId: 'chat-1',
+      awaitReply: true, degradeToAsync: true, awaitSignal: ac.signal,
+    });
+    await tick();
+    ac.abort();                                                      // no reason
+    const r = await p;
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('aborted');
+    expect(stopArgs).not.toBeNull();
   });
 });
 

--- a/tests/peerd-runtime/actor-messaging.test.ts
+++ b/tests/peerd-runtime/actor-messaging.test.ts
@@ -170,6 +170,83 @@ describe('message_actor — awaitReply (in-band reply mode)', () => {
     await tick();
     expect(reentries.length).toBe(0);
   });
+
+  test('await unwinds on a LIVE mid-flight abort (signal fires WHILE the turn runs) and stops the delegate', async () => {
+    // The already-aborted case above tests the queued-before-start path; this
+    // pins the RUNNING path — the abort arrives after the turn is in flight, so
+    // stopActorForAwait must slot-cancel the actor this await is waiting on.
+    let stopArgs: unknown[] | null = null;
+    const { messageActor, reentries } = harness({
+      runActorTurn: () => new Promise(() => {}),                 // hangs — only the abort can settle it
+      turnSlots: {
+        runWhenIdle: (_sid: string, fn: () => void) => { fn(); },
+        advanceQueue: () => {},
+        stop: (...a: unknown[]) => { stopArgs = a; return true; },
+      },
+    });
+    const ac = new AbortController();
+    const p = messageActor({
+      to: 'app-1', message: 'x', senderSessionId: 'chat-1', awaitReply: true, awaitSignal: ac.signal,
+    });
+    await tick();                                                // let the turn queue + start running
+    ac.abort();                                                  // fire the abort MID-FLIGHT
+    const r = await p;
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('aborted');
+    expect(stopArgs).not.toBeNull();                            // the running delegate was slot-cancelled
+    await tick();
+    expect(reentries.length).toBe(0);
+  });
+
+  test('the orchestrator await DEGRADES TO ASYNC at the wall-clock cap — reply re-routes to a later turn, not dropped', async () => {
+    // The orchestrator's turn signal has no wall-clock; the cap is that bound.
+    // At the cap the actor is NOT cancelled — the await returns a truthful "still
+    // working" note and the eventual reply must land as a later-turn wake.
+    let resolveTurn: () => void = () => {};
+    const turnDone = new Promise<void>((res) => { resolveTurn = res; });
+    const { messageActor, reentries } = harness({
+      runActorTurn: async () => { await turnDone; return { result: 'the late price is $42' }; },
+      turnSlots: { runWhenIdle: (_sid: string, fn: () => void) => { fn(); }, advanceQueue: () => {}, stop: () => true },
+    });
+    const r = await messageActor({
+      to: 'app-1', message: 'find the price', senderSessionId: 'chat-1',
+      awaitReply: true, degradeToAsync: true, awaitCapMs: 5,
+    });
+    // capped out: a NON-failed "still working" note comes back NOW
+    expect(r.ok).toBe(true);
+    expect(r.content).toContain('still working');
+    // the actor was not cancelled, so nothing has re-entered yet
+    expect(reentries.length).toBe(0);
+    // now the actor finishes — its reply must arrive as a later-turn wake (deliver), never dropped
+    resolveTurn();
+    await tick(); await tick();
+    expect(reentries.length).toBe(1);
+    expect(reentries[0].userText).toContain('<u origin="app-1">the late price is $42</u>');
+  });
+
+  test('the cap is NOT armed without degradeToAsync (ephemeral path keeps abort-only semantics)', async () => {
+    // An ephemeral child passes awaitCapMs-less, degradeToAsync-less: even if a
+    // cap value leaked in, it must not degrade — a child has no later turn, so
+    // degrading would DROP its reply. Proof: a hung turn resolves ONLY via abort
+    // (failed), never via a cap-degrade "still working" (which would be ok:true).
+    const { messageActor, reentries } = harness({
+      runActorTurn: () => new Promise(() => {}),
+      turnSlots: { runWhenIdle: (_sid: string, fn: () => void) => { fn(); }, advanceQueue: () => {}, stop: () => true },
+    });
+    const ac = new AbortController();
+    const p = messageActor({
+      to: 'app-1', message: 'x', senderSessionId: 'chat-1',
+      awaitReply: true, awaitSignal: ac.signal, awaitCapMs: 5,       // cap value present…
+      // …but degradeToAsync omitted → the cap must stay disarmed.
+    });
+    await new Promise((r) => setTimeout(r, 20));                     // outlast the 5ms cap
+    ac.abort();
+    const r = await p;
+    expect(r.ok).toBe(false);                                        // resolved by ABORT, not a cap-degrade
+    expect(r.error).toContain('aborted');
+    await tick();
+    expect(reentries.length).toBe(0);
+  });
 });
 
 describe('message_actor — error path still wakes the sender', () => {

--- a/tests/peerd-runtime/actor-messaging.test.ts
+++ b/tests/peerd-runtime/actor-messaging.test.ts
@@ -134,6 +134,44 @@ describe('message_actor — happy path + correlation', () => {
   });
 });
 
+describe('message_actor — awaitReply (in-band reply mode)', () => {
+  test('await resolves the fenced reply INTO the tool result — no later-turn wake', async () => {
+    const { messageActor, reentries, turnsRun } = harness();
+    // The orchestrator opts into an in-band await for a single primary task.
+    const r = await messageActor({
+      to: 'app-1', message: 'get the price', senderSessionId: 'chat-1', awaitReply: true,
+    });
+    // The actor turn still ran on the actor session, exactly like the async path.
+    expect(turnsRun).toEqual([{ actorSessionId: 'res-1', message: 'get the price' }]);
+    // The substance came back HERE, fenced — the caller answers with it directly,
+    // instead of ending its turn on an "I'll report back" deferral.
+    expect(r.ok).toBe(true);
+    expect(r.content).toContain('<u origin="app-1">built the thing</u>');
+    // …and it did NOT re-enter the sender on a later turn (that's the async path).
+    await tick();
+    expect(reentries.length).toBe(0);
+  });
+
+  test('await unwinds on the abort signal (Stop / turn timeout) with a failure result', async () => {
+    // A hung actor turn that never replies — the exact "parked forever" case the
+    // race exists to prevent. The already-aborted signal must resolve the await now.
+    const { messageActor, reentries } = harness({
+      runActorTurn: () => new Promise(() => {}),
+      turnSlots: { runWhenIdle: (_sid: string, fn: () => void) => { fn(); }, advanceQueue: () => {}, stop: () => true },
+    });
+    const ac = new AbortController();
+    ac.abort();
+    const r = await messageActor({
+      to: 'app-1', message: 'x', senderSessionId: 'chat-1', awaitReply: true, awaitSignal: ac.signal,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('aborted');
+    // No later-turn wake fires for an awaited call, even on abort.
+    await tick();
+    expect(reentries.length).toBe(0);
+  });
+});
+
 describe('message_actor — error path still wakes the sender', () => {
   test('a thrown actor turn re-enters the sender with an error notice', async () => {
     const { messageActor, reentries } = harness({

--- a/tests/peerd-runtime/tools/message-actor.test.ts
+++ b/tests/peerd-runtime/tools/message-actor.test.ts
@@ -72,6 +72,28 @@ describe('message_actor — case 6: strict boolean coercions', () => {
     await messageActorTool.execute({ to: 'web', message: 'hi', await: 'yes' }, loose.ctx);
     expect(loose.seen.req.awaitReply).toBe(false); // 'yes' !== true
   });
+
+  test('degradeToAsync is set ONLY for the orchestrator opt-in, never an ephemeral child', async () => {
+    // The wall-clock cap degrades to a later-turn wake — valid only for a sender
+    // that HAS a later turn. An ephemeral child (kind:'spawned') has none, so it
+    // must never degrade even though it awaits, or its reply would be dropped.
+    const orch = recordingCtx({ session: { sessionId: 's', kind: 'main' } });
+    await messageActorTool.execute({ to: 'web', message: 'hi', await: true }, orch.ctx);
+    expect(orch.seen.req.degradeToAsync).toBe(true);
+    expect(typeof orch.seen.req.awaitCapMs).toBe('number');
+    expect(orch.seen.req.awaitCapMs).toBeGreaterThan(0);
+
+    // A spawned child awaits (awaitReply true) but must NOT degrade.
+    const child = recordingCtx({ session: { sessionId: 's', kind: 'spawned' } });
+    await messageActorTool.execute({ to: 'web', message: 'hi' }, child.ctx);
+    expect(child.seen.req.awaitReply).toBe(true);
+    expect(child.seen.req.degradeToAsync).toBe(false);
+
+    // The orchestrator's DEFAULT (async, no opt-in) does not degrade either.
+    const asyncMain = recordingCtx({ session: { sessionId: 's', kind: 'main' } });
+    await messageActorTool.execute({ to: 'web', message: 'hi' }, asyncMain.ctx);
+    expect(asyncMain.seen.req.degradeToAsync).toBe(false);
+  });
 });
 
 describe('message_actor — case 7: pass-through of args + ctx fields', () => {

--- a/tests/peerd-runtime/tools/message-actor.test.ts
+++ b/tests/peerd-runtime/tools/message-actor.test.ts
@@ -51,14 +51,26 @@ describe('message_actor — case 6: strict boolean coercions', () => {
     expect(missing.seen.req.inbound).toBe(false);
   });
 
-  test('awaitReply is true ONLY for an actor session (PR #134 reply mode)', async () => {
+  test('awaitReply: a spawned actor ALWAYS awaits; the orchestrator opts in with await:true', async () => {
+    // A spawned (ephemeral) actor awaits its reply no matter what (PR #134).
     const sub = recordingCtx({ session: { sessionId: 's', kind: 'spawned' } });
     await messageActorTool.execute({ to: 'web', message: 'hi' }, sub.ctx);
     expect(sub.seen.req.awaitReply).toBe(true);
 
+    // The orchestrator ('main') defaults to the async wake — reply on a later turn.
     const main = recordingCtx({ session: { sessionId: 's', kind: 'main' } });
     await messageActorTool.execute({ to: 'web', message: 'hi' }, main.ctx);
-    expect(main.seen.req.awaitReply).toBe(false); // 'main' !== 'spawned'
+    expect(main.seen.req.awaitReply).toBe(false); // default: fire-and-continue
+
+    // …but the orchestrator can OPT IN to an in-band await for a primary task.
+    const awaited = recordingCtx({ session: { sessionId: 's', kind: 'main' } });
+    await messageActorTool.execute({ to: 'web', message: 'hi', await: true }, awaited.ctx);
+    expect(awaited.seen.req.awaitReply).toBe(true);
+
+    // Strict boolean: a truthy non-true does NOT flip the default async path.
+    const loose = recordingCtx({ session: { sessionId: 's', kind: 'main' } });
+    await messageActorTool.execute({ to: 'web', message: 'hi', await: 'yes' }, loose.ctx);
+    expect(loose.seen.req.awaitReply).toBe(false); // 'yes' !== true
   });
 });
 


### PR DESCRIPTION
**Why**

After #197 the web actor reports real substance, but the orchestrator still fires the delegation async and ends its turn on an "I'll report back" deferral. In the OM2W root-cause pass, 88 of the 126 fixable failures are that deferral.

**What**

- Opt-in `await:true` on `message_actor` resolves the actor's reply into the tool result, reusing #134's `awaitReply`.
- Default stays async (fire-and-continue, later-turn reply); fan-out unaffected.
- `turn-driver.js` threads the turn abort signal onto the tool ctx, so Stop or the turn timeout unwinds a hung await.
- Reply stays `wrapUntrusted`-fenced either way. Draft: the blocking semantics are @NotASithLord's call to ratify.

**How**

- New tests under `tests/peerd-runtime/`: await resolves the fenced reply, aborts on the turn signal, default stays async.
- Gates green: typecheck, lint, boundary, imports, tscheck, gen-drift, 2835 bun tests, 621 in-browser.
- OM2W A/B still pending (estimated +7-11pp).
