### PR TITLE
feat(sidepanel): watch mode — foreground + follow the agent's tab

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -2020,8 +2020,11 @@ const closeSidePanel = async () => {
 // calls noteAgentTab/scheduleWebTabHint/broadcastAgentTab/showWebTabHint from
 // its tool-context + port wiring, and setTabAnchor from the actor-turn start.
 const {
-  noteAgentTab, broadcastAgentTab, scheduleWebTabHint, showWebTabHint, setTabAnchor, isHomeOpen,
-} = makeTabAffordances({ browser, uiPorts, denylistStore, closeSidePanel });
+  noteAgentTab, broadcastAgentTab, scheduleWebTabHint, showWebTabHint, setTabAnchor, isHomeOpen, focusAgentTab,
+} = makeTabAffordances({
+  browser, uiPorts, denylistStore, closeSidePanel,
+  isWatchOn: () => settingsStore.get().watchAgentTab === true,
+});
 
 // Confirmation coordinator. The dispatcher's async confirmation step
 // calls ctx.confirm(prompt); this pushes a 'confirm/request' to the side
@@ -3060,6 +3063,9 @@ const leaveDwebAgentInbox = async () => {
 const onSettingsChanged = () => {
   if (dwebAgentOn()) joinDwebAgentInbox().catch(() => {});
   else leaveDwebAgentInbox().catch(() => {});
+  // Watch mode just flipped on → foreground the agent's current tab immediately,
+  // rather than waiting for its next tab touch. No-op when off / no agent tab.
+  if (settingsStore.get().watchAgentTab === true) focusAgentTab();
 };
 // The base host tore down (master OFF) → every room closed, incl. the inbox, so
 // clear the SW-side membership flag for a clean re-join on the next start.

--- a/extension/background/settings-patch.js
+++ b/extension/background/settings-patch.js
@@ -120,6 +120,12 @@ export const normalizeSettingsPatch = (patch, {
     // off switch is about the background model calls, not writes.
     next.autoMemoryEnabled = patch.autoMemoryEnabled;
   }
+  if (typeof patch.watchAgentTab === 'boolean') {
+    // Watch mode: foreground + follow the agent's tab (background/watch-mode.js).
+    // The SW's onSettingsChanged foregrounds the current agent tab the moment
+    // this flips on; each later agent tab touch follows while it stays on.
+    next.watchAgentTab = patch.watchAgentTab;
+  }
   if (typeof patch.confirmWebWrites === 'boolean') {
     // #53: anti-exfil gate. When OFF, non-GET web egress (fetch_url + the WebVM
     // bridge) is auto-approved (risk-acknowledged); ON (default) confirms.

--- a/extension/background/tab-affordances.js
+++ b/extension/background/tab-affordances.js
@@ -21,6 +21,7 @@ import { openHome } from '/shared/open-home.js';
 import { decidePullIn } from './panel-affordance.js';
 import { pullInHintInjected } from '/peerd-runtime/index.js';
 import { matchesDenylist } from '/peerd-egress/index.js';
+import { shouldFollowAgentTab } from './watch-mode.js';
 
 // The home agent-tab card's Open button draws a fresh brand color each time the
 // card is (re)generated — the sanctioned "peers/actions are the content" accent
@@ -33,8 +34,9 @@ const AGENT_TAB_COLORS = ['#00B7EB', '#EF4444', '#F59E0B', '#22C55E', '#D946EF']
  * @param {{ broadcast: (m: any) => void, hasNamed: (name: string) => boolean }} deps.uiPorts
  * @param {{ patterns: () => any }} deps.denylistStore
  * @param {() => Promise<any>} deps.closeSidePanel
+ * @param {() => boolean} [deps.isWatchOn]  live read of the watchAgentTab setting (default off)
  */
-export const makeTabAffordances = ({ browser, uiPorts, denylistStore, closeSidePanel }) => {
+export const makeTabAffordances = ({ browser, uiPorts, denylistStore, closeSidePanel, isWatchOn = () => false }) => {
   const HOME_URL = browser.runtime.getURL('home/home.html');
 
   // ── 1. the agent-tab card ──────────────────────────────────────────────────
@@ -90,6 +92,27 @@ export const makeTabAffordances = ({ browser, uiPorts, denylistStore, closeSideP
     // passive current-flag refresh on tab activation).
     agentTabInfo = { tabId, windowId, kind, name, label: text, color, opened, parentToolUseId };
     broadcastAgentTab(true);
+    // Watch mode: FOLLOW the agent onto this tab. No-op unless the user opted in
+    // (isWatchOn) and it isn't already the active tab — see focusAgentTab.
+    focusAgentTab();
+  };
+
+  // Bring the agent's tab to the foreground (+ its window), the OPT-IN inverse of
+  // DESIGN-12's no-focus-steal: only when the user turned watch mode on. Called on
+  // every agent tab touch (noteAgentTab) so watching FOLLOWS the agent across tabs,
+  // and by the SW the instant the setting flips on (onSettingsChanged). The agent
+  // addresses tabs by id, never by focus, so foregrounding a tab for the user never
+  // changes what the agent does — it just un-hides the work. Best-effort: a
+  // vanished tab/window is swallowed (the follow is cosmetic, never load-bearing).
+  const focusAgentTab = async () => {
+    if (!shouldFollowAgentTab({ watchOn: isWatchOn(), agentTabId, activeTabId })) return;
+    const winId = agentTabInfo?.windowId;
+    try {
+      await browser.tabs?.update?.(agentTabId, { active: true });
+      if (typeof winId === 'number') await browser.windows?.update?.(winId, { focused: true });
+    } catch (e) {
+      console.debug('[sw] watch-mode focus skipped', (/** @type {{ message?: string }} */ (e))?.message ?? e);
+    }
   };
   // Track the active tab so the card hides when you're on the agent tab, and shows
   // again when you move away.
@@ -253,5 +276,5 @@ export const makeTabAffordances = ({ browser, uiPorts, denylistStore, closeSideP
     pullInPeerd(/** @type {number} */ (tab?.windowId ?? lastFocusedWindowId), { fromShortcut: true });
   });
 
-  return { noteAgentTab, broadcastAgentTab, scheduleWebTabHint, showWebTabHint, setTabAnchor, isHomeOpen };
+  return { noteAgentTab, broadcastAgentTab, scheduleWebTabHint, showWebTabHint, setTabAnchor, isHomeOpen, focusAgentTab };
 };

--- a/extension/background/watch-mode.js
+++ b/extension/background/watch-mode.js
@@ -1,0 +1,30 @@
+// @ts-check
+// background/watch-mode.js — the pure decision behind "watch the agent's tab".
+//
+// Watch mode is the OPT-IN inverse of the no-focus-steal rule (DESIGN-12). By
+// default peerd drives its tab in the BACKGROUND so it never interrupts the
+// user. When the user turns watch mode ON, they are explicitly asking to see
+// the page: peerd brings the agent's current tab to the foreground and follows
+// it as the agent moves between tabs. The browser itself is the viewer — no
+// screenshotting, no capture, full fidelity, works on every channel (it is a
+// plain tabs.update, no CDP and no new permission).
+//
+// This is the SW-side wiring's ONLY non-IO bit, lifted out so it is unit-tested:
+// given the live state, should we foreground the agent's tab right now?
+
+/**
+ * Should watch mode foreground the agent's tab at this moment?
+ *
+ * True only when: watch mode is on, we actually know the agent's tab, and it is
+ * not ALREADY the active tab (foregrounding the active tab is a no-op that would
+ * still needlessly steal window focus). The caller does the tabs.update; this is
+ * the guard, kept pure so "when do we yank focus" is a testable value, not an
+ * effect buried in a listener.
+ *
+ * @param {{ watchOn: boolean, agentTabId: number | null | undefined, activeTabId: number | null | undefined }} p
+ * @returns {boolean}
+ */
+export const shouldFollowAgentTab = ({ watchOn, agentTabId, activeTabId }) =>
+  watchOn === true
+  && typeof agentTabId === 'number'
+  && agentTabId !== activeTabId;

--- a/extension/shared/channel-config.js
+++ b/extension/shared/channel-config.js
@@ -31,6 +31,7 @@ export const CHANNEL_DEFAULTS = Object.freeze({
   ollamaHost: "http://localhost:11434",
   openrouterModels: [],
   advancedAutomationEnabled: true,
+  watchAgentTab: false,
   runnerModel: "",
   prewalkEnabled: false,
   enginePrewalkEnabled: false,

--- a/extension/sidepanel/components/app.js
+++ b/extension/sidepanel/components/app.js
@@ -145,6 +145,17 @@ const TopBar = {
       // right-align (owner call, 2026-06-12).
       m('.spacer'),
       unlocked ? m('.topbar-actions', [
+        // Watch mode: bring the agent's tab to the foreground and follow it, so
+        // you see the real page it's driving. Opt-in inverse of no-focus-steal;
+        // active state + tooltip carry the meaning (the top bar is icon-only).
+        m('button.icon', {
+          class: state.settings?.watchAgentTab ? 'is-active' : '',
+          title: state.settings?.watchAgentTab
+            ? 'Watching the agent’s tab — click to stop following'
+            : 'Watch the agent’s tab (bring it to the front and follow along)',
+          'aria-pressed': state.settings?.watchAgentTab ? 'true' : 'false',
+          onclick: () => send({ type: 'settings/update', patch: { watchAgentTab: !state.settings?.watchAgentTab } }),
+        }, '◉'),
         m('button.icon', {
           title: 'Chats',
           onclick: () => m.route.set(

--- a/extension/sidepanel/styles.css
+++ b/extension/sidepanel/styles.css
@@ -814,6 +814,13 @@ button.icon {
   cursor: pointer;
 }
 button.icon:hover { background: var(--bg); }
+/* Active toggle (watch mode on): filled monochrome — invert fg/bg, no new accent
+   color (brand rule: grayscale surfaces, the five brand marks are the only color). */
+button.icon.is-active {
+  background: var(--fg);
+  color: var(--bg);
+  border-color: var(--fg);
+}
 
 /* --- chat view layout --- */
 .app-shell { display: flex; flex-direction: column; min-height: 100%; }

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -87,7 +87,7 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // 505/506 → 510: the #119 (page bridge + OM2W eval) and #187 (fetch content
 // pipeline) file sets merge — both ledgers above are kept; the union floor.
 // 510 → 511: the Z.ai GLM provider adapter (peerd-provider/adapters/glm.js).
-const COVERED_FLOOR = 521;
+const COVERED_FLOOR = 522;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/packaging/default-settings.mjs
+++ b/packaging/default-settings.mjs
@@ -124,6 +124,15 @@ export const defaults = {
   // no chrome.debugger API, so the setting is moot there on either channel.
   advancedAutomationEnabled: { store: false, preview: true },
 
+  // Watch mode (background/watch-mode.js): the OPT-IN inverse of DESIGN-12's
+  // no-focus-steal. OFF by default — peerd drives its tab in the background so
+  // it never interrupts you. Toggle it on from the side-panel top bar and peerd
+  // brings the agent's current tab to the foreground and FOLLOWS it as the agent
+  // moves between tabs, so you watch the real page live (the browser is the
+  // viewer — no screenshot/capture, no new permission, both channels). Off both
+  // channels: watching is a per-moment choice, not a default posture.
+  watchAgentTab: { store: false, preview: false },
+
   // Web actor model override. '' is NO override — the web actor resolves to
   // the active provider's fast default (Haiku on Anthropic via
   // adapter.defaultRunnerModel; resolveRunnerModel), NOT the chat model. So out

--- a/tests/background/watch-mode.test.ts
+++ b/tests/background/watch-mode.test.ts
@@ -1,0 +1,33 @@
+// Watch mode's only non-IO decision: given the live state, do we foreground the
+// agent's tab right now? The guard matters because the effect steals window
+// focus — so it must fire ONLY when the user opted in AND the tab isn't already
+// front. Kept pure so "when do we yank focus" is a tested value, not an effect.
+
+import { describe, test, expect } from 'bun:test';
+import { shouldFollowAgentTab } from '../../extension/background/watch-mode.js';
+
+describe('shouldFollowAgentTab', () => {
+  test('follows only when watch is ON', () => {
+    expect(shouldFollowAgentTab({ watchOn: true, agentTabId: 7, activeTabId: 3 })).toBe(true);
+    expect(shouldFollowAgentTab({ watchOn: false, agentTabId: 7, activeTabId: 3 })).toBe(false);
+  });
+
+  test('never follows a tab that is already active (no needless focus steal / no-op update)', () => {
+    expect(shouldFollowAgentTab({ watchOn: true, agentTabId: 7, activeTabId: 7 })).toBe(false);
+  });
+
+  test('never follows when there is no known agent tab', () => {
+    expect(shouldFollowAgentTab({ watchOn: true, agentTabId: null, activeTabId: 3 })).toBe(false);
+    expect(shouldFollowAgentTab({ watchOn: true, agentTabId: undefined, activeTabId: 3 })).toBe(false);
+  });
+
+  test('follows even before any tab is active (activeTabId null → differs from the agent tab)', () => {
+    expect(shouldFollowAgentTab({ watchOn: true, agentTabId: 7, activeTabId: null })).toBe(true);
+  });
+
+  test('watchOn is strict — only literal true arms it', () => {
+    // The setting is a strict boolean; a truthy non-true must not arm focus-steal.
+    expect(shouldFollowAgentTab({ watchOn: 1 as unknown as boolean, agentTabId: 7, activeTabId: 3 })).toBe(false);
+    expect(shouldFollowAgentTab({ watchOn: 'yes' as unknown as boolean, agentTabId: 7, activeTabId: 3 })).toBe(false);
+  });
+});


### PR DESCRIPTION
## What & why

The web actor drives its tab in the **background** (peerd never steals focus, DESIGN-12), so while you're in the side panel you can't see the page it's working on. **Watch mode** is the opt-in inverse: a top-bar toggle (`◉`) that brings the agent's current tab to the foreground and **follows** it as the agent moves between tabs — you watch the real page live, chat docked beside it.

## Why foreground-follow, not PiP/screenshot mirror

We explored a Picture-in-Picture / screenshot-stream mirror first. It loses on every axis:
- Capturing a **backgrounded** tab needs CDP (`Page.captureScreenshot`) — which is **preview-only** (`debugger` is stripped from the store build); `captureVisibleTab` only grabs the *foreground* tab.
- Even where it works, it's a laggy, low-fidelity copy.

Foreground-follow uses the **browser itself as the viewer**: full fidelity, real-time, no capture, **no new permission**, works on **both channels**. It's the honest inverse of no-focus-steal (the user explicitly asked to watch), and it's **behaviour-neutral for the agent** — the agent addresses tabs by id, never by focus, so foregrounding a tab for the user changes nothing about what it does (it also un-throttles the tab).

## Shape
- **`watch-mode.js`** — the pure follow decision `shouldFollowAgentTab({watchOn, agentTabId, activeTabId})`: foreground only when watch is on *and* the agent tab isn't already active (no needless focus-steal / no-op update). Pure, so "when do we yank focus" is a tested value.
- **`tab-affordances.js`** — `focusAgentTab()` foregrounds the agent tab (+ its window); called on every agent tab touch (the *follow*) and by the SW the instant the toggle flips on (`onSettingsChanged`). Best-effort — a vanished tab/window is swallowed.
- **`watchAgentTab` setting** (default **off**, both channels) + the top-bar toggle with an `is-active` filled-monochrome state (no new accent color — brand rule).

## Tests / verify
- **bun** (`watch-mode.test.ts`): 5 cases — on/off, already-active no-op, no agent tab, follows before any active tab, strict-boolean guard.
- **Verify loop**: `e2e:verify --functional` **113/113** across 19 states; toggle render eyeballed in the top bar (`◉ ☰ + ⌂ ⚙ ✕`).
- Gates: typecheck, lint, boundary, imports, tscheck (522/522, floor bumped), **2940 bun** — all green.

Note: the full foreground-follow *behaviour* isn't e2e-covered because the verify harness fakes the model wire and doesn't drive a real agent tab; the pure decision is unit-tested and the IO is a best-effort `tabs.update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)