### PR TITLE
fix(runtime): a hung tool dispatch can no longer wedge the turn (#176)

### DIFF
--- a/extension/background/debugger-pool.js
+++ b/extension/background/debugger-pool.js
@@ -38,6 +38,21 @@ export const createDebuggerPool = () => {
   const attached = new Set();
   /** @type {Map<number, string[]>} per-tab console-event buffer */
   const consoleBufs = new Map();
+  // In-flight Runtime.evaluate rejectors, per tab (issue #176). With
+  // awaitPromise:true an evaluate against a page whose promise never settles
+  // (hung navigation/network) — or a tab that closes / detaches mid-call —
+  // never resolves, parking the agent turn forever. Tab-close and detach
+  // reject every pending evaluate for that tab; a deadline (below) bounds the
+  // hung-page case.
+  /** @type {Map<number, Set<(err: Error) => void>>} */
+  const pendingEvals = new Map();
+  /** @param {number} tabId @param {string} why */
+  const rejectPendingEvals = (tabId, why) => {
+    const set = pendingEvals.get(tabId);
+    if (!set) return;
+    pendingEvals.delete(tabId);
+    for (const reject of set) reject(new Error(`page_exec: ${why}`));
+  };
 
   // why: `chrome.debugger` may not exist in this build at all. It's a
   // CHANNEL-GATED permission — required (install-time) in the preview/dev
@@ -75,6 +90,7 @@ export const createDebuggerPool = () => {
       console.log('[debugger-pool] detach', source.tabId, reason);
       attached.delete(source.tabId);
       consoleBufs.delete(source.tabId);
+      rejectPendingEvals(source.tabId, `debugger detached (${reason ?? 'unknown'}) mid-evaluate`);
     });
   };
 
@@ -84,6 +100,7 @@ export const createDebuggerPool = () => {
   browser.tabs.onRemoved.addListener((tabId) => {
     attached.delete(tabId);
     consoleBufs.delete(tabId);
+    rejectPendingEvals(tabId, 'the tab closed mid-evaluate');
   });
 
   const attach = async (tabId) => {
@@ -124,7 +141,13 @@ export const createDebuggerPool = () => {
     consoleBufs.delete(tabId);
   };
 
-  const evaluate = async (tabId, expression, opts = {}) => {
+  // Deadline for one Runtime.evaluate (issue #176). Generous — an agent
+  // script may legitimately await slow fetches/navigation — but finite, so a
+  // never-settling page promise rejects instead of hanging the dispatch.
+  // Callers can widen per-call via opts.timeoutMs (kept OUT of the CDP params).
+  const EVALUATE_DEADLINE_MS = 120_000;
+
+  const evaluate = async (tabId, expression, { timeoutMs = EVALUATE_DEADLINE_MS, ...opts } = {}) => {
     await attach(tabId);
     // Reset console buffer just before the call so we capture only
     // this evaluate's output. Concurrent evals on the same tab would
@@ -149,21 +172,40 @@ export const createDebuggerPool = () => {
     const wrapped = `(async () => {\n${expression}\n})()`;
     let result;
     try {
-      result = await browser.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
-        expression: wrapped,
-        // The IIFE returns a Promise; awaitPromise unwraps it so we
-        // get the actual return value (or thrown rejection) back.
-        awaitPromise: true,
-        returnByValue: true,
-        // Trusted-Types pages (`require-trusted-types-for 'script'`,
-        // e.g. Gmail / Notion / Slack) reject injected script, so
-        // evaluation uses CDP's sanctioned opt-in for user-privileged
-        // tooling — the same channel DevTools uses.
-        allowUnsafeEvalBlockedByCSP: true,
-        // Treat the eval as a user gesture so gesture-gated APIs
-        // (focus, clipboard, fullscreen) work from the script.
-        userGesture: true,
-        ...opts,
+      // Race the CDP call against the deadline and the per-tab rejectors
+      // (tab close / debugger detach) — sendCommand itself never times out,
+      // and awaitPromise pins it on the page's promise. The loser command may
+      // still settle later inside Chrome; its result is dropped.
+      result = await new Promise((resolve, reject) => {
+        const set = pendingEvals.get(tabId) ?? new Set();
+        pendingEvals.set(tabId, set);
+        const timer = setTimeout(() => {
+          fail(new Error(`page_exec: the page script did not settle within ${Math.round(timeoutMs / 1000)}s — hung promise or unresponsive page`));
+        }, timeoutMs);
+        /** @param {Error} e */
+        const fail = (e) => { cleanup(); reject(e); };
+        const cleanup = () => {
+          clearTimeout(timer);
+          set.delete(fail);
+          if (set.size === 0 && pendingEvals.get(tabId) === set) pendingEvals.delete(tabId);
+        };
+        set.add(fail);
+        browser.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
+          expression: wrapped,
+          // The IIFE returns a Promise; awaitPromise unwraps it so we
+          // get the actual return value (or thrown rejection) back.
+          awaitPromise: true,
+          returnByValue: true,
+          // Trusted-Types pages (`require-trusted-types-for 'script'`,
+          // e.g. Gmail / Notion / Slack) reject injected script, so
+          // evaluation uses CDP's sanctioned opt-in for user-privileged
+          // tooling — the same channel DevTools uses.
+          allowUnsafeEvalBlockedByCSP: true,
+          // Treat the eval as a user gesture so gesture-gated APIs
+          // (focus, clipboard, fullscreen) work from the script.
+          userGesture: true,
+          ...opts,
+        }).then((/** @type {any} */ r) => { cleanup(); resolve(r); }, fail);
       });
     } finally {
       // Always drain the buffer, even on throw, so the next call starts

--- a/extension/peerd-runtime/loop/agent-loop.js
+++ b/extension/peerd-runtime/loop/agent-loop.js
@@ -80,6 +80,20 @@ const REQUIRED_CTX = [
 // clicks or two file edits must not interleave).
 const CONCURRENT_TOOLS = new Set(['actor_create']);
 
+// Hard ceiling on ONE tool dispatch (issue #176). A dispatch that never
+// settles — the concrete leaf is an un-timed CDP Runtime.evaluate against a
+// hung page — parks the turn generator forever: the turn's finally never runs,
+// the slot never releases, and Stop/session-reset abort a controller nobody
+// observes. Racing every dispatch against the turn's abort signal AND this
+// deadline converts a hang into a normal errored tool result, so the loop
+// advances and the slot unwinds. why 10 minutes: generous enough for the
+// legitimately-slow tools (WebVM commands, an awaited actor delegation, slow
+// page loads — and a confirm-parked tool decline-settles at its own 120s
+// timeout), while still bounding "forever". NOTE the loser keeps running
+// detached — its eventual settlement is dropped; late side effects are
+// possible but strictly better than a permanently wedged session.
+const DISPATCH_DEADLINE_MS = 10 * 60_000;
+
 // Yield settled values in completion order. Each input promise MUST resolve
 // (the dispatcher below never rejects), so there is no rejection branch —
 // one sibling's failure becomes its own error result, never a batch reject.
@@ -762,7 +776,41 @@ export async function* runUserTurn(ctx) {
       /** @type {ToolResult} */
       let dispatchResult;
       try {
-        dispatchResult = await toolDispatch({ id: tu.id, name: tu.name, args: tu.input });
+        // Race the dispatch against the turn's abort signal + the hard deadline
+        // (issue #176) — see DISPATCH_DEADLINE_MS. Without this, an un-settling
+        // dispatch pins the generator between wave boundaries (the only places
+        // wasAborted() is checked), making Stop / session-reset a no-op against
+        // a hung turn. The synthesized failure result lets the wave complete;
+        // the boundary abort check right after the waves then ends the turn.
+        dispatchResult = await /** @type {Promise<ToolResult>} */ (new Promise((resolveDispatch) => {
+          let settled = false;
+          /** @param {ToolResult} v */
+          const finish = (v) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(deadline);
+            if (signal) { try { signal.removeEventListener('abort', onAbort); } catch { /* stub signal in tests */ } }
+            resolveDispatch(v);
+          };
+          /** @param {string} error */
+          const failWith = (error) => finish({
+            ok: false, error,
+            meta: { toolName: tu.name, primitive: 'unknown', gates: [], durationMs: 0 },
+          });
+          const onAbort = () => failWith('tool call aborted (Stop / steer / halt) before it settled');
+          const deadline = setTimeout(
+            () => failWith(`tool call did not settle within ${Math.round(DISPATCH_DEADLINE_MS / 60_000)} minutes — treating it as hung and moving on`),
+            DISPATCH_DEADLINE_MS,
+          );
+          toolDispatch({ id: tu.id, name: tu.name, args: tu.input }).then(
+            (/** @type {ToolResult} */ r) => finish(r),
+            (/** @type {unknown} */ e) => failWith(/** @type {{ message?: string }} */ (e)?.message ?? String(e)),
+          );
+          if (signal) {
+            if (signal.aborted) onAbort();
+            else signal.addEventListener('abort', onAbort, { once: true });
+          }
+        }));
       } catch (e) {
         dispatchResult = {
           ok: false,

--- a/extension/peerd-runtime/loop/turn-slots.js
+++ b/extension/peerd-runtime/loop/turn-slots.js
@@ -36,14 +36,15 @@
  *   runWhenIdle: (sessionId: string, fn: () => void) => void,
  *   advanceQueue: (sessionId: string) => void,
  * }}
- * @param {{ onAbort?: (sessionId: string) => void }} [deps]
+ * @param {{ onAbort?: (sessionId: string) => void, forceReleaseMs?: number }} [deps]
  *   onAbort fires whenever a session's turn is aborted (a steer-live supersede
  *   or Stop). The SW wires it to confirmCoordinator.declineSession, so a turn
  *   parked on ctx.confirm() is unblocked (declined) instead of left stranded
  *   for the full timeout while a steered turn writes the same session. Default
  *   no-op (tests / orchestrators that don't need it).
+ *   forceReleaseMs overrides the abort watchdog delay (tests).
  */
-export const makeTurnSlots = ({ onAbort } = {}) => {
+export const makeTurnSlots = ({ onAbort, forceReleaseMs = 15_000 } = {}) => {
   /** @type {Map<string, AbortController>} */
   const slots = new Map();
   /** @type {Map<string, Array<() => void>>} idle-wake queue per session */
@@ -67,6 +68,25 @@ export const makeTurnSlots = ({ onAbort } = {}) => {
     // the post-Stop gen-skip in actor-messaging) must call advanceQueue below
     // to keep the pump moving.
     try { fn(); } catch { /* swallowed */ }
+  };
+
+  // Abort watchdog (issue #176). Slot removal normally relies on the turn's
+  // own release() — but a turn parked on an abort-ignoring await (an un-timed
+  // CDP call, a stuck page promise) never unwinds, so abort() alone would pin
+  // the slot for the SW lifetime: the session reads busy forever and queued
+  // idle-wakes never drain. After an abort, if the SAME controller still owns
+  // the slot once the grace elapses, force-release it. Self-scoped like
+  // release(): if the turn DID unwind (or a steer re-claimed), the guard
+  // no-ops. The zombie turn's own late release() is equally self-scoped, so a
+  // forced release can't clear a newer turn's claim.
+  /** @param {string} sessionId @param {AbortController} controller */
+  const forceReleaseAfterGrace = (sessionId, controller) => {
+    setTimeout(() => {
+      if (slots.get(sessionId) === controller) {
+        slots.delete(sessionId);
+        drainIdle(sessionId);
+      }
+    }, forceReleaseMs);
   };
 
   return {
@@ -96,6 +116,11 @@ export const makeTurnSlots = ({ onAbort } = {}) => {
       if (!controller) return false;
       controller.abort();
       onAbort?.(sessionId); // decline any confirm this turn is parked on
+      // A well-behaved turn observes the abort and release()s within ms; a
+      // hung one never does — reap it so Stop actually frees the session.
+      // (claim()'s supersede path needs no watchdog: it re-claims the slot
+      // for the new turn in the same tick.)
+      forceReleaseAfterGrace(sessionId, controller);
       return true;
     },
 

--- a/extension/tests/unit/peerd-runtime/agent-loop.test.js
+++ b/extension/tests/unit/peerd-runtime/agent-loop.test.js
@@ -376,6 +376,39 @@ describe('agent loop — runUserTurn', () => {
       expect(asEv(stops[stops.length - 1]).stopReason).toBe('aborted');
     });
 
+    it('Stop mid-dispatch unwinds a NEVER-SETTLING tool call instead of hanging the turn (issue #176)', async () => {
+      // The concrete hang: an un-timed CDP Runtime.evaluate against a hung
+      // page never settles, and wasAborted() is only checked at wave
+      // boundaries — so pre-fix, Stop aborted a controller nobody observed
+      // and this drain() would never return. The dispatch race converts the
+      // abort into a synthesized error result, the wave completes, and the
+      // boundary check ends the turn.
+      const controller = new AbortController();
+      const { sessions, ctx } = buildCtx({
+        callModel: buildToolUsingCallModel(),
+        signal: controller.signal,
+      });
+      let dispatchCalls = 0;
+      ctx.tools = [{ name: 'inspect_storage', description: '', schema: {} }];
+      ctx.toolDispatch = () => new Promise(() => {
+        dispatchCalls += 1;
+        setTimeout(() => controller.abort(), 20);   // Stop lands while the call is parked
+        // never settles — the hung-page promise
+      });
+      const session = await sessions.create();
+      ctx.sessionId = session.sessionId;
+
+      const events = await drain(runUserTurn(asRunCtx(ctx)));   // must terminate
+
+      expect(dispatchCalls).toBe(1);
+      const stops = events.filter((e) => e.type === 'stop');
+      expect(asEv(stops[stops.length - 1]).stopReason).toBe('aborted');
+      // The turn is marked aborted, not left streaming/pending.
+      const stored = present(await sessions.get(session.sessionId));
+      const assistant = msg(stored.messages.find((m) => m.role === 'assistant'));
+      expect(assistant.stopReason).toBe('aborted');
+    });
+
     it('runs consecutive READ-class calls concurrently when a classifier is injected', async () => {
       // Two reads in one turn + ctx.classifyToolCall → both dispatches must
       // be in flight together, results persist in EMITTED order even though

--- a/tests/peerd-runtime/loop/turn-slots.test.ts
+++ b/tests/peerd-runtime/loop/turn-slots.test.ts
@@ -203,3 +203,34 @@ describe('makeTurnSlots — onAbort (decline parked confirms on abort)', () => {
     expect(slots.isBusy('a')).toBe(true);
   });
 });
+
+// The abort watchdog (issue #176): stop() on a turn parked on an
+// abort-ignoring await must eventually free the slot, or the session reads
+// busy forever and queued wakes never drain.
+describe('makeTurnSlots — stop watchdog (force-release a hung turn)', () => {
+  const tick = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+  test('a hung turn (never releases after abort) is force-released after the grace', async () => {
+    const slots = makeTurnSlots({ forceReleaseMs: 10 });
+    slots.claim('a');                                // the turn never release()s
+    let woke = false;
+    expect(slots.stop('a')).toBe(true);
+    slots.runWhenIdle('a', () => { woke = true; });  // queued behind the zombie
+    expect(slots.isBusy('a')).toBe(true);            // still pinned pre-watchdog
+    await tick(30);
+    expect(slots.isBusy('a')).toBe(false);           // watchdog reaped the slot
+    expect(woke).toBe(true);                         // and drained the queue
+  });
+
+  test('a well-behaved turn that unwinds in time is NOT double-released onto a successor', async () => {
+    const slots = makeTurnSlots({ forceReleaseMs: 10 });
+    const first = slots.claim('a');
+    slots.stop('a');
+    first.release();                                 // unwinds promptly, as normal
+    const second = slots.claim('a');                 // a new turn claims before the grace fires
+    await tick(30);
+    // The watchdog is controller-scoped: it must not free the NEW turn's claim.
+    expect(slots.isBusy('a')).toBe(true);
+    expect(second.controller.signal.aborted).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes the top three items of #176's fix plan - a web-actor turn could hang **forever** on an un-timed CDP `Runtime.evaluate`, and Stop / `session/reset` were no-ops against it (abort observed only at wave boundaries; the parked generator never released its slot; one hung actor + attachment + tab leaked per stuck task until Chrome degraded).

## The three layers

1. **agent-loop - bound + abort-race every dispatch** (the issue's "highest leverage"). Each `toolDispatch` races the turn's abort signal and a 10-minute deadline; a loser synthesizes an `is_error` result so the wave completes, the boundary abort check ends the turn, and the slot unwinds. Stop now works mid-dispatch. (Confirm-parked tools decline-settle at their own 120s timeout, well inside the deadline; the loser dispatch keeps running detached - its settlement is dropped, which is strictly better than a wedged session.)
2. **debugger-pool - defense at the CDP leaf.** `Runtime.evaluate` races a 120s deadline (per-call override via `opts.timeoutMs`, kept out of the CDP params) and rejects on tab close / debugger detach for that tab.
3. **turn-slots - `stop()` watchdog.** After abort, if the same controller still owns the slot once the grace (15s, injectable for tests) elapses, force-release + drain the idle queue. Controller-scoped like `release()`, so it can never clear a successor turn's claim. (`claim()`'s supersede path needs no watchdog - it re-claims in the same tick.)

**Not addressed (issue item 4):** reaping the leaked debugger attachment + adopted tab on stop - separate follow-up.

## Tests
- `turn-slots.test.ts`: watchdog reaps a hung turn + drains queued wakes; never double-releases onto a successor turn. **Revert-proven** (fails against the pre-fix module).
- `agent-loop.test.js` (in-browser): Stop mid-dispatch on a **never-settling** tool call terminates the turn with `stopReason: 'aborted'` - pre-fix this test hangs.
- Gates: typecheck, lint, 2829 bun, 622 in-browser all green.

Closes #176 (items 1-3; item 4 tracked as follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)