### PR TITLE
test(voice): pin the engine-picker truth table

### DIFF
--- a/tests/peerd-runtime/voice-engine-picker.test.ts
+++ b/tests/peerd-runtime/voice-engine-picker.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from 'bun:test';
+import { resolveEngine } from '../../extension/peerd-runtime/voice/engine-picker.js';
+
+// resolveEngine is the pure chokepoint for the web-speech-default reframe, so
+// this pins its whole truth table across preference, browser engine presence,
+// and Moonshine readiness.
+
+type Pref = 'auto' | 'web-speech' | 'moonshine';
+type Engine = 'web-speech' | 'moonshine' | null;
+
+const cases: Array<[Pref, boolean, boolean, Engine]> = [
+  // Forced Moonshine wins whenever the model is ready, with or without Web Speech.
+  ['moonshine', true, true, 'moonshine'],
+  ['moonshine', false, true, 'moonshine'],
+  // Forced Moonshine degrades to Web Speech when the model is not ready.
+  ['moonshine', true, false, 'web-speech'],
+  ['moonshine', false, false, null],
+  // Forced Web Speech wins whenever the browser engine is present.
+  ['web-speech', true, true, 'web-speech'],
+  ['web-speech', true, false, 'web-speech'],
+  // Forced Web Speech falls back to Moonshine when the browser engine is absent.
+  ['web-speech', false, true, 'moonshine'],
+  ['web-speech', false, false, null],
+  // Auto prefers Web Speech, then Moonshine, then nothing.
+  ['auto', true, true, 'web-speech'],
+  ['auto', true, false, 'web-speech'],
+  ['auto', false, true, 'moonshine'],
+  ['auto', false, false, null],
+];
+
+describe('resolveEngine', () => {
+  for (const [pref, webSpeech, moonshine, expected] of cases) {
+    test(`${pref} with webSpeech=${webSpeech} moonshine=${moonshine} resolves to ${expected}`, () => {
+      expect(resolveEngine(pref, webSpeech, moonshine)).toBe(expected);
+    });
+  }
+});


### PR DESCRIPTION
The engine picker file notes that `resolveEngine` is exported pure so its truth table can be unit tested without stubbing globals, but it had no tests. This adds them.

`resolveEngine(pref, webSpeech, moonshine)` is covered across all twelve combinations of the preference (`auto`, `web-speech`, `moonshine`), whether the browser Web Speech API is present, and whether Moonshine is ready:

* a forced Moonshine preference wins when the model is ready, and degrades to Web Speech when it is not;
* a forced Web Speech preference wins when the browser engine is present, and falls back to Moonshine when it is absent;
* `auto` prefers Web Speech, then Moonshine, then resolves to null.

Pure function, so it runs in the Bun suite. `bun test ./tests`, `bun run typecheck` and `bun run preflight` all pass locally.