### PR TITLE
Engine-actor prewalk: VM/Notebook/App actors plan on the frontier, execute cheap

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -2477,8 +2477,10 @@ const { runAgentTurn, maybeAutoResume } = makeTurnDriver({
   safeFetch, REASONING_BUDGET_TOKENS, REASONING_EFFORT_LEVELS, DEFAULT_SETTINGS, trimEnricher,
   contextWindowFor, liveContextWindow, currentAppScope, checkpointMgr, detectInterruptedTurn,
   recordModelCall: contextSnapshots.record,
-  // prewalk: the turn-boundary reconcile (swap/restore) + the per-tool-call gate.
+  // prewalk: the turn-boundary reconcile (swap/restore) + the per-tool-call gate,
+  // plus the engine-actor reconcile (VM/Notebook/App swap after their first turn).
   reconcilePrewalk: prewalk.reconcile, maybePrewalkSwap: prewalk.maybeSwap,
+  reconcileEngineActor: prewalk.reconcileEngineActor,
   // postChatNote is declared just below this call — defer the reference so it
   // resolves at call-time (the same late-declared-dep pattern the orchestrator
   // wiring above uses, see the note at the postChatNote site).
@@ -2701,6 +2703,12 @@ const mintActor = async (/** @type {{ reg: any, kind: string }} */ entry, /** @t
   await entry.reg.setDefaultForSession(created.sessionId, record.id);
   await entry.reg.setActorSession(record.id, created.sessionId);
   auditLog.append({ type: 'actor_minted', sessionId: created.sessionId, details: { instanceId: record.id, kind: entry.kind } }).catch(() => {});
+  // Engine-actor prewalk: an engine actor is minted on the frontier (owner
+  // chat) model; when enginePrewalkEnabled, arm it so it keeps that model for
+  // its first turn and swaps to the cheap executor thereafter. Quiet no-op when
+  // the setting is off or no distinct executor resolves. Awaited so the state
+  // is on the record before the actor's first turn renders.
+  await prewalk.armEngineActor(created.sessionId);
   return created.sessionId;
 };
 

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -3513,8 +3513,18 @@ browser.tabs?.onRemoved?.addListener((/** @type {number} */ tabId) => {
 // clients, no chrome.* — its model call + every tool call relay to SW-gated routes.
 const runActorTurnOffscreen = async (/** @type {any} */ { actorSessionId, message, instanceId, kind, actorTabId, oneShot, display }) => {
   if (!actorClient) return null;
-  const rec = await sessions.get(actorSessionId);
-  if (!rec) return null;
+  const loaded = await sessions.get(actorSessionId);
+  if (!loaded) return null;
+  // Engine-actor prewalk swap on the OFFSCREEN path. reconcileEngineActor is ALSO
+  // wired into the in-SW turn-driver, but a Chrome engine actor runs HERE and
+  // returns before that path is reached — so without this the swap NEVER fires on
+  // the primary platform. why here: the worker is seeded from rec.provider/rec.model
+  // below, so the swap must land (and persist) before we read them; costOf + the
+  // card then also read the executor model. No-op for a non-engine / unarmed actor
+  // (returns the record unchanged when there's no prewalk).
+  let rec = loaded;
+  try { rec = (await prewalk.reconcileEngineActor(rec)) ?? rec; }
+  catch (e) { console.warn('[actor] engine prewalk reconcile failed', e); }
   const { controller, release } = turnSlots.claim(actorSessionId);
   try {
     // Prompt PARITY with the in-SW actor turn: temporal grounding + any /system

--- a/extension/background/settings-patch.js
+++ b/extension/background/settings-patch.js
@@ -156,6 +156,11 @@ export const normalizeSettingsPatch = (patch, {
     // executor inherits the live context at the first landed action.
     next.prewalkEnabled = patch.prewalkEnabled;
   }
+  if (typeof patch.enginePrewalkEnabled === 'boolean') {
+    // Engine-actor prewalk: VM/Notebook/App actors run turn 1 on the frontier
+    // model, then swap to the cheap executor for the rest of their life.
+    next.enginePrewalkEnabled = patch.enginePrewalkEnabled;
+  }
   if (typeof patch.prewalkExecutorModel === 'string') {
     // Prewalk executor pin. '' = the provider's fast default
     // (defaultRunnerModel); non-empty = a SAME-PROVIDER model id — the same

--- a/extension/eval/eval-engine.js
+++ b/extension/eval/eval-engine.js
@@ -20,7 +20,7 @@ import { sleep } from '/shared/util.js';
 
 /**
  * @typedef {{ inputTokens?: number, outputTokens?: number, cacheReadTokens?: number, cacheWriteTokens?: number, cost?: number }} Usage
- * @typedef {{ session: any, tools: string[], tokens: number, cost: Usage | null, runner: { inputTokens: number, outputTokens: number, cacheReadTokens: number, cacheWriteTokens: number }, error: string | null, started: boolean, resolveDone: ((value?: any) => void) | null, goalMode: boolean, modelsSeen: Set<string> }} Turn
+ * @typedef {{ session: any, tools: string[], tokens: number, cost: Usage | null, runner: { inputTokens: number, outputTokens: number, cacheReadTokens: number, cacheWriteTokens: number }, runnerUsd: number, error: string | null, started: boolean, resolveDone: ((value?: any) => void) | null, goalMode: boolean, modelsSeen: Set<string> }} Turn
  */
 
 // The runner's own $ for a task. 'local' (the on-device runner) is FREE; a cloud
@@ -44,7 +44,7 @@ const costFields = (c) => c ? {
   costUsd: typeof c.cost === 'number' ? c.cost : 0,
 } : { ...ZERO_COST };
 /** @returns {Turn} */
-const newTurn = () => ({ session: null, tools: [], tokens: 0, cost: null, runner: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 }, error: null, started: false, resolveDone: null, goalMode: false, modelsSeen: new Set() });
+const newTurn = () => ({ session: null, tools: [], tokens: 0, cost: null, runner: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 }, runnerUsd: 0, error: null, started: false, resolveDone: null, goalMode: false, modelsSeen: new Set() });
 
 /** @param {any} session */
 const finalAnswer = (session) => {
@@ -111,6 +111,28 @@ export function createEvalEngine({ browser, log = () => {}, onProgress = () => {
           turn.runner.cacheReadTokens += msg.usage.cacheReadTokens || 0;
           turn.runner.cacheWriteTokens += msg.usage.cacheWriteTokens || 0;
         }
+        break;
+      // message_actor-driven actors (WEB + the engine VM/Notebook/App actors)
+      // broadcast turn/actor-cost, NOT turn/spawned-cost (which is the
+      // actor_create/spawn path). Fold it into the SAME runner bucket — without
+      // this an engine actor's spend is invisible here, so the engine-actor
+      // prewalk down-shift wouldn't register in the A/B. Tokens ride msg.usage
+      // (absent on the in-SW fallback, which sends cost only); the SW-priced USD
+      // (msg.cost.cost) is accumulated so the row reports the actor's REAL spend.
+      case 'turn/actor-cost':
+        if (msg.usage) {
+          turn.runner.inputTokens += msg.usage.inputTokens || 0;
+          turn.runner.outputTokens += msg.usage.outputTokens || 0;
+          turn.runner.cacheReadTokens += msg.usage.cacheReadTokens || 0;
+          turn.runner.cacheWriteTokens += msg.usage.cacheWriteTokens || 0;
+        }
+        if (typeof msg.cost?.cost === 'number') turn.runnerUsd += msg.cost.cost;
+        break;
+      // An actor turn's session snapshot — its model(s) show the planner→
+      // executor handoff (engine-actor prewalk). turn/actor-state, not
+      // turn/state (which is the subject/main session only).
+      case 'turn/actor-state':
+        if (msg.session?.model) turn.modelsSeen.add(msg.session.model);
         break;
       case 'turn/error': turn.error = msg.error; break;
       case 'turn/streaming':
@@ -280,7 +302,11 @@ export function createEvalEngine({ browser, log = () => {}, onProgress = () => {
     const cost = costFields(turn.cost);
     const freshTok = cost.inputTokens + cost.outputTokens;
     const runnerTokens = turn.runner.inputTokens + turn.runner.outputTokens + turn.runner.cacheReadTokens + turn.runner.cacheWriteTokens;
-    const runnerCostUsd = priceRunnerUsd(runnerCfg, turn.runner);
+    // Prefer the ACTUAL accumulated actor spend (turn/actor-cost, SW-priced from
+    // the actor's real model — so an engine-actor prewalk down-shift shows here)
+    // over re-pricing by runnerCfg, which exists for the runner-model A/B and
+    // reads 'local' (=$0) otherwise.
+    const runnerCostUsd = turn.runnerUsd > 0 ? turn.runnerUsd : priceRunnerUsd(runnerCfg, turn.runner);
     const models = [...turn.modelsSeen];
     log(`  ${res.pass ? '✓ PASS' : '✗ FAIL'} — ${res.detail}  [${state.steps} steps · ${(durationMs / 1000).toFixed(1)}s · runner ${runnerTokens} tok · $${runnerCostUsd.toFixed(4)} runner + $${cost.costUsd.toFixed(4)} main${models.length > 1 ? ` · models ${models.join(' → ')}` : ''}]`);
     if (!res.pass && state.answer) log(`       agent said: "${state.answer.slice(0, 200).replace(/\s+/g, ' ')}"`);
@@ -342,13 +368,17 @@ export function createEvalEngine({ browser, log = () => {}, onProgress = () => {
   const readPrewalk = async () => { try { const r = await browser.runtime.sendMessage({ type: 'state/get' }); return r?.state?.settings?.prewalkEnabled === true; } catch { return false; } };
   /** @param {boolean} val */
   const setPrewalk = (val) => browser.runtime.sendMessage({ type: 'settings/update', patch: { prewalkEnabled: !!val } });
+  // Engine-actor prewalk arm — the switch for the VM/Notebook/App handoff.
+  const readEnginePrewalk = async () => { try { const r = await browser.runtime.sendMessage({ type: 'state/get' }); return r?.state?.settings?.enginePrewalkEnabled === true; } catch { return false; } };
+  /** @param {boolean} val */
+  const setEnginePrewalk = (val) => browser.runtime.sendMessage({ type: 'settings/update', patch: { enginePrewalkEnabled: !!val } });
 
-  // config = { mainProvider, mainModel, runnerCfg, goal?, prewalk? }. Sets the
-  // models + the prewalk arm, runs the suite (as goal runs when goal:true),
-  // returns the scorecard. (The caller restores the user's settings.)
+  // config = { mainProvider, mainModel, runnerCfg, goal?, prewalk?, enginePrewalk? }.
+  // Sets the models + both prewalk arms, runs the suite (as goal runs when
+  // goal:true), returns the scorecard. (The caller restores the user's settings.)
   /**
    * @param {string} label
-   * @param {{ mainProvider?: string, mainModel?: string, runnerCfg?: string, goal?: boolean, prewalk?: boolean }} config
+   * @param {{ mainProvider?: string, mainModel?: string, runnerCfg?: string, goal?: boolean, prewalk?: boolean, enginePrewalk?: boolean }} config
    * @param {string} suiteId @param {boolean} showTabs
    * @param {(p: { index: number, total: number, id: string }) => void} [onTask]
    */
@@ -356,31 +386,34 @@ export function createEvalEngine({ browser, log = () => {}, onProgress = () => {
     const rm = await configToRunnerModel(config.runnerCfg);
     if (config.mainProvider && config.mainModel) await setMainModel(config.mainProvider, config.mainModel);
     await setRunnerModel(rm);
-    // prewalk only means anything on goal runs; set it explicitly per leg so
-    // an A/B is always a controlled comparison, whatever the user's setting.
+    // Set BOTH prewalk arms explicitly per leg so an A/B is always a controlled
+    // comparison, whatever the user's own settings are.
     await setPrewalk(!!config.prewalk);
+    await setEnginePrewalk(!!config.enginePrewalk);
     await sleep(200); // let the SW rebuild the session + tool-contexts with the new models
-    log(`\n──────── ${label}: main "${config.mainModel}" · runner "${config.runnerCfg}"${config.goal ? ' · goal' : ''}${config.prewalk ? ' · prewalk' : ''} ────────`);
+    log(`\n──────── ${label}: main "${config.mainModel}" · runner "${config.runnerCfg}"${config.goal ? ' · goal' : ''}${config.prewalk ? ' · prewalk' : ''}${config.enginePrewalk ? ' · engine-prewalk' : ''} ────────`);
     const { card, results } = await runSuite(suiteId, showTabs, onTask, config.runnerCfg, { goal: !!config.goal });
     return { label, config, card, results };
   }
 
-  // Save the user's models + prewalk arm, run, restore — the Lab never leaves
-  // your chat on a different model (or a flipped experiment) than you set.
+  // Save the user's models + both prewalk arms, run, restore — the Lab never
+  // leaves your chat on a different model (or a flipped experiment) than you set.
   /** @param {() => Promise<any>} fn */
   async function withSavedModels(fn) {
     const savedMain = await readMainModel();
     const savedRunner = await readRunnerModel();
     const savedPrewalk = await readPrewalk();
+    const savedEnginePrewalk = await readEnginePrewalk();
     try { return await fn(); }
     finally {
       await setMainModel(savedMain.provider, savedMain.model);
       await setRunnerModel(savedRunner);
       await setPrewalk(savedPrewalk);
-      log(`\nrestored your settings (main ${JSON.stringify(savedMain.model)}, runner ${JSON.stringify(savedRunner)}, prewalk ${savedPrewalk ? 'on' : 'off'}).`);
+      await setEnginePrewalk(savedEnginePrewalk);
+      log(`\nrestored your settings (main ${JSON.stringify(savedMain.model)}, runner ${JSON.stringify(savedRunner)}, prewalk ${savedPrewalk ? 'on' : 'off'}, engine-prewalk ${savedEnginePrewalk ? 'on' : 'off'}).`);
     }
   }
-  /** @typedef {{ mainProvider?: string, mainModel?: string, runnerCfg?: string, goal?: boolean, prewalk?: boolean }} ArmConfig */
+  /** @typedef {{ mainProvider?: string, mainModel?: string, runnerCfg?: string, goal?: boolean, prewalk?: boolean, enginePrewalk?: boolean }} ArmConfig */
   /**
    * @param {ArmConfig} config
    * @param {string} suiteId @param {boolean} showTabs

--- a/extension/eval/eval-engine.js
+++ b/extension/eval/eval-engine.js
@@ -20,7 +20,7 @@ import { sleep } from '/shared/util.js';
 
 /**
  * @typedef {{ inputTokens?: number, outputTokens?: number, cacheReadTokens?: number, cacheWriteTokens?: number, cost?: number }} Usage
- * @typedef {{ session: any, tools: string[], tokens: number, cost: Usage | null, runner: { inputTokens: number, outputTokens: number, cacheReadTokens: number, cacheWriteTokens: number }, runnerUsd: number, error: string | null, started: boolean, resolveDone: ((value?: any) => void) | null, goalMode: boolean, modelsSeen: Set<string> }} Turn
+ * @typedef {{ session: any, tools: string[], tokens: number, cost: Usage | null, runner: { inputTokens: number, outputTokens: number, cacheReadTokens: number, cacheWriteTokens: number }, runnerUsd: number, runnerUsdByKey: Map<string, number>, error: string | null, started: boolean, resolveDone: ((value?: any) => void) | null, goalMode: boolean, modelsSeen: Set<string> }} Turn
  */
 
 // The runner's own $ for a task. 'local' (the on-device runner) is FREE; a cloud
@@ -44,7 +44,7 @@ const costFields = (c) => c ? {
   costUsd: typeof c.cost === 'number' ? c.cost : 0,
 } : { ...ZERO_COST };
 /** @returns {Turn} */
-const newTurn = () => ({ session: null, tools: [], tokens: 0, cost: null, runner: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 }, runnerUsd: 0, error: null, started: false, resolveDone: null, goalMode: false, modelsSeen: new Set() });
+const newTurn = () => ({ session: null, tools: [], tokens: 0, cost: null, runner: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 }, runnerUsd: 0, runnerUsdByKey: new Map(), error: null, started: false, resolveDone: null, goalMode: false, modelsSeen: new Set() });
 
 /** @param {any} session */
 const finalAnswer = (session) => {
@@ -126,7 +126,15 @@ export function createEvalEngine({ browser, log = () => {}, onProgress = () => {
           turn.runner.cacheReadTokens += msg.usage.cacheReadTokens || 0;
           turn.runner.cacheWriteTokens += msg.usage.cacheWriteTokens || 0;
         }
-        if (typeof msg.cost?.cost === 'number') turn.runnerUsd += msg.cost.cost;
+        // USD accounting differs by broadcaster: the offscreen heap-split path
+        // (service-worker) fires ONCE per actor turn with that turn's TOTAL, while
+        // the in-SW path (turn-driver onCost) RE-EMITS a GROWING CUMULATIVE per
+        // usage fold. Key the latest value per actor turn (parentToolUseId) and sum
+        // the keys — correct for both; a straight += multiply-counts the in-SW stream.
+        if (typeof msg.cost?.cost === 'number') {
+          turn.runnerUsdByKey.set(msg.parentToolUseId ?? 'anon', msg.cost.cost);
+          turn.runnerUsd = [...turn.runnerUsdByKey.values()].reduce((sum, v) => sum + v, 0);
+        }
         break;
       // An actor turn's session snapshot — its model(s) show the planner→
       // executor handoff (engine-actor prewalk). turn/actor-state, not

--- a/extension/eval/tasks.js
+++ b/extension/eval/tasks.js
@@ -1019,12 +1019,46 @@ export const FETCH_TASKS = [
   },
 ];
 
+// --- engine-actor suite: multi-turn VM/Notebook actor work ------------------
+// The suite for the ENGINE-ACTOR prewalk A/B (home/eval-section.js). These
+// tasks force the orchestrator to round-trip a SINGLE long-lived engine actor
+// several times — each step's input is the PREVIOUS step's actual output, so
+// the orchestrator cannot batch them into one message_actor call. That yields
+// turn 1 on the frontier model and turns 2+ on the cheap executor, which is
+// exactly the handoff the A/B measures (watch the per-task `models` trail and
+// runner-$ drop). Scored answer-only — check(state) can't see the actor's
+// transcript, only the value the main agent reports back (recon-confirmed).
+const ENGINE_ACTOR_TASKS = [
+  {
+    id: 'vm-chain',
+    title: 'WebVM — data-dependent 3-step chain',
+    startUrl: null,
+    // 123×456 = 56088 → largest prime factor 41 → 41²+1 = 1682 → factors 2·29·29.
+    // Each step needs the prior step's REAL shell output (a factorization the
+    // agent can't know without running `factor`), so it can't shortcut or batch.
+    prompt: 'Spin up a single Linux VM and keep using that SAME VM for all steps. '
+      + 'Do these in order, running each as its own shell command and reading the '
+      + 'result before moving on: (1) compute 123 multiplied by 456; (2) run `factor` '
+      + 'on that result and take its LARGEST prime factor; (3) square that prime factor, '
+      + 'add 1, and run `factor` on the result. Tell me that final `factor` output.',
+    timeoutMs: 240_000,
+    check: (/** @type {any} */ s) => s.error ? no(`errored: ${s.error}`)
+      : (includesCI(s.answer, '1682') && includesCI(s.answer, '29'))
+          ? ok('completed the 3-step chain (1682 = 2·29·29)')
+          : no(`expected 1682 = 2·29·29, answer="${(s.answer || '').slice(0, 100)}"`),
+  },
+  // edit-file-flow is already a genuine multi-turn Notebook-actor task (create
+  // → run → edit → re-run), so it doubles as an engine-actor swap probe.
+  ...SIMPLE_TASKS.filter((/** @type {any} */ t) => t.id === 'edit-file-flow'),
+];
+
 // The suite registry the eval UI picks from.
 export const SUITES = Object.freeze({
   simple: { id: 'simple', label: 'Simple', tasks: SIMPLE_TASKS },
   robust: { id: 'robust', label: 'Robust', tasks: ROBUST_TASKS },
   'web-actor': { id: 'web-actor', label: 'Web Actor', tasks: WEB_ACTOR_TASKS },
   fetch: { id: 'fetch', label: 'Fetch (content pipeline)', tasks: FETCH_TASKS },
+  'engine-actor': { id: 'engine-actor', label: 'Engine Actor', tasks: ENGINE_ACTOR_TASKS },
 });
 
 // Back-compat: existing importers (runner.js) use TASKS — keep it the simple set.

--- a/extension/home/eval-section.js
+++ b/extension/home/eval-section.js
@@ -148,6 +148,28 @@ async function runPrewalkAB() {
   finally { ui.running = false; ui.progress = null; m.redraw(); }
 }
 
+// Engine-actor A/B — side A's config, both legs NORMAL turns (not goal), on the
+// engine-actor suite; the only variable is enginePrewalk. The gate for flipping
+// enginePrewalkEnabled on: pass rate holds while runner-$ (the engine actor's
+// spend) drops. Forces the engine-actor suite so there's multi-turn actor work
+// to swap on.
+async function runEnginePrewalkAB() {
+  if (ui.running) return;
+  ui.running = true; ui.ab = null; ui.single = null; ui.log = []; ui.progress = null;
+  const suiteId = 'engine-actor';
+  m.redraw();
+  try {
+    const base = configFor('A');
+    ui.ab = await ensureEngine().runAB(
+      { ...base, enginePrewalk: false },
+      { ...base, enginePrewalk: true },
+      suiteId, ui.showTabs,
+      (/** @type {any} */ p) => { ui.progress = p; m.redraw(); },
+    );
+  } catch (e) { pushLog(`engine-actor A/B aborted: ${/** @type {{ message?: string }} */ (e)?.message ?? e}`); }
+  finally { ui.running = false; ui.progress = null; m.redraw(); }
+}
+
 /** @param {number} ms */
 const secs = (ms) => `${(ms / 1000).toFixed(1)}s`;
 /** @param {number} [n] */
@@ -156,9 +178,9 @@ const usd = (n) => `$${(n ?? 0).toFixed(5)}`;
 const runnerUsd = (n) => ((n ?? 0) > 0 ? usd(n) : 'free'); // local runner reads "free"
 /** @param {string} id */
 const shortModel = (id) => String(id).replace(/^[a-z-]+\//, '').replace(/-\d{8}$/, ''); // strip provider/ + date
-/** @param {{ mainModel: string, runnerCfg: string, goal?: boolean, prewalk?: boolean }} cfg */
+/** @param {{ mainModel: string, runnerCfg: string, goal?: boolean, prewalk?: boolean, enginePrewalk?: boolean }} cfg */
 const pairLabel = (cfg) => `${shortModel(cfg.mainModel)} / ${cfg.runnerCfg === 'local' ? 'local' : shortModel(cfg.runnerCfg)}`
-  + `${cfg.goal ? ' · goal' : ''}${cfg.prewalk ? ' · prewalk' : ''}`;
+  + `${cfg.goal ? ' · goal' : ''}${cfg.prewalk ? ' · prewalk' : ''}${cfg.enginePrewalk ? ' · engine-prewalk' : ''}`;
 
 /** @param {{ a: any, b: any, delta: any }} result */
 function abBoard({ a, b, delta }) {
@@ -216,7 +238,7 @@ export const EvalSection = {
       m('p.eval-note', 'A run takes over the agent session (your current chat resets) and drives a hidden browser window — don\'t start a chat while it runs.'),
       m('.eval-controls', [
         m('label.eval-field', ['suite', m('select', { value: ui.suiteId, disabled: ui.running, onchange: (/** @type {{ target: HTMLSelectElement }} */ e) => { ui.suiteId = e.target.value; } },
-          [m('option', { value: 'simple' }, 'Simple · 30 tasks'), m('option', { value: 'robust' }, 'Robust · 55 tasks')])]),
+          Object.values(SUITES).map((/** @type {any} */ s) => m('option', { value: s.id }, `${s.label} · ${s.tasks.length} tasks`)))]),
         m('label.eval-check', {
           title: 'Off: the agent runs in a hidden, background window. On: a visible window (its own tab bar) you can watch — it never takes focus either way.',
         }, [m('input', { type: 'checkbox', checked: ui.showTabs, disabled: ui.running, onchange: (/** @type {{ target: HTMLInputElement }} */ e) => { ui.showTabs = e.target.checked; } }), 'show tabs']),
@@ -233,6 +255,11 @@ export const EvalSection = {
           title: 'Side A\'s config, two legs of goal runs: baseline vs prewalk (plan on the main model, hand the live context to a cheap executor at the first landed action). The gate for turning the prewalk setting on: pass rate must hold while $ and time drop.',
           onclick: runPrewalkAB,
         }, 'Run prewalk A/B'),
+        m('button.eval-btn', {
+          disabled: ui.running || !ui.mainA,
+          title: 'Side A\'s config on the engine-actor suite (multi-turn VM/Notebook work): baseline vs engine-prewalk (VM/Notebook/App actors run turn 1 on the main model, then swap to the cheap executor). The gate for turning engine-actor prewalk on: pass rate holds while the runner-$ (the actor\'s spend) drops.',
+          onclick: runEnginePrewalkAB,
+        }, 'Run engine A/B'),
       ]),
       m('button.eval-disclosure', { onclick: () => { ui.showTasks = !ui.showTasks; } },
         `${ui.showTasks ? '▾' : '▸'} exactly what the ${suite()?.tasks.length ?? 0} ${ui.suiteId} tasks run`),

--- a/extension/home/eval-section.js
+++ b/extension/home/eval-section.js
@@ -159,7 +159,10 @@ async function runEnginePrewalkAB() {
   const suiteId = 'engine-actor';
   m.redraw();
   try {
-    const base = configFor('A');
+    // Force normal turns (not goal) whatever the 'goal runs' checkbox says — this
+    // A/B isolates the engine-actor swap on plain message_actor turns, per the
+    // contract note above. (runPrewalkAB is the goal-run counterpart.)
+    const base = { ...configFor('A'), goal: false };
     ui.ab = await ensureEngine().runAB(
       { ...base, enginePrewalk: false },
       { ...base, enginePrewalk: true },
@@ -226,6 +229,16 @@ const pairCol = (side) => m('.eval-pair', [
 // The selected suite (the id is a free string in state; SUITES is keyed).
 const suite = () => SUITES[/** @type {keyof typeof SUITES} */ (ui.suiteId)];
 
+// Suites the home Lab can actually run. The web-actor suite uses the __FIXTURE__
+// sentinel that ONLY eval/runner.js (the CDP bench, fed by a local fixture server)
+// substitutes — the home Lab's eval-engine has no fixture server, so those tasks
+// would all-fail here. Hide any suite whose tasks carry the sentinel (self-
+// maintaining: a new fixture suite is filtered automatically). why detect the
+// sentinel, not the id: keeps the two surfaces from drifting.
+const usesFixture = (/** @type {any} */ s) => (s.tasks ?? []).some((/** @type {any} */ t) =>
+  String(t.startUrl ?? '').includes('__FIXTURE__') || String(t.prompt ?? '').includes('__FIXTURE__'));
+const labSuites = Object.values(SUITES).filter((/** @type {any} */ s) => !usesFixture(s));
+
 export const EvalSection = {
   oninit() { if (!ui.loaded) loadModels().catch(() => {}); },
   view() {
@@ -238,7 +251,7 @@ export const EvalSection = {
       m('p.eval-note', 'A run takes over the agent session (your current chat resets) and drives a hidden browser window — don\'t start a chat while it runs.'),
       m('.eval-controls', [
         m('label.eval-field', ['suite', m('select', { value: ui.suiteId, disabled: ui.running, onchange: (/** @type {{ target: HTMLSelectElement }} */ e) => { ui.suiteId = e.target.value; } },
-          Object.values(SUITES).map((/** @type {any} */ s) => m('option', { value: s.id }, `${s.label} · ${s.tasks.length} tasks`)))]),
+          labSuites.map((/** @type {any} */ s) => m('option', { value: s.id }, `${s.label} · ${s.tasks.length} tasks`)))]),
         m('label.eval-check', {
           title: 'Off: the agent runs in a hidden, background window. On: a visible window (its own tab bar) you can watch — it never takes focus either way.',
         }, [m('input', { type: 'checkbox', checked: ui.showTabs, disabled: ui.running, onchange: (/** @type {{ target: HTMLInputElement }} */ e) => { ui.showTabs = e.target.checked; } }), 'show tabs']),

--- a/extension/options/sections/behavior.js
+++ b/extension/options/sections/behavior.js
@@ -155,7 +155,32 @@ export const BehaviorSection = {
               },
             }, ui.prewalkBusy ? '…' : pwOn ? 'Turn off prewalk' : 'Turn on prewalk'),
           ]),
-          pwOn ? [
+          (() => {
+            const engOn = state.settings?.enginePrewalkEnabled === true;
+            return [
+              m('div', { style: 'display:flex; gap:8px; align-items:center; margin-top:8px;' }, [
+                m('button.secondary', {
+                  type: 'button',
+                  disabled: ui.enginePrewalkBusy,
+                  onclick: async () => {
+                    if (ui.enginePrewalkBusy) return;
+                    ui.enginePrewalkBusy = true; m.redraw();
+                    try {
+                      await send({ type: 'settings/update', patch: { enginePrewalkEnabled: !engOn } });
+                    } catch (e) {
+                      console.warn('[options] engine prewalk toggle failed', e);
+                    } finally {
+                      ui.enginePrewalkBusy = false; m.redraw();
+                    }
+                  },
+                }, ui.enginePrewalkBusy ? '…' : engOn ? 'Turn off engine-actor prewalk' : 'Turn on engine-actor prewalk'),
+              ]),
+              m('p.hint', engOn
+                ? 'On. VM/Notebook/App actors run their first turn on your chat model, then swap to the executor below — lower cost on multi-turn engine work.'
+                : 'Also apply prewalk to engine actors (VM/Notebook/App): first turn on your chat model to plan against the real instance state, then the cheaper executor for the rest. Benchmark it in the home Lab first.'),
+            ];
+          })(),
+          (pwOn || state.settings?.enginePrewalkEnabled === true) ? [
             m('.input-row', [
               m('label', { for: 'prewalk-executor' }, 'Executor model'),
               m('input', {
@@ -169,7 +194,7 @@ export const BehaviorSection = {
                 },
               }),
             ]),
-            m('p.hint', 'A model id on the SAME provider as the chat. Leave empty to use the provider’s fast default — the same model the web actor rides.'),
+            m('p.hint', 'A model id on the SAME provider as the chat, shared by goal-run and engine-actor prewalk. Leave empty to use the provider’s fast default — the same model the web actor rides.'),
           ] : null,
         ];
       })(),
@@ -358,7 +383,7 @@ export const BehaviorSection = {
       resetRow(send, [
         'reasoningEnabled', 'reasoningEffort', 'confirmWebWrites', 'advancedAutomationEnabled', 'devMode',
         'autoResumeInterruptedTurns', 'providerFailoverEnabled', 'providerFallbacks',
-        'prewalkEnabled', 'prewalkExecutorModel',
+        'prewalkEnabled', 'enginePrewalkEnabled', 'prewalkExecutorModel',
       ]),
     ]);
   },

--- a/extension/peerd-runtime/loop/prewalk-controller.js
+++ b/extension/peerd-runtime/loop/prewalk-controller.js
@@ -24,8 +24,18 @@
 //   - arm() ALWAYS clears stale state first (a crashed run's leftovers),
 //     THEN gates the re-arm on the setting — so a disabled setting can never
 //     leave a prior run's executor state stranded on the record.
+//
+// The controller ALSO carries the ENGINE-ACTOR prewalk path (armEngineActor /
+// reconcileEngineActor): the same context-window handoff aimed at the three
+// engine actor kinds (VM/Notebook/App), which are minted on the frontier
+// (owner-chat) model. It's simpler than the goal-run path — no run-liveness
+// coupling, no todo/mutating gate, no restore — the actor runs turn 1 on the
+// frontier model and lives out its life on the executor. See prewalk.js.
 
-import { armPrewalk, shouldPrewalkSwap, markPrewalkSwapped, resolvePrewalkExecutor } from './prewalk.js';
+import {
+  armPrewalk, shouldPrewalkSwap, markPrewalkSwapped, resolvePrewalkExecutor,
+  shouldEngineActorSwap, isEngineActorKind,
+} from './prewalk.js';
 
 /**
  * @typedef {Object} PrewalkControllerDeps
@@ -33,7 +43,7 @@ import { armPrewalk, shouldPrewalkSwap, markPrewalkSwapped, resolvePrewalkExecut
  * @property {{ isActive: (id: string) => boolean, isPersisted?: (id: string) => Promise<boolean> }} goalRunner
  *   isActive — the live in-memory run map. isPersisted — the durable mirror
  *   (optional; absent → treated as false, i.e. in-memory only).
- * @property {{ get: () => { prewalkEnabled?: boolean, prewalkExecutorModel?: string } }} settings
+ * @property {{ get: () => { prewalkEnabled?: boolean, enginePrewalkEnabled?: boolean, prewalkExecutorModel?: string } }} settings
  * @property {() => Array<{ name?: string, defaultRunnerModel?: string }>} listProviders
  * @property {(name: string) => ({ sideEffect?: string } | undefined)} getTool
  * @property {(entry: { type: string, sessionId?: string, details?: object }) => unknown} [appendAudit]
@@ -157,5 +167,62 @@ export const makePrewalkController = ({
     }
   };
 
-  return { armForRun, reconcile, maybeSwap, restoreForRun };
+  // ── engine-actor prewalk ──────────────────────────────────────────────────
+
+  /**
+   * Arm an engine actor at mint time (VM/Notebook/App). Quiet no-op unless the
+   * setting is on, the session is an engine actor, and a distinct cheap
+   * executor resolves (armPrewalk returns null when the executor equals the
+   * actor's own model). Idempotent — a session already carrying prewalk is left
+   * alone. No stale-cleanup needed: an actor session is freshly minted here.
+   * @param {string} sessionId
+   */
+  const armEngineActor = async (sessionId) => {
+    try {
+      if (!sessionId || !settings.get().enginePrewalkEnabled) return;
+      const session = await sessions.get(sessionId);
+      if (!session || session.kind !== 'actor' || !isEngineActorKind(session.actorType)) return;
+      if (session.prewalk) return;
+      const provider = listProviders().find((p) => p.name === session.provider);
+      const executor = resolvePrewalkExecutor({ settings: settings.get(), provider });
+      const armed = armPrewalk(session, executor, now());
+      if (!armed) return;
+      await sessions.setPrewalk(sessionId, armed);
+      audit('engine_prewalk_armed', sessionId, { actorType: session.actorType, executorProvider: armed.executorProvider, executorModel: armed.executorModel });
+    } catch (e) {
+      console.warn('[prewalk] engine actor arm failed', e);
+    }
+  };
+
+  /**
+   * Reconcile at an engine actor's turn start (turn-driver, engine kinds only).
+   * Keeps the frontier model for the first turn; once the actor is past it (a
+   * prior assistant turn exists), swaps model→executor and marks executing — in
+   * ONE write (setPrewalk carries the model patch). No restore: the actor stays
+   * on the executor for the rest of its life. Returns the (possibly swapped)
+   * session the turn should run on.
+   * @param {any} session
+   */
+  const reconcileEngineActor = async (session) => {
+    const pw = session?.prewalk;
+    if (!pw) return session;
+    const sid = session.sessionId;
+    const onExecutor = session.provider === pw.executorProvider && session.model === pw.executorModel;
+    // Already swapped and on the executor — nothing to do.
+    if (pw.phase === 'executing' && onExecutor) return session;
+    const hasPriorAssistant = Array.isArray(session.messages)
+      && session.messages.some((/** @type {any} */ m) => m?.role === 'assistant');
+    if (!shouldEngineActorSwap({ prewalk: pw, hasPriorAssistant, provider: session.provider, model: session.model })) {
+      return session;
+    }
+    // Past the first turn (or drifted off the executor) → land on the executor,
+    // marking executing, in a single atomic write.
+    const swapped = await sessions.setPrewalk(sid, markPrewalkSwapped(pw, now()), {
+      provider: pw.executorProvider, model: pw.executorModel,
+    });
+    audit('engine_prewalk_swapped', sid, { actorType: session.actorType, executorProvider: pw.executorProvider, executorModel: pw.executorModel });
+    return swapped;
+  };
+
+  return { armForRun, reconcile, maybeSwap, restoreForRun, armEngineActor, reconcileEngineActor };
 };

--- a/extension/peerd-runtime/loop/prewalk.js
+++ b/extension/peerd-runtime/loop/prewalk.js
@@ -165,3 +165,43 @@ export const shouldPrewalkSwap = ({ prewalk, todosCount, toolName, sideEffect, o
 export const markPrewalkSwapped = (prewalk, now) => ({
   ...prewalk, phase: 'executing', swappedAt: now,
 });
+
+// ── engine-actor prewalk ────────────────────────────────────────────────────
+// The three ENGINE actor kinds (VM/Notebook/App) are minted on the owner
+// chat's (frontier) model — unlike the web actor, which is already on the
+// cheap runner tier. Engine-actor prewalk keeps that frontier model for the
+// actor's FIRST turn (plan + first action against the real instance state the
+// orchestrator was blind to), then swaps to the cheap executor for every later
+// turn. It's the same context-window handoff as the goal-run path, aimed at a
+// different tier — and SIMPLER: no run-liveness coupling, no todo/mutating
+// gate, and NO restore (a disposable, instance-bound actor lives out its life
+// on the executor; when its instance is deleted the session goes with it).
+//
+// why turn-boundary (not first-action): an actor's model is fixed per turn, so
+// the swap can only land BETWEEN turns. The first message_actor delegation is
+// the plan-forming turn on the frontier model; the swap takes effect from the
+// second delegation onward. A one-shot actor (a single delegation) never
+// swaps and stays on the frontier — correct: there's no later turn to make
+// cheaper, and nothing was lost.
+export const ENGINE_ACTOR_KINDS = Object.freeze(new Set(['webvm', 'notebook', 'app']));
+
+/** @param {string} [kind] */
+export const isEngineActorKind = (kind) => ENGINE_ACTOR_KINDS.has(kind ?? '');
+
+/**
+ * Should an armed engine actor swap to its executor now? True once it is PAST
+ * its first turn (a prior assistant message exists in its session) and not yet
+ * on the executor. Pure — the caller reads liveness from the session record.
+ *
+ * @param {Object} inputs
+ * @param {PrewalkState | null | undefined} inputs.prewalk
+ * @param {boolean} inputs.hasPriorAssistant  does the actor session already carry an assistant turn?
+ * @param {string | undefined} inputs.provider  the session's current provider
+ * @param {string | undefined} inputs.model     the session's current model
+ * @returns {boolean}
+ */
+export const shouldEngineActorSwap = ({ prewalk, hasPriorAssistant, provider, model }) => (
+  !!prewalk
+  && hasPriorAssistant === true
+  && (provider !== prewalk.executorProvider || model !== prewalk.executorModel)
+);

--- a/extension/peerd-runtime/loop/turn-driver.js
+++ b/extension/peerd-runtime/loop/turn-driver.js
@@ -58,6 +58,9 @@ export const makeTurnDriver = (/** @type {any} */ deps) => {
     // model; maybePrewalkSwap is the per-tool-call gate that flips the phase.
     reconcilePrewalk = null,
     maybePrewalkSwap = null,
+    // Engine-actor prewalk: swaps a VM/Notebook/App actor to its cheap executor
+    // from its second turn onward. Optional so actor/test drivers stay inert.
+    reconcileEngineActor = null,
   } = deps;
 
 /**
@@ -115,10 +118,19 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
   // Prewalk turn-boundary reconcile: apply a pending executor swap (so THIS
   // turn's model/pricing/window all read the executor), or restore a stale
   // planner (a run that died without its run-end restore). Best-effort — a
-  // reconcile failure runs the turn on the unreconciled record.
-  if (turnSession?.prewalk && turnSession.kind !== 'actor' && typeof reconcilePrewalk === 'function') {
-    try { turnSession = (await reconcilePrewalk(turnSession)) ?? turnSession; }
-    catch (e) { console.warn('[turn] prewalk reconcile failed', e); }
+  // reconcile failure runs the turn on the unreconciled record. Two disjoint
+  // paths: the goal-run reconcile for a CHAT session, and the engine-actor
+  // reconcile for an ENGINE actor (VM/Notebook/App) — the actor swaps to its
+  // cheap executor from its second turn onward. A web/dweb/spawned actor
+  // carries no prewalk and is untouched.
+  if (turnSession?.prewalk) {
+    try {
+      if (turnSession.kind !== 'actor' && typeof reconcilePrewalk === 'function') {
+        turnSession = (await reconcilePrewalk(turnSession)) ?? turnSession;
+      } else if (turnSession.kind === 'actor' && typeof reconcileEngineActor === 'function') {
+        turnSession = (await reconcileEngineActor(turnSession)) ?? turnSession;
+      }
+    } catch (e) { console.warn('[turn] prewalk reconcile failed', e); }
   }
   const isActor = turnSession?.kind === 'actor';
   /** @type {string|undefined} */

--- a/extension/shared/channel-config.js
+++ b/extension/shared/channel-config.js
@@ -33,6 +33,7 @@ export const CHANNEL_DEFAULTS = Object.freeze({
   advancedAutomationEnabled: true,
   runnerModel: "",
   prewalkEnabled: false,
+  enginePrewalkEnabled: false,
   prewalkExecutorModel: "",
   spendLimitUsd: 0,
   pricingOverrides: {},

--- a/packaging/default-settings.mjs
+++ b/packaging/default-settings.mjs
@@ -142,11 +142,20 @@ export const defaults = {
   // (home/eval-section.js); flip deliberately, not by shipping.
   prewalkEnabled: { store: false, preview: false },
 
+  // Engine-actor prewalk (loop/prewalk-controller.js): the three engine actor
+  // kinds (VM/Notebook/App) are minted on the chat's (frontier) model. With
+  // this on, an engine actor runs its FIRST turn on that model, then swaps to
+  // the cheap executor for every later turn — lower cost on multi-turn engine
+  // work (a VM build, a notebook iteration) at held-or-better quality. Shares
+  // the prewalkExecutorModel pin below. OFF by default on BOTH channels until
+  // the Lab's engine-actor A/B validates it (home/eval-section.js).
+  enginePrewalkEnabled: { store: false, preview: false },
+
   // Prewalk executor override. '' = no pin — resolve the active provider's
   // fast default (the same defaultRunnerModel rung the web actor rides, e.g.
   // Haiku on Anthropic). A non-empty value pins a SAME-PROVIDER model id
   // (cross-provider executors are a deliberate later step — keys, failover
-  // and pricing are provider-scoped).
+  // and pricing are provider-scoped). Shared by goal-run and engine-actor prewalk.
   prewalkExecutorModel: { store: '', preview: '' },
 
   // Cost telemetry: the meter is always on; the hard limit is opt-in.

--- a/tests/peerd-runtime/prewalk-lifecycle.test.ts
+++ b/tests/peerd-runtime/prewalk-lifecycle.test.ts
@@ -44,11 +44,11 @@ const TOOLS: Record<string, { sideEffect: string }> = {
 };
 
 // A controllable rig: real store + controller, fake run-liveness + settings.
-const rig = (opts: { prewalkEnabled?: boolean; executor?: string } = {}) => {
+const rig = (opts: { prewalkEnabled?: boolean; enginePrewalkEnabled?: boolean; executor?: string } = {}) => {
   const store = makeStore();
   const active = new Set<string>();
   const persisted = new Set<string>();
-  const settings = { prewalkEnabled: opts.prewalkEnabled ?? true, prewalkExecutorModel: opts.executor ?? 'claude-haiku-4-5' };
+  const settings = { prewalkEnabled: opts.prewalkEnabled ?? true, enginePrewalkEnabled: opts.enginePrewalkEnabled ?? true, prewalkExecutorModel: opts.executor ?? 'claude-haiku-4-5' };
   const audits: any[] = [];
   let clock = 1;
   const controller = makePrewalkController({
@@ -222,5 +222,73 @@ describe('prewalk controller — the review findings', () => {
     active.add(same.sessionId);
     await controller.armForRun(same.sessionId);
     expect('prewalk' in (await store.get(same.sessionId))!).toBe(false);
+  });
+});
+
+describe('prewalk controller — engine actors', () => {
+  // A VM/Notebook/App actor session, minted on the frontier (owner-chat) model.
+  const newEngineActor = (store: ReturnType<typeof makeStore>, actorType = 'webvm') =>
+    store.create({ provider: 'anthropic', model: 'claude-opus-4-8', kind: 'actor', actorType: actorType as any, instanceId: 'vm-1' });
+  // Append one assistant turn (the "first turn happened" signal reconcile reads).
+  const addAssistantTurn = async (store: ReturnType<typeof makeStore>, sid: string, i: number) =>
+    store.appendMessage(sid, { role: 'assistant', content: 'ran a command', id: `a${i}`, when: i } as any);
+
+  test('arm on mint, first turn stays on frontier, second turn swaps to executor, then lives there', async () => {
+    const { store, controller } = rig();
+    const a = await newEngineActor(store);
+
+    // ARM (mintActor). Planning phase; model unchanged (frontier).
+    await controller.armEngineActor(a.sessionId);
+    let rec: any = await store.get(a.sessionId);
+    expect(rec.prewalk.phase).toBe('planning');
+    expect(rec.model).toBe('claude-opus-4-8');
+
+    // FIRST turn (no prior assistant) → reconcile keeps the frontier model.
+    rec = await controller.reconcileEngineActor(rec);
+    expect(rec.model).toBe('claude-opus-4-8');
+    expect(rec.prewalk.phase).toBe('planning');
+
+    // The first turn produces an assistant message.
+    await addAssistantTurn(store, a.sessionId, 1);
+
+    // SECOND turn → reconcile swaps to the executor + marks executing, one write.
+    rec = await controller.reconcileEngineActor((await store.get(a.sessionId))!);
+    expect(rec.model).toBe('claude-haiku-4-5');
+    expect(rec.prewalk.phase).toBe('executing');
+
+    // THIRD turn → already on the executor, no-op (and never restores).
+    await addAssistantTurn(store, a.sessionId, 2);
+    rec = await controller.reconcileEngineActor((await store.get(a.sessionId))!);
+    expect(rec.model).toBe('claude-haiku-4-5');
+    expect('prewalk' in rec).toBe(true);   // NO restore — the actor lives on the executor
+  });
+
+  test('armEngineActor no-ops: setting off, non-engine actor kind, and executor == model', async () => {
+    const { store, controller, settings } = rig();
+
+    settings.enginePrewalkEnabled = false;
+    const off = await newEngineActor(store);
+    await controller.armEngineActor(off.sessionId);
+    expect('prewalk' in (await store.get(off.sessionId))!).toBe(false);
+
+    settings.enginePrewalkEnabled = true;
+    // A WEB actor is already cheap — not an engine kind, must not arm.
+    const web = await store.create({ provider: 'anthropic', model: 'claude-opus-4-8', kind: 'actor', actorType: 'web' as any });
+    await controller.armEngineActor(web.sessionId);
+    expect('prewalk' in (await store.get(web.sessionId))!).toBe(false);
+
+    // Engine actor already on the cheap model → no distinct executor, no arm.
+    const cheap = await store.create({ provider: 'anthropic', model: 'claude-haiku-4-5', kind: 'actor', actorType: 'notebook' as any, instanceId: 'nb-1' });
+    await controller.armEngineActor(cheap.sessionId);
+    expect('prewalk' in (await store.get(cheap.sessionId))!).toBe(false);
+  });
+
+  test('armEngineActor is idempotent — a second call leaves the state alone', async () => {
+    const { store, controller } = rig();
+    const a = await newEngineActor(store, 'app');
+    await controller.armEngineActor(a.sessionId);
+    const first = (await store.get(a.sessionId))!.prewalk;
+    await controller.armEngineActor(a.sessionId);
+    expect((await store.get(a.sessionId))!.prewalk).toEqual(first);
   });
 });

--- a/tests/peerd-runtime/prewalk.test.ts
+++ b/tests/peerd-runtime/prewalk.test.ts
@@ -8,6 +8,7 @@ import { describe, test, expect } from 'bun:test';
 import {
   resolvePrewalkExecutor, armPrewalk, shouldPrewalkSwap, markPrewalkSwapped,
   PREWALK_EXEMPT_TOOLS, PREWALK_NUDGE,
+  ENGINE_ACTOR_KINDS, isEngineActorKind, shouldEngineActorSwap,
 } from '../../extension/peerd-runtime/loop/prewalk.js';
 
 const anthropic = { name: 'anthropic', defaultRunnerModel: 'claude-haiku-4-5' };
@@ -86,6 +87,31 @@ describe('markPrewalkSwapped', () => {
     expect(swapped.swappedAt).toBe(NOW + 5);
     expect(swapped.plannerModel).toBe('claude-opus-4-8');
     expect(swapped.executorModel).toBe('claude-haiku-4-5');
+  });
+});
+
+describe('engine-actor prewalk helpers', () => {
+  const armed = { phase: 'planning', plannerProvider: 'anthropic', plannerModel: 'claude-opus-4-8', executorProvider: 'anthropic', executorModel: 'claude-haiku-4-5', armedAt: NOW } as const;
+
+  test('the engine actor kinds are exactly VM/Notebook/App (not web/dweb)', () => {
+    expect([...ENGINE_ACTOR_KINDS].sort()).toEqual(['app', 'notebook', 'webvm']);
+    expect(isEngineActorKind('webvm')).toBe(true);
+    expect(isEngineActorKind('notebook')).toBe(true);
+    expect(isEngineActorKind('app')).toBe(true);
+    expect(isEngineActorKind('web')).toBe(false);   // already cheap — not armed
+    expect(isEngineActorKind('dweb')).toBe(false);
+    expect(isEngineActorKind(undefined)).toBe(false);
+  });
+
+  test('swaps only PAST the first turn (a prior assistant exists) and not already on the executor', () => {
+    // First turn: no prior assistant → stay on the frontier planner.
+    expect(shouldEngineActorSwap({ prewalk: armed, hasPriorAssistant: false, provider: 'anthropic', model: 'claude-opus-4-8' })).toBe(false);
+    // Second turn: prior assistant exists, still on planner → swap.
+    expect(shouldEngineActorSwap({ prewalk: armed, hasPriorAssistant: true, provider: 'anthropic', model: 'claude-opus-4-8' })).toBe(true);
+    // Already on the executor → no-op.
+    expect(shouldEngineActorSwap({ prewalk: armed, hasPriorAssistant: true, provider: 'anthropic', model: 'claude-haiku-4-5' })).toBe(false);
+    // No prewalk → never.
+    expect(shouldEngineActorSwap({ prewalk: null, hasPriorAssistant: true, provider: 'anthropic', model: 'claude-opus-4-8' })).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What & why

Extends prewalk (#210, #214) to **engine actors**. The insight that makes this the strongest actor target: engine actors (VM/Notebook/App) are minted on the owner chat's **frontier** model and run *every* turn on it — unlike the web actor, which is already on the cheap runner tier. So a prewalk down-shift here isn't "quality for a little cost," it's the **pure main-loop win**: lower cost at held-or-better quality. A VM actor iterating on a build, or a Notebook actor editing-and-re-running, currently pays frontier prices on every turn — exactly the O(reads) waste prewalk targets.

The engine-actor version is *simpler* than the goal-run path: no run-liveness coupling, no todo/mutating gate, and **no restore** — a disposable, instance-bound actor runs turn 1 on the frontier model (to plan against the real instance state the orchestrator was blind to), then lives out its life on the cheap executor.

Closes #

### Mechanism (`loop/prewalk-controller.js`, `loop/prewalk.js`)

- `armEngineActor` stamps planner/executor state at `mintActor` (VM/Notebook/App only; the web actor is untouched). Quiet no-op when the setting is off or no distinct executor resolves.
- `reconcileEngineActor` runs at the actor's turn start and swaps `session.model` → executor once the actor is **past its first turn** (a prior assistant message exists), in one atomic write. why turn-boundary: an actor's model is fixed per turn, so the swap lands from the second `message_actor` delegation onward; a one-shot actor never swaps and stays on the frontier (nothing lost).
- The turn-driver now runs this on the actor path that previously skipped prewalk entirely (`kind !== 'actor'`); **the goal-run path is untouched**. The merged cross-model thinking-strip already covers the mid-life model change.
- Pure gate (`shouldEngineActorSwap`, `ENGINE_ACTOR_KINDS`) + the real-controller lifecycle are both Bun-tested (arm → first turn stays frontier → second turn swaps → lives on executor, never restores; plus the no-op/idempotence guards).

### Setting

`enginePrewalkEnabled` — default **OFF** both channels, sharing the existing `prewalkExecutorModel` pin. Normalizer + a Behavior-section toggle.

### Lab (prerequisite fix + new arm)

The Lab couldn't have measured this without a fix: engine/web actors driven by `message_actor` broadcast **`turn/actor-cost`**, which `eval-engine.js` never consumed (it only handled `turn/spawned-cost` from the `actor_create` path). So engine-actor spend was **invisible** in the Lab, and a down-shift wouldn't register. Ported the `turn/actor-cost` case from the standalone `runner.js` (fold into the runner bucket; prefer the SW-priced actor USD), and capture `turn/actor-state` models for swap attribution. Added an engine-prewalk A/B leg + an **engine-actor** suite with a data-dependent VM chain (each step needs the prior step's real shell output, so the orchestrator can't batch → multi-turn actor work to swap on).

## Checklist

- [x] `bun run preflight` components pass: `bun test` (2935 pass), `bun run typecheck` (clean), `eslint` (clean), in-browser via CDP (622 pass), **full functional e2e 113/113** (every actor state intact), dweb-boundary + packaged-import graph clean, no generated drift, tscheck floor 521/521
- [x] Only original code — no GPL / AGPL / copyleft
- [x] Tests added — pure engine-actor helpers + real-controller lifecycle (arm/first-turn/swap/no-restore/idempotence)
- [x] No hand-edited generated files — `channel-config.js` regenerated via `bun run gen:dev`
- [x] Danger zone — model selection (per-actor) + session store

## Notes for reviewers

Off by default; the behavioral contract for existing actors is unchanged (arming no-ops when the setting is off — confirmed by the e2e actor states passing). The one structural touch is the turn-driver's prewalk block, now two disjoint paths (goal-run reconcile for a chat session; engine-actor reconcile for a VM/Notebook/App actor) — a web/dweb/spawned actor carries no prewalk and is untouched.

The `turn/actor-cost` capture in `eval-engine.js` is a general Lab improvement beyond this feature: it also fixes under-counting of **web-actor** spend in the existing goal-run / web-actor A/Bs (message_actor-driven actor cost was previously dropped in the Lab engine, though the standalone `runner.js` already caught it).

Same-provider executor only, as with the goal-run path (the on-device local-model executor remains the future step, gated on these Lab numbers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GFzj7zsiZnvszmu2HzDg2

---
_Generated by [Claude Code](https://claude.ai/code/session_012GFzj7zsiZnvszmu2HzDg2)_