### PR TITLE
fix(dweb): Stop terminates an in-flight a2a_run (#153)

### DIFF
--- a/extension/background/offscreen-js-client.js
+++ b/extension/background/offscreen-js-client.js
@@ -20,7 +20,9 @@ export const makeOffscreenJsClient = ({ ensureOffscreen, sendMessage }) => ({
    *   sealed worker (default = the historical js_run surface); caps.page also
    *   needs ownerSessionId — the actor session the page bridge dispatches FOR,
    *   set only from a trusted ctx (PR #119). ownerSessionId / ownerToolUseId /
-   *   runId ride as trusted job params to the relay routes.
+   *   runId ride as trusted job params to the relay routes. runId forwards on
+   *   ANY lane (#153) — a runId-carrying job registers with the runner's
+   *   liveJobs map, which is what lets abortHeadless terminate it on Stop.
    * @returns {Promise<{ value: unknown, consoleOutput: {level:string,text:string}[], durationMs: number, error: string|null, usedEgress?: boolean, usedActors?: boolean, actorsTrace?: Array<{ seq: number, method: string, to?: string, goal?: string, ok: boolean, ms: number, error?: string }> }>}
    */
   execHeadless: async (code, { timeoutMs, a2a, ownerSessionId, actors, ownerToolUseId, runId, caps } = {}) => {
@@ -28,8 +30,9 @@ export const makeOffscreenJsClient = ({ ensureOffscreen, sendMessage }) => ({
     const reply = await sendMessage({
       type: 'job/run', code, timeoutMs,
       ...(a2a ? { a2a: true, ownerSessionId } : {}),
-      ...(actors ? { actors: true, ownerSessionId, ownerToolUseId, runId } : {}),
+      ...(actors ? { actors: true, ownerSessionId, ownerToolUseId } : {}),
       ...(caps ? { caps, ownerSessionId } : {}),
+      ...(runId ? { runId } : {}),
     });
     if (!reply?.ok) throw new Error(reply?.error ?? 'headless job failed');
     return reply.result;

--- a/extension/peerd-runtime/tools/defs/a2a-run.js
+++ b/extension/peerd-runtime/tools/defs/a2a-run.js
@@ -72,18 +72,39 @@ export const a2aRunTool = {
 
   execute: async (args, ctx) => {
     if (typeof args?.code !== 'string' || !args.code.trim()) return { ok: false, error: 'code_required' };
-    const jsOffscreenClient = /** @type {{ execHeadless?: (code: string, opts: object) => Promise<any> } | undefined} */ (
-      /** @type {any} */ (ctx).jsOffscreenClient);
+    const c = /** @type {{ jsOffscreenClient?: { execHeadless?: (code: string, opts: object) => Promise<any>, abortHeadless?: (runId: string, ownerSessionId?: string) => Promise<void> }, abortSignal?: { aborted: boolean, addEventListener: Function, removeEventListener?: Function } }} */ (
+      /** @type {unknown} */ (ctx));
+    const jsOffscreenClient = c.jsOffscreenClient;
     if (!jsOffscreenClient?.execHeadless) return { ok: false, error: 'a2a_unavailable' };
     const ownerSessionId = ctx.session?.sessionId;
     if (!ownerSessionId) return { ok: false, error: 'a2a: no owner session' };
+    // A turn that is ALREADY stopped must not launch a worker at all — the
+    // 'abort' event never re-fires on an aborted signal, so a run started now
+    // would hold a shared headless slot for its full 135s wall-clock (#153).
+    if (c.abortSignal?.aborted) {
+      return { ok: false, error: 'a2a_aborted: the turn was stopped before the run started' };
+    }
     const timeoutMs = clamp(args.timeoutMs ?? DEFAULT_TIMEOUT_MS, 1000, MAX_TIMEOUT_MS);
+    // Stop plumbing (#153, mirrors the script tool): a runId-carrying job is
+    // registered by the offscreen runner, so aborting the dweb-actor turn
+    // terminates the worker promptly instead of orphaning it to its timeout.
+    const runId = `a2arun-${ownerSessionId}-${Date.now().toString(36)}${Math.random().toString(36).slice(2, 7)}`;
+    /** @type {(() => void) | undefined} */
+    let onAbort;
+    if (c.abortSignal && jsOffscreenClient.abortHeadless) {
+      onAbort = () => { jsOffscreenClient.abortHeadless?.(runId, ownerSessionId); };
+      c.abortSignal.addEventListener('abort', onAbort, { once: true });
+    }
     try {
-      const result = await jsOffscreenClient.execHeadless(args.code, { timeoutMs, a2a: true, ownerSessionId });
+      const result = await jsOffscreenClient.execHeadless(args.code, { timeoutMs, a2a: true, ownerSessionId, runId });
       return { ok: true, content: formatA2AResult(args.code, result) };
     } catch (e) {
       const err = /** @type {{ name?: string, message?: string }} */ (e);
       return { ok: false, error: `a2a_run_failed: ${err?.name ?? 'Error'}: ${err?.message ?? String(e)}` };
+    } finally {
+      if (onAbort && c.abortSignal) {
+        try { c.abortSignal.removeEventListener?.('abort', onAbort); } catch { /* stub signal in tests */ }
+      }
     }
   },
 };

--- a/extension/tests/unit/offscreen/job-runner.test.js
+++ b/extension/tests/unit/offscreen/job-runner.test.js
@@ -176,6 +176,31 @@ describe('offscreen job-runner (real sealed worker)', () => {
     expect(String(r.value)).toBe('no-mesh');
   });
 
+  it('a2a: abortJob(runId) terminates a live mesh run instead of orphaning it to its timeout (#153)', async () => {
+    // Pre-fix, the a2a lane never carried a runId, so a Stop left the worker
+    // holding a shared headless slot for its full wall-clock. The runner's
+    // runId registration is lane-agnostic; this pins it for a2a specifically,
+    // owner-bound the way the SW job/abort route passes it.
+    const pending = runJob(
+      {
+        code: 'await mesh.ask("did:key:z6MkBob", "long ask"); return "never";',
+        a2a: true, ownerSessionId: 'dweb-sess-1', runId: 'a2a-abort-1', timeoutMs: 30000,
+      },
+      {
+        sendToSW: (type) => new Promise((resolve) => {
+          // the ask hangs (a live peer exchange) until the abort fires
+          if (type === 'a2a/call') setTimeout(() => resolve({ ok: false, error: 'aborted' }), 5000);
+          else resolve({ ok: true });
+        }),
+      },
+    );
+    // give the worker a beat to issue the ask, then Stop
+    await new Promise((res) => setTimeout(res, 400));
+    abortJob('a2a-abort-1', 'dweb-sess-1');
+    const r = await pending;
+    expect(r.error).toContain('aborted');
+  });
+
   // ── the actors delegation surface (script orchestration) ─────────────────
 
   it('actors: ask relays to the SW actors/call route with owner ids from TRUSTED job params', async () => {

--- a/tests/peerd-runtime/tools/a2a-run.test.ts
+++ b/tests/peerd-runtime/tools/a2a-run.test.ts
@@ -1,0 +1,75 @@
+// a2a_run's Stop plumbing (#153): the tool must mint + thread a runId so the
+// offscreen runner can register the job, wire the dispatch abort signal to
+// abortHeadless so Stop terminates the worker promptly, refuse to launch on an
+// already-stopped turn, and detach its listener once the run settles. Mirrors
+// the message-actor test style: a recording ctx pins what execute() forwards.
+
+import { describe, test, expect } from 'bun:test';
+import { a2aRunTool } from '../../../extension/peerd-runtime/tools/defs/a2a-run.js';
+
+const RESULT = { value: 'ok', consoleOutput: [], durationMs: 1, error: null };
+
+// Typed `any` (like tests/.../message-actor.test.ts) — the mock only needs the
+// slots a2a_run actually reads.
+const makeCtx = (over: any = {}) => {
+  const seen: { exec?: any; aborts: Array<{ runId: string; owner?: string }> } = { aborts: [] };
+  const ctx: any = {
+    session: { sessionId: 'dweb-1' },
+    jsOffscreenClient: {
+      execHeadless: async (_code: string, opts: any) => { seen.exec = opts; return RESULT; },
+      abortHeadless: async (runId: string, owner?: string) => { seen.aborts.push({ runId, owner }); },
+    },
+    ...over,
+  };
+  return { ctx, seen };
+};
+
+describe('a2a_run — Stop plumbing (#153)', () => {
+  test('threads a minted runId (+ owner) into the job so the runner can register it', async () => {
+    const { ctx, seen } = makeCtx();
+    const r = await a2aRunTool.execute({ code: 'return await mesh.peers();' }, ctx);
+    expect(r.ok).toBe(true);
+    expect(seen.exec.a2a).toBe(true);
+    expect(seen.exec.ownerSessionId).toBe('dweb-1');
+    expect(String(seen.exec.runId)).toMatch(/^a2arun-dweb-1-/);
+  });
+
+  test('aborting the turn mid-run calls abortHeadless with the run id + owner', async () => {
+    const controller = new AbortController();
+    const seen: { exec?: any; aborts: Array<{ runId: string; owner?: string }> } = { aborts: [] };
+    const ctx: any = {
+      session: { sessionId: 'dweb-1' },
+      abortSignal: controller.signal,
+      jsOffscreenClient: {
+        execHeadless: async (_code: string, opts: any) => {
+          seen.exec = opts;
+          controller.abort();                    // Stop lands while the job is in flight
+          await new Promise((r) => setTimeout(r, 5));
+          return RESULT;
+        },
+        abortHeadless: async (runId: string, owner?: string) => { seen.aborts.push({ runId, owner }); },
+      },
+    };
+    await a2aRunTool.execute({ code: 'return 1;' }, ctx);
+    expect(seen.aborts).toEqual([{ runId: seen.exec.runId, owner: 'dweb-1' }]);
+  });
+
+  test('a turn already stopped refuses to launch a worker at all', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const { ctx, seen } = makeCtx({ abortSignal: controller.signal });
+    const r = await a2aRunTool.execute({ code: 'return 1;' }, ctx);
+    expect(r.ok).toBe(false);
+    expect(String((r as { error?: string }).error)).toContain('a2a_aborted');
+    expect(seen.exec).toBeUndefined();           // no worker was launched
+  });
+
+  test('the abort listener detaches after the run — a later Stop cannot abort a finished job', async () => {
+    const controller = new AbortController();
+    const { ctx, seen } = makeCtx({ abortSignal: controller.signal });
+    await a2aRunTool.execute({ code: 'return 1;' }, ctx);
+    controller.abort();                          // fires AFTER the run settled
+    await new Promise((r) => setTimeout(r, 5));
+    expect(seen.aborts).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What & why

When the user hit Stop (or the dweb-actor turn aborted), `a2a_run`'s await rejected in the actor heap but the offscreen Worker **kept running to its wall-clock** (135s default) - an orphan holding one of the shared headless slots (`MAX_CONCURRENT_JOBS`).

The runner-side machinery already existed and needed **zero changes**: `job/abort` → `abortJob(runId, owner)` → `kill()`, runId-keyed, owner-bound, with early-abort tombstones (the script tool's Stop plumbing). The a2a path just never used it.

## The change
- **`a2a-run.js`**: mints a runId, threads it into the job, wires the dispatch abort signal → `abortHeadless(runId, owner)` (detached once the run settles), and refuses to launch on an already-stopped turn (an aborted signal never re-fires - that run would be unkillable until its cap).
- **`offscreen-js-client.js`**: forwards `runId` on ANY lane (previously only the `actors` spread carried it).
- `job-runner.js`: untouched - its runId registration is lane-agnostic.

## Tests
- **bun** (`a2a-run.test.ts`): runId+owner threading; mid-run abort calls `abortHeadless` with the run's id+owner; already-stopped refusal; listener detach. **Revert-proven** - 3 fail against the pre-fix tool.
- **in-browser** (`job-runner.test.js`): `abortJob(runId)` terminates a live a2a-lane worker run (real sealed worker), owner-bound.
- Gates: typecheck, lint, 2831 bun, 622 in-browser green.

Closes #153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)