### PR TITLE
apps: raise size cap 2M → 50M so WASM-heavy dwapps can be imported

### DIFF
--- a/extension/background/app-client.js
+++ b/extension/background/app-client.js
@@ -19,7 +19,11 @@ export const APP_TAB_GROUP_TITLE = 'peerd';
 // Write-layer cap on total app file size. Mirrors the sandbox_create app arm’s
 // MAX_TOTAL_CHARS (the tool pre-checks for a nicer error); this is the
 // backstop every create() caller hits, including the dweb install routes.
-const MAX_APP_TOTAL_CHARS = 2_000_000;
+// why 50M: real dwapps ship WASM + a 3D engine (a game is millions of chars);
+// the dweb loader already accepts 50M/256 files, but this backstop was the
+// true ceiling on every path and capped them at 2M. Raised to match the loader
+// so a WASM-heavy app (Three.js + Rapier + assets) can actually be imported.
+const MAX_APP_TOTAL_CHARS = 50_000_000;
 
 /** @param {string} appId */
 const opfsForApp = (appId) => opfsHelpers(['peerd-apps', appId]);

--- a/extension/peerd-runtime/tools/defs/app-create.js
+++ b/extension/peerd-runtime/tools/defs/app-create.js
@@ -9,7 +9,10 @@
 
 import { APP_RUNTIME_NOTE } from './code-style-note.js';
 
-const MAX_TOTAL_CHARS = 2_000_000;
+// Mirrors the write-layer backstop in background/app-client.js — kept aligned
+// with the dweb loader's 50M ceiling so a WASM-heavy dwapp (a game engine, a
+// physics runtime) can be authored/imported, not just a small hand-written app.
+const MAX_TOTAL_CHARS = 50_000_000;
 
 /**
  * Create + open an App from files/html; returns { id, name, kind, entryFile,


### PR DESCRIPTION
First step of importing a real game (Three.js + Rapier) as a dwapp: the App size cap.

The write-layer backstop in `background/app-client.js` (`MAX_APP_TOTAL_CHARS`) was the true ceiling on **every** App path — `sandbox_create`, `.peerd` import, and `dweb_install` — and capped them at **2M chars**, even though the dweb loader (`peerd-distributed/apps/loader.js`) already accepts 50M/256 files. A real dwapp ships a WASM runtime + a 3D engine (millions of chars, with binary assets riding as base64 today), so 2M made big dwapps un-importable via any path.

Raises the backstop and the mirrored `sandbox_create` pre-check to **50M**, matching the loader's existing ceiling.

**Verified:** full bun suite (3017 pass / 0 fail), dweb-boundary check, eslint clean on the changed files.

Follow-ups (specced, not in this PR): a binary-file path to drop the base64 tax; evolving the `app` actor to see + drive its own tab (`view` + `page_keys`) for a full iterate-with-feedback loop; and app-actor P2P access + an orchestrator "spin up a second copy" so two instances can test multiplayer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XDAG5jAMBJiuA6GvMahr5

---
_Generated by [Claude Code](https://claude.ai/code/session_017XDAG5jAMBJiuA6GvMahr5)_