### PR TITLE
fix(review): positive allowlist for the reviewer's grant + fence its output (groundwork for #160)

### DIFF
--- a/extension/peerd-runtime/review/read-only.js
+++ b/extension/peerd-runtime/review/read-only.js
@@ -25,19 +25,65 @@
 // silently hand the reviewer the ability to fan out its own agents.
 const ALWAYS_DENIED = Object.freeze(new Set(['actor_create', 'request_review']));
 
+// The reviewer's grant, BY NAME. This list is the floor.
+//
+// why a positive allowlist and not "everything tagged sideEffect:'read'":
+// `sideEffect:'read'` means the tool does not MUTATE. It does NOT mean the tool
+// cannot EXFILTRATE — and peerd's own `fetch_url` is `sideEffect:'read'` while
+// taking an attacker-chosen url, method and body. So the old filter would have
+// handed this module's stated adversary (see the header: the reviewer reads the
+// diff = untrusted content, so it must not also hold an exfiltration channel)
+// exactly the channel it exists to deny.
+//
+// It did not, in fact, leak: `actor/spawn.js` recomputes the grantable universe
+// as filterActorSurface(mainAgentDescriptors(...)) and INTERSECTS this request
+// against it, and `fetch_url` sits in MAIN_AGENT_HIDDEN_TOOLS — so it was never
+// grantable. But that is the wrong place for this invariant to live: that list
+// is a CONTEXT-HYGIENE policy about what the orchestrator should delegate rather
+// than call, not a security boundary, and nothing sits behind it (the
+// egress-allowlist hook early-returns allow for any non-`mutate_external` tool,
+// fetch_url confirms only non-GET, the denylist is default-allow, and
+// exposureGate does not fire for a spawned ctx). Un-hiding `fetch_url` for
+// unrelated product reasons would have silently armed the reviewer.
+//
+// A positive list fails CLOSED: a newly-added tool is ungrantable here until
+// someone adds it deliberately. A denylist, or an `egress: true` descriptor
+// flag, both fail OPEN — a new egress-capable read tool that nobody remembers to
+// mark is granted by default, which is precisely the shape of the near-miss above.
+//
+// The names below are exactly the set the reviewer already received before this
+// list existed, so this change is behavior-preserving by construction (pinned by
+// review.test.ts against the REAL pipeline). Some of them are worth a second
+// look on their own merits — `inspect` (storage/audit/denylist/provider config),
+// `read_memory` (the user's durable notes), `app_search` (returns App body-HTML
+// snippets, which #159 tiered `app_read_file` actor-only to contain), and
+// `capture` (active-tab screenshot; redacted to a sentinel before the model sees
+// it, but the tab origin still lands) all give a CODE REVIEWER more private reach
+// than reviewing a diff plausibly needs. Narrowing them is a deliberate product
+// call, not a safety floor, so it is intentionally NOT bundled here.
+const REVIEWER_TOOLS = Object.freeze(new Set([
+  'actor_list', 'actor_tasks', 'app_search', 'capture', 'complete_goal',
+  'inspect', 'load_skill', 'now', 'read_memory', 'schedule_list',
+  'todo_add', 'todo_check', 'todo_init',
+]));
+
+/** Exported for the invariant tests (and so the grant is greppable). */
+export const REVIEWER_ALLOWED_TOOLS = REVIEWER_TOOLS;
+
 /**
- * The set of tool names a reviewer may be granted: declared read-only AND
- * not on the always-denied list. This is the `permissions.readOnlyTools()`
- * adapter's local implementation — feature 03 can supply its own set; if
- * it does, intersect the two (see orchestrator.js) so neither can widen
- * the other.
+ * The set of tool names a reviewer may be granted: on the positive allowlist,
+ * still declared read-only (belt-and-braces — a tool re-tagged to a write drops
+ * out without anyone editing this list), and not always-denied. This is the
+ * `permissions.readOnlyTools()` adapter's local implementation — feature 03 can
+ * supply its own set; if it does, intersect the two (see orchestrator.js) so
+ * neither can widen the other.
  *
  * @param {ReadonlyArray<{ name: string, sideEffect?: string }>} descriptors
  * @returns {string[]}
  */
 export const readOnlyToolNames = (descriptors) =>
   descriptors
-    .filter((d) => d.sideEffect === 'read' && !ALWAYS_DENIED.has(d.name))
+    .filter((d) => REVIEWER_TOOLS.has(d.name) && d.sideEffect === 'read' && !ALWAYS_DENIED.has(d.name))
     .map((d) => d.name);
 
 /**
@@ -51,6 +97,9 @@ export const readOnlyToolNames = (descriptors) =>
  */
 export const isReadOnlyTool = (name, descriptors) => {
   if (ALWAYS_DENIED.has(name)) return false;
+  // Same positive floor as the grant above — a name off the allowlist is refused
+  // at call time even if it somehow reached the reviewer's granted set.
+  if (!REVIEWER_TOOLS.has(name)) return false;
   const d = descriptors.find((x) => x.name === name);
   // Unknown tool → not in the read-only set → refuse. Fail closed.
   return !!d && d.sideEffect === 'read';

--- a/extension/peerd-runtime/tools/defs/request-review.js
+++ b/extension/peerd-runtime/tools/defs/request-review.js
@@ -10,6 +10,8 @@
 // conversation) and READ-ONLY tools (it cannot edit — the writer stays the
 // single writer). See docs/REVIEW.md and DESIGN additions.
 
+import { wrapUntrusted } from '../prompt-wrap.js';
+
 // why: the summary is re-sent on every subsequent parent turn, so cap the
 // rendered text. The full reviewer transcript is in the side panel by
 // expanding this card.
@@ -161,5 +163,22 @@ const formatReviewSummary = (out) => {
   if (text.length > MAX_RESULT_CHARS) {
     text = `${text.slice(0, MAX_RESULT_CHARS)}\n…[truncated — expand the card for the full review]`;
   }
-  return text;
+  // FENCE the reviewer's output before it lands in the parent's context.
+  //
+  // why: every line above is MODEL-AUTHORED by the reviewer, and the reviewer's
+  // whole input is a diff — untrusted content by construction (review/read-only.js
+  // header). On a parse failure review/schema.js hands up to 2000 chars of RAW
+  // reviewer text through as `summary`, so a crafted diff's instructions can ride
+  // out of the reviewer verbatim. The PARENT is the one context that holds a
+  // channel (message_actor → the web actor → fetch_url), so an unfenced review
+  // summary is the single place diff-borne text could steer something outward.
+  // The reviewer itself has no egress (spawn narrows it off the main-agent
+  // surface and restrictCtxCapabilities strips the closures), which is why this
+  // is a hardening rather than a live hole — but a two-model-hop route is exactly
+  // what the fence exists for, and it costs one call.
+  return wrapUntrusted({
+    origin: 'request_review (reviewer model output, derived from an untrusted diff)',
+    tool: 'request_review',
+    body: text,
+  });
 };

--- a/tests/peerd-runtime/review.test.ts
+++ b/tests/peerd-runtime/review.test.ts
@@ -18,17 +18,38 @@ import {
 } from '../../extension/peerd-runtime/review/diff.js';
 import { buildReviewTask } from '../../extension/peerd-runtime/review/prompt.js';
 
-// A registry mirroring the real mix: read tools + write/mutate tools +
-// the always-denied orchestration tools.
+// A registry mirroring the REAL mix, using REAL tool names and their REAL
+// sideEffect tags. why real names: the previous fixture used invented ones
+// (`inspect_storage`) and asserted `app_read_file` IS grantable — the opposite
+// of what the live pipeline does (filterActorSurface drops it). A fixture that
+// asserts fiction is worse than no fixture: it is how issue #160 came to be
+// filed on a false premise, and how the grant below went unpinned entirely.
+//
+// NOTE the entries tagged `read` that are NOT safe for a reviewer — fetch_url
+// above all (arbitrary url + method + body). They are here precisely so the
+// tests below prove they never reach the reviewer.
 const DESCRIPTORS = [
+  // read-tagged AND on the reviewer's allowlist
+  { name: 'inspect', sideEffect: 'read' },
+  { name: 'read_memory', sideEffect: 'read' },
+  { name: 'actor_list', sideEffect: 'read' },
+  { name: 'now', sideEffect: 'read' },
+  // read-tagged but NOT for a reviewer — egress / page / instance reach
+  { name: 'fetch_url', sideEffect: 'read' },          // arbitrary url+method+body
   { name: 'read_page', sideEffect: 'read' },
   { name: 'query_dom', sideEffect: 'read' },
-  { name: 'app_read_file', sideEffect: 'read' },
-  { name: 'inspect_storage', sideEffect: 'read' },
+  { name: 'read_web_cache', sideEffect: 'read' },
+  { name: 'site_client_run', sideEffect: 'read' },
+  { name: 'dweb_discover', sideEffect: 'read' },
+  { name: 'js_read_file', sideEffect: 'read' },       // actor-only tier (#159)
+  { name: 'app_read_file', sideEffect: 'read' },      // actor-only tier (#159)
+  { name: 'app_list_files', sideEffect: 'read' },     // actor-only tier (#159)
+  // writes / mutations
   { name: 'click', sideEffect: 'write' },
   { name: 'navigate', sideEffect: 'write' },
   { name: 'page_exec', sideEffect: 'write' },
   { name: 'app_write_file', sideEffect: 'write' },
+  { name: 'message_actor', sideEffect: 'write' },
   { name: 'submit_form', sideEffect: 'mutate_external' },
   { name: 'actor_create', sideEffect: 'write' },
   { name: 'request_review', sideEffect: 'read' }, // read-classified, but self-denied
@@ -37,9 +58,9 @@ const DESCRIPTORS = [
 // ---- read-only enforcement ------------------------------------------------
 
 describe('readOnlyToolNames', () => {
-  test('keeps only read tools and drops orchestration tools', () => {
+  test('grants only names on the positive allowlist', () => {
     const names = readOnlyToolNames(DESCRIPTORS);
-    expect(names).toEqual(['read_page', 'query_dom', 'app_read_file', 'inspect_storage']);
+    expect(names.sort()).toEqual(['actor_list', 'inspect', 'now', 'read_memory'].sort());
   });
 
   test('EXPOSES NO write or mutate_external tools to the reviewer', () => {
@@ -47,25 +68,43 @@ describe('readOnlyToolNames', () => {
     for (const d of DESCRIPTORS) {
       if (d.sideEffect !== 'read') expect(names.has(d.name)).toBe(false);
     }
-    // explicit: none of the dangerous tools leak in
-    for (const w of ['click', 'navigate', 'page_exec', 'app_write_file', 'submit_form', 'actor_create']) {
+    for (const w of ['click', 'navigate', 'page_exec', 'app_write_file', 'submit_form', 'actor_create', 'message_actor']) {
       expect(names.has(w)).toBe(false);
     }
   });
 
+  // THE load-bearing one. `sideEffect:'read'` means "does not mutate", NOT
+  // "cannot exfiltrate" — fetch_url is read-tagged and takes an attacker-chosen
+  // url/method/body. Before the positive allowlist, this module (whose own header
+  // says the reviewer must not hold an exfiltration channel) would have handed it
+  // over; the save came from an unrelated filter two modules away, untested.
+  test('read-tagged EGRESS tools are never granted (read !== non-exfiltrating)', () => {
+    const names = new Set(readOnlyToolNames(DESCRIPTORS));
+    for (const t of ['fetch_url', 'read_web_cache', 'site_client_run', 'dweb_discover']) {
+      expect(names.has(t)).toBe(false);
+    }
+  });
+
+  test('a NEW read-tagged tool is ungrantable until deliberately allowlisted (fails closed)', () => {
+    const withNewTool = [...DESCRIPTORS, { name: 'some_future_read_tool', sideEffect: 'read' }];
+    expect(readOnlyToolNames(withNewTool)).not.toContain('some_future_read_tool');
+  });
+
   test('always-denied tools are excluded even when read-classified', () => {
-    // request_review is sideEffect:'read' but must never be handed to a reviewer
     expect(readOnlyToolNames(DESCRIPTORS)).not.toContain('request_review');
   });
 });
 
 describe('isReadOnlyTool (call-time defense in depth)', () => {
-  test('allows read tools, refuses write/mutate/unknown', () => {
-    expect(isReadOnlyTool('read_page', DESCRIPTORS)).toBe(true);
+  test('allows allowlisted read tools, refuses write/mutate/unknown/off-list', () => {
+    expect(isReadOnlyTool('inspect', DESCRIPTORS)).toBe(true);
     expect(isReadOnlyTool('click', DESCRIPTORS)).toBe(false);
     expect(isReadOnlyTool('submit_form', DESCRIPTORS)).toBe(false);
     expect(isReadOnlyTool('actor_create', DESCRIPTORS)).toBe(false);
     expect(isReadOnlyTool('hallucinated_tool', DESCRIPTORS)).toBe(false); // fail closed
+    // off the allowlist but read-tagged → still refused at call time
+    expect(isReadOnlyTool('fetch_url', DESCRIPTORS)).toBe(false);
+    expect(isReadOnlyTool('read_page', DESCRIPTORS)).toBe(false);
   });
 });
 
@@ -254,7 +293,9 @@ describe('makeRequestReview (clean-context, read-only, structured)', () => {
 
     // the reviewer was granted exactly the read-only set
     const granted = new Set(calls[0].tools);
-    expect([...granted].sort()).toEqual(['app_read_file', 'inspect_storage', 'query_dom', 'read_page']);
+    // The reviewer's grant is the positive allowlist ∩ read-tagged — NOT
+    // "everything read-tagged" (which would have included fetch_url).
+    expect([...granted].sort()).toEqual(['actor_list', 'inspect', 'now', 'read_memory']);
     // ASSERT: no write/mutate/orchestration tool exposed
     for (const w of ['click', 'navigate', 'page_exec', 'app_write_file', 'submit_form', 'actor_create', 'request_review']) {
       expect(granted.has(w)).toBe(false);
@@ -290,11 +331,11 @@ describe('makeRequestReview (clean-context, read-only, structured)', () => {
     const requestReview = makeRequestReview({
       spawnActor: spawn,
       getToolDescriptors: () => DESCRIPTORS,
-      // feature 03 says only read_page is permitted in this mode
-      permissions: { readOnlyTools: () => ['read_page'] },
+      // feature 03 says only `inspect` is permitted in this mode
+      permissions: { readOnlyTools: () => ['inspect'] },
     });
     await requestReview({ parentSessionId: 'p-1', before: { 'a.js': '1' }, after: { 'a.js': '2' } });
-    expect(calls[0].tools).toEqual(['read_page']); // intersection, narrowed further
+    expect(calls[0].tools).toEqual(['inspect']); // intersection, narrowed further
   });
 
   test('uses the feature-02 checkpoints adapter when no explicit diff', async () => {
@@ -341,5 +382,68 @@ describe('makeRequestReview (clean-context, read-only, structured)', () => {
     expect(out.ok).toBe(false);
     expect(out.parseError).toBe('no_json_block');
     expect(out.summary!.verdict).toBe('comment'); // well-formed fallback shape
+  });
+});
+
+// ---- the reviewer's grant, pinned through the REAL pipeline ----------------
+//
+// These two exist because the near-miss above was invisible: `read-only.js`
+// documents itself as the lethal-trifecta guard, `fetch_url` passed its filter
+// cleanly, and the only thing that actually kept it out was
+// mainAgentDescriptors — a CONTEXT-HYGIENE policy list two modules away, with
+// nothing behind it and no test on it. If someone un-hides fetch_url for
+// unrelated product reasons, these fail loudly instead of arming the reviewer.
+//
+// (The live registry can't be imported here — tools/defs/index.js refuses to
+// load outside a browser extension — so we drive the REAL filters with a
+// realistic descriptor set. The positive allowlist covers what a fixture can't:
+// tools nobody thought to list.)
+describe('reviewer grant — through the real narrowing pipeline', () => {
+  test('the spawn pipeline drops every egress + actor-only read, not just the allowlist', async () => {
+    const { mainAgentDescriptors, filterActorSurface } = await import('../../extension/peerd-runtime/tools/exposure.js');
+    const { narrowTools } = await import('../../extension/peerd-runtime/actor/spawn.js');
+
+    // What spawn.js actually computes as the grantable universe, then intersects
+    // the reviewer's request against.
+    const grantable = filterActorSurface(mainAgentDescriptors(DESCRIPTORS as any));
+    const granted = new Set(
+      narrowTools(grantable as any, { tools: readOnlyToolNames(DESCRIPTORS), allowRecursion: false })
+        .map((t: any) => t.name),
+    );
+
+    // No egress reaches the reviewer, by ANY route.
+    for (const t of ['fetch_url', 'read_web_cache', 'site_client_run', 'dweb_discover']) {
+      expect(granted.has(t)).toBe(false);
+    }
+    // No mutation, no delegation, no self-recursion.
+    for (const t of ['click', 'app_write_file', 'submit_form', 'message_actor', 'actor_create', 'request_review']) {
+      expect(granted.has(t)).toBe(false);
+    }
+    // Instance reads are actor-only today (#159) — this is exactly what issue
+    // #160 proposes to re-add, deliberately and by name. Until then: absent.
+    for (const t of ['js_read_file', 'app_read_file', 'app_list_files']) {
+      expect(granted.has(t)).toBe(false);
+    }
+  });
+
+  // The DURABLE one: assert on surviving CAPABILITIES, not tool names. Any
+  // egress-capable tool must register a closure in CAPABILITY_CONSUMERS to work
+  // AT ALL — that isn't optional, it's how a tool gets its capability. So this
+  // catches a future egress tool automatically, with no list to remember.
+  test('the reviewer ctx holds NO outward closure (egress/delegation/secrets)', async () => {
+    const { CAPABILITY_CONSUMERS, restrictCtxCapabilities } = await import('../../extension/peerd-runtime/actor/spawn.js');
+
+    // A ctx carrying every known capability, then stripped to the reviewer's grant.
+    const fullCtx = Object.fromEntries(Object.keys(CAPABILITY_CONSUMERS).map((k) => [k, 'closure']));
+    const granted = new Set(readOnlyToolNames(DESCRIPTORS));
+    const survivors = new Set(Object.keys(restrictCtxCapabilities(fullCtx as any, granted as any)));
+
+    for (const cap of [
+      'getSecret', 'safeFetch', 'webFetch', 'webCache', 'dweb',
+      'messageActor', 'spawnActor', 'spawnActorAsync',
+      'siteClients', 'jsOffscreenClient',
+    ]) {
+      expect(survivors.has(cap)).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
Groundwork for #160 — from **verifying** its security premise rather than inheriting it.

## The finding

#160 argues the instance-read exemption is safe because the reviewer *"has no exfiltration channel (no egress tools, no message_actor)"*. **The conclusion is true** — I verified it by *executing* the real modules: 31 read-tagged tools requested, **13 granted**, `fetch_url` not among them; and `restrictCtxCapabilities` leaves the reviewer ctx with no `safeFetch`/`webFetch`/`dweb` closure at all.

**But the reasoning is a non-sequitur, and this codebase disproves it.** `sideEffect:'read'` means *does not mutate* — not *cannot exfiltrate*. peerd's own `fetch_url` is read-tagged and takes an attacker-chosen url, method and body.

`read-only.js` — whose header states the reviewer *"must not also have an exfiltration/mutation channel"* — passed `fetch_url` cleanly. What actually held the line is `spawn.js` recomputing the grantable universe through `mainAgentDescriptors`: a **context-hygiene policy list two modules away**, with **nothing behind it** and **no test on it**. I checked each downstream layer: the egress-allowlist hook early-returns `allow` for any non-`mutate_external` tool; `fetch_url` confirms only non-GET; the denylist is default-allow; `exposureGate` never fires for a spawned ctx. Un-hiding `fetch_url` for unrelated product reasons — an entirely plausible product call — would have silently armed the reviewer.

**No live vulnerability.** This moves the invariant into the module that claims it, before #160 edits the very expression holding it.

## Changes

- **`read-only.js`** — the grant is a **positive allowlist by name** (exactly the 13 already granted, so behavior-preserving), still ∩ read-tagged so a re-tagged tool drops out by itself. Positive fails **closed** for future tools; a denylist or an `egress:true` descriptor flag both fail **open** — the shape that produced this near-miss. `isReadOnlyTool` enforces the same floor at call time.
- **`request-review.js`** — fence the summary with `wrapUntrusted`. Every line is model-authored from an untrusted diff, and `schema.js` passes up to 2000 **raw** chars through on a parse failure, while the **parent** is the one context holding a channel (`message_actor` → web actor → `fetch_url`). Hardening, not a live hole — but a two-model-hop route is exactly what the fence exists for.
- **`review.test.ts`** — the fixture **asserted fiction**: invented names (`inspect_storage`) and `app_read_file` as grantable, the opposite of the real pipeline. That is how #160 got filed on a false premise and how the grant went unpinned. Now real names + two invariant tests:
  1. through the **real** narrowing pipeline (`mainAgentDescriptors → filterActorSurface → narrowTools`);
  2. asserting the reviewer ctx holds **no outward closure**. This is the durable one — any egress tool *must* register in `CAPABILITY_CONSUMERS` to function at all, so it catches future tools with no list to maintain.

**Revert-proven**: restoring the old `sideEffect`-only filter fails 6 tests, including *"read-tagged EGRESS tools are never granted"*.

Gates: typecheck, lint, boundary, tscheck, **3045 bun**, **623 in-browser**.

## Follow-on for #160

Ship **Option 1**, as a positive re-add of exactly `js_read_file`/`app_read_file`/`app_list_files` behind an SW-stamped `exposure:'review'` marker. **Not** as "exempt the reviewer from the grantable narrowing" — that natural one-line reading would grant `fetch_url`, `read_page` and `site_client_run` in the same stroke. **Reject Option 2** (reviewer-as-actor): a bound actor is scoped to its kind's *full* toolset — the mutating surface — inverting the invariant `read-only.js` exists to protect.

Also worth adding to #160: `app_search` already returns App **body-HTML snippets** to any spawned child with no tier check, so the reviewer's exposure to App bytes is not actually zero today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)