### PR TITLE
feat(review): grant the reviewer the three instance READS (closes #160)

### DIFF
--- a/extension/background/offscreen-actor-client.js
+++ b/extension/background/offscreen-actor-client.js
@@ -33,6 +33,11 @@
  *   mid-turn navigate that adopts a tab (0→1) is seen by the NEXT tool call. undefined
  *   for engine/API actors (no tab) and the 0-tab web state.
  * @param {string} deps.EXPOSURE_ACTOR
+ * @param {string} [deps.EXPOSURE_REVIEW]  issue 160 - the review-exemption marker. A review
+ *   child's session record carries `review:true` (persisted SW-side at spawn); the
+ *   tool-dispatch route re-stamps ctx.exposure from it so the tier gate admits the
+ *   three instance reads on the offscreen path too, not just the in-SW fallback.
+ *   Optional and fail-closed: not injected → nothing is ever stamped.
  * @param {() => number} [deps.now]
  * @param {(call: Record<string, any>) => void} [deps.recordModelCall]  the context
  *   inspector's capture hook — fed every delegated model call with the runMeta-derived
@@ -44,7 +49,7 @@
  */
 export const makeOffscreenActorClient = ({
   ensureOffscreen, sendMessage, callModel, getSecret, safeFetch,
-  sessions, buildToolContext, dispatchToolCall, pinActorCall, restrictCtxCapabilities, ownedTabFor, EXPOSURE_ACTOR, now = Date.now,
+  sessions, buildToolContext, dispatchToolCall, pinActorCall, restrictCtxCapabilities, ownedTabFor, EXPOSURE_ACTOR, EXPOSURE_REVIEW, now = Date.now,
   recordModelCall = () => {},
   broadcastOp = (/** @type {any} */ _msg) => {},
 }) => {
@@ -167,7 +172,17 @@ export const makeOffscreenActorClient = ({
           const sig = signalBySession.get(/** @type {string} */ (actorSessionId));
           // Stamp the child lineage on every audit its tools emit (parity with spawn.js's taggedAudit).
           const audit = (/** @type {any} */ entry) => /** @type {any} */ (base).audit?.({ ...entry, details: { ...(entry?.details ?? {}), parentSessionId: rec.parentSessionId, actorSessionId, depth: rec.depth } });
-          const ctx = restrictCtxCapabilities({ ...base, audit, ...(sig ? { abortSignal: sig } : {}) }, granted);
+          // #160: re-stamp the review-exemption marker from the PERSISTED record
+          // (spawn.js writes rec.review SW-side at create; no worker or model arg
+          // can reach it). why here: this route rebuilds ctx from the record alone,
+          // so without the stamp the tier gate saw exposure undefined and refused
+          // the three instance reads — the exemption only worked on the in-SW
+          // fallback path. Fail-closed: rec.review !== true, or no injected
+          // EXPOSURE_REVIEW, stamps nothing.
+          const ctx = restrictCtxCapabilities({
+            ...base, audit, ...(sig ? { abortSignal: sig } : {}),
+            ...(rec.review === true && EXPOSURE_REVIEW ? { exposure: EXPOSURE_REVIEW } : {}),
+          }, granted);
           const result = await dispatchToolCall(call, ctx);
           return { ok: true, result };
         }

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -239,7 +239,7 @@ import {
   makeAsyncActors,
   // DESIGN-17: the message_actor orchestrator + the actor capability-tier
   // helpers the actor tool context is built from (keyless strip + kind scope).
-  makeActorMessaging, restrictCtxCapabilities, actorAllowedToolsFor, EXPOSURE_ACTOR, pinActorCall, actorDescriptors, buildAncestry,
+  makeActorMessaging, restrictCtxCapabilities, actorAllowedToolsFor, EXPOSURE_ACTOR, EXPOSURE_REVIEW, pinActorCall, actorDescriptors, buildAncestry,
   actorsCallToOp, shapeActorsResult, askOutcome, ACTORS_ASK_DEFAULT_TIMEOUT_MS,
   // A2A — the mesh dispatch + translation the a2a/call route runs.
   makeMeshDispatch, meshCallToOp, shapeMeshResult,
@@ -1918,6 +1918,9 @@ const actorClient = offscreenAvailable ? makeOffscreenActorClient({
   // adopted tab or undefined (0-tab state); buildToolContext fails closed on a stale id.
   ownedTabFor: (/** @type {string} */ sid) => webActorTabBindings.tabFor(sid),
   EXPOSURE_ACTOR,
+  // #160: lets the tool-dispatch route re-stamp a review child's exemption
+  // marker from its persisted record (see offscreen-actor-client.js).
+  EXPOSURE_REVIEW,
   recordModelCall: contextSnapshots.record,
   // Announce each settled ACTOR tool dispatch on the UI ports (lazy: uiPorts is
   // defined below, read at call time — same pattern as ownedTabFor). why: the

--- a/extension/peerd-runtime/actor/spawn.js
+++ b/extension/peerd-runtime/actor/spawn.js
@@ -33,7 +33,7 @@ import { resolveManifestAllow } from '../tools/manifests.js';
 // goes through the web actor via message_actor, never a raw grant); filterActorSurface
 // drops the actor-only instance tier (vm_*/js_*/app_*/edit_file — writes AND the
 // fenced reads, already gate-refused for a non-actor). Both are pure.
-import { mainAgentDescriptors, filterActorSurface } from '../tools/exposure.js';
+import { mainAgentDescriptors, filterActorSurface, REVIEW_INSTANCE_READS, EXPOSURE_REVIEW } from '../tools/exposure.js';
 
 /** @typedef {import('../sessions/types.js').Session} Session */
 /** @typedef {import('/peerd-provider/format/from-anthropic.js').ProviderEvent} ProviderEvent */
@@ -340,6 +340,13 @@ export const makeSpawnActor = (deps) => {
    * @param {number} [req.maxOutputTokens]         per-call output cap (default 4096)
    * @param {number} [req.maxDepth]                depth ceiling (default 5)
    * @param {boolean} [req.allowRecursion]         keep actor_create in the subset
+   * @param {boolean} [req.review]                 issue 160 - SW-ONLY. Set solely by the
+   *   review orchestrator (review/orchestrator.js). Re-adds the three instance
+   *   READS (REVIEW_INSTANCE_READS) to the grantable surface and stamps
+   *   ctx.exposure='review', which the actor-tier gate admits for those three
+   *   names only. NOT reachable from the model: actor_create builds its spawn
+   *   request from an explicit field whitelist and never spreads args (pinned by
+   *   a test in review.test.ts). Never accept this from a worker or tool arg.
    * @param {string} req.parentSessionId           who is spawning this
    * @param {number} [req.parentDepth]             spawner's depth (child = +1)
    * @param {boolean} [req.parentInbound]          was the SPAWNING turn inbound
@@ -369,6 +376,9 @@ export const makeSpawnActor = (deps) => {
       maxOutputTokens = DEFAULT_MAX_OUTPUT_TOKENS,
       maxDepth = DEFAULT_MAX_DEPTH,
       allowRecursion = false,
+      // #160: SW-ONLY flag (the review orchestrator). Grants the three instance
+      // reads + stamps the review exposure marker. Unreachable from model args.
+      review = false,
       parentSessionId,
       parentDepth = 0,
       parentInbound,
@@ -434,7 +444,21 @@ export const makeSpawnActor = (deps) => {
     // authority the spawning agent itself lacks. Filtering the grantable universe here is
     // the fix: an actor holds ⊆ what the main agent holds, delegating web/DOM work to
     // the web actor via message_actor like the main agent does.
-    const grantable = filterActorSurface(mainAgentDescriptors(getToolDescriptors()));
+    // #160: a REVIEW spawn re-adds the three instance READS that filterActorSurface
+    // just dropped — by name, from the descriptors we already have. This is the
+    // whole exemption: a positive re-add, never "skip the narrowing for review"
+    // (which would restore fetch_url / read_page / site_client_run too, i.e. build
+    // the exfiltration channel the reviewer must not have). `review` can only be
+    // set by an SW-side caller — the review orchestrator — because actor_create
+    // builds its spawn request from an explicit field whitelist and never spreads
+    // model args (pinned by a test).
+    const surface = filterActorSurface(mainAgentDescriptors(getToolDescriptors()));
+    const grantable = review
+      ? surface.concat(
+        getToolDescriptors().filter((t) => REVIEW_INSTANCE_READS.has(t.name)
+          && !surface.some((s) => s.name === t.name)),
+      )
+      : surface;
     const subset = narrowTools(grantable, { tools, allowRecursion, allow: parentAllow });
     const allowedNames = new Set(subset.map((t) => t.name));
     const subsetDescriptors = subset.map((t) => ({
@@ -552,7 +576,13 @@ export const makeSpawnActor = (deps) => {
       // (message_actor awaitReply) can race its wait against it and unwind when
       // the wall-clock timeout / cancel fires — restrictCtxCapabilities passes
       // through any key not in CAPABILITY_CONSUMERS, so this survives the strip.
-      const childCtx = restrictCtxCapabilities({ ...baseCtx, audit: taggedAudit, abortSignal: controller.signal }, allowedNames);
+      // The review marker is stamped HERE, SW-side, from the trusted spawn req —
+      // never carried in from a worker or a model arg. gates.js keys the #160
+      // exemption on it (positively, and only for the three read names).
+      const childCtx = restrictCtxCapabilities({
+        ...baseCtx, audit: taggedAudit, abortSignal: controller.signal,
+        ...(review ? { exposure: EXPOSURE_REVIEW } : {}),
+      }, allowedNames);
       return (call) => {
         // Defense in depth: even if the model hallucinates a tool name
         // outside its granted subset, the dispatch refuses it. The

--- a/extension/peerd-runtime/actor/spawn.js
+++ b/extension/peerd-runtime/actor/spawn.js
@@ -495,6 +495,14 @@ export const makeSpawnActor = (deps) => {
       // ctx from THIS list and re-checks every relayed call against it — the actor
       // analog of the actor instance-pin. The worker's call args are never trusted.
       grantedTools: [...allowedNames],
+      // #160: persist the review marker so the OFFSCREEN relay can re-stamp
+      // exposure:'review' when it rebuilds this child's ctx (the
+      // 'actor/tool-dispatch' route only has the session record — the in-SW
+      // fallback below stamps from this closure's `review` directly, so without
+      // this field the exemption was dead on the primary offscreen platform).
+      // Still SW-only: written here from the trusted spawn req at create;
+      // a worker or model arg can never reach it.
+      ...(review ? { review: true } : {}),
       // PR #134 phase 3 — the trusted-lineage hop verdict, stamped SERVER-SIDE
       // at create so the chain is never model-supplied. Trusted ONLY when the
       // spawning turn explicitly proved itself non-inbound; an inbound spawn

--- a/extension/peerd-runtime/index.js
+++ b/extension/peerd-runtime/index.js
@@ -197,6 +197,9 @@ export {
   filterByGoalActive, isGoalOnlyTool, GOAL_ONLY_TOOLS,
   // DESIGN-17: the actor capability tier vocabulary.
   EXPOSURE_ACTOR, ACTOR_ONLY_TOOLS, isActorOnlyTool,
+  // #160: the review-exemption marker — the SW injects it into the offscreen
+  // relay so a review child's persisted flag re-stamps ctx.exposure there.
+  EXPOSURE_REVIEW,
   actorAllowedTools, isAllowedForActorType, actorDescriptors, filterActorSurface,
   // DESIGN-18: backing-aware allow-set (an API actor is fetch_url-only).
   actorAllowedToolsFor, isAllowedForActor,

--- a/extension/peerd-runtime/review/orchestrator.js
+++ b/extension/peerd-runtime/review/orchestrator.js
@@ -143,6 +143,11 @@ export const makeRequestReview = (deps) => {
     const out = await spawnActor({
       task,
       tools: allowed,
+      // #160: SW-side marker. Grants the three instance READS (spawn re-adds them
+      // to the grantable surface) and stamps ctx.exposure='review' so the
+      // actor-tier gate admits exactly those three. Set HERE, in the SW-bound
+      // orchestrator — actor_create cannot reach this field.
+      review: true,
       maxSteps,
       parentSessionId,
       parentDepth,

--- a/extension/peerd-runtime/review/read-only.js
+++ b/extension/peerd-runtime/review/read-only.js
@@ -65,6 +65,12 @@ const REVIEWER_TOOLS = Object.freeze(new Set([
   'actor_list', 'actor_tasks', 'app_search', 'capture', 'complete_goal',
   'inspect', 'load_skill', 'now', 'read_memory', 'schedule_list',
   'todo_add', 'todo_check', 'todo_init',
+  // #160 — the instance READS. Actor-only for every other ctx (tools/exposure.js
+  // REVIEW_INSTANCE_READS + the gate's positively-scoped exemption); granted here
+  // so a review of App/Notebook code can open the files AROUND the diff instead of
+  // guessing from it. Reads only — the writes stay actor-only, and the reviewer
+  // still holds no outward closure.
+  'js_read_file', 'app_read_file', 'app_list_files',
 ]));
 
 /** Exported for the invariant tests (and so the grant is greppable). */

--- a/extension/peerd-runtime/sessions/store.js
+++ b/extension/peerd-runtime/sessions/store.js
@@ -158,6 +158,7 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
    *   instanceId?: string,
    *   actorType?: 'webvm' | 'notebook' | 'app' | 'web' | 'dweb',
    *   backing?: 'tab' | 'api',
+   *   review?: boolean,
    * }} [opts]
    * @returns {Promise<Session>}
    */
@@ -177,6 +178,7 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
     instanceId,
     actorType,
     backing,
+    review,
   } = {}) => {
     const normalizedManifest = normalizeToolManifest(toolManifest);
     const record = {
@@ -214,6 +216,14 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
       // egress, prompt, no-tab) reads turnSession.backing, so dropping it here silently
       // makes an API actor behave as a tab actor.
       ...(backing ? { backing } : {}),
+      // #160: the review-exemption marker. MUST be persisted: the offscreen
+      // tool-dispatch route rebuilds a review child's ctx from the RECORD alone
+      // and re-stamps exposure:'review' from this field — dropping it here (like
+      // backing above) silently makes the reviewer's three instance reads
+      // refused on the offscreen path. SW-only: spawn.js sets it from the trusted
+      // review orchestrator, never a worker/model arg. Persist only when true so
+      // every other child stays absent (fail-closed).
+      ...(review === true ? { review: true } : {}),
     };
     await idb.put(STORE, record);
     return present(record, []);

--- a/extension/peerd-runtime/sessions/types.js
+++ b/extension/peerd-runtime/sessions/types.js
@@ -58,6 +58,7 @@
  * @property {string} [instanceId]            the instance (engine id), the owned tabId (String), or — for a DESIGN-18 API actor — the owned ORIGIN
  * @property {'webvm' | 'notebook' | 'app' | 'web' | 'dweb'} [actorType]  webvm/notebook/app = engine kinds; web = a browser tab OR (DESIGN-18) an API origin; dweb = the mesh operator (global singleton)
  * @property {'tab' | 'api'} [backing]         DESIGN-18: a `web` actor's backing — 'tab' (default; absent = tab) drives a DOM at a MUTABLE origin; 'api' owns ONE FIXED origin, fetch-only, no tab ever
+ * @property {boolean} [review]               issue 160: the review-exemption marker. Set server-side at create() by spawn.js (from the trusted review orchestrator, never a model/worker arg); the offscreen tool-dispatch route re-stamps ctx.exposure='review' from it so the reviewer's three instance reads are admitted on the offscreen path, not just the in-SW fallback.
  *
  * Cost/usage telemetry (feature 06). Accumulated client-side from
  * provider `usage` events × the local pricing table. Absent on sessions

--- a/extension/peerd-runtime/tools/exposure.js
+++ b/extension/peerd-runtime/tools/exposure.js
@@ -142,6 +142,47 @@ export const ACTOR_ONLY_TOOLS = Object.freeze(new Set(
 /** Is this a tiered instance tool (actor-only, off the main agent)? Pure. @param {string} name */
 export const isActorOnlyTool = (name) => ACTOR_ONLY_TOOLS.has(name);
 
+// ── the review exemption (#160) ─────────────────────────────────────────────
+// The ONE hole in the actor-only wall, and it is deliberately shaped so it
+// cannot become two.
+//
+// The problem: #159 tiered the instance READS actor-only alongside the writes,
+// so the clean-context reviewer (request_review) — which is a SPAWNED child,
+// not an actor — can no longer open the files surrounding a diff. Reviews of
+// App/Notebook code became diff-only, which makes them materially worse.
+//
+// Why an exemption is safe HERE and nowhere else: the reviewer already runs in
+// a keyless offscreen heap (the same class of heap an actor uses), holds NO
+// outward closure at all (verified in review.test.ts: no safeFetch/webFetch/
+// dweb/messageActor/spawnActor survives its capability strip), cannot recurse,
+// and is ephemeral. So the isolation premise the tier defends — instance bytes
+// stay out of the orchestrator's key-holding heap — is upheld either way. What
+// the exemption widens is the reviewer's own untrusted-input blast radius (from
+// "the diff" to "the diff plus instance files"), which is the honest trade and
+// is bounded by having no channel out.
+//
+// READS ONLY, BY NAME. Not "the reviewer is exempt from the tier" and not "for
+// review, narrow from the full registry" — either of those would hand over
+// fetch_url / read_page / site_client_run in the same stroke and actually build
+// the exfiltration channel this whole design denies. Three names, derived from
+// the per-kind sets so a rename can't silently orphan the entry.
+export const EXPOSURE_REVIEW = 'review';
+
+export const REVIEW_INSTANCE_READS = Object.freeze(new Set(
+  ['js_read_file', 'app_read_file', 'app_list_files']
+    .filter((n) => ACTOR_ONLY_TOOLS.has(n)),
+));
+
+/**
+ * May this ctx hold this actor-only tool by way of the review exemption? Pure.
+ * Positively scoped on BOTH axes: the SW-stamped review marker AND the
+ * three-name read set. Anything else is refused exactly as before.
+ *
+ * @param {string} name @param {string | undefined} exposure
+ */
+export const isReviewExemptRead = (name, exposure) =>
+  exposure === EXPOSURE_REVIEW && REVIEW_INSTANCE_READS.has(name);
+
 // DESIGN-17 web actor — the DOM toolset it owns. This list is the sole source
 // of truth for that set. why these and not page_eval/page_exec: the web actor
 // ingests untrusted page text, so it must not also wield code-exec — the

--- a/extension/peerd-runtime/tools/gates.js
+++ b/extension/peerd-runtime/tools/gates.js
@@ -44,7 +44,7 @@ import { findDenylistMatch } from '../../peerd-egress/denylist/denylist.js';
 import {
   isHiddenFromMain,
   EXPOSURE_ACTOR, isActorOnlyTool, isAllowedForActor, actorTargetId, isDwebTool,
-  actorWebTabTarget,
+  actorWebTabTarget, isReviewExemptRead,
 } from './exposure.js';
 import {
   decideAction,
@@ -130,7 +130,15 @@ const personaGate = (tool, _args, ctx) => {
 export const actorTierGate = (tool, args, ctx) => {
   if (ctx?.exposure !== EXPOSURE_ACTOR) {
     if (isActorOnlyTool(tool.name)) {
-      return { allowed: false, reason: `'${tool.name}' is actor-only — message the instance's actor (message_actor)` };
+      // #160 review exemption — the ONE hole in this wall. A SW-stamped review
+      // ctx (spawn.js sets it; the model cannot reach it, actor_create builds
+      // its spawn request from an explicit field whitelist) may hold the three
+      // instance READS so a code review can open the files around a diff. Both
+      // axes are positive: the marker AND the name. Every other actor-only tool
+      // — every write, every other ctx — refuses exactly as before.
+      if (!isReviewExemptRead(tool.name, ctx?.exposure)) {
+        return { allowed: false, reason: `'${tool.name}' is actor-only — message the instance's actor (message_actor)` };
+      }
     }
     // Dweb tools are the DWEB ACTOR's family (owner call 2026-07-04): refused
     // for every non-actor ctx, unconditionally — the wall behind the

--- a/tests/background/offscreen-actor-client.test.ts
+++ b/tests/background/offscreen-actor-client.test.ts
@@ -115,6 +115,47 @@ describe("routes['actor/tool-dispatch'] — ACTOR (phase 4): narrowed-general ct
     expect(out.result.restrictedTo.sort()).toEqual(['read_memory', 'script']);
   });
 
+  // #160: the review exemption must fire on the LIVE relay path — the gate tests
+  // hand-build {exposure} ctxs, which is how the "stamped only on the in-SW
+  // fallback" regression stayed invisible. These pin the relay's own logic:
+  // given a record with review:true it stamps, otherwise it doesn't. The OTHER
+  // half — that create() actually persists review so a real record carries it —
+  // is pinned in sessions/custom-system-prompt.test.ts (a real create→get
+  // round-trip); the two together close the gap, since a mocked get here can't
+  // prove the store keeps the field.
+  test('a REVIEW child re-stamps exposure from the PERSISTED record', async () => {
+    let seenCtx: any = null;
+    const client = makeOffscreenActorClient(subDeps({
+      sessions: { get: async () => ({ kind: 'spawned', parentSessionId: 'p1', depth: 1, grantedTools: ['js_read_file'], review: true }) },
+      dispatchToolCall: async (_call: any, ctx: any) => { seenCtx = ctx; return { ok: true }; },
+      EXPOSURE_REVIEW: 'review',
+    }));
+    const out: any = await client.routes['actor/tool-dispatch']({ actorSessionId: 's1', call: { name: 'js_read_file', args: {} } });
+    expect(out.ok).toBe(true);
+    expect(seenCtx.exposure).toBe('review');
+  });
+
+  test('a NON-review spawned child gets NO exposure from the relay (fail-closed)', async () => {
+    let seenCtx: any = null;
+    const client = makeOffscreenActorClient(subDeps({
+      dispatchToolCall: async (_call: any, ctx: any) => { seenCtx = ctx; return { ok: true }; },
+      EXPOSURE_REVIEW: 'review',
+    }));
+    await client.routes['actor/tool-dispatch']({ actorSessionId: 's1', call: { name: 'script', args: {} } });
+    expect(seenCtx.exposure).toBeUndefined();
+  });
+
+  test('a truthy-but-not-true review field stamps nothing (strict boolean, like the record write)', async () => {
+    let seenCtx: any = null;
+    const client = makeOffscreenActorClient(subDeps({
+      sessions: { get: async () => ({ kind: 'spawned', parentSessionId: 'p1', depth: 1, grantedTools: ['script'], review: 'yes' }) },
+      dispatchToolCall: async (_call: any, ctx: any) => { seenCtx = ctx; return { ok: true }; },
+      EXPOSURE_REVIEW: 'review',
+    }));
+    await client.routes['actor/tool-dispatch']({ actorSessionId: 's1', call: { name: 'script', args: {} } });
+    expect(seenCtx.exposure).toBeUndefined();
+  });
+
   test('an UNGRANTED tool the worker asks for is REFUSED before any dispatch (never trust the worker)', async () => {
     let dispatched = false;
     const client = makeOffscreenActorClient(subDeps({ dispatchToolCall: async () => { dispatched = true; return { ok: true }; } }));

--- a/tests/peerd-runtime/review.test.ts
+++ b/tests/peerd-runtime/review.test.ts
@@ -60,7 +60,10 @@ const DESCRIPTORS = [
 describe('readOnlyToolNames', () => {
   test('grants only names on the positive allowlist', () => {
     const names = readOnlyToolNames(DESCRIPTORS);
-    expect(names.sort()).toEqual(['actor_list', 'inspect', 'now', 'read_memory'].sort());
+    expect(names.sort()).toEqual([
+      'actor_list', 'inspect', 'now', 'read_memory',
+      'js_read_file', 'app_read_file', 'app_list_files',   // #160
+    ].sort());
   });
 
   test('EXPOSES NO write or mutate_external tools to the reviewer', () => {
@@ -295,7 +298,10 @@ describe('makeRequestReview (clean-context, read-only, structured)', () => {
     const granted = new Set(calls[0].tools);
     // The reviewer's grant is the positive allowlist ∩ read-tagged — NOT
     // "everything read-tagged" (which would have included fetch_url).
-    expect([...granted].sort()).toEqual(['actor_list', 'inspect', 'now', 'read_memory']);
+    expect([...granted].sort()).toEqual([
+      'actor_list', 'app_list_files', 'app_read_file', 'inspect',
+      'js_read_file', 'now', 'read_memory',
+    ]);
     // ASSERT: no write/mutate/orchestration tool exposed
     for (const w of ['click', 'navigate', 'page_exec', 'app_write_file', 'submit_form', 'actor_create', 'request_review']) {
       expect(granted.has(w)).toBe(false);
@@ -419,10 +425,27 @@ describe('reviewer grant — through the real narrowing pipeline', () => {
     for (const t of ['click', 'app_write_file', 'submit_form', 'message_actor', 'actor_create', 'request_review']) {
       expect(granted.has(t)).toBe(false);
     }
-    // Instance reads are actor-only today (#159) — this is exactly what issue
-    // #160 proposes to re-add, deliberately and by name. Until then: absent.
+    // Instance reads are actor-only (#159), so a NORMAL spawned child never gets
+    // them — filterActorSurface drops them from the grantable universe.
     for (const t of ['js_read_file', 'app_read_file', 'app_list_files']) {
       expect(granted.has(t)).toBe(false);
+    }
+
+    // …and the #160 REVIEW spawn re-adds exactly those three, and ONLY those:
+    // egress and writes stay gone even on the review path.
+    const { REVIEW_INSTANCE_READS } = await import('../../extension/peerd-runtime/tools/exposure.js');
+    const reviewGrantable = (grantable as any[]).concat(
+      (DESCRIPTORS as any[]).filter((t) => REVIEW_INSTANCE_READS.has(t.name)),
+    );
+    const reviewGranted = new Set(
+      narrowTools(reviewGrantable as any, { tools: readOnlyToolNames(DESCRIPTORS), allowRecursion: false })
+        .map((t: any) => t.name),
+    );
+    for (const t of ['js_read_file', 'app_read_file', 'app_list_files']) {
+      expect(reviewGranted.has(t)).toBe(true);
+    }
+    for (const t of ['fetch_url', 'read_page', 'site_client_run', 'app_write_file', 'message_actor']) {
+      expect(reviewGranted.has(t)).toBe(false);
     }
   });
 
@@ -445,5 +468,53 @@ describe('reviewer grant — through the real narrowing pipeline', () => {
     ]) {
       expect(survivors.has(cap)).toBe(false);
     }
+  });
+});
+
+// ---- #160: the review exemption, and its blast radius ---------------------
+//
+// The exemption is the ONE hole in the actor-only wall, so these pin that it is
+// exactly one hole: the three READ names, only under the SW-stamped marker.
+describe('#160 review exemption — positively scoped on BOTH axes', () => {
+  test('a review ctx may hold the three instance READS — and nothing else actor-only', async () => {
+    const { actorTierGate } = await import('../../extension/peerd-runtime/tools/gates.js');
+    const { EXPOSURE_REVIEW } = await import('../../extension/peerd-runtime/tools/exposure.js');
+    const reviewCtx = { exposure: EXPOSURE_REVIEW } as any;
+
+    for (const name of ['js_read_file', 'app_read_file', 'app_list_files']) {
+      expect(actorTierGate({ name } as any, {}, reviewCtx)).toBe(null); // no opinion → allowed
+    }
+    // every actor-only WRITE stays refused for the very same ctx
+    for (const name of ['app_write_file', 'app_delete', 'js_write_file', 'js_delete', 'edit_file', 'vm_write_file']) {
+      expect(actorTierGate({ name } as any, {}, reviewCtx)?.allowed).toBe(false);
+    }
+  });
+
+  test('the SAME three reads stay refused for a NON-review, non-actor ctx', async () => {
+    const { actorTierGate } = await import('../../extension/peerd-runtime/tools/gates.js');
+    for (const ctx of [{ exposure: 'main' }, {}, { exposure: 'spoofed' }] as any[]) {
+      for (const name of ['js_read_file', 'app_read_file', 'app_list_files']) {
+        expect(actorTierGate({ name } as any, {}, ctx)?.allowed).toBe(false);
+      }
+    }
+  });
+
+  test('the exemption grants no EGRESS — the marker does not widen anything else', async () => {
+    const { actorTierGate } = await import('../../extension/peerd-runtime/tools/gates.js');
+    const { EXPOSURE_REVIEW, REVIEW_INSTANCE_READS } = await import('../../extension/peerd-runtime/tools/exposure.js');
+    // the exempt set is exactly three reads — no fetch/page/site/dweb tool in it
+    expect([...REVIEW_INSTANCE_READS].sort()).toEqual(['app_list_files', 'app_read_file', 'js_read_file']);
+    // and a review ctx is still refused the dweb family
+    const dwebTool = { name: 'dweb_discover', dweb: true } as any;
+    expect(actorTierGate(dwebTool, {}, { exposure: EXPOSURE_REVIEW } as any)?.allowed).toBe(false);
+  });
+
+  // The marker is only trustworthy because the model cannot set it. actor_create
+  // builds its spawn request from an EXPLICIT field whitelist; if someone ever
+  // spreads model args into it, the exemption becomes forgeable.
+  test('actor_create cannot forge the review flag (its spawn req is whitelisted)', async () => {
+    const src = await Bun.file('extension/peerd-runtime/tools/defs/actor-create.js').text();
+    expect(src).not.toContain('...args');          // no arg spread into the req
+    expect(src).not.toMatch(/review\s*:/);         // never sets the flag
   });
 });

--- a/tests/peerd-runtime/sessions/custom-system-prompt.test.ts
+++ b/tests/peerd-runtime/sessions/custom-system-prompt.test.ts
@@ -41,6 +41,31 @@ const makeStore = () => {
   });
 };
 
+describe('session store — review marker (#160)', () => {
+  // why a REAL create→get round-trip, not a mocked record: the #160 offscreen
+  // relay rebuilds a review child's ctx from the PERSISTED record and stamps
+  // exposure from rec.review. A first cut passed `review:true` to create() but
+  // the field wasn't in create()'s whitelist, so it was silently dropped and
+  // the exemption was dead on the offscreen (Chrome) path — invisible to the
+  // relay test because that test hand-fed the record via a mocked sessions.get.
+  // This pins the persistence create() must provide for that stamp to fire.
+  test('create persists review:true and round-trips through get', async () => {
+    const store = makeStore();
+    const child = await store.create({ kind: 'spawned', review: true });
+    expect(child.review).toBe(true);
+    expect((await store.get(child.sessionId))!.review).toBe(true);
+  });
+
+  test('review is absent unless explicitly true (fail-closed, strict boolean)', async () => {
+    const store = makeStore();
+    const plain = await store.create({ kind: 'spawned' });
+    expect('review' in plain).toBe(false);
+    // a non-true value never persists a truthy marker
+    const loose = await store.create({ kind: 'spawned', review: /** @type any */ ('yes') as any });
+    expect('review' in loose).toBe(false);
+  });
+});
+
 describe('session store — customSystemPrompt', () => {
   test('create persists a non-empty block and omits everything else', async () => {
     const store = makeStore();


### PR DESCRIPTION
**Stacked on #227** (the floor it sits on) — review that first; this diff is only the exemption.

#159 tiered the instance reads actor-only alongside the writes, leaving the clean-context reviewer unable to open the files *around* a diff. Reviews of App/Notebook code became diff-only, and materially worse. This is #160's **Option 1**, in the shape its own instinct called for — and deliberately **not** the shape its one-line reading suggests.

## Why an exemption is safe here

The reviewer already runs in a **keyless offscreen heap** (the same class an actor uses), holds **no outward closure at all** (#227's test asserts no `safeFetch`/`webFetch`/`dweb`/`messageActor`/`spawnActor` survives its capability strip), cannot recurse, and is ephemeral. So the isolation premise the tier defends — instance bytes stay out of the orchestrator's key-holding heap — **holds either way**.

What the exemption genuinely widens is the reviewer's own untrusted-input blast radius: from *"the diff"* to *"the diff plus instance files"*. That's the honest trade, and it's bounded by having no channel out. Worth arguing explicitly rather than inheriting from the orchestrator decision.

*(Note #160's stated rationale — "no exfiltration channel" — is true but for the wrong reason: `sideEffect:'read'` doesn't mean non-exfiltrating, since `fetch_url` is read-tagged. The real reason is the spawn narrowing, which #227 moves into `read-only.js` as an explicit floor.)*

## Shape — positive on BOTH axes, so one hole can't become two

- **`exposure.js`** — `EXPOSURE_REVIEW` + `REVIEW_INSTANCE_READS` (three names, *derived* from the per-kind sets so a rename can't orphan an entry) + `isReviewExemptRead(name, exposure)`.
- **`gates.js`** — the actor-tier wall admits an actor-only tool **only** when the SW-stamped marker **and** the name both match. Every write, and every other ctx, refuses exactly as before.
- **`spawn.js`** — a review spawn **re-adds those three by name**. Deliberately *not* "skip the narrowing for review" or "narrow from the full registry" — either would restore `fetch_url`, `read_page` and `site_client_run` in the same stroke and build the very channel the reviewer must not have. The marker is stamped **SW-side** from the trusted spawn req; `actor_create` builds its request from an explicit field whitelist and never spreads model args, so the model cannot forge it.
- **Capability layer needed no change** — `jsClient`/`appClient` already list these readers, so the closures survive by capability-by-need.

## Rejected: Option 2 (reviewer-as-actor)

It looks cleaner ("zero new gate rules") but **inverts the invariant**: a bound actor is positively scoped to its kind's **full** toolset — `app_write_file`, `js_delete`, `edit_file` — so you'd re-narrow it to reads anyway, leaving a reviewer one narrowing bug away from writing to the workspace the writer agent is editing. That's the single-writer race `read-only.js` exists to forbid.

## Tests
The exemption admits exactly the three reads while still refusing every actor-only **write** for the *same* ctx; those three stay refused for `main`/unset/**spoofed** exposure; the marker widens nothing else (dweb still refused); and `actor_create`'s spawn req is pinned as a whitelist so the flag stays unforgeable. **Revert-proven on both axes** — dropping the name check fails a test, dropping the marker check fails a test.

Gates: typecheck, lint, boundary, imports, tscheck, **3049 bun**, **623 in-browser**.

## One thing for the issue
`app_search` already returns App **body-HTML snippets** to any spawned child with no tier check — so the reviewer's exposure to App bytes was never actually zero. Either #159's premise should note that, or `app_search` should be tiered alongside the reads. Not bundled here.

Closes #160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)