### PR TITLE
fix(web): stop stealing OS focus on key dispatch — emulate focus, never bringToFront

### DIFF
--- a/extension/background/debugger-pool.js
+++ b/extension/background/debugger-pool.js
@@ -112,6 +112,21 @@ export const createDebuggerPool = () => {
       }
     }
     await browser.debugger.sendCommand({ tabId }, 'Runtime.enable');
+    // why: the driven tab is usually BACKGROUNDED — peerd never steals focus
+    // (DESIGN-12). But Gmail-class pages gate keyboard shortcuts, caret
+    // placement, and focus/blur-driven behavior on document.hasFocus(), which
+    // is false for a background tab. Focus EMULATION makes the page believe
+    // it's focused without raising anything — the no-steal replacement for
+    // Page.bringToFront, which yanked the whole browser window to the OS
+    // foreground on every key dispatch and hijacked the user's focus while
+    // they worked in other apps/windows. Cleared automatically on detach;
+    // re-applied here on every (re-)attach. Best-effort: an engine without
+    // the command just loses the emulation, never the attach.
+    try {
+      await browser.debugger.sendCommand({ tabId }, 'Emulation.setFocusEmulationEnabled', { enabled: true });
+    } catch (e) {
+      console.debug('[debugger-pool] focus emulation unavailable', e?.message ?? e);
+    }
     attached.add(tabId);
     console.log('[debugger-pool] attached + Runtime enabled on', tabId);
   };
@@ -187,15 +202,13 @@ export const createDebuggerPool = () => {
    */
   const dispatchKeys = async (tabId, events) => {
     await attach(tabId);
-    // why: Gmail and friends listen on focusable elements for keyboard
-    // shortcuts. The active element needs to be document.body (or some
-    // non-input element) for shortcuts like `*+u` to register; if the
-    // search box has focus, the keys go to the input instead. The
-    // caller is expected to manage focus, but we ensure the page is
-    // focused first via the focus() RPC.
-    try {
-      await browser.debugger.sendCommand({ tabId }, 'Page.bringToFront');
-    } catch { /* not critical */ }
+    // why NO Page.bringToFront here: it brought the tab's whole browser
+    // window to the OS foreground on EVERY call — an agent typing its way
+    // through a page repeatedly stole the user's focus out of other apps and
+    // windows (the DESIGN-12 no-focus-steal rule applies to key dispatch
+    // too). Gmail-class shortcut handlers that gate on document.hasFocus()
+    // still work: attach() enables focus emulation, so the page believes
+    // it's focused while staying in the background.
     for (const ev of events) {
       const base = {
         key: ev.key,


### PR DESCRIPTION
## What & why

While the agent drives a tab, every `page_keys` call fired `Page.bringToFront`, raising the driven tab's whole browser window to the OS foreground — continuously stealing focus from whatever app or other window the user was working in. Replaced with CDP focus emulation (`Emulation.setFocusEmulationEnabled`), enabled once per (re-)attach in the debugger pool: the backgrounded page *believes* it's focused (`document.hasFocus()` true), so Gmail-class shortcut handlers that gate on document focus still work, but the tab and window are never raised — key dispatch now honors the same DESIGN-12 no-focus-steal rule as every other agent surface.

Closes #

## Checklist

- [x] `bun test ./tests` (2838 pass), `bun run typecheck`, `bun run lint`, `bun run check:boundary`, `bun run check:tscheck` all pass (in-browser/e2e not run in this container — change is in the CDP pool, not a rendered surface; mechanism verified separately, see notes)
- [x] Only original or permissively-licensed code — **no GPL / AGPL / copyleft**
- [x] Tests added or updated (or N/A) — N/A: the pool binds `browser.debugger` directly (no injected dep to stub); mechanism verified end-to-end against a real browser instead
- [x] No hand-edited generated files (`manifest.json`, `shared/channel-config.js`)
- [x] Called out below if this touches a **danger zone** (egress / vault / gates / runner & sandbox boundaries / dweb)

## Notes for reviewers

- **Danger zone**: touches `background/debugger-pool.js` (CDP surface). No change to attach/detach lifecycle, gating, or what the pool exposes — one command removed from `dispatchKeys`, one best-effort command added at attach time. Focus emulation is cleared by Chrome on detach and re-applied on every (re-)attach, so the banner-Cancel → re-attach path stays correct.
- `Emulation.setFocusEmulationEnabled` is experimental CDP, same as `Accessibility.getFullAXTree` which the pool already ships through `chrome.debugger`; the call is try/catch best-effort, so an engine without it loses only the emulation, never the attach or the key dispatch.
- Verified against headed Chromium over raw CDP (Playwright's high-level API couldn't be used — it force-enables this same emulation on every page it opens, which both masks the before/after and confirms this is the standard mechanism for the problem): a genuinely backgrounded tab (`hasFocus` false, `visibilityState` hidden) gains emulated focus, receives dispatched keys, and the real foreground tab stays active throughout; a `Page.bringToFront` control leg reproduces the activation steal this PR removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qm4GmpL92kbh3ud16Eh1Qi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qm4GmpL92kbh3ud16Eh1Qi)_