### PR TITLE
Prewalk: frontier model plans a goal run, a cheap executor finishes it

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -136,6 +136,12 @@ import {
   filterByGoalActive,
   makeGoalRunner,
   GOAL_MAX_ITERATIONS,
+  formatTodoBlock,
+  // prewalk (loop/prewalk.js) — pure policy; the SW owns the IO below
+  resolvePrewalkExecutor,
+  armPrewalk,
+  shouldPrewalkSwap,
+  markPrewalkSwapped,
   makeToolsCommand,
   dispatchToolCall,
   BUILTIN_TOOLS,
@@ -803,6 +809,13 @@ const resolvePermission = async (activeSession) => {
   return { mode: normalizeMode(rawMode), confirmActions: normalizeConfirmActions(rawConfirm) };
 };
 
+// Per-session promise chains serializing todo read-modify-writes (the
+// ctx.todoStore below). Keyed by sessionId; an entry is just the tail of the
+// chain, so the map stays tiny and dies with the SW (the persisted list is
+// the durable state).
+/** @type {Map<string, Promise<unknown>>} */
+const todoChains = new Map();
+
 /**
  * Build a ToolContext for the current call. The agent loop (commit 2)
  * will pass this into the dispatcher per tool call; the side-panel
@@ -1001,6 +1014,31 @@ const buildToolContext = async (/** @type {any} */ { sessionId: overrideSessionI
     // outside an active run, which the tool surfaces as a harmless no-op.
     completeGoalRun: sessionId
       ? (/** @type {string} */ summary) => goalRunner?.complete(/** @type {string} */ (sessionId), summary) ?? false
+      : undefined,
+    // why: the todo_* tools mutate the session's plan-of-record through this
+    // serialized read-modify-write (todoChains, module scope) — two todo ops
+    // in one concurrent tool wave would otherwise race the record and lose an
+    // update. apply(fn): fn is PURE (todo/core.js); a result with ok+todos is
+    // persisted, anything else is returned untouched. Goal-run-scoped like
+    // completeGoalRun: absent outside a live run, so the tools no-op cleanly.
+    todoStore: sessionId && goalRunner?.isActive(/** @type {string} */ (sessionId))
+      ? {
+          apply: (/** @type {(todos: any) => any} */ fn) => {
+            const sid = /** @type {string} */ (sessionId);
+            const next = (todoChains.get(sid) ?? Promise.resolve()).then(async () => {
+              const rec = await sessions.get(sid);
+              const out = fn(rec?.todos);
+              if (out?.ok && Array.isArray(out.todos)) {
+                await sessions.update(sid, { todos: out.todos });
+              }
+              return out;
+            });
+            // why swallow for the CHAIN only: a failed apply must not wedge
+            // every later todo op; the caller still sees its own rejection.
+            todoChains.set(sid, next.catch(() => {}));
+            return next;
+          },
+        }
       : undefined,
     dom: undefined,
     // why: vm is a SW-side client that proxies vm/run + vm/write-file
@@ -2387,6 +2425,119 @@ const turnSlots = makeTurnSlots({ onAbort: (sid) => confirmCoordinator.declineSe
 // orchestrator wiring uses). filterByGoalActive is a pure descriptor filter.
 /** @type {ReturnType<typeof makeGoalRunner> | null} */
 let goalRunner = null;
+
+// ---------------------------------------------------------------------------
+// Prewalk (loop/prewalk.js) — the SW-side IO around the pure policy: arm a
+// goal run, flip planning→executing when the gate fires, apply the model swap
+// at turn boundaries, restore the planner when the run ends (or is found
+// stale). The session record is the single source of truth; this Set is only
+// the O(1) "is anything armed here" guard so the per-tool-call gate does no
+// IO for the 99.9% of calls with no prewalk in play. Rebuilt lazily by
+// reconcilePrewalk after an SW restart.
+/** @type {Set<string>} */
+const prewalkPlanningSessions = new Set();
+
+// Turn-boundary reconcile (turn-driver calls it right after loading the turn
+// session, main sessions only). Three jobs: (a) restore + clear STALE state —
+// a run that died without its run-end restore (rare: requires losing both the
+// in-memory run and the kv mirror; a vault-lock PAUSE can also look stale for
+// the one turn before resume() re-drives, costing only the swap, never the
+// chat); (b) seed the planning Set after an SW restart; (c) apply the pending
+// executor swap so this turn's model/pricing/window all read the executor.
+const reconcilePrewalk = async (/** @type {any} */ session) => {
+  const pw = session?.prewalk;
+  if (!pw) return session;
+  const sid = session.sessionId;
+  if (!(goalRunner?.isActive(sid) ?? false)) {
+    prewalkPlanningSessions.delete(sid);
+    const restored = await sessions.setPrewalk(sid, null, {
+      provider: pw.plannerProvider, model: pw.plannerModel,
+    });
+    auditLog.append({ type: 'prewalk_restored', sessionId: sid, details: { reason: 'stale', plannerModel: pw.plannerModel } }).catch(() => {});
+    return restored;
+  }
+  if (pw.phase === 'planning') {
+    prewalkPlanningSessions.add(sid);
+    return session;
+  }
+  if (session.provider !== pw.executorProvider || session.model !== pw.executorModel) {
+    const swapped = await sessions.update(sid, {
+      provider: pw.executorProvider, model: pw.executorModel,
+    });
+    auditLog.append({ type: 'prewalk_swap_applied', sessionId: sid, details: { executorProvider: pw.executorProvider, executorModel: pw.executorModel } }).catch(() => {});
+    postChatNote(`Prewalk: plan landed — continuing on ${pw.executorModel}.`);
+    return swapped;
+  }
+  return session;
+};
+
+// The per-tool-call gate (turn-driver's toolDispatch): a successful mutating
+// call during the planning phase, with the todo list committed, flips the
+// phase. The MODEL swap itself waits for the next turn's reconcile — see
+// loop/prewalk.js for why boundaries.
+const maybePrewalkSwap = async (/** @type {{ sessionId?: string|null, name?: string, ok?: boolean }} */ { sessionId, name, ok }) => {
+  if (!sessionId || ok !== true || !prewalkPlanningSessions.has(sessionId)) return;
+  const session = await sessions.get(sessionId);
+  const pw = /** @type {any} */ (session)?.prewalk;
+  const fire = shouldPrewalkSwap({
+    prewalk: pw,
+    todosCount: /** @type {any} */ (session)?.todos?.length ?? 0,
+    toolName: String(name ?? ''),
+    sideEffect: getTool(String(name ?? ''))?.sideEffect,
+    ok: true,
+  });
+  if (!fire) return;
+  await sessions.setPrewalk(sessionId, markPrewalkSwapped(pw, Date.now()));
+  prewalkPlanningSessions.delete(sessionId);
+  auditLog.append({ type: 'prewalk_swapped', sessionId, details: { trigger: name, executorProvider: pw.executorProvider, executorModel: pw.executorModel } }).catch(() => {});
+};
+
+// Arm a fresh goal run (called by startGoalRun below, before the runner
+// starts driving). Quiet no-op unless the setting is on AND an executor
+// distinct from the session's model resolves. Any stale state from an
+// earlier run is restored first so arming reads the true planner model.
+const armPrewalkForRun = async (/** @type {string} */ sessionId) => {
+  try {
+    if (!sessionId || !settingsStore.get().prewalkEnabled) return;
+    let session = await sessions.get(sessionId);
+    if (!session) return;
+    const stale = /** @type {any} */ (session).prewalk;
+    if (stale) {
+      session = await sessions.setPrewalk(sessionId, null, {
+        provider: stale.plannerProvider, model: stale.plannerModel,
+      });
+    }
+    if (!session) return;
+    const provider = listProviders().find((/** @type {any} */ p) => p.name === session.provider);
+    const executor = resolvePrewalkExecutor({ settings: settingsStore.get(), provider });
+    const armed = armPrewalk(session, executor, Date.now());
+    if (!armed) return;
+    await sessions.setPrewalk(sessionId, armed);
+    prewalkPlanningSessions.add(sessionId);
+    auditLog.append({ type: 'prewalk_armed', sessionId, details: { executorProvider: armed.executorProvider, executorModel: armed.executorModel } }).catch(() => {});
+  } catch (e) {
+    console.warn('[sw] prewalk arm failed', e);
+  }
+};
+
+// Run-end restore: put the chat back on the planner model and clear the
+// state, whatever phase the run ended in. Keyed restore (not a snapshot
+// write), so it composes with the reconcile path's stale-cleanup.
+const restorePrewalkForRun = async (/** @type {string} */ sessionId) => {
+  try {
+    prewalkPlanningSessions.delete(sessionId);
+    const session = await sessions.get(sessionId);
+    const pw = /** @type {any} */ (session)?.prewalk;
+    if (!pw) return;
+    await sessions.setPrewalk(sessionId, null, {
+      provider: pw.plannerProvider, model: pw.plannerModel,
+    });
+    auditLog.append({ type: 'prewalk_restored', sessionId, details: { reason: 'run-end', plannerModel: pw.plannerModel, swapped: !!pw.swappedAt } }).catch(() => {});
+  } catch (e) {
+    console.warn('[sw] prewalk restore failed', e);
+  }
+};
+
 const { runAgentTurn, maybeAutoResume } = makeTurnDriver({
   vault, VaultLockedError, sessionCache, ensureActiveProvider, resolvePermission,
   sessions, sessionState, turnSlots, buildTemporalBlock, memory, browser, originOfTabUrl,
@@ -2400,6 +2551,8 @@ const { runAgentTurn, maybeAutoResume } = makeTurnDriver({
   safeFetch, REASONING_BUDGET_TOKENS, REASONING_EFFORT_LEVELS, DEFAULT_SETTINGS, trimEnricher,
   contextWindowFor, liveContextWindow, currentAppScope, checkpointMgr, detectInterruptedTurn,
   recordModelCall: contextSnapshots.record,
+  // prewalk: the turn-boundary swap/restore + the per-tool-call gate (above).
+  reconcilePrewalk, maybePrewalkSwap,
   // postChatNote is declared just below this call — defer the reference so it
   // resolves at call-time (the same late-declared-dep pattern the orchestrator
   // wiring above uses, see the note at the postChatNote site).
@@ -2418,7 +2571,11 @@ goalRunner = makeGoalRunner({
   // transcript (cap / halt). 'done' needs none — complete_goal's tool result is
   // the visible record. (Permission needs no restore: resolvePermission computes
   // the autonomy from the live run, so it reverts on its own when the run ends.)
-  onRunEnd: (/** @type {any} */ _sid, /** @type {any} */ info) => {
+  onRunEnd: (/** @type {any} */ sid, /** @type {any} */ info) => {
+    // Prewalk: put the chat back on the planner model whatever way the run
+    // ended. Fire-and-forget — the reconcile path self-heals if this write
+    // is lost.
+    restorePrewalkForRun(sid).catch(() => {});
     if (info?.phase === 'capped') postChatNote(`Goal run stopped — hit the ${GOAL_MAX_ITERATIONS}-turn limit without finishing.`);
     else if (info?.phase === 'halted') postChatNote(info?.reason ? `Goal run stopped (${info.reason}).` : 'Goal run stopped.');
   },
@@ -2427,6 +2584,10 @@ goalRunner = makeGoalRunner({
   // resume() (on vault unlock) re-drives them. Without it the run is in-memory
   // only and an MV3 recycle would silently drop it.
   kv,
+  // The live plan-of-record for each continuation prompt — re-read per turn
+  // so check-offs show; '' when no list yet (todo/core.js formatTodoBlock).
+  getTodoBlock: async (/** @type {string} */ sid) =>
+    formatTodoBlock(/** @type {any} */ (await sessions.get(sid))?.todos),
 });
 
 // ---------------------------------------------------------------------------
@@ -3668,7 +3829,13 @@ const handleToolsCommand = async (/** @type {string} */ arg) => {
 // Goal mode (the Goal toggle). Autonomy is NOT a stored flip — resolvePermission
 // computes Act+confirm-off from the live run — so start/halt are just the runner
 // surface. resumeGoalRuns re-drives persisted runs after an interactive unlock.
-const startGoalRun = (/** @type {{ sessionId: string, goal: string }} */ req) => /** @type {any} */ (goalRunner)?.start(req);
+// why arm-then-start: prewalk state must be on the session BEFORE the run's
+// first turn renders its system prompt (the planning nudge reads it). Arming
+// is a quiet no-op when the setting is off or no distinct executor resolves.
+const startGoalRun = async (/** @type {{ sessionId: string, goal: string }} */ req) => {
+  await armPrewalkForRun(req?.sessionId);
+  return /** @type {any} */ (goalRunner)?.start(req);
+};
 // why stop() not halt(): user-initiated cancels (Stop button, steer-takeover,
 // new-chat, archive) must DURABLY end the run — halt() only marks an in-memory
 // run, so a vault-lock-PAUSED run (evicted from the runner's map but kept in the

--- a/extension/background/settings-patch.js
+++ b/extension/background/settings-patch.js
@@ -151,6 +151,17 @@ export const normalizeSettingsPatch = (patch, {
     // with saved settings; resolveRunnerModel reads this pin.
     next.runnerModel = patch.runnerModel.trim().slice(0, 200);
   }
+  if (typeof patch.prewalkEnabled === 'boolean') {
+    // Prewalk (loop/prewalk.js): frontier model plans a goal run, a cheap
+    // executor inherits the live context at the first landed action.
+    next.prewalkEnabled = patch.prewalkEnabled;
+  }
+  if (typeof patch.prewalkExecutorModel === 'string') {
+    // Prewalk executor pin. '' = the provider's fast default
+    // (defaultRunnerModel); non-empty = a SAME-PROVIDER model id — the same
+    // contract as runnerModel above.
+    next.prewalkExecutorModel = patch.prewalkExecutorModel.trim().slice(0, 200);
+  }
   // Idle vault auto-lock interval (ms). 0 = never; otherwise clamp to a
   // sane range [1min, 24h]. The caller applies this to the live vault so
   // the change takes effect without an SW restart.

--- a/extension/eval/eval-engine.js
+++ b/extension/eval/eval-engine.js
@@ -20,7 +20,7 @@ import { sleep } from '/shared/util.js';
 
 /**
  * @typedef {{ inputTokens?: number, outputTokens?: number, cacheReadTokens?: number, cacheWriteTokens?: number, cost?: number }} Usage
- * @typedef {{ session: any, tools: string[], tokens: number, cost: Usage | null, runner: { inputTokens: number, outputTokens: number, cacheReadTokens: number, cacheWriteTokens: number }, error: string | null, started: boolean, resolveDone: ((value?: any) => void) | null }} Turn
+ * @typedef {{ session: any, tools: string[], tokens: number, cost: Usage | null, runner: { inputTokens: number, outputTokens: number, cacheReadTokens: number, cacheWriteTokens: number }, error: string | null, started: boolean, resolveDone: ((value?: any) => void) | null, goalMode: boolean, modelsSeen: Set<string> }} Turn
  */
 
 // The runner's own $ for a task. 'local' (the on-device runner) is FREE; a cloud
@@ -44,7 +44,7 @@ const costFields = (c) => c ? {
   costUsd: typeof c.cost === 'number' ? c.cost : 0,
 } : { ...ZERO_COST };
 /** @returns {Turn} */
-const newTurn = () => ({ session: null, tools: [], tokens: 0, cost: null, runner: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 }, error: null, started: false, resolveDone: null });
+const newTurn = () => ({ session: null, tools: [], tokens: 0, cost: null, runner: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 }, error: null, started: false, resolveDone: null, goalMode: false, modelsSeen: new Set() });
 
 /** @param {any} session */
 const finalAnswer = (session) => {
@@ -77,7 +77,12 @@ export function createEvalEngine({ browser, log = () => {}, onProgress = () => {
   const port = browser.runtime.connect({ name: 'eval' });
   port.onMessage.addListener((/** @type {any} */ msg) => {
     switch (msg?.type) {
-      case 'turn/state': turn.session = msg.session; turn.started = true; break;
+      case 'turn/state':
+        turn.session = msg.session; turn.started = true;
+        // Which model(s) actually ran this task — the prewalk arm's "did the
+        // swap happen" signal (planner then executor both show up here).
+        if (msg.session?.model) turn.modelsSeen.add(msg.session.model);
+        break;
       case 'turn/delta': turn.started = true; break;
       case 'turn/tool-use': turn.started = true; turn.tools.push(msg.name); break;
       case 'turn/cost': if (msg.turn) { turn.tokens = tally(msg.turn); turn.cost = msg.turn; } break;
@@ -92,7 +97,15 @@ export function createEvalEngine({ browser, log = () => {}, onProgress = () => {
       case 'turn/error': turn.error = msg.error; break;
       case 'turn/streaming':
         if (msg.streaming) turn.started = true;
-        else if (turn.started && turn.resolveDone) { const r = turn.resolveDone; turn.resolveDone = null; r(); }
+        // Goal-mode tasks span MANY turns — streaming:false fires between every
+        // iteration, so only the goal/state terminal below may resolve them.
+        else if (!turn.goalMode && turn.started && turn.resolveDone) { const r = turn.resolveDone; turn.resolveDone = null; r(); }
+        break;
+      case 'goal/state':
+        turn.started = true;
+        if (turn.goalMode && msg.active === false && turn.resolveDone) {
+          const r = turn.resolveDone; turn.resolveDone = null; r();
+        }
         break;
       case 'local-model/progress': onProgress(msg.progress || {}); break;
       default: break;
@@ -193,9 +206,15 @@ export function createEvalEngine({ browser, log = () => {}, onProgress = () => {
     return { url, title, text };
   }
 
-  /** @param {any} task @param {string} [runnerCfg] */
-  async function runTask(task, runnerCfg) {
+  // goal=true runs the task as a GOAL RUN (agent/send goal:true): the agent
+  // keeps taking turns until complete_goal / cap / stop — the arc the prewalk
+  // arm exercises (prewalk only engages on goal runs). Completion is the
+  // run's terminal goal/state, not turn/streaming; timeouts stop the run so
+  // it can't keep driving turns into the NEXT task's session.
+  /** @param {any} task @param {string} [runnerCfg] @param {{ goal?: boolean }} [opts] */
+  async function runTask(task, runnerCfg, opts = {}) {
     turn = newTurn();
+    turn.goalMode = !!opts.goal;
     log(`\n▶ ${task.id} — ${task.title}`);
     await browser.runtime.sendMessage({ type: 'session/reset' });
     await closeAgentTabs();
@@ -205,17 +224,26 @@ export function createEvalEngine({ browser, log = () => {}, onProgress = () => {
     /** @type {Promise<void>} */
     const donePromise = new Promise((res) => { turn.resolveDone = res; });
     const start = Date.now();
-    const reply = await browser.runtime.sendMessage({ type: 'agent/send', text: task.prompt, activeTabId: subjId });
+    const reply = await browser.runtime.sendMessage({
+      type: 'agent/send', text: task.prompt, activeTabId: subjId,
+      ...(turn.goalMode ? { goal: true } : {}),
+    });
     if (!reply?.ok) {
       const detail = `agent/send rejected: ${reply?.error}`;
       log(`  ✗ ${detail}`);
       return { id: task.id, pass: false, detail, error: reply?.error, steps: 0, tokens: 0, ...ZERO_COST, runnerTokens: 0, runnerCostUsd: 0, durationMs: 0, tools: [] };
     }
-    await Promise.race([donePromise, sleep(task.timeoutMs ?? 90_000)]);
+    // A goal run is many turns; give it more wall clock than a single turn.
+    const timeoutMs = task.timeoutMs ?? (turn.goalMode ? 300_000 : 90_000);
+    await Promise.race([donePromise, sleep(timeoutMs)]);
     const durationMs = Date.now() - start;
     const timedOut = !!turn.resolveDone;
     turn.resolveDone = null;
-    if (timedOut) log('  ⏱ timed out (still scoring end state)');
+    if (timedOut) {
+      log('  ⏱ timed out (still scoring end state)');
+      // A live goal run would keep driving turns past this task — halt it.
+      if (turn.goalMode) await browser.runtime.sendMessage({ type: 'agent/stop' }).catch(() => {});
+    }
     await settleSubject();
     const end = await resolveEndTab();
     const tabInfo = await readTab(end?.id ?? subjId);
@@ -230,9 +258,10 @@ export function createEvalEngine({ browser, log = () => {}, onProgress = () => {
     const freshTok = cost.inputTokens + cost.outputTokens;
     const runnerTokens = turn.runner.inputTokens + turn.runner.outputTokens + turn.runner.cacheReadTokens + turn.runner.cacheWriteTokens;
     const runnerCostUsd = priceRunnerUsd(runnerCfg, turn.runner);
-    log(`  ${res.pass ? '✓ PASS' : '✗ FAIL'} — ${res.detail}  [${state.steps} steps · ${(durationMs / 1000).toFixed(1)}s · runner ${runnerTokens} tok · $${runnerCostUsd.toFixed(4)} runner + $${cost.costUsd.toFixed(4)} main]`);
+    const models = [...turn.modelsSeen];
+    log(`  ${res.pass ? '✓ PASS' : '✗ FAIL'} — ${res.detail}  [${state.steps} steps · ${(durationMs / 1000).toFixed(1)}s · runner ${runnerTokens} tok · $${runnerCostUsd.toFixed(4)} runner + $${cost.costUsd.toFixed(4)} main${models.length > 1 ? ` · models ${models.join(' → ')}` : ''}]`);
     if (!res.pass && state.answer) log(`       agent said: "${state.answer.slice(0, 200).replace(/\s+/g, ' ')}"`);
-    return { id: task.id, pass: res.pass, detail: res.detail, error: state.error, steps: state.steps, tokens: state.tokens, ...cost, runnerTokens, runnerCostUsd, durationMs, tools: state.tools };
+    return { id: task.id, pass: res.pass, detail: res.detail, error: state.error, steps: state.steps, tokens: state.tokens, ...cost, runnerTokens, runnerCostUsd, durationMs, tools: state.tools, models };
   }
 
   // onTask({ index, total, id }) lets the UI show live progress per task.
@@ -243,18 +272,19 @@ export function createEvalEngine({ browser, log = () => {}, onProgress = () => {
    * @param {string} suiteId @param {boolean} showTabs
    * @param {(p: { index: number, total: number, id: string }) => void} [onTask]
    * @param {string} [runnerCfg]
+   * @param {{ goal?: boolean }} [opts]  goal:true runs every task as a goal run
    */
-  async function runSuite(suiteId, showTabs, onTask = () => {}, runnerCfg) {
+  async function runSuite(suiteId, showTabs, onTask = () => {}, runnerCfg, opts = {}) {
     wireListeners();
     await ensureSubject(showTabs);
     const tasks = /** @type {Record<string, { tasks: any[] }>} */ (SUITES)[suiteId]?.tasks ?? TASKS;
-    log(`  suite: ${suiteId} (${tasks.length} tasks)`);
+    log(`  suite: ${suiteId} (${tasks.length} tasks${opts.goal ? ' · goal mode' : ''})`);
     /** @type {any[]} */
     const results = [];
     for (let i = 0; i < tasks.length; i++) {
       const task = tasks[i];
       onTask({ index: i, total: tasks.length, id: task.id });
-      try { results.push(await runTask(task, runnerCfg)); }
+      try { results.push(await runTask(task, runnerCfg, opts)); }
       catch (e) { log(`  ✗ runner error: ${/** @type {{ message?: string }} */ (e)?.message ?? e}`); results.push({ id: task.id, pass: false, detail: 'runner error', error: String(e), steps: 0, tokens: 0, ...ZERO_COST, runnerTokens: 0, runnerCostUsd: 0, durationMs: 0, tools: [] }); }
     }
     return { card: aggregate(results), results };
@@ -284,11 +314,18 @@ export function createEvalEngine({ browser, log = () => {}, onProgress = () => {
   const setMainModel = (provider, model) => browser.runtime.sendMessage({ type: 'settings/update', patch: { providerName: provider, providerModel: model } });
   const readMainModel = async () => { try { const r = await browser.runtime.sendMessage({ type: 'state/get' }); const s = r?.state?.settings; return { provider: s?.providerName ?? '', model: s?.providerModel ?? '' }; } catch { return { provider: '', model: '' }; } };
 
-  // config = { mainProvider, mainModel, runnerCfg }. Sets BOTH models, runs the
-  // suite, returns the scorecard. (The caller restores the user's settings.)
+  // Prewalk arm control — the benchmarking switch for the goal-run handoff
+  // (loop/prewalk.js). Set per config leg, saved/restored with the models.
+  const readPrewalk = async () => { try { const r = await browser.runtime.sendMessage({ type: 'state/get' }); return r?.state?.settings?.prewalkEnabled === true; } catch { return false; } };
+  /** @param {boolean} val */
+  const setPrewalk = (val) => browser.runtime.sendMessage({ type: 'settings/update', patch: { prewalkEnabled: !!val } });
+
+  // config = { mainProvider, mainModel, runnerCfg, goal?, prewalk? }. Sets the
+  // models + the prewalk arm, runs the suite (as goal runs when goal:true),
+  // returns the scorecard. (The caller restores the user's settings.)
   /**
    * @param {string} label
-   * @param {{ mainProvider?: string, mainModel?: string, runnerCfg?: string }} config
+   * @param {{ mainProvider?: string, mainModel?: string, runnerCfg?: string, goal?: boolean, prewalk?: boolean }} config
    * @param {string} suiteId @param {boolean} showTabs
    * @param {(p: { index: number, total: number, id: string }) => void} [onTask]
    */
@@ -296,36 +333,44 @@ export function createEvalEngine({ browser, log = () => {}, onProgress = () => {
     const rm = await configToRunnerModel(config.runnerCfg);
     if (config.mainProvider && config.mainModel) await setMainModel(config.mainProvider, config.mainModel);
     await setRunnerModel(rm);
+    // prewalk only means anything on goal runs; set it explicitly per leg so
+    // an A/B is always a controlled comparison, whatever the user's setting.
+    await setPrewalk(!!config.prewalk);
     await sleep(200); // let the SW rebuild the session + tool-contexts with the new models
-    log(`\n──────── ${label}: main "${config.mainModel}" · runner "${config.runnerCfg}" ────────`);
-    const { card, results } = await runSuite(suiteId, showTabs, onTask, config.runnerCfg);
+    log(`\n──────── ${label}: main "${config.mainModel}" · runner "${config.runnerCfg}"${config.goal ? ' · goal' : ''}${config.prewalk ? ' · prewalk' : ''} ────────`);
+    const { card, results } = await runSuite(suiteId, showTabs, onTask, config.runnerCfg, { goal: !!config.goal });
     return { label, config, card, results };
   }
 
-  // Save the user's models, run, restore — the Lab never leaves your chat on a
-  // different model than you set.
+  // Save the user's models + prewalk arm, run, restore — the Lab never leaves
+  // your chat on a different model (or a flipped experiment) than you set.
   /** @param {() => Promise<any>} fn */
   async function withSavedModels(fn) {
     const savedMain = await readMainModel();
     const savedRunner = await readRunnerModel();
+    const savedPrewalk = await readPrewalk();
     try { return await fn(); }
     finally {
       await setMainModel(savedMain.provider, savedMain.model);
       await setRunnerModel(savedRunner);
-      log(`\nrestored your models (main ${JSON.stringify(savedMain.model)}, runner ${JSON.stringify(savedRunner)}).`);
+      await setPrewalk(savedPrewalk);
+      log(`\nrestored your settings (main ${JSON.stringify(savedMain.model)}, runner ${JSON.stringify(savedRunner)}, prewalk ${savedPrewalk ? 'on' : 'off'}).`);
     }
   }
+  /** @typedef {{ mainProvider?: string, mainModel?: string, runnerCfg?: string, goal?: boolean, prewalk?: boolean }} ArmConfig */
   /**
-   * @param {{ mainProvider?: string, mainModel?: string, runnerCfg?: string }} config
+   * @param {ArmConfig} config
    * @param {string} suiteId @param {boolean} showTabs
    * @param {(p: { index: number, total: number, id: string }) => void} [onTask]
    */
   const runOne = (config, suiteId, showTabs, onTask = () => {}) =>
     withSavedModels(() => runOneConfig('A', config, suiteId, showTabs, onTask));
-  // Run the suite under config A, then config B (each a main+runner pair).
+  // Run the suite under config A, then config B. Each config is a main+runner
+  // pair plus the run-shape flags (goal / prewalk) — so the same helper drives
+  // a model A/B or a baseline-vs-prewalk arm comparison.
   /**
-   * @param {{ mainProvider?: string, mainModel?: string, runnerCfg?: string }} configA
-   * @param {{ mainProvider?: string, mainModel?: string, runnerCfg?: string }} configB
+   * @param {ArmConfig} configA
+   * @param {ArmConfig} configB
    * @param {string} suiteId @param {boolean} showTabs
    * @param {(p: { index: number, total: number, id: string }) => void} [onTask]
    */

--- a/extension/home/eval-section.js
+++ b/extension/home/eval-section.js
@@ -30,6 +30,7 @@ import { SUITES } from '../eval/tasks.js';
  * @property {any} progress
  * @property {string} suiteId
  * @property {boolean} showTabs
+ * @property {boolean} goalRuns
  * @property {boolean} showTasks
  * @property {string} mainA
  * @property {string} runnerA
@@ -49,7 +50,7 @@ let engine = null;
 /** @type {EvalUi} */
 const ui = {
   loaded: false, warn: '', running: false, progress: null,
-  suiteId: 'simple', showTabs: false, showTasks: false,
+  suiteId: 'simple', showTabs: false, goalRuns: false, showTasks: false,
   mainA: '', runnerA: '', mainB: '', runnerB: '',
   allOptions: [], cloudOptions: [], localLabel: null,
   ab: null, single: null, log: [],
@@ -65,7 +66,7 @@ const parseMain = (val) => { const i = String(val).indexOf('::'); return i < 0 ?
 /** @param {'A' | 'B'} side */
 const configFor = (side) => {
   const { provider, model } = parseMain(side === 'A' ? ui.mainA : ui.mainB);
-  return { mainProvider: provider, mainModel: model, runnerCfg: side === 'A' ? ui.runnerA : ui.runnerB };
+  return { mainProvider: provider, mainModel: model, runnerCfg: side === 'A' ? ui.runnerA : ui.runnerB, goal: ui.goalRuns };
 };
 
 async function loadModels() {
@@ -128,6 +129,25 @@ async function runSingle() {
   finally { ui.running = false; ui.progress = null; m.redraw(); }
 }
 
+// Baseline vs prewalk — the SAME config (side A's pair), both legs as goal
+// runs; the only variable is the prewalk handoff. This is THE gate for
+// flipping prewalkEnabled on by default: it must hold pass rate while
+// cutting $ and time (compare stencil.so/blog/prewalk's receipts).
+async function runPrewalkAB() {
+  if (ui.running) return;
+  ui.running = true; ui.ab = null; ui.single = null; ui.log = []; ui.progress = null; m.redraw();
+  try {
+    const base = { ...configFor('A'), goal: true };
+    ui.ab = await ensureEngine().runAB(
+      { ...base, prewalk: false },
+      { ...base, prewalk: true },
+      ui.suiteId, ui.showTabs,
+      (/** @type {any} */ p) => { ui.progress = p; m.redraw(); },
+    );
+  } catch (e) { pushLog(`prewalk A/B aborted: ${/** @type {{ message?: string }} */ (e)?.message ?? e}`); }
+  finally { ui.running = false; ui.progress = null; m.redraw(); }
+}
+
 /** @param {number} ms */
 const secs = (ms) => `${(ms / 1000).toFixed(1)}s`;
 /** @param {number} [n] */
@@ -136,8 +156,9 @@ const usd = (n) => `$${(n ?? 0).toFixed(5)}`;
 const runnerUsd = (n) => ((n ?? 0) > 0 ? usd(n) : 'free'); // local runner reads "free"
 /** @param {string} id */
 const shortModel = (id) => String(id).replace(/^[a-z-]+\//, '').replace(/-\d{8}$/, ''); // strip provider/ + date
-/** @param {{ mainModel: string, runnerCfg: string }} cfg */
-const pairLabel = (cfg) => `${shortModel(cfg.mainModel)} / ${cfg.runnerCfg === 'local' ? 'local' : shortModel(cfg.runnerCfg)}`;
+/** @param {{ mainModel: string, runnerCfg: string, goal?: boolean, prewalk?: boolean }} cfg */
+const pairLabel = (cfg) => `${shortModel(cfg.mainModel)} / ${cfg.runnerCfg === 'local' ? 'local' : shortModel(cfg.runnerCfg)}`
+  + `${cfg.goal ? ' · goal' : ''}${cfg.prewalk ? ' · prewalk' : ''}`;
 
 /** @param {{ a: any, b: any, delta: any }} result */
 function abBoard({ a, b, delta }) {
@@ -199,11 +220,19 @@ export const EvalSection = {
         m('label.eval-check', {
           title: 'Off: the agent runs in a hidden, background window. On: a visible window (its own tab bar) you can watch — it never takes focus either way.',
         }, [m('input', { type: 'checkbox', checked: ui.showTabs, disabled: ui.running, onchange: (/** @type {{ target: HTMLInputElement }} */ e) => { ui.showTabs = e.target.checked; } }), 'show tabs']),
+        m('label.eval-check', {
+          title: 'Run every task as an autonomous GOAL run (plan → todo checklist → turns until complete_goal) instead of a single chat turn. Slower per task; exercises the goal loop the prewalk A/B measures.',
+        }, [m('input', { type: 'checkbox', checked: ui.goalRuns, disabled: ui.running, onchange: (/** @type {{ target: HTMLInputElement }} */ e) => { ui.goalRuns = e.target.checked; } }), 'goal runs']),
       ]),
       m('.eval-pairs', [pairCol('A'), m('.eval-pair-vs', 'vs'), pairCol('B')]),
       m('.eval-controls', [
         m('button.eval-btn.primary', { disabled: ui.running || !ui.mainA || !ui.mainB, onclick: runAB }, 'Run A/B'),
         m('button.eval-btn', { disabled: ui.running || !ui.mainA, onclick: runSingle }, 'Run A only'),
+        m('button.eval-btn', {
+          disabled: ui.running || !ui.mainA,
+          title: 'Side A\'s config, two legs of goal runs: baseline vs prewalk (plan on the main model, hand the live context to a cheap executor at the first landed action). The gate for turning the prewalk setting on: pass rate must hold while $ and time drop.',
+          onclick: runPrewalkAB,
+        }, 'Run prewalk A/B'),
       ]),
       m('button.eval-disclosure', { onclick: () => { ui.showTasks = !ui.showTasks; } },
         `${ui.showTasks ? '▾' : '▸'} exactly what the ${suite()?.tasks.length ?? 0} ${ui.suiteId} tasks run`),

--- a/extension/options/sections/behavior.js
+++ b/extension/options/sections/behavior.js
@@ -131,6 +131,50 @@ export const BehaviorSection = {
       // never steals focus. open_tab active:false opens quietly when needed.)
 
       m('.settings-divider'),
+      m('h3', 'Prewalk (experimental)'),
+      (() => {
+        const pwOn = state.settings?.prewalkEnabled === true;
+        return [
+          m('p', pwOn
+            ? 'On. Goal runs open on your chat model for the planning phase (explore → commit a todo checklist → first action), then hand the live context to a cheaper executor model for the rest of the run. Spend drops; the plan and progress stay visible in the todo card.'
+            : 'Off. Goal runs stay on your chat model end-to-end. Turning this on makes a goal run plan on your chat model, then continue on a cheaper executor model once its first action lands — same context, lower spend. Benchmark it first in the home page Lab (baseline vs prewalk).'),
+          m('div', { style: 'display:flex; gap:8px; align-items:center;' }, [
+            m('button.secondary', {
+              type: 'button',
+              disabled: ui.prewalkBusy,
+              onclick: async () => {
+                if (ui.prewalkBusy) return;
+                ui.prewalkBusy = true; m.redraw();
+                try {
+                  await send({ type: 'settings/update', patch: { prewalkEnabled: !pwOn } });
+                } catch (e) {
+                  console.warn('[options] prewalk toggle failed', e);
+                } finally {
+                  ui.prewalkBusy = false; m.redraw();
+                }
+              },
+            }, ui.prewalkBusy ? '…' : pwOn ? 'Turn off prewalk' : 'Turn on prewalk'),
+          ]),
+          pwOn ? [
+            m('.input-row', [
+              m('label', { for: 'prewalk-executor' }, 'Executor model'),
+              m('input', {
+                id: 'prewalk-executor',
+                type: 'text',
+                placeholder: 'empty = provider fast default (e.g. Haiku)',
+                value: state.settings?.prewalkExecutorModel ?? '',
+                onchange: async (/** @type {{ target: HTMLInputElement }} */ e) => {
+                  await send({ type: 'settings/update', patch: { prewalkExecutorModel: e.target.value } });
+                  m.redraw();
+                },
+              }),
+            ]),
+            m('p.hint', 'A model id on the SAME provider as the chat. Leave empty to use the provider’s fast default — the same model the web actor rides.'),
+          ] : null,
+        ];
+      })(),
+
+      m('.settings-divider'),
       m('h3', 'Advanced automation'),
       (() => {
         // Firefox has no chrome.debugger WebExtension API (the build
@@ -314,6 +358,7 @@ export const BehaviorSection = {
       resetRow(send, [
         'reasoningEnabled', 'reasoningEffort', 'confirmWebWrites', 'advancedAutomationEnabled', 'devMode',
         'autoResumeInterruptedTurns', 'providerFailoverEnabled', 'providerFallbacks',
+        'prewalkEnabled', 'prewalkExecutorModel',
       ]),
     ]);
   },

--- a/extension/peerd-runtime/index.js
+++ b/extension/peerd-runtime/index.js
@@ -24,6 +24,15 @@ export { makeTurnDriver } from './loop/turn-driver.js';
 // Goal mode (the mode-row Goal toggle): auto-continuing agent turns until the
 // agent calls complete_goal (or the cap / Stop). loop/goal-runner.js.
 export { makeGoalRunner, GOAL_MAX_ITERATIONS, goalContinuationPrompt } from './loop/goal-runner.js';
+// The goal run's plan-of-record (session.todos) — pure list ops + the
+// prompt-facing renderer the SW binds into the goal continuation.
+export { initTodos, checkTodo, addTodo, nextPending, todoProgress, formatTodoBlock, MAX_TODO_ITEMS } from './todo/core.js';
+// Prewalk (loop/prewalk.js): frontier model plans a goal run, a cheap
+// executor inherits the live context at the first landed action. Pure
+// policy — the SW owns the session writes and the run lifecycle.
+export {
+  resolvePrewalkExecutor, armPrewalk, shouldPrewalkSwap, markPrewalkSwapped, PREWALK_NUDGE,
+} from './loop/prewalk.js';
 // Long-session context compression: the rolling trim-summary core +
 // the post-turn enrichment shell the SW binds behind the loop's
 // enrichTrimSummary seam.

--- a/extension/peerd-runtime/loop/agent-loop.js
+++ b/extension/peerd-runtime/loop/agent-loop.js
@@ -431,6 +431,17 @@ export async function* runUserTurn(ctx) {
       // here is safe.
       let historyForModel = injectResumeNotes(
         /** @type {InternalMessage[]} */ (trimPlan.messages));
+      // why: signed thinking blocks are MODEL-BOUND — replaying one authored
+      // by a different model (a prewalk executor swap, or any future
+      // mid-session model change) fails the provider's signature check and
+      // 400s the turn. Assistant messages record the model that wrote them,
+      // so strip thinkingBlocks that don't match the model about to be
+      // called; the visible `thinking` text stays for the transcript.
+      historyForModel = historyForModel.map((msg) => (
+        msg.role === 'assistant' && Array.isArray(msg.thinkingBlocks)
+          && msg.model && msg.model !== session.model
+          ? { ...msg, thinkingBlocks: undefined }
+          : msg));
       // why: the model must see the attachment BYTES on the turn they
       // were sent (every step of it — history is rebuilt from the
       // session per step), while the persisted record stays stripped.

--- a/extension/peerd-runtime/loop/goal-runner.js
+++ b/extension/peerd-runtime/loop/goal-runner.js
@@ -33,13 +33,18 @@ export const GOAL_RUNS_KEY = 'goal.runs.v1';
  * The hidden continuation nudge sent as turns 2..N. Frames the autonomy
  * contract and points the agent at complete_goal. The goal text is repeated
  * verbatim so a long run never loses the north star (each turn's history is
- * trimmed independently).
+ * trimmed independently) — and the live todo list rides along for the same
+ * reason: the plan-of-record is re-surfaced every turn, so the model (or the
+ * cheaper model prewalk swapped in) steers by the checklist instead of by
+ * memory of it.
  * @param {string} goal
+ * @param {string} [todoBlock]  formatTodoBlock(session.todos); '' when no list
  */
-export const goalContinuationPrompt = (goal) => [
+export const goalContinuationPrompt = (goal, todoBlock = '') => [
   'Continue working autonomously toward this goal:',
   '',
   goal,
+  ...(todoBlock ? ['', todoBlock, '', 'Work the next unchecked item; call todo_check the moment its validation passes.'] : []),
   '',
   'Take the next concrete step now. Do NOT stop to ask me for confirmation or',
   'permission — keep going. When (and ONLY when) the goal is FULLY achieved,',
@@ -75,10 +80,14 @@ export const goalContinuationPrompt = (goal) => [
  * @param {{ get(k:string):Promise<any>, set(k:string,v:any):Promise<void>, delete(k:string):Promise<void> }} [deps.kv]
  *   Durable mirror of the active runs (storage.local). Omit for pure in-memory
  *   (tests): persistence + resume become no-ops.
+ * @param {(sessionId: string) => Promise<string>} [deps.getTodoBlock]
+ *   Renders the session's live todo list for the continuation prompt
+ *   (formatTodoBlock over session.todos, bound by the SW). Optional + best-
+ *   effort: absent or throwing → the continuation goes out without the block.
  * @param {number} [deps.maxIterations]
  * @param {() => number} [deps.now]
  */
-export const makeGoalRunner = ({ runTurn, onEvent = () => {}, onRunEnd = () => {}, kv, maxIterations = GOAL_MAX_ITERATIONS, now = Date.now }) => {
+export const makeGoalRunner = ({ runTurn, onEvent = () => {}, onRunEnd = () => {}, kv, getTodoBlock, maxIterations = GOAL_MAX_ITERATIONS, now = Date.now }) => {
   /** @type {Map<string, GoalRun>} */
   const runs = new Map();
 
@@ -200,10 +209,17 @@ export const makeGoalRunner = ({ runTurn, onEvent = () => {}, onRunEnd = () => {
         emit(sid, 'running');
         /** @type {{ ok?: boolean, stopReason?: string } | void} */
         let outcome;
+        // The live plan-of-record for this continuation — re-read per turn so
+        // check-offs from the previous turn show. Best-effort: a read failure
+        // just drops the block, never the turn.
+        let todoBlock = '';
+        if (!first && typeof getTodoBlock === 'function') {
+          try { todoBlock = await getTodoBlock(sid); } catch { todoBlock = ''; }
+        }
         try {
           outcome = await runTurn({
             sessionId: sid,
-            userText: first ? run.goal : goalContinuationPrompt(run.goal),
+            userText: first ? run.goal : goalContinuationPrompt(run.goal, todoBlock),
             // turn 1 is the user's real goal message; continuations are hidden.
             synthetic: !first,
             // DESIGN-17: a goal is USER-initiated, so each continuation is a

--- a/extension/peerd-runtime/loop/prewalk.js
+++ b/extension/peerd-runtime/loop/prewalk.js
@@ -1,0 +1,154 @@
+// @ts-check
+// peerd-runtime/loop/prewalk — swap the frontier model for a cheap executor
+// once a goal run's plan has survived contact with the world.
+//
+// The economics (can1357's "prewalk", stencil.so/blog/prewalk, 2026-07): an
+// agent's bill is O(reads) — the expensive part is the frontier model READING
+// its way to understanding, not the acting that follows. A /plan-style
+// handoff (frontier plans in prose → cheap model executes) duplicates the
+// reading at both prices and hands the executor a postcard instead of the
+// journey. Prewalk hands off the CONTEXT WINDOW itself:
+//
+//   1. The goal run opens on the user's configured (frontier) model with a
+//      hidden planning nudge appended to the system prompt: explore, then
+//      commit the plan as a todo checklist, then take the first action.
+//   2. The moment the first MUTATING tool call succeeds after the todo list
+//      exists — the point where the plan met the world and held — the session
+//      is marked phase:'executing'.
+//   3. From the NEXT turn the session runs on the cheap executor model, and
+//      the planning nudge is no longer rendered. The executor wakes inside a
+//      trajectory it believes is its own: recon done, checklist ticking, one
+//      valid move already landed — nothing in context looks like planning or
+//      desperation, so it executes instead of re-deriving (or flailing).
+//
+// why turn-boundary (not mid-turn) swaps: each goal iteration is one agent
+// turn, and the turn driver resolves model, pricing, reasoning, and context
+// window fresh per turn — so a boundary swap gets accurate per-model cost
+// attribution, no cross-model thinking-signature replay inside a live tool
+// loop, and a correctly-sized trim window, all for free. The nudge herds the
+// opening turn to end soon after the first action lands, so the boundary
+// arrives quickly.
+//
+// Everything here is pure (Bun-tested); the IO — session reads/writes, the
+// live goal-run check, audit — lives in the SW wiring and turn-driver seams.
+
+/**
+ * Prewalk state, persisted on the session record for the run's lifetime.
+ *
+ * @typedef {Object} PrewalkState
+ * @property {'planning' | 'executing'} phase
+ * @property {string} plannerProvider   what to restore when the run ends
+ * @property {string} plannerModel
+ * @property {string} executorProvider
+ * @property {string} executorModel
+ * @property {number} armedAt
+ * @property {number} [swappedAt]       set when the gate fires
+ */
+
+// The hidden planning instruction, appended to the system prompt ONLY while
+// phase === 'planning' (turn-driver getSystemPrompt). Pruned by construction
+// after the swap: the prompt is re-rendered every turn, so the executor never
+// sees an instruction it would have to reconcile with mid-task context.
+// Deliberately says nothing about models or swapping — the handoff is the
+// harness's business, not the transcript's.
+export const PREWALK_NUDGE = [
+  '<goal_opening_discipline>',
+  'For this goal, open with a tight plan-first sequence:',
+  '1. Explore first (read-only) until you understand the task surface — but',
+  '   keep it lean; stop exploring the moment you can commit to a plan.',
+  '2. Commit the plan with todo_init: few, concrete steps, each with a',
+  '   "validation" saying how you will verify it worked.',
+  '3. Take the first concrete action toward item 1 immediately after.',
+  '4. Once that first action lands, finish the step you are on and end your',
+  '   turn — the loop continues automatically; do not front-load everything',
+  '   into one turn.',
+  '</goal_opening_discipline>',
+].join('\n');
+
+// Action classes that count as "the plan met the world": a successful call
+// in one of these classes, after the todo list exists, fires the swap.
+const SWAP_SIDE_EFFECTS = new Set(['write', 'mutate_external', 'destructive']);
+
+// Bookkeeping and recon writes that must NOT fire the gate — they are not
+// evidence the plan works. open_tab is Plan-mode-legal navigation (recon);
+// remember is memory bookkeeping; wait_until is waiting; actor_cancel is
+// cleanup; the todo/goal tools are the plan itself.
+export const PREWALK_EXEMPT_TOOLS = Object.freeze(new Set([
+  'open_tab', 'remember', 'wait_until', 'actor_cancel',
+  'todo_init', 'todo_check', 'todo_add', 'complete_goal',
+]));
+
+/**
+ * Resolve the executor (the cheap model the run swaps into). Resolution:
+ *   1. the explicit Settings pin (prewalkExecutorModel), when set;
+ *   2. the active provider's fast default (defaultRunnerModel — the same
+ *      rung the web actor rides, e.g. Haiku on Anthropic).
+ * Same-provider only for now: the transcript is provider-neutral, but keys,
+ * failover chains and pricing are all provider-scoped — cross-provider
+ * executors are a deliberate later step, not a config accident.
+ *
+ * @param {{ settings?: { prewalkExecutorModel?: string }, provider?: { name?: string, defaultRunnerModel?: string } }} inputs
+ * @returns {{ provider: string, model: string } | null} null → nothing usable; don't arm
+ */
+export const resolvePrewalkExecutor = ({ settings, provider } = {}) => {
+  const providerName = provider?.name ?? '';
+  if (!providerName) return null;
+  const pinned = typeof settings?.prewalkExecutorModel === 'string'
+    ? settings.prewalkExecutorModel.trim() : '';
+  const model = pinned || provider?.defaultRunnerModel || '';
+  return model ? { provider: providerName, model } : null;
+};
+
+/**
+ * Build the armed state for a fresh run, or null when arming is pointless
+ * (no executor, or the executor IS the session's model — nothing to save).
+ *
+ * @param {{ provider?: string, model?: string }} session
+ * @param {{ provider: string, model: string } | null} executor
+ * @param {number} now
+ * @returns {PrewalkState | null}
+ */
+export const armPrewalk = (session, executor, now) => {
+  if (!executor || !session?.provider || !session?.model) return null;
+  if (executor.provider === session.provider && executor.model === session.model) return null;
+  return {
+    phase: 'planning',
+    plannerProvider: session.provider,
+    plannerModel: session.model,
+    executorProvider: executor.provider,
+    executorModel: executor.model,
+    armedAt: now,
+  };
+};
+
+/**
+ * The swap gate — fires exactly when the plan has met the world:
+ * phase 'planning', the todo list exists, and a non-exempt mutating tool
+ * call just SUCCEEDED. Pure; the caller persists the transition.
+ *
+ * @param {Object} inputs
+ * @param {PrewalkState | null | undefined} inputs.prewalk
+ * @param {number} inputs.todosCount      current session.todos length
+ * @param {string} inputs.toolName
+ * @param {string | undefined} inputs.sideEffect   the tool's declared class
+ * @param {boolean} inputs.ok              did the call succeed
+ * @returns {boolean}
+ */
+export const shouldPrewalkSwap = ({ prewalk, todosCount, toolName, sideEffect, ok }) => (
+  !!prewalk
+  && prewalk.phase === 'planning'
+  && ok === true
+  && todosCount > 0
+  && !PREWALK_EXEMPT_TOOLS.has(toolName)
+  && SWAP_SIDE_EFFECTS.has(sideEffect ?? '')
+);
+
+/**
+ * The planning → executing transition. Pure.
+ * @param {PrewalkState} prewalk
+ * @param {number} now
+ * @returns {PrewalkState}
+ */
+export const markPrewalkSwapped = (prewalk, now) => ({
+  ...prewalk, phase: 'executing', swappedAt: now,
+});

--- a/extension/peerd-runtime/loop/turn-driver.js
+++ b/extension/peerd-runtime/loop/turn-driver.js
@@ -26,6 +26,10 @@ import { SessionNotFoundError } from '../errors.js';
 // Pure policy helpers (not IO) — direct import is the gates.js precedent, and
 // keeps the actor turn setup readable. Flag-gated so they're inert when off.
 import { EXPOSURE_ACTOR, actorDescriptors, filterActorSurface, pinActorCall } from '../tools/exposure.js';
+// The prewalk planning nudge (loop/prewalk.js) — appended to the system
+// prompt only while session.prewalk.phase === 'planning'. Pure text; the
+// swap/restore IO rides the injected reconcilePrewalk/maybePrewalkSwap deps.
+import { PREWALK_NUDGE } from './prewalk.js';
 
 // pinActorCall moved to tools/exposure.js (shared with the offscreen actor tool
 // relay, a security seam — one implementation, no drift).
@@ -47,6 +51,13 @@ export const makeTurnDriver = (/** @type {any} */ deps) => {
     // The context inspector's capture hook (optional; a no-op default so the
     // driver never depends on the debug surface being wired).
     recordModelCall = () => {},
+    // Prewalk (loop/prewalk.js), both optional so actor/test drivers stay
+    // inert: reconcilePrewalk applies a pending planning→executing model swap
+    // (or restores stale state) at the TURN boundary — before pricing,
+    // context-window and reasoning resolve, so all three see the swapped
+    // model; maybePrewalkSwap is the per-tool-call gate that flips the phase.
+    reconcilePrewalk = null,
+    maybePrewalkSwap = null,
   } = deps;
 
 /**
@@ -100,7 +111,15 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
   // (cost/clamp/scheduler/key/egress below) but a kind-aware per-turn SETUP: no
   // user-tab/memory context, an actor-only descriptor list + tuned prompt, the
   // 'actor' exposure marker, and the per-instance pin. Reused for cost.
-  const turnSession = sessionId ? await sessions.get(sessionId) : null;
+  let turnSession = sessionId ? await sessions.get(sessionId) : null;
+  // Prewalk turn-boundary reconcile: apply a pending executor swap (so THIS
+  // turn's model/pricing/window all read the executor), or restore a stale
+  // planner (a run that died without its run-end restore). Best-effort — a
+  // reconcile failure runs the turn on the unreconciled record.
+  if (turnSession?.prewalk && turnSession.kind !== 'actor' && typeof reconcilePrewalk === 'function') {
+    try { turnSession = (await reconcilePrewalk(turnSession)) ?? turnSession; }
+    catch (e) { console.warn('[turn] prewalk reconcile failed', e); }
+  }
   const isActor = turnSession?.kind === 'actor';
   /** @type {string|undefined} */
   const actorType = isActor ? turnSession.actorType : undefined;
@@ -193,7 +212,14 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
     // defense text). Absent → collapses to nothing. The per-change cache
     // break this causes is by design.
     const promptSession = await sessions.get(sessionId);
-    return renderSystemPrompt({
+    // Prewalk: the planning nudge rides the prompt ONLY during the planning
+    // phase. Because the prompt re-renders per turn, the executor's first
+    // turn simply never contains it — the "prune the planning instruction"
+    // half of the handoff falls out of the render, no history surgery.
+    const prewalkBlock = !isActor && promptSession?.prewalk?.phase === 'planning'
+      ? `\n\n${PREWALK_NUDGE}`
+      : '';
+    return (await renderSystemPrompt({
       memoryBlock,
       temporalBlock,
       skillsBlock,
@@ -209,7 +235,9 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
       // PR #119: a tab web actor's action surface ('tools'|'code'), resolved by
       // buildToolContext from the setting — the prompt teaches page.* for 'code'.
       ...(isActor ? { actorType, backing: actorBacking, instanceId: actorInstanceId, actorSurface: toolContext.actorSurface } : {}),
-    });
+    // why await: renderSystemPrompt is async — concatenating the un-awaited
+    // promise would bake "[object Promise]" into the prompt.
+    })) + prewalkBlock;
   };
 
   // Tool descriptors passed to the provider — name, description, and
@@ -303,6 +331,15 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
     // If a CDP-backed tool reported the debugger isn't available, surface a
     // one-time "enable advanced automation" nudge to the side panel.
     maybeNudgeDebuggerGrant(result);
+    // Prewalk swap gate: a successful mutating call while the session is in
+    // its planning phase may flip it to 'executing' (the model swap itself
+    // applies at the next turn's reconcile). Awaited so the phase write can't
+    // race this turn's remaining dispatches; a gate failure never breaks the
+    // tool result. Main turns only — actors have no prewalk state.
+    if (!isActor && typeof maybePrewalkSwap === 'function') {
+      try { await maybePrewalkSwap({ sessionId, name: call?.name, ok: /** @type {any} */ (result)?.ok === true }); }
+      catch (e) { console.warn('[turn] prewalk swap gate failed', e); }
+    }
     return result;
   };
   // why: the loop's concurrent-dispatch scheduler partitions a multi-tool

--- a/extension/peerd-runtime/sessions/store.js
+++ b/extension/peerd-runtime/sessions/store.js
@@ -405,6 +405,30 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
   };
 
   /**
+   * Set or CLEAR the session's prewalk state (loop/prewalk.js). null removes
+   * the field entirely (absent = "no prewalk", the shape every consumer keys
+   * on) — a generic update() spread can't unset a key, hence this setter.
+   * Optionally restores the planner provider/model in the SAME write, so a
+   * run-end restore can't be torn by a crash between two writes.
+   *
+   * @param {string} sessionId
+   * @param {import('../loop/prewalk.js').PrewalkState | null} state
+   * @param {{ provider?: string, model?: string }} [modelPatch]
+   */
+  const setPrewalk = async (sessionId, state, modelPatch) => {
+    const record = await getRecord(sessionId);
+    if (!record) throw new SessionNotFoundError(sessionId);
+    const { prewalk: _removed, ...rest } = record;
+    const updated = {
+      ...rest,
+      ...(modelPatch ?? {}),
+      ...(state ? { prewalk: state } : {}),
+    };
+    await idb.put(STORE, updated);
+    return assemble(updated);
+  };
+
+  /**
    * Persist the session's rolling trim-summary state.
    *
    * @param {string} sessionId
@@ -430,6 +454,7 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
     setCustomSystemPrompt,
     setToolManifest,
     setCost,
+    setPrewalk,
     setTrimSummary,
   });
 };

--- a/extension/peerd-runtime/sessions/types.js
+++ b/extension/peerd-runtime/sessions/types.js
@@ -64,6 +64,19 @@
  * created before the feature; defaulted to an empty tally at read time.
  * @property {import('../cost/accumulator.js').CostTally} [cost]
  *
+ * Goal-run plan-of-record (todo/core.js) — written by the todo_* tools
+ * during a goal run, rendered live by the side panel's todo card (it rides
+ * the ordinary state snapshots), and re-surfaced in every goal continuation
+ * prompt. Absent until a run calls todo_init.
+ * @property {import('../todo/core.js').TodoItem[]} [todos]
+ *
+ * Prewalk state (loop/prewalk.js) — present only while a prewalk-armed goal
+ * run owns this session. phase 'planning' = frontier model, nudge injected;
+ * 'executing' = the first mutating action landed, the session runs on the
+ * executor model from the next turn. Cleared (and the planner model
+ * restored) when the run ends.
+ * @property {import('../loop/prewalk.js').PrewalkState} [prewalk]
+ *
  * Plan/Act permission state, written at create() and flipped
  * mid-session via update() so the choice survives a SW restart
  * (absent-key contract). Records carry only `confirmActions` — read via

--- a/extension/peerd-runtime/todo/core.js
+++ b/extension/peerd-runtime/todo/core.js
@@ -1,0 +1,165 @@
+// @ts-check
+// peerd-runtime/todo — the session plan-of-record, pure core.
+//
+// A goal run's todo list is the plan the agent writes for ITSELF (todo_init)
+// and then works through (todo_check). It exists because a plan held only in
+// model context evaporates: a cheap executor — or the same model forty turns
+// later — forgets what it derived, but it cannot forget a checklist the
+// harness re-surfaces every turn (the goal continuation prompt embeds
+// formatTodoBlock). This is also the prewalk contract's spine: the planner
+// model's understanding is handed to the executor as a ticking checklist in
+// shared context, not as a prose plan it would have to re-derive.
+//
+// Everything here is pure (values in, values out) — the persisted list lives
+// on the session record (session.todos); IO stays in the SW-injected
+// ctx.todoStore the tool defs call. Bun-tested in tests/peerd-runtime.
+
+// why a hard cap: small executors game unbounded lists (60 micro-items
+// checked off in batches teaches the loop nothing), and a plan that long is
+// recon deferred, not planning. The init tool REJECTS an over-cap list so the
+// model consolidates — a silent clip would leave it believing steps exist
+// that were dropped.
+export const MAX_TODO_ITEMS = 12;
+
+// Item text bounds — a todo is a checklist line, not a design doc.
+const MAX_TEXT_CHARS = 200;
+const MAX_VALIDATION_CHARS = 200;
+
+/**
+ * One plan step. `validation` is the "how I'll know it worked" the planning
+ * nudge asks for — kept as its own field so the check-off turn re-reads the
+ * success criterion instead of trusting a vibe.
+ *
+ * @typedef {Object} TodoItem
+ * @property {number} id                 1-based, stable for the list's lifetime
+ * @property {string} text
+ * @property {string} [validation]
+ * @property {'pending' | 'done'} status
+ */
+
+/** @param {unknown} s @param {number} cap */
+const cleanText = (s, cap) => String(s ?? '').replace(/\s+/g, ' ').trim().slice(0, cap);
+
+/**
+ * Build a fresh list from the model's raw items. Replaces any prior list —
+ * re-planning is a deliberate act, not an append.
+ *
+ * @param {unknown} rawItems
+ * @returns {{ ok: true, todos: TodoItem[] } | { ok: false, error: string }}
+ */
+export const initTodos = (rawItems) => {
+  if (!Array.isArray(rawItems) || rawItems.length === 0) {
+    return { ok: false, error: 'todo_init needs a non-empty items array.' };
+  }
+  if (rawItems.length > MAX_TODO_ITEMS) {
+    return {
+      ok: false,
+      error: `Too many items (${rawItems.length}). Consolidate the plan into at most `
+        + `${MAX_TODO_ITEMS} concrete steps — group related work into one item.`,
+    };
+  }
+  /** @type {TodoItem[]} */
+  const todos = [];
+  for (const raw of rawItems) {
+    const rec = /** @type {{ text?: unknown, validation?: unknown }} */ (
+      typeof raw === 'string' ? { text: raw } : (raw ?? {}));
+    const text = cleanText(rec.text, MAX_TEXT_CHARS);
+    if (!text) return { ok: false, error: `Item ${todos.length + 1} has no text.` };
+    const validation = cleanText(rec.validation, MAX_VALIDATION_CHARS);
+    todos.push({
+      id: todos.length + 1,
+      text,
+      ...(validation ? { validation } : {}),
+      status: 'pending',
+    });
+  }
+  return { ok: true, todos };
+};
+
+/**
+ * Mark one item done. Pure — returns a NEW list.
+ *
+ * @param {ReadonlyArray<TodoItem>} todos
+ * @param {unknown} rawId
+ * @returns {{ ok: true, todos: TodoItem[], item: TodoItem } | { ok: false, error: string }}
+ */
+export const checkTodo = (todos, rawId) => {
+  const id = Number(rawId);
+  if (!Array.isArray(todos) || todos.length === 0) {
+    return { ok: false, error: 'No todo list exists yet — call todo_init first.' };
+  }
+  const item = todos.find((t) => t.id === id);
+  if (!item) return { ok: false, error: `No todo item with id ${String(rawId)}.` };
+  if (item.status === 'done') {
+    return { ok: false, error: `Item ${id} ("${item.text}") is already done.` };
+  }
+  const done = /** @type {TodoItem} */ ({ ...item, status: 'done' });
+  return { ok: true, todos: todos.map((t) => (t.id === id ? done : t)), item: done };
+};
+
+/**
+ * Append one item (a step discovered mid-run). Same cap as init.
+ *
+ * @param {ReadonlyArray<TodoItem> | undefined} todos
+ * @param {unknown} rawText
+ * @param {unknown} [rawValidation]
+ * @returns {{ ok: true, todos: TodoItem[], item: TodoItem } | { ok: false, error: string }}
+ */
+export const addTodo = (todos, rawText, rawValidation) => {
+  const list = Array.isArray(todos) ? todos : [];
+  if (list.length >= MAX_TODO_ITEMS) {
+    return {
+      ok: false,
+      error: `The list is at its ${MAX_TODO_ITEMS}-item cap. Finish or fold existing items first.`,
+    };
+  }
+  const text = cleanText(rawText, MAX_TEXT_CHARS);
+  if (!text) return { ok: false, error: 'todo_add needs non-empty text.' };
+  const validation = cleanText(rawValidation, MAX_VALIDATION_CHARS);
+  // why max+1 (not length+1): ids must stay unique for the list's lifetime,
+  // and a future remove-item op would otherwise recycle a checked id.
+  const id = list.reduce((m, t) => Math.max(m, t.id), 0) + 1;
+  const item = /** @type {TodoItem} */ ({
+    id, text, ...(validation ? { validation } : {}), status: 'pending',
+  });
+  return { ok: true, todos: [...list, item], item };
+};
+
+/**
+ * The first unchecked item — "what's next" for steering text.
+ * @param {ReadonlyArray<TodoItem> | undefined} todos
+ * @returns {TodoItem | null}
+ */
+export const nextPending = (todos) =>
+  (Array.isArray(todos) ? todos.find((t) => t.status !== 'done') ?? null : null);
+
+/**
+ * @param {ReadonlyArray<TodoItem> | undefined} todos
+ * @returns {{ done: number, total: number }}
+ */
+export const todoProgress = (todos) => {
+  const list = Array.isArray(todos) ? todos : [];
+  return { done: list.filter((t) => t.status === 'done').length, total: list.length };
+};
+
+/**
+ * Render the list as the compact block the goal continuation prompt (and the
+ * todo tools' own results) embed. This re-surfacing IS the steering
+ * mechanism: the model sees the live plan every turn without having to hold
+ * it in its head.
+ *
+ * @param {ReadonlyArray<TodoItem> | undefined} todos
+ * @returns {string} '' when there is no list
+ */
+export const formatTodoBlock = (todos) => {
+  if (!Array.isArray(todos) || todos.length === 0) return '';
+  const next = nextPending(todos);
+  const lines = todos.map((t) => {
+    const box = t.status === 'done' ? '[x]' : '[ ]';
+    const arrow = next && t.id === next.id ? '  ← next' : '';
+    const check = t.validation && t.status !== 'done' ? ` (verify: ${t.validation})` : '';
+    return `${box} ${t.id}. ${t.text}${check}${arrow}`;
+  });
+  const { done, total } = todoProgress(todos);
+  return [`Plan (${done}/${total} done):`, ...lines].join('\n');
+};

--- a/extension/peerd-runtime/tools/defs/index.js
+++ b/extension/peerd-runtime/tools/defs/index.js
@@ -53,6 +53,7 @@ import { rememberTool }                from './remember.js';
 import { readMemoryTool }              from './read-memory.js';
 import { requestReviewTool }          from './request-review.js';
 import { completeGoalTool }            from './complete-goal.js';
+import { todoInitTool, todoCheckTool, todoAddTool } from './todo.js';
 import { dwebShareTool }               from './dweb-share.js';
 import { dwebDiscoverTool }            from './dweb-discover.js';
 import { dwebInstallTool }             from './dweb-install.js';
@@ -117,6 +118,9 @@ export {
   requestReviewTool,
   // goal mode (Goal toggle — exposure-gated to active runs only)
   completeGoalTool,
+  todoInitTool,
+  todoCheckTool,
+  todoAddTool,
   // dweb (network — preview only, exposure-gated off the store build)
   dwebShareTool,
   dwebDiscoverTool,
@@ -205,8 +209,11 @@ export const BUILTIN_TOOLS = Object.freeze([
   // review (clean-context read-only reviewer — feature 08)
   requestReviewTool,
   // goal mode (the Goal toggle — loop/goal-runner.js). Registered always but
-  // exposure.js reveals it to the model ONLY while a goal run is active.
+  // exposure.js reveals them to the model ONLY while a goal run is active.
   completeGoalTool,
+  todoInitTool,
+  todoCheckTool,
+  todoAddTool,
   // dweb (network publish/discover/install — preview only; exposure.js hides
   // these from the agent on the store build, where DWEB_ENABLED is false)
   dwebDiscoverTool,

--- a/extension/peerd-runtime/tools/defs/todo.js
+++ b/extension/peerd-runtime/tools/defs/todo.js
@@ -1,0 +1,158 @@
+// @ts-check
+// todo_init / todo_check / todo_add — the goal run's plan-of-record tools.
+//
+// Revealed to the model ONLY while a goal run is active (tools/exposure.js
+// GOAL_ONLY_TOOLS, same seam as complete_goal): a normal chat never sees
+// them, so they cost normal turns zero tokens. Like complete_goal, the gate
+// is the descriptor filter, not the dispatcher — execute() no-ops gracefully
+// when called outside a run (no ctx.todoStore).
+//
+// The list itself lives on the SESSION record (session.todos), so it rides
+// the state snapshots the side panel already receives — the visible todo
+// card needs no new event plumbing — and it survives an SW restart with the
+// run (goal-runner resumes; the plan is still there).
+//
+// Read-class: mutating the agent's own bookkeeping is not a page/world side
+// effect, so these never confirm and stay legal in every goal iteration
+// (mirrors complete_goal's classification). All list logic is pure
+// (todo/core.js, Bun-tested); ctx.todoStore.apply is the SW-injected
+// serialized read-modify-write bound to this session, so two ops in one
+// concurrent wave can't lose an update.
+
+import {
+  initTodos, checkTodo, addTodo, nextPending, todoProgress, formatTodoBlock, MAX_TODO_ITEMS,
+} from '../../todo/core.js';
+
+/** @typedef {import('/shared/tool-types.js').Tool} Tool */
+/** @typedef {import('/shared/tool-types.js').ToolContext} ToolContext */
+/** @typedef {import('../../todo/core.js').TodoItem} TodoItem */
+/** @typedef {import('/shared/tool-types.js').ToolResult | { ok: false, error: string, content?: string }} GoalToolResult */
+/** @typedef {Omit<Tool, 'primitive' | 'execute'> & { primitive: 'goal', execute: (args: any, ctx: ToolContext) => Promise<GoalToolResult> }} GoalTool */
+
+/**
+ * The SW-injected store bound to this session (buildToolContext). apply()
+ * serializes read-modify-writes so concurrent same-turn ops compose.
+ * @param {ToolContext} ctx
+ * @returns {{ apply: (fn: (todos: TodoItem[] | undefined) => { ok: boolean, todos?: TodoItem[], error?: string, [k: string]: unknown }) => Promise<any> } | null}
+ */
+const storeOf = (ctx) => {
+  const store = /** @type {{ todoStore?: unknown }} */ (ctx).todoStore;
+  return store && typeof (/** @type {any} */ (store).apply) === 'function'
+    ? /** @type {any} */ (store)
+    : null;
+};
+
+const NO_RUN = {
+  ok: /** @type {const} */ (false),
+  error: 'no_active_goal_run',
+  content: 'The todo tools are only available during an active goal run.',
+};
+
+/**
+ * Progress + what's-next footer every todo result carries — the check-off
+ * turn always leaves the model looking at the live plan.
+ * @param {TodoItem[] | undefined} todos
+ */
+const footer = (todos) => {
+  const { done, total } = todoProgress(todos);
+  const next = nextPending(todos);
+  return next
+    ? `${done}/${total} done. Next: ${next.id}. ${next.text}${next.validation ? ` (verify: ${next.validation})` : ''}`
+    : `${done}/${total} done. All items complete — verify the goal end-to-end, then call complete_goal.`;
+};
+
+/** @type {GoalTool} */
+export const todoInitTool = {
+  name: 'todo_init',
+  primitive: 'goal',
+  description: [
+    'Set the goal run\'s plan as a todo checklist (replaces any existing list).',
+    `Use ${MAX_TODO_ITEMS} items or fewer — concrete steps, each with a short`,
+    '"validation" describing how you will verify that step worked. Call this once',
+    'your plan is formed, before you start executing. The list persists across',
+    'turns and is shown to the user.',
+  ].join(' '),
+  schema: {
+    type: 'object',
+    properties: {
+      items: {
+        type: 'array',
+        description: `The plan steps, in order (max ${MAX_TODO_ITEMS}).`,
+        items: {
+          type: 'object',
+          properties: {
+            text: { type: 'string', description: 'The step, one concrete action.' },
+            validation: { type: 'string', description: 'How you will verify this step worked.' },
+          },
+          required: ['text'],
+        },
+      },
+    },
+    required: ['items'],
+  },
+  sideEffect: 'read',
+  origins: () => [],
+  execute: async (args, ctx) => {
+    const store = storeOf(ctx);
+    if (!store) return NO_RUN;
+    const out = await store.apply(() => initTodos(args?.items));
+    if (!out.ok) return { ok: false, error: out.error };
+    return {
+      ok: true,
+      content: `Plan recorded (${out.todos.length} items).\n${formatTodoBlock(out.todos)}`,
+    };
+  },
+};
+
+/** @type {GoalTool} */
+export const todoCheckTool = {
+  name: 'todo_check',
+  primitive: 'goal',
+  description: [
+    'Mark one todo item done — call it the moment that step\'s validation',
+    'passes, not in batches at the end. The result shows what\'s next.',
+  ].join(' '),
+  schema: {
+    type: 'object',
+    properties: {
+      id: { type: 'integer', description: 'The item id to mark done.' },
+    },
+    required: ['id'],
+  },
+  sideEffect: 'read',
+  origins: () => [],
+  execute: async (args, ctx) => {
+    const store = storeOf(ctx);
+    if (!store) return NO_RUN;
+    const out = await store.apply((todos) => checkTodo(todos ?? [], args?.id));
+    if (!out.ok) return { ok: false, error: out.error };
+    return { ok: true, content: `Done: ${out.item.id}. ${out.item.text}\n${footer(out.todos)}` };
+  },
+};
+
+/** @type {GoalTool} */
+export const todoAddTool = {
+  name: 'todo_add',
+  primitive: 'goal',
+  description: [
+    'Append one step to the todo list — for work discovered mid-run that the',
+    'plan missed. Include a validation for it like any other step.',
+  ].join(' '),
+  schema: {
+    type: 'object',
+    properties: {
+      text: { type: 'string', description: 'The new step, one concrete action.' },
+      validation: { type: 'string', description: 'How you will verify this step worked.' },
+    },
+    required: ['text'],
+  },
+  sideEffect: 'read',
+  origins: () => [],
+  execute: async (args, ctx) => {
+    const store = storeOf(ctx);
+    if (!store) return NO_RUN;
+    const out = await store.apply((todos) => addTodo(todos, args?.text, args?.validation));
+    if (!out.ok) return { ok: false, error: out.error };
+    return { ok: true, content: `Added: ${out.item.id}. ${out.item.text}\n${footer(out.todos)}` };
+  },
+};

--- a/extension/peerd-runtime/tools/exposure.js
+++ b/extension/peerd-runtime/tools/exposure.js
@@ -403,7 +403,12 @@ export const filterByDwebActive = (descriptors, dwebActive) =>
 // a run — otherwise a normal chat would see a "complete the goal" tool with no
 // goal. It's dropped unless the session has a live run; a stray call when it's
 // hidden still dispatches, but the tool's execute() no-ops (see complete-goal.js).
-export const GOAL_ONLY_TOOLS = Object.freeze(new Set(['complete_goal']));
+export const GOAL_ONLY_TOOLS = Object.freeze(new Set([
+  'complete_goal',
+  // The plan-of-record checklist (todo/core.js) — the goal run's spine, and
+  // what a prewalk executor steers by. Same reveal contract as complete_goal.
+  'todo_init', 'todo_check', 'todo_add',
+]));
 
 /** Is this a tool that should appear ONLY during an active goal run? Pure. @param {string} name */
 export const isGoalOnlyTool = (name) => GOAL_ONLY_TOOLS.has(name);

--- a/extension/shared/channel-config.js
+++ b/extension/shared/channel-config.js
@@ -32,6 +32,8 @@ export const CHANNEL_DEFAULTS = Object.freeze({
   openrouterModels: [],
   advancedAutomationEnabled: true,
   runnerModel: "",
+  prewalkEnabled: false,
+  prewalkExecutorModel: "",
   spendLimitUsd: 0,
   pricingOverrides: {},
   confirmWebWrites: true,

--- a/extension/sidepanel/chat-reducer.js
+++ b/extension/sidepanel/chat-reducer.js
@@ -505,8 +505,14 @@ export const reduceChat = (state, msg) => {
       // Per-session guard: a turn streaming in a BACKGROUND chat must not snap
       // the view to its transcript. Null current = fresh surface adopting it.
       if (state.session.sessionId && state.session.sessionId !== msg.session.sessionId) return state;
+      // why todos here: the goal run's plan-of-record (session.todos) is
+      // written mid-turn by the todo_* tools, and the TodoCard reads it off
+      // state.session — but this LIVE push carries only sessionId+messages, so
+      // without it the card wouldn't tick until the next full 'state' snapshot.
+      // undefined on non-goal turns (the card self-hides), so it's harmless.
       return { ...state, session: { ...state.session,
-        sessionId: msg.session.sessionId, messages: msg.session.messages }, lastError: null };
+        sessionId: msg.session.sessionId, messages: msg.session.messages,
+        todos: msg.session.todos }, lastError: null };
     case 'turn/cost':
       if (state.session.sessionId && msg.sessionId && state.session.sessionId !== msg.sessionId) return state;
       return { ...state, cost: { ...state.cost, turn: msg.turn, session: msg.session,

--- a/extension/sidepanel/chat-reducer.js
+++ b/extension/sidepanel/chat-reducer.js
@@ -55,6 +55,7 @@
  * @property {{ mode?: string, confirmActions?: boolean }} [permission]
  * @property {string} [customSystemPrompt]
  * @property {string} [toolManifest]
+ * @property {import('/peerd-runtime/todo/core.js').TodoItem[]} [todos]  the goal run's plan-of-record (TodoCard)
  */
 
 /**

--- a/extension/sidepanel/components/chat-view.js
+++ b/extension/sidepanel/components/chat-view.js
@@ -16,6 +16,7 @@ import { MessageList } from './message-list.js';
 import { InputBar } from './input-bar.js';
 import { ModeSelector, EffortDial, GoalToggle } from './mode-badge.js';
 import { GoalBar } from './goal-bar.js';
+import { TodoCard } from './todo-card.js';
 import { AsyncTasksBar } from './async-tasks-bar.js';
 import { ContextInspector } from './context-inspector.js';
 
@@ -137,6 +138,14 @@ export const ChatView = {
       // otherwise.
       m(GoalBar, { goal: state.goalRuns?.[state.session?.sessionId ?? ''], send }),
 
+      // The goal run's plan-of-record (session.todos, the todo_* tools) — the
+      // visible checklist that ticks as the run works. Renders straight off
+      // the session snapshot; stays up after the run ends as its receipt.
+      m(TodoCard, {
+        todos: /** @type {any} */ (state.session)?.todos,
+        active: !!state.goalRuns?.[state.session?.sessionId ?? '']?.active,
+      }),
+
       // In-flight async spawned (DESIGN-11). Pinned + self-hiding: the agent
       // can fire background spawned whose results land later as wake turns,
       // so this shows what's still cooking. Keyed to the ACTIVE session —
@@ -193,11 +202,14 @@ export const ChatView = {
           : null,
         // Goal arming — the in-chat entry point for goal mode. Arms the NEXT
         // send to launch an autonomous goal run; the InputBar consumes the arm
-        // and disarms. Greyed until there's a key (the send it arms needs one).
+        // and disarms — but the toggle STAYS lit while the run itself is live
+        // (it reflects state.goalRuns), and clicking it then stops the run.
         m(GoalToggle, {
           armed: ui.goalArmed,
+          run: state.goalRuns?.[sid ?? ''] ?? null,
           disabled: !hasKey,
           onToggle: (/** @type {boolean} */ next) => { ui.goalArmed = next; },
+          onStop: () => send({ type: 'agent/stop' }),
         }),
         m('.spacer'),
         // /system presence chip — the session's custom instructions

--- a/extension/sidepanel/components/mode-badge.js
+++ b/extension/sidepanel/components/mode-badge.js
@@ -96,43 +96,61 @@ export const ModeSelector = {
 };
 
 /**
- * Goal toggle. The mode-row entry point for goal mode (loop/goal-runner.js):
- * it arms the NEXT message to be the goal of an autonomous run — the agent
- * keeps taking turns toward it, visibly in the chat, until it calls
- * complete_goal (or Stop / a cap). The InputBar consumes the arm (sending
- * `agent/send` with goal:true) and disarms — one launch per arm. While a run
- * is live it shows in the GoalBar. why "Goal" not "Loop": the control is a
- * one-shot launch-with-a-goal, not a sticky mode — the word matches the
- * behavior. Same pill family + accent-when-armed as the planact controls
- * (owner call for this row).
+ * Goal toggle. The mode-row entry point for goal mode (loop/goal-runner.js),
+ * and — while a run is live — its STATE light. Three faces:
+ *
+ *   off      "Goal"           click arms the next message as a goal
+ *   armed    "Goal: on"       click disarms (the send consumes the arm)
+ *   running  "Goal · turn N"  the toggle STAYS lit for the whole run —
+ *                             armed hands off to running when the run's
+ *                             goal/state arrives, so launching a goal never
+ *                             reads as the switch "turning itself off".
+ *                             Click stops the run (same route as the
+ *                             GoalBar's Stop).
+ *
+ * why sticky: the original one-shot arm untoggled on send, which read as
+ * "did it even start?" — the control now mirrors the run's actual lifecycle
+ * (owner direction 2026-07-15). Same pill family + accent as the planact
+ * controls.
  *
  * attrs:
  *   armed     — whether the next send is armed to launch a goal run
+ *   run       — this chat's live goal-run state (state.goalRuns[sid]) or null
  *   disabled  — no API key yet (the send it arms can't fire)
  *   onToggle  — flip handler; receives the next armed boolean
+ *   onStop    — stop the live run (only consulted while running)
  */
 export const GoalToggle = {
   /**
    * @param {{ attrs: {
    *   armed?: boolean,
+   *   run?: { active?: boolean, iteration?: number } | null,
    *   disabled?: boolean,
    *   onToggle: (next: boolean) => void,
+   *   onStop?: () => void,
    * } }} vnode
    */
-  view: ({ attrs: { armed, disabled, onToggle } }) => {
-    const on = !!armed;
+  view: ({ attrs: { armed, run, disabled, onToggle, onStop } }) => {
+    const running = !!run?.active;
+    const on = running || !!armed;
+    const label = running
+      ? `Goal · turn ${run?.iteration ?? '…'}`
+      : on ? 'Goal: on' : 'Goal';
     return m('button.goal-toggle', {
-      class: on ? 'is-on' : '',
-      disabled: !!disabled,
+      class: [on ? 'is-on' : '', running ? 'is-running' : ''].filter(Boolean).join(' '),
+      disabled: !!disabled && !running,
       'aria-pressed': String(on),
-      title: on
-        ? 'Goal is armed — your next message starts an autonomous run: the agent '
-          + 'keeps taking turns, acting WITHOUT per-action confirmation, until the '
-          + 'goal is met or you Stop. Click to disarm.'
-        : 'Goal — arm the next message to run as an autonomous goal: the agent keeps '
-          + 'taking turns, acting without per-action confirmation, until it\'s done or you Stop.',
-      onclick: () => onToggle(!on),
-    }, on ? 'Goal: on' : 'Goal');
+      title: running
+        ? 'A goal run is live in this chat — the agent keeps taking turns until '
+          + 'it\'s done. Click to stop the run.'
+        : on
+          ? 'Goal is armed — your next message starts an autonomous run: the agent '
+            + 'keeps taking turns, acting WITHOUT per-action confirmation, until the '
+            + 'goal is met or you Stop. Click to disarm.'
+          : 'Goal — arm the next message to run as an autonomous goal: the agent keeps '
+            + 'taking turns, acting without per-action confirmation, until it\'s done or you Stop.',
+      onclick: () => (running ? onStop?.() : onToggle(!on)),
+    }, label);
   },
 };
 

--- a/extension/sidepanel/components/todo-card.js
+++ b/extension/sidepanel/components/todo-card.js
@@ -1,0 +1,44 @@
+// @ts-check
+// Todo card — the chat view's live window onto the goal run's plan-of-record
+// (session.todos, written by the todo_* tools during a goal run).
+//
+// This is the "is it actually working?" answer for goal mode: the agent
+// commits its plan as a checklist and the card ticks items off as the run
+// progresses — no event plumbing of its own, it just renders the session
+// snapshots the panel already receives. Self-hiding when the session has no
+// list. It stays visible after a run ends: a finished checklist is the
+// run's receipt, not chrome to clean up. Grayscale per the brand rule.
+
+import m from '/vendor/mithril/mithril.js';
+
+/** @typedef {import('/peerd-runtime/todo/core.js').TodoItem} TodoItem */
+
+export const TodoCard = {
+  /** @param {{ attrs: { todos?: TodoItem[] | null, active?: boolean } }} vnode */
+  view: ({ attrs: { todos, active } }) => {
+    if (!Array.isArray(todos) || todos.length === 0) return null;
+    const done = todos.filter((t) => t.status === 'done').length;
+    const next = todos.find((t) => t.status !== 'done') ?? null;
+    return m('.todo-card', { role: 'status', 'aria-label': `Plan: ${done} of ${todos.length} steps done` }, [
+      m('.todo-card-head', [
+        m('span.todo-card-title', 'Plan'),
+        m('span.todo-card-meta', `${done}/${todos.length}`),
+        // The run's liveness is the GoalBar's job; here just a soft hint
+        // that the list is still being worked (vs a finished receipt).
+        active && next ? m('span.todo-card-live', 'in progress') : null,
+      ]),
+      m('ul.todo-list', todos.map((t) => {
+        const isDone = t.status === 'done';
+        const isNext = !!next && t.id === next.id;
+        return m('li.todo-item', {
+          key: t.id,
+          class: [isDone ? 'is-done' : '', isNext ? 'is-next' : ''].filter(Boolean).join(' '),
+          title: t.validation ? `verify: ${t.validation}` : undefined,
+        }, [
+          m('span.todo-box', { 'aria-hidden': 'true' }, isDone ? '✓' : ''),
+          m('span.todo-text', t.text),
+        ]);
+      })),
+    ]);
+  },
+};

--- a/extension/sidepanel/styles.css
+++ b/extension/sidepanel/styles.css
@@ -660,6 +660,15 @@ html, body, #app {
   outline-offset: -2px;
 }
 .goal-toggle:disabled { opacity: 0.5; cursor: not-allowed; }
+/* Live run — the toggle is the run's state light (mode-badge.js). Slightly
+ * softer than the armed accent so "running" reads as steady state, not a
+ * hot switch; tabular digits keep "turn N" from wobbling as N ticks. */
+.goal-toggle.is-running {
+  background: var(--bg-elev);
+  color: var(--fg);
+  border-color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+}
 
 .body { flex: 1; padding: 14px; overflow-y: auto; }
 
@@ -1924,6 +1933,47 @@ button.icon:hover { background: var(--bg); }
   max-width: 16ch;
 }
 .goal-bar-stop { font-size: 11px; padding: 2px 10px; }
+
+/* Todo card (components/todo-card.js) — the goal run's visible
+   plan-of-record. Same calm bordered-card voice as .goal-bar: grayscale,
+   check marks and dimming carry the progress, no accent color. Capped
+   height so a full 12-item plan can't crowd the transcript. */
+.todo-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-elev);
+  padding: 8px 10px;
+  font-size: 12px;
+}
+.todo-card-head {
+  display: flex; align-items: baseline; gap: 8px;
+  margin-bottom: 6px;
+}
+.todo-card-title { font-weight: 600; }
+.todo-card-meta { color: var(--fg-muted); font-variant-numeric: tabular-nums; }
+.todo-card-live { color: var(--fg-muted); font-size: 11px; margin-left: auto; }
+.todo-list {
+  list-style: none;
+  margin: 0; padding: 0;
+  max-height: 168px;
+  overflow-y: auto;
+  display: flex; flex-direction: column; gap: 3px;
+}
+.todo-item { display: flex; align-items: baseline; gap: 7px; min-width: 0; }
+.todo-box {
+  flex: none;
+  width: 13px; height: 13px;
+  border: 1px solid var(--fg-muted);
+  border-radius: 3px;
+  font-size: 10px; line-height: 12px; text-align: center;
+  color: var(--fg);
+}
+.todo-item.is-done .todo-box { background: var(--fg-muted); color: var(--bg); border-color: var(--fg-muted); }
+.todo-item.is-done .todo-text { color: var(--fg-muted); text-decoration: line-through; }
+.todo-item.is-next .todo-text { font-weight: 600; }
+.todo-text {
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
 
 /* In-flight async-actor status bar (DESIGN-11) — mirrors .goal-bar:
    a bordered elevated card, grayscale, the brand spinner the only color. */

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -87,7 +87,7 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // 505/506 → 510: the #119 (page bridge + OM2W eval) and #187 (fetch content
 // pipeline) file sets merge — both ledgers above are kept; the union floor.
 // 510 → 511: the Z.ai GLM provider adapter (peerd-provider/adapters/glm.js).
-const COVERED_FLOOR = 514;
+const COVERED_FLOOR = 515;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -87,7 +87,7 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // 505/506 → 510: the #119 (page bridge + OM2W eval) and #187 (fetch content
 // pipeline) file sets merge — both ledgers above are kept; the union floor.
 // 510 → 511: the Z.ai GLM provider adapter (peerd-provider/adapters/glm.js).
-const COVERED_FLOOR = 511;
+const COVERED_FLOOR = 514;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/packaging/default-settings.mjs
+++ b/packaging/default-settings.mjs
@@ -134,6 +134,21 @@ export const defaults = {
   // Same on both channels.
   runnerModel: { store: '', preview: '' },
 
+  // Prewalk (loop/prewalk.js): a goal run opens on the chat's (frontier)
+  // model with a hidden plan-first nudge, then hands the LIVE context to a
+  // cheap executor model at the first landed action — todo list ticking, one
+  // valid move already in history. OFF by default on BOTH channels until the
+  // in-extension Lab's baseline-vs-prewalk arms validate spend/pass/speed
+  // (home/eval-section.js); flip deliberately, not by shipping.
+  prewalkEnabled: { store: false, preview: false },
+
+  // Prewalk executor override. '' = no pin — resolve the active provider's
+  // fast default (the same defaultRunnerModel rung the web actor rides, e.g.
+  // Haiku on Anthropic). A non-empty value pins a SAME-PROVIDER model id
+  // (cross-provider executors are a deliberate later step — keys, failover
+  // and pricing are provider-scoped).
+  prewalkExecutorModel: { store: '', preview: '' },
+
   // Cost telemetry: the meter is always on; the hard limit is opt-in.
   spendLimitUsd: { store: 0, preview: 0 },
   pricingOverrides: { store: {}, preview: {} },

--- a/scripts/cdp/states.mjs
+++ b/scripts/cdp/states.mjs
@@ -153,26 +153,50 @@ export const STATES = [
   },
 
   // --- functional: the goal-mode autonomous loop -----------------------------
+  // Also covers the plan-of-record (todo_init/todo_check → the visible
+  // TodoCard) and the sticky Goal toggle (lit "running" while the run drives,
+  // not untoggled on send). The faked model plans, ticks one item, then ends
+  // the run — so the card renders 1/2 and the toggle reads running mid-flight.
   {
     name: 'goal', kind: 'functional', phase: 'post-unlock',
     responder: (callIndex) => {
-      if (callIndex === 0) return { delayMs: 250, sse: sseText('On it — starting the goal.') };
-      if (callIndex === 1) return { delayMs: 250, sse: sseToolCall('complete_goal', { summary: 'all tidy' }) };
+      if (callIndex === 0) return { delayMs: 200, sse: sseText('On it — planning the goal.') };
+      if (callIndex === 1) return { delayMs: 200, sse: sseToolCall('todo_init', { items: [
+        { text: 'tidy the repo', validation: 'no stray files' },
+        { text: 'verify the build', validation: 'tests pass' },
+      ] }) };
+      if (callIndex === 2) return { delayMs: 200, sse: sseToolCall('todo_check', { id: 1 }) };
+      if (callIndex === 3) return { delayMs: 200, sse: sseToolCall('complete_goal', { summary: 'all tidy' }) };
       return { delayMs: 120, sse: sseText('Goal complete.') };
     },
     async run(ctx, rec) {
       const sent = await rpc(ctx.page, { type: 'agent/send', text: 'tidy the repo', goal: true });
       rec.check('goal run started', sent?.ok && sent.handled === 'goal', JSON.stringify(sent));
       const goalBarSeen = await waitFor(() => evalIn(ctx.page, `!!document.querySelector('.goal-bar')`), { budgetMs: 10_000, pollMs: 50 });
-      // Snapshot WHILE the bar is up (best-effort — the loop is quick).
+      // The Goal toggle is the run's state light — it must read "running", not
+      // fall back to unlit, the instant the run is live (the fix for "did it
+      // even start?"). Best-effort snapshot while the run drives.
+      const toggleRunning = await waitFor(
+        () => evalIn(ctx.page, `!!document.querySelector('.goal-toggle.is-running')`),
+        { budgetMs: 8_000, pollMs: 50 });
+      // The plan-of-record card appears once todo_init lands and ticks to 1/2
+      // after todo_check — the visible checklist that answers "is it working?".
+      const todoSeen = await waitFor(
+        () => evalIn(ctx.page, `/1\\/2/.test(document.querySelector('.todo-card .todo-card-meta')?.textContent || '')`),
+        { budgetMs: 12_000, pollMs: 50 });
       if (goalBarSeen) await rec.shot('goal-bar');
       let out = {};
       await waitFor(async () => { out = await probe(ctx); return !out.goalBar && !out.busy; }, { budgetMs: 25_000 });
       const calls = ctx.modelCallCount();
       rec.check('Goal bar appeared while driving', !!goalBarSeen);
+      rec.check('Goal toggle read "running" while live (sticky, not untoggled)', !!toggleRunning);
+      rec.check('TodoCard rendered the plan and ticked to 1/2 after todo_check', !!todoSeen);
       rec.check('loop drove >1 autonomous turn', calls >= 3, `model calls: ${calls}`);
-      rec.check('complete_goal ended it cleanly (not the cap)', !out.capped && calls < 10, `capped=${out.capped} calls=${calls}`);
+      rec.check('complete_goal ended it cleanly (not the cap)', !out.capped && calls < 12, `capped=${out.capped} calls=${calls}`);
       rec.check('run reaches terminal: Goal bar cleared + idle', out.goalBar === false && out.busy === false);
+      // The finished checklist stays as the run's receipt (does not vanish on end).
+      const todoAfter = await evalIn(ctx.page, `!!document.querySelector('.todo-card')`);
+      rec.check('TodoCard persists after the run as its receipt', !!todoAfter);
       rec.check('submitted goal text round-trips as the first user message', !!out.userText && out.userText.includes('tidy the repo'), JSON.stringify(out.userText));
       await rec.shot('final');
     },

--- a/tests/peerd-runtime/goal-runner.test.ts
+++ b/tests/peerd-runtime/goal-runner.test.ts
@@ -54,6 +54,48 @@ describe('makeGoalRunner — the goal loop', () => {
     expect(runner.get('s1')).toBe(null);
   });
 
+  it('continuations embed the live todo block (the per-turn plan reminder)', async () => {
+    const calls: TurnArgs[] = [];
+    let runner: ReturnType<typeof makeGoalRunner>;
+    runner = makeGoalRunner({
+      runTurn: async (args: TurnArgs) => {
+        calls.push(args);
+        if (calls.length === 3) runner.complete('s-todo');
+      },
+      // The SW binds this to formatTodoBlock(session.todos) — here a fake
+      // that changes between turns, pinning the RE-READ-per-turn contract.
+      getTodoBlock: async () => (calls.length < 2 ? 'Plan (0/2 done):\n[ ] 1. a  ← next' : 'Plan (1/2 done):\n[x] 1. a'),
+      maxIterations: 10,
+    });
+    await runner.start({ sessionId: 's-todo', goal: 'g' });
+    await settle(() => !runner.isActive('s-todo'));
+
+    expect(calls.length).toBe(3);
+    expect(calls[0].userText).toBe('g');                        // turn 1: bare goal, no list yet
+    expect(calls[1].userText).toContain('Plan (0/2 done):');    // fresh read each continuation
+    expect(calls[1].userText).toContain('todo_check');          // the steering line rides along
+    expect(calls[2].userText).toContain('Plan (1/2 done):');
+  });
+
+  it('a throwing getTodoBlock degrades to a block-less continuation, never a dead turn', async () => {
+    const calls: TurnArgs[] = [];
+    let runner: ReturnType<typeof makeGoalRunner>;
+    runner = makeGoalRunner({
+      runTurn: async (args: TurnArgs) => {
+        calls.push(args);
+        if (calls.length === 2) runner.complete('s-todo-err');
+      },
+      getTodoBlock: async () => { throw new Error('idb hiccup'); },
+      maxIterations: 10,
+    });
+    await runner.start({ sessionId: 's-todo-err', goal: 'g' });
+    await settle(() => !runner.isActive('s-todo-err'));
+
+    expect(calls.length).toBe(2);
+    expect(calls[1].userText).toContain('Continue working autonomously');
+    expect(calls[1].userText).not.toContain('Plan (');
+  });
+
   it('halt() stops it after the in-flight turn (terminal phase = halted)', async () => {
     const calls: TurnArgs[] = [];
     const events: any[] = [];

--- a/tests/peerd-runtime/prewalk-lifecycle.test.ts
+++ b/tests/peerd-runtime/prewalk-lifecycle.test.ts
@@ -1,0 +1,152 @@
+// Prewalk lifecycle against the REAL session store — the layer between the
+// pure gate (prewalk.test.ts) and the full SW. Drives the exact sequence the
+// SW glue runs (arm on start → gate on a mutating call → reconcile-swap at the
+// next turn → restore at run end) over a fake IDB, so the persisted state
+// transitions and the model swap/restore are pinned without a browser.
+//
+// setPrewalk (store): set/clear-with-absent-key + the atomic model restore.
+
+import { describe, test, expect } from 'bun:test';
+import { createSessionStore } from '../../extension/peerd-runtime/sessions/store.js';
+import {
+  resolvePrewalkExecutor, armPrewalk, shouldPrewalkSwap, markPrewalkSwapped,
+} from '../../extension/peerd-runtime/loop/prewalk.js';
+import type { Session } from '../../extension/peerd-runtime/sessions/types.js';
+
+const makeIdb = () => {
+  const stores = new Map<string, Map<string, any>>();
+  const tbl = (name: string) => {
+    if (!stores.has(name)) stores.set(name, new Map());
+    return stores.get(name)!;
+  };
+  return {
+    get: async (store: string, key: string) => tbl(store).get(key),
+    put: async (store: string, val: any) => { tbl(store).set(val.id ?? val.sessionId, val); },
+    getAll: async (store: string) => [...tbl(store).values()],
+  };
+};
+const makeStore = () => {
+  let i = 0;
+  return createSessionStore({ idb: makeIdb(), now: () => 1000, makeId: () => `id-${++i}` });
+};
+
+// A known tool → its sideEffect class (the SW reads this off the registry).
+const SIDE_EFFECT: Record<string, string> = {
+  message_actor: 'write', edit_file: 'write', remember: 'write', open_tab: 'mutate_external',
+  read_page: 'read', todo_init: 'read',
+};
+
+describe('session store — setPrewalk', () => {
+  test('sets state, clears with the key ABSENT, and restores the model atomically', async () => {
+    const store = makeStore();
+    const s = await store.create({ provider: 'anthropic', model: 'claude-opus-4-8' });
+    const state = armPrewalk(s, { provider: 'anthropic', model: 'claude-haiku-4-5' }, 1000)!;
+
+    const armed: Session = await store.setPrewalk(s.sessionId, state);
+    expect(armed.prewalk!.phase).toBe('planning');
+    expect((await store.get(s.sessionId))!.prewalk!.plannerModel).toBe('claude-opus-4-8');
+
+    // Clear + restore the planner model in one write.
+    const cleared = await store.setPrewalk(s.sessionId, null, { provider: 'anthropic', model: 'claude-opus-4-8' });
+    expect('prewalk' in cleared).toBe(false);
+    expect(cleared.model).toBe('claude-opus-4-8');
+    expect('prewalk' in (await store.get(s.sessionId))!).toBe(false);
+  });
+
+  test('clearing preserves every other field (todos, messages, provider)', async () => {
+    const store = makeStore();
+    const s = await store.create({ provider: 'anthropic', model: 'm-1' });
+    await store.appendMessage(s.sessionId, { role: 'user', content: 'hi', id: 'm1', when: 1 });
+    await store.update(s.sessionId, { todos: [{ id: 1, text: 'a', status: 'pending' }] });
+    const state = armPrewalk({ provider: 'anthropic', model: 'm-1' }, { provider: 'anthropic', model: 'm-2' }, 1000)!;
+    await store.setPrewalk(s.sessionId, state);
+
+    const cleared = await store.setPrewalk(s.sessionId, null, { provider: 'anthropic', model: 'm-1' });
+    expect(cleared.provider).toBe('anthropic');
+    expect(cleared.messages.length).toBe(1);
+    expect((cleared as any).todos).toHaveLength(1);
+  });
+});
+
+describe('prewalk full lifecycle over the store', () => {
+  // The SW glue, distilled: arm → (planning turns) → first mutating call fires
+  // the gate → next turn reconciles the model swap → run end restores.
+  test('opus plans, haiku executes after the first landed mutation, opus restored at end', async () => {
+    const store = makeStore();
+    const s = await store.create({ provider: 'anthropic', model: 'claude-opus-4-8' });
+
+    // 1. ARM (startGoalRun → armPrewalkForRun).
+    const executor = resolvePrewalkExecutor({
+      settings: { prewalkExecutorModel: 'claude-haiku-4-5' },
+      provider: { name: 'anthropic', defaultRunnerModel: 'claude-haiku-4-5' },
+    });
+    const state = armPrewalk(s, executor, 1000)!;
+    await store.setPrewalk(s.sessionId, state);
+    expect((await store.get(s.sessionId))!.model).toBe('claude-opus-4-8'); // still the planner
+
+    // 2. Planning turn commits the plan (todo_init is exempt — no swap).
+    await store.update(s.sessionId, { todos: [{ id: 1, text: 'do it', status: 'pending' }] });
+    const beforePlan = await store.get(s.sessionId);
+    expect(shouldPrewalkSwap({
+      prewalk: beforePlan!.prewalk, todosCount: beforePlan!.todos!.length,
+      toolName: 'todo_init', sideEffect: SIDE_EFFECT.todo_init, ok: true,
+    })).toBe(false);
+    expect(beforePlan!.prewalk!.phase).toBe('planning'); // unchanged
+
+    // 3. First NON-exempt mutating call succeeds → gate fires (maybePrewalkSwap).
+    const preSwap = await store.get(s.sessionId);
+    const fire = shouldPrewalkSwap({
+      prewalk: preSwap!.prewalk, todosCount: preSwap!.todos!.length,
+      toolName: 'message_actor', sideEffect: SIDE_EFFECT.message_actor, ok: true,
+    });
+    expect(fire).toBe(true);
+    await store.setPrewalk(s.sessionId, markPrewalkSwapped(preSwap!.prewalk!, 1001));
+    const swapped = await store.get(s.sessionId);
+    expect(swapped!.prewalk!.phase).toBe('executing');
+    expect(swapped!.model).toBe('claude-opus-4-8'); // model NOT changed yet — that's the reconcile's job
+
+    // 4. Next turn boundary reconciles: phase 'executing' + model mismatch → swap the model.
+    const pw = swapped!.prewalk!;
+    if (swapped!.provider !== pw.executorProvider || swapped!.model !== pw.executorModel) {
+      await store.update(s.sessionId, { provider: pw.executorProvider, model: pw.executorModel });
+    }
+    expect((await store.get(s.sessionId))!.model).toBe('claude-haiku-4-5'); // now on the executor
+
+    // 5. Run end (restorePrewalkForRun): planner restored, state cleared.
+    const atEnd = await store.get(s.sessionId);
+    await store.setPrewalk(s.sessionId, null, {
+      provider: atEnd!.prewalk!.plannerProvider, model: atEnd!.prewalk!.plannerModel,
+    });
+    const restored = await store.get(s.sessionId);
+    expect(restored!.model).toBe('claude-opus-4-8');
+    expect('prewalk' in restored!).toBe(false);
+  });
+
+  test('a failed mutating call does NOT swap (the action was not evidence the plan works)', async () => {
+    const store = makeStore();
+    const s = await store.create({ provider: 'anthropic', model: 'claude-opus-4-8' });
+    await store.setPrewalk(s.sessionId, armPrewalk(s, { provider: 'anthropic', model: 'claude-haiku-4-5' }, 1000)!);
+    await store.update(s.sessionId, { todos: [{ id: 1, text: 'x', status: 'pending' }] });
+    const rec = await store.get(s.sessionId);
+    expect(shouldPrewalkSwap({
+      prewalk: rec!.prewalk, todosCount: rec!.todos!.length,
+      toolName: 'edit_file', sideEffect: SIDE_EFFECT.edit_file, ok: false,
+    })).toBe(false);
+  });
+
+  test('stale reconcile: an orphaned prewalk (run gone) restores the planner and clears', async () => {
+    // Models the reconcile path when goalRunner.isActive() is false but the
+    // session still carries prewalk state (a run that died without restore).
+    const store = makeStore();
+    const s = await store.create({ provider: 'anthropic', model: 'claude-haiku-4-5' }); // stuck on executor
+    await store.setPrewalk(s.sessionId, markPrewalkSwapped(
+      armPrewalk({ provider: 'anthropic', model: 'claude-opus-4-8' }, { provider: 'anthropic', model: 'claude-haiku-4-5' }, 1000)!, 1001));
+
+    const stale = await store.get(s.sessionId);
+    const restored = await store.setPrewalk(s.sessionId, null, {
+      provider: stale!.prewalk!.plannerProvider, model: stale!.prewalk!.plannerModel,
+    });
+    expect(restored.model).toBe('claude-opus-4-8'); // back on the planner
+    expect('prewalk' in restored).toBe(false);
+  });
+});

--- a/tests/peerd-runtime/prewalk.test.ts
+++ b/tests/peerd-runtime/prewalk.test.ts
@@ -1,0 +1,102 @@
+// Prewalk policy core (extension/peerd-runtime/loop/prewalk.js).
+// Pins: executor resolution (pin → provider fast default → nothing), arming
+// (no-op when the executor IS the chat model), the swap gate's exact firing
+// conditions (planning phase + committed todos + a successful non-exempt
+// mutating call), and the planning→executing transition.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  resolvePrewalkExecutor, armPrewalk, shouldPrewalkSwap, markPrewalkSwapped,
+  PREWALK_EXEMPT_TOOLS, PREWALK_NUDGE,
+} from '../../extension/peerd-runtime/loop/prewalk.js';
+
+const anthropic = { name: 'anthropic', defaultRunnerModel: 'claude-haiku-4-5' };
+const session = { provider: 'anthropic', model: 'claude-opus-4-8' };
+const NOW = 1_752_600_000_000;
+
+const armed = () => {
+  const state = armPrewalk(session, { provider: 'anthropic', model: 'claude-haiku-4-5' }, NOW);
+  if (!state) throw new Error('expected an armed state');
+  return state;
+};
+
+describe('resolvePrewalkExecutor', () => {
+  test('explicit pin wins; provider fast default is the fallback', () => {
+    expect(resolvePrewalkExecutor({
+      settings: { prewalkExecutorModel: 'claude-sonnet-5' }, provider: anthropic,
+    })).toEqual({ provider: 'anthropic', model: 'claude-sonnet-5' });
+    expect(resolvePrewalkExecutor({ settings: { prewalkExecutorModel: '' }, provider: anthropic }))
+      .toEqual({ provider: 'anthropic', model: 'claude-haiku-4-5' });
+  });
+
+  test('nothing usable → null (no provider, or no default and no pin)', () => {
+    expect(resolvePrewalkExecutor({})).toBeNull();
+    expect(resolvePrewalkExecutor({ provider: { name: 'ollama' } })).toBeNull();
+  });
+});
+
+describe('armPrewalk', () => {
+  test('captures planner + executor and opens in planning phase', () => {
+    expect(armed()).toEqual({
+      phase: 'planning',
+      plannerProvider: 'anthropic', plannerModel: 'claude-opus-4-8',
+      executorProvider: 'anthropic', executorModel: 'claude-haiku-4-5',
+      armedAt: NOW,
+    });
+  });
+
+  test('no-op when the executor IS the session model, or inputs are missing', () => {
+    expect(armPrewalk({ provider: 'anthropic', model: 'claude-haiku-4-5' },
+      { provider: 'anthropic', model: 'claude-haiku-4-5' }, NOW)).toBeNull();
+    expect(armPrewalk(session, null, NOW)).toBeNull();
+    expect(armPrewalk({}, { provider: 'anthropic', model: 'claude-haiku-4-5' }, NOW)).toBeNull();
+  });
+});
+
+describe('shouldPrewalkSwap — the gate', () => {
+  const base = { prewalk: armed(), todosCount: 3, toolName: 'message_actor', sideEffect: 'write', ok: true };
+
+  test('fires on a successful mutating call once the plan is committed', () => {
+    expect(shouldPrewalkSwap(base)).toBe(true);
+    expect(shouldPrewalkSwap({ ...base, sideEffect: 'mutate_external', toolName: 'dweb_share' })).toBe(true);
+    expect(shouldPrewalkSwap({ ...base, sideEffect: 'destructive', toolName: 'vm_delete' })).toBe(true);
+  });
+
+  test('holds while any condition is missing', () => {
+    expect(shouldPrewalkSwap({ ...base, prewalk: null })).toBe(false);
+    expect(shouldPrewalkSwap({ ...base, prewalk: markPrewalkSwapped(armed(), NOW) })).toBe(false); // already executing
+    expect(shouldPrewalkSwap({ ...base, todosCount: 0 })).toBe(false);   // no committed plan yet
+    expect(shouldPrewalkSwap({ ...base, ok: false })).toBe(false);       // the action FAILED — not evidence
+    expect(shouldPrewalkSwap({ ...base, sideEffect: 'read' })).toBe(false);
+    expect(shouldPrewalkSwap({ ...base, sideEffect: undefined })).toBe(false); // unknown tool — fail closed
+  });
+
+  test('recon/bookkeeping writes are exempt by name', () => {
+    for (const name of ['open_tab', 'remember', 'wait_until', 'actor_cancel', 'todo_init', 'complete_goal']) {
+      expect(PREWALK_EXEMPT_TOOLS.has(name)).toBe(true);
+      expect(shouldPrewalkSwap({ ...base, toolName: name, sideEffect: 'write' })).toBe(false);
+    }
+  });
+});
+
+describe('markPrewalkSwapped', () => {
+  test('flips the phase, stamps the time, keeps the models', () => {
+    const swapped = markPrewalkSwapped(armed(), NOW + 5);
+    expect(swapped.phase).toBe('executing');
+    expect(swapped.swappedAt).toBe(NOW + 5);
+    expect(swapped.plannerModel).toBe('claude-opus-4-8');
+    expect(swapped.executorModel).toBe('claude-haiku-4-5');
+  });
+});
+
+describe('PREWALK_NUDGE', () => {
+  test('teaches plan→todo→act and never mentions models or swapping', () => {
+    expect(PREWALK_NUDGE).toContain('todo_init');
+    expect(PREWALK_NUDGE).toContain('validation');
+    // The handoff is the harness's business — the transcript must not hint
+    // that a different model takes over.
+    expect(PREWALK_NUDGE.toLowerCase()).not.toContain('model');
+    expect(PREWALK_NUDGE.toLowerCase()).not.toContain('swap');
+    expect(PREWALK_NUDGE.toLowerCase()).not.toContain('cheap');
+  });
+});

--- a/tests/peerd-runtime/todo-core.test.ts
+++ b/tests/peerd-runtime/todo-core.test.ts
@@ -1,0 +1,114 @@
+// The goal run's plan-of-record — pure list ops (extension/peerd-runtime/todo/core.js).
+// Pins: init validation + the hard item cap (reject, never clip), check/add
+// purity (fresh arrays, stable ids), next-pending steering, and the prompt
+// block render the goal continuation embeds.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  initTodos, checkTodo, addTodo, nextPending, todoProgress, formatTodoBlock, MAX_TODO_ITEMS,
+} from '../../extension/peerd-runtime/todo/core.js';
+
+const okInit = (items: unknown) => {
+  const out = initTodos(items);
+  if (!out.ok) throw new Error(`init failed: ${(out as { error: string }).error}`);
+  return out.todos;
+};
+
+describe('initTodos', () => {
+  test('builds 1-based pending items from {text, validation} records', () => {
+    const todos = okInit([
+      { text: 'open the dashboard', validation: 'URL shows /dashboard' },
+      { text: 'export the report' },
+    ]);
+    expect(todos).toEqual([
+      { id: 1, text: 'open the dashboard', validation: 'URL shows /dashboard', status: 'pending' },
+      { id: 2, text: 'export the report', status: 'pending' },
+    ]);
+  });
+
+  test('accepts bare strings and collapses whitespace', () => {
+    const todos = okInit(['  step\n one  ']);
+    expect(todos[0]).toEqual({ id: 1, text: 'step one', status: 'pending' });
+  });
+
+  test('REJECTS an over-cap list (never silently clips)', () => {
+    const out = initTodos(Array.from({ length: MAX_TODO_ITEMS + 1 }, (_, i) => `s${i}`));
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.error).toContain(String(MAX_TODO_ITEMS));
+  });
+
+  test('rejects empty input and empty item text', () => {
+    expect(initTodos([]).ok).toBe(false);
+    expect(initTodos(undefined).ok).toBe(false);
+    expect(initTodos([{ text: '   ' }]).ok).toBe(false);
+  });
+});
+
+describe('checkTodo', () => {
+  test('marks one item done and returns a NEW list', () => {
+    const todos = okInit(['a', 'b']);
+    const out = checkTodo(todos, 1);
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.item.status).toBe('done');
+    expect(out.todos[0].status).toBe('done');
+    expect(out.todos[1].status).toBe('pending');
+    expect(todos[0].status).toBe('pending'); // input untouched — pure
+  });
+
+  test('refuses unknown ids, double-checks, and a missing list', () => {
+    const todos = okInit(['a']);
+    expect(checkTodo(todos, 9).ok).toBe(false);
+    const once = checkTodo(todos, 1);
+    if (!once.ok) throw new Error('unexpected');
+    expect(checkTodo(once.todos, 1).ok).toBe(false);
+    expect(checkTodo([], 1).ok).toBe(false);
+  });
+});
+
+describe('addTodo', () => {
+  test('appends with a never-recycled id and honors the cap', () => {
+    const todos = okInit(['a', 'b']);
+    const out = addTodo(todos, 'c', 'c works');
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.item).toEqual({ id: 3, text: 'c', validation: 'c works', status: 'pending' });
+    const full = okInit(Array.from({ length: MAX_TODO_ITEMS }, (_, i) => `s${i}`));
+    expect(addTodo(full, 'one more').ok).toBe(false);
+  });
+
+  test('starts a list from nothing and rejects empty text', () => {
+    const out = addTodo(undefined, 'first');
+    expect(out.ok).toBe(true);
+    if (out.ok) expect(out.item.id).toBe(1);
+    expect(addTodo([], '  ').ok).toBe(false);
+  });
+});
+
+describe('steering reads', () => {
+  test('nextPending walks the first unchecked item; progress counts', () => {
+    const todos = okInit(['a', 'b', 'c']);
+    const one = checkTodo(todos, 1);
+    if (!one.ok) throw new Error('unexpected');
+    expect(nextPending(one.todos)?.id).toBe(2);
+    expect(todoProgress(one.todos)).toEqual({ done: 1, total: 3 });
+    expect(nextPending(undefined)).toBeNull();
+    expect(todoProgress(undefined)).toEqual({ done: 0, total: 0 });
+  });
+
+  test('formatTodoBlock renders boxes, the next arrow, and pending validations only', () => {
+    const todos = okInit([
+      { text: 'a', validation: 'a passes' },
+      { text: 'b', validation: 'b passes' },
+    ]);
+    const one = checkTodo(todos, 1);
+    if (!one.ok) throw new Error('unexpected');
+    const block = formatTodoBlock(one.todos);
+    expect(block).toContain('Plan (1/2 done):');
+    expect(block).toContain('[x] 1. a');
+    expect(block).not.toContain('a passes');            // done → validation dropped
+    expect(block).toContain('[ ] 2. b (verify: b passes)  ← next');
+    expect(formatTodoBlock([])).toBe('');
+    expect(formatTodoBlock(undefined)).toBe('');
+  });
+});


### PR DESCRIPTION
## What & why

Applies can1357's **prewalk** ([stencil.so/blog/prewalk](https://stencil.so/blog/prewalk)) to peerd's goal mode. The insight: an agent's bill is `O(reads)` — the frontier model reading its way to understanding is the cost, not the acting. A `/plan`-style handoff (frontier writes a prose plan → cheap model executes) duplicates the reading at both prices. Prewalk instead hands off the **context window itself**: the frontier model plans and lands the first action, then a cheap executor inherits the live trajectory — todo list ticking, one valid move already in history — and grinds the rest.

Three layers, each usable on its own:

1. **Todo plan-of-record** — a session-persisted checklist (`todo/core.js`, pure) the agent writes via goal-only tools (`todo_init` / `todo_check` / `todo_add`), re-surfaced in every goal continuation prompt so the plan steers the run instead of evaporating from context. Rendered live in a side-panel **TodoCard** that ticks as the run works and stays up after as the receipt.
2. **Goal mode rework** — the Goal toggle is now **sticky**: it stays lit (`Goal · turn N`) for the whole run instead of untoggling on send, and clicking it while live stops the run. Fixes the "toggled off — is it still working?" gap.
3. **Prewalk swap** — with `prewalkEnabled` on, a goal run opens on the chat (frontier) model with a hidden plan-first nudge; the first successful non-exempt mutating tool call after `todo_init` flips the phase; the model swap + nudge-prune apply at the next turn boundary (so pricing/reasoning/context-window all resolve against the model actually running). Run end restores the planner model. Cross-model thinking blocks are stripped from replayed history (signed blocks are model-bound). **OFF by default** on both channels until the Lab arms validate it.
4. **Lab arms** — `home/eval-section.js` gets a "goal runs" mode and a one-click **baseline-vs-prewalk A/B** that measures spend / pass / speed per arm (the existing `score.js` metrics) — the gate for flipping the default.

Closes #

## Checklist

- [x] `bun run preflight` passes — verified its components individually: `bun test` (2864 pass), `bun run typecheck` (clean), `eslint` (clean), in-browser suite via CDP (621 pass), dweb-boundary (clean), packaged-import graph (clean, store build prunes cleanly), no manifest/channel-config drift, tscheck floor 515/515
- [x] Only original code — no GPL / AGPL / copyleft
- [x] Tests added — `todo-core`, `prewalk`, `prewalk-lifecycle` (store-backed), extended `goal-runner`; e2e `goal` state extended to drive `todo_init`/`todo_check` and assert the card + sticky toggle (full functional suite **113/113**)
- [x] No hand-edited generated files — `shared/channel-config.js` regenerated via `bun run gen:dev`
- [x] Called out below — touches model selection + the session store

## Notes for reviewers

**Danger zone — model selection & session store.** Prewalk swaps `session.provider`/`session.model` mid-run and restores at run end. Design choices worth a look:

- **Swaps only at turn boundaries** (`turn-driver` reconcile), never mid-turn — so cost attribution, the trim/context-window sizing, and thinking-block replay all resolve against the model actually running that turn.
- **Same-provider only** for now (`resolvePrewalkExecutor`) — keys, failover chains, and pricing are provider-scoped; cross-provider executors (incl. the on-device local runner) are a deliberate next step, not a config accident.
- **State lives on the session record** (`session.prewalk`), single source of truth. `reconcilePrewalk` self-heals a stale/orphaned state (run died without restore) by restoring the planner model — the `prewalk-lifecycle` test pins this.
- **Thinking-block strip** (`agent-loop.js`): replaying a signed thinking block authored by a different model 400s the provider, so blocks whose `model` ≠ the model about to be called are dropped from the wire history (visible `thinking` text kept).
- No changes to egress, vault, or the gate chain. The todo tools are read-class and goal-only (same reveal seam as `complete_goal`); their store writes go through a per-session serialized read-modify-write so a concurrent tool wave can't lose an update.

Visual e2e baselines diff 100% in this environment including screens I never touched (`initial-screen`) — that's the documented per-machine baseline mismatch (CI runs `--functional`), not a regression; I did not overwrite the committed baselines with sandbox renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GFzj7zsiZnvszmu2HzDg2

---
_Generated by [Claude Code](https://claude.ai/code/session_012GFzj7zsiZnvszmu2HzDg2)_