### PR TITLE
fix(e2e): settle sessions-list message count before snapshot

### DIFF
--- a/scripts/cdp/states.mjs
+++ b/scripts/cdp/states.mjs
@@ -835,6 +835,16 @@ export const STATES = [
       await waitFor(async () => { const o = await probe(ctx); return o.assistantText && !o.busy; }, { budgetMs: 20_000 });
       await evalIn(ctx.page, `document.querySelector('.topbar-actions button[title="Chats"]')?.click()`);
       await waitFor(() => evalIn(ctx.page, `!!document.querySelector('.sessions-list .session-row')`), { budgetMs: 8_000, pollMs: 50 });
+      // why: the active row's `${messageCount} msgs` is written from the
+      // persisted session record, which lags the assistantText+!busy signal by
+      // one message-store write — the just-finished turn can render "1 msg"
+      // (user only) before the assistant message lands, a stable per-run race
+      // that flips the top row's count vs the committed baseline. Wait for the
+      // count to settle to its true post-turn value (2) so the snapshot is
+      // deterministic. (Not a clock/timestamp issue — the time-ago is stable.)
+      await waitFor(() => evalIn(ctx.page,
+        `/\\b2 msgs\\b/.test(document.querySelector('.sessions-list .session-row')?.textContent || '')`),
+        { budgetMs: 8_000, pollMs: 50 });
       await rec.visual('sessions-list');
       // Return to the chat view for later states.
       await evalIn(ctx.page, `document.querySelector('.topbar-actions button[title="Chats"]')?.click()`);


### PR DESCRIPTION
## What & why

The `sessions-list` visual e2e state (`scripts/cdp/states.mjs`) snapshots the Chats view immediately after the last turn reports `assistantText && !busy`. But each row's `${messageCount} msgs` is rendered from the **persisted session record**, which lags that signal by one message-store write. So the active (top) row can render **"1 msg"** (the user turn only) before the assistant message lands — flipping the top row's count against the committed baseline (**"2 msgs"**).

That's a stable per-run race with nothing to do with the change under test. It surfaced on the non-UI security-arc PRs (#245/#246/#247), where the pure-logic diffs can't move the render yet the `visual` job went red at ~0.09% on the `sessions-list` frame (top row: baseline "2 msgs" vs run "1 msg"), dark and light alike.

## The fix

After opening the Chats view, wait for the active row's count to settle to its true post-turn value (**2 msgs**) before `rec.visual`. One added `waitFor`, harness-only.

- **No baseline reseed.** "2 msgs" is the correct render (the session completed a user+assistant exchange); "1 msg" was the raced one. Reseeding would bless the wrong frame.
- **Not a clock leak.** The time-ago string is stable ("just now") for freshly-created sessions; the diff is purely the count.

## Scope

Test-infra only — `scripts/cdp/states.mjs`. No extension code, no baseline changes. Unblocks the `visual` lane for every in-flight non-UI PR off `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRfeF2q9Nw7Goiudk6PwQ8)_