### PR TITLE
feat(actor): pure cores for origin-segmented web actors (#251)

### DIFF
--- a/extension/peerd-runtime/actor/landing-rule.js
+++ b/extension/peerd-runtime/actor/landing-rule.js
@@ -1,0 +1,170 @@
+// @ts-check
+// peerd-runtime/actor — what happens when a web actor's tab lands somewhere.
+// (issue #251, the decision half.)
+//
+// PURE. State in, verdict out. No IO, no clock of its own (`now` is injected),
+// no knowledge of tabs or gates — so every branch below is exhaustively
+// testable and the enforcement points stay thin.
+//
+// THE ONE RULE, and the reason this file is small:
+//
+//     Judge the LANDING, never the request.
+//
+// A tab's origin can change three ways, and an earlier draft of #251 tried to
+// handle them separately:
+//   1. the actor calls navigate()                     — a tool call we see
+//   2. that navigation 302s somewhere else            — NO tool call for the hop
+//   3. the page redirects itself (meta refresh / JS)  — no tool call at all
+// Checking `args.url` catches only (1), and is defeated by any open redirect —
+// which is not hypothetical: navigate.js RE-STAMPS the actor's pin to wherever
+// the tab landed, so today (2) silently launders an origin change into an owned
+// one. Testing where the tab ACTUALLY IS collapses all three into one check
+// that no redirect chain can walk around.
+//
+// WHY A ROAMING ACTOR IS STOPPED RATHER THAN WARNED. An earlier draft let a
+// roaming actor enter a credentialed site and relied on #242's forced confirm
+// to catch the bad case. That makes the user's attention the boundary, which is
+// backwards: a confirm is a backstop for where a boundary is missing, not a
+// substitute for one. A roaming actor never holds the authority in the first
+// place, so there is nothing for a hijack to spend.
+
+import { sameOrigin } from './origin-sensitivity.js';
+import { normalizeApiOrigin } from './web-actor.js';
+
+/**
+ * @typedef {'continue' | 'handoff' | 'end'} LandingAction
+ *
+ *   continue  nothing to do — the actor may proceed.
+ *   handoff   a ROAMING actor reached a credentialed origin. It ends, and the
+ *             orchestrator is told to route the work to that origin's bound
+ *             actor. The distinction from `end` is that there IS a successor.
+ *   end       the actor's environment is gone or foreign. It stops. No successor
+ *             is implied; the orchestrator decides what to do next.
+ */
+
+/**
+ * @typedef {object} Excursion
+ * @property {string} returnTo   the owned origin the excursion must come back to
+ * @property {number} budget     navigations remaining before it is over
+ * @property {number} deadline   epoch ms after which it is over regardless
+ */
+
+/**
+ * @typedef {object} LandingVerdict
+ * @property {LandingAction} action
+ * @property {string} reason         one line, user-facing, no identifiers
+ * @property {string} [handoffTo]    the origin whose bound actor should take over
+ * @property {Excursion} [excursion] the excursion state going forward.
+ *
+ *   READ THIS AS A REPLACEMENT, NEVER AS A PATCH. Absent means "no excursion is
+ *   running" — including the case where one just ENDED by returning home. A
+ *   caller that writes `verdict.excursion ?? stored` would keep a discharged
+ *   excursion alive forever, turning the one bounded exception in this file
+ *   into a permanent hole. Always assign, never coalesce.
+ */
+
+/** The excursion budget. Small on purpose — an SSO round trip is a handful of
+ * hops (app → IdP → maybe a consent screen → back). A generous budget is just a
+ * wider corridor for an attacker to work in, and the cost of being wrong is one
+ * re-delegation, not a broken flow. */
+export const EXCURSION_BUDGET = 4;
+/** why a deadline as well as a budget: a budget only decrements on navigation,
+ * so a tab parked mid-excursion would hold the exception open indefinitely. */
+export const EXCURSION_MS = 3 * 60_000;
+
+/**
+ * Decide what happens now that the tab is at `landing`.
+ *
+ * @param {object} state
+ * @param {'roaming' | 'bound'} state.mode
+ * @param {string | null} [state.ownedOrigin]   bound actors only; null before the first landing
+ * @param {unknown} state.landing               where the tab actually is now
+ * @param {boolean} state.landingIsSensitive    from classifyOriginSensitivity
+ * @param {boolean} [state.landingIsIdp]        is the landing a known identity provider
+ * @param {Excursion | null} [state.excursion]  in-flight excursion, if any
+ * @param {number} [state.now]                  injected clock
+ * @returns {LandingVerdict}
+ */
+export const decideLanding = (state) => {
+  const {
+    mode, ownedOrigin = null, landing, landingIsSensitive,
+    landingIsIdp = false, excursion = null, now = 0,
+  } = state;
+
+  const landingOrigin = normalizeApiOrigin(landing);
+
+  // A tab that is nowhere usable — blank, about:, an extension page, junk.
+  // Not a violation and not a place to work: let the caller's own null-tab
+  // handling deal with it rather than ending an actor over a transient state.
+  if (!landingOrigin) return { action: 'continue', reason: 'no page loaded' };
+
+  if (mode === 'roaming') {
+    // THE NO-ENTRY RULE. A roaming actor holds no credentials and must not
+    // acquire any by walking into a site where the user has an identity.
+    if (landingIsSensitive) {
+      return {
+        action: 'handoff',
+        handoffTo: landingOrigin,
+        reason: 'this is a site you have an account on, so its own helper should do the work',
+      };
+    }
+    return { action: 'continue', reason: 'ordinary page' };
+  }
+
+  // ── bound ────────────────────────────────────────────────────────────────
+  // First landing after mint DEFINES what this actor owns. Mirrors the API
+  // actor, whose origin is fixed at mint; a bound actor starts on a blank tab
+  // and cannot know its origin before it arrives.
+  if (!ownedOrigin) return { action: 'continue', reason: 'first landing defines the owned site' };
+
+  if (sameOrigin(landingOrigin, ownedOrigin)) {
+    // Home. Any excursion that was running is over, successfully — this is the
+    // ONLY way an excursion ends well, which is what makes it bounded rather
+    // than a hole.
+    return { action: 'continue', reason: 'still on the owned site' };
+  }
+
+  // Off-origin. The only survivable case is an auth excursion still in credit.
+  if (excursion) {
+    const expired = now > excursion.deadline;
+    const spent = excursion.budget <= 0;
+    if (expired || spent) {
+      return {
+        action: 'end',
+        reason: expired
+          ? 'the sign-in step took too long, so this task was stopped'
+          : 'the sign-in step went further than expected, so this task was stopped',
+      };
+    }
+    // Still travelling. Decrement and carry on.
+    return {
+      action: 'continue',
+      reason: 'signing in',
+      excursion: { ...excursion, budget: excursion.budget - 1 },
+    };
+  }
+
+  // No excursion running. Landing on a known IdP OPENS one — this is the OAuth
+  // solve, and it is deliberately narrow: only a bound actor, only toward a
+  // known IdP, only with a budget and a deadline, and it can only be discharged
+  // by returning to the owned origin.
+  if (landingIsIdp) {
+    return {
+      action: 'continue',
+      reason: 'signing in',
+      excursion: {
+        returnTo: ownedOrigin,
+        budget: EXCURSION_BUDGET,
+        deadline: now + EXCURSION_MS,
+      },
+    };
+  }
+
+  // Anywhere else: the environment this actor owned is not where it is.
+  // Whether a redirect, a hijack, or the user driving the tab themselves, the
+  // answer is the same and the caller reports which via environment_changed.
+  return {
+    action: 'end',
+    reason: 'this helper works only on one site, and the tab left it',
+  };
+};

--- a/extension/peerd-runtime/actor/landing-rule.js
+++ b/extension/peerd-runtime/actor/landing-rule.js
@@ -10,8 +10,7 @@
 //
 //     Judge the LANDING, never the request.
 //
-// A tab's origin can change three ways, and an earlier draft of #251 tried to
-// handle them separately:
+// A tab's origin can change three ways:
 //   1. the actor calls navigate()                     — a tool call we see
 //   2. that navigation 302s somewhere else            — NO tool call for the hop
 //   3. the page redirects itself (meta refresh / JS)  — no tool call at all
@@ -27,6 +26,13 @@
 // backwards: a confirm is a backstop for where a boundary is missing, not a
 // substitute for one. A roaming actor never holds the authority in the first
 // place, so there is nothing for a hijack to spend.
+//
+// FAIL CLOSED, EVERYWHERE. This file's whole job is to REMOVE an authority an
+// actor would otherwise keep, so an unrecognized input must never read as
+// permission. Two places where a first draft got that backwards, both found in
+// review and both now explicit: an unrecognized `mode` ends the actor rather
+// than falling through, and a landing we cannot canonicalize is treated as
+// FOREIGN rather than as "no page".
 
 import { sameOrigin } from './origin-sensitivity.js';
 import { normalizeApiOrigin } from './web-actor.js';
@@ -36,17 +42,28 @@ import { normalizeApiOrigin } from './web-actor.js';
  *
  *   continue  nothing to do — the actor may proceed.
  *   handoff   a ROAMING actor reached a credentialed origin. It ends, and the
- *             orchestrator is told to route the work to that origin's bound
- *             actor. The distinction from `end` is that there IS a successor.
+ *             orchestrator routes the work to that origin's bound actor. The
+ *             distinction from `end` is that there IS a successor.
  *   end       the actor's environment is gone or foreign. It stops. No successor
- *             is implied; the orchestrator decides what to do next.
+ *             is implied; the orchestrator decides what happens next.
  */
 
 /**
+ * An auth excursion: the ONE way a bound actor may be off its owned origin.
+ *
  * @typedef {object} Excursion
- * @property {string} returnTo   the owned origin the excursion must come back to
- * @property {number} budget     navigations remaining before it is over
- * @property {number} deadline   epoch ms after which it is over regardless
+ * @property {string} returnTo    the owned origin this must come back to
+ * @property {string} openedAt    the IdP origin that opened it. why recorded:
+ *   without it, "is this hop part of the sign-in I authorized" is not merely
+ *   unenforced but UNREPRESENTABLE, and an open corridor becomes a free window
+ *   onto any origin at all.
+ * @property {string} lastLanding the landing this excursion last saw. why: the
+ *   budget is spent per NAVIGATION, but this function is called per TOOL CALL
+ *   (resolveTargetTab runs on every DOM tool). Without this, a single-page login
+ *   — snapshot, type, click, snapshot — would burn the budget standing still and
+ *   end the actor mid-sign-in.
+ * @property {number} budget      navigations remaining
+ * @property {number} deadline    epoch ms after which it is over regardless
  */
 
 /**
@@ -54,57 +71,116 @@ import { normalizeApiOrigin } from './web-actor.js';
  * @property {LandingAction} action
  * @property {string} reason         one line, user-facing, no identifiers
  * @property {string} [handoffTo]    the origin whose bound actor should take over
+ * @property {string} [adoptOrigin]  first landing only — the origin this actor now
+ *   owns. why returned rather than re-derived by the caller: the obvious helper
+ *   over there (`originOfUrl`) canonicalizes differently from `normalizeApiOrigin`
+ *   on exactly the hosts that matter, so a caller deriving its own would disagree
+ *   with the rule that later judges it.
  * @property {Excursion} [excursion] the excursion state going forward.
  *
  *   READ THIS AS A REPLACEMENT, NEVER AS A PATCH. Absent means "no excursion is
  *   running" — including the case where one just ENDED by returning home. A
  *   caller that writes `verdict.excursion ?? stored` would keep a discharged
- *   excursion alive forever, turning the one bounded exception in this file
- *   into a permanent hole. Always assign, never coalesce.
+ *   excursion alive forever, turning the one bounded exception in this file into
+ *   a permanent hole. Always assign, never coalesce.
  */
 
-/** The excursion budget. Small on purpose — an SSO round trip is a handful of
- * hops (app → IdP → maybe a consent screen → back). A generous budget is just a
- * wider corridor for an attacker to work in, and the cost of being wrong is one
- * re-delegation, not a broken flow. */
+/** Navigations one sign-in may take: app → IdP → consent → back is three. */
 export const EXCURSION_BUDGET = 4;
 /** why a deadline as well as a budget: a budget only decrements on navigation,
  * so a tab parked mid-excursion would hold the exception open indefinitely. */
 export const EXCURSION_MS = 3 * 60_000;
+/** How many excursions one bound actor may open, ever.
+ *
+ * why a lifetime cap and not just a per-leg budget: discharging at home CLEARS
+ * the corridor, so without this a hostile page on the owned origin loops
+ * home → IdP → hops → home → repeat and buys a fresh budget and deadline every
+ * two navigations. Bounded per leg, unbounded per task — which is the bound that
+ * actually matters. Legitimate work re-authenticates approximately never. */
+export const MAX_EXCURSIONS = 2;
+
+/**
+ * Where is this tab, in the only three categories that matter?
+ *
+ *   'none'    no page to speak of — blank, about:, an extension page, a data:
+ *             or javascript: URL, or a tab mid-load. Transient and not a
+ *             violation; the caller's own null-tab handling owns it.
+ *   'named'   a real http(s) page whose origin we can canonicalize.
+ *   'unnamed' a real, LOADABLE http(s) page whose host `normalizeApiOrigin`
+ *             refuses to name — an IP literal, IPv6, a trailing-dot FQDN, an
+ *             underscore label, a single-label intranet host.
+ *
+ * why 'unnamed' exists as its own category, and why it was the worst bug in the
+ * first draft of this file: normalizeApiOrigin's host rule was written so an
+ * ADDRESSED origin can't collide with the literal 'web' or a numeric tabId — its
+ * own comment says exactly that. It is not a "where is this tab" predicate.
+ * Reusing it as one folded every host above into 'no page loaded', so a bound
+ * actor 302'd to `https://evil.com./pwn` or `http://192.168.1.9/admin` was told
+ * to CONTINUE. Those pages load fine. That inverts the file's only invariant,
+ * and unlike the classifier's fail-open — which declines to ADD a protection —
+ * it REMOVES one.
+ *
+ * @param {unknown} landing
+ * @returns {{ kind: 'none' | 'named' | 'unnamed', origin: string | null }}
+ */
+const locate = (landing) => {
+  const raw = String(landing ?? '').trim();
+  if (!raw) return { kind: 'none', origin: null };
+  let u;
+  try { u = new URL(raw); } catch { return { kind: 'none', origin: null }; }
+  // Anything that isn't a real web page: about:, chrome-extension:, data:,
+  // javascript:, file:. Not somewhere an actor does work, and reachable
+  // transiently during a load.
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') return { kind: 'none', origin: null };
+  const origin = normalizeApiOrigin(raw);
+  return origin ? { kind: 'named', origin } : { kind: 'unnamed', origin: null };
+};
 
 /**
  * Decide what happens now that the tab is at `landing`.
  *
  * @param {object} state
  * @param {'roaming' | 'bound'} state.mode
- * @param {string | null} [state.ownedOrigin]   bound actors only; null before the first landing
+ * @param {string | null} [state.ownedOrigin]   bound only; null before the first landing
  * @param {unknown} state.landing               where the tab actually is now
  * @param {boolean} state.landingIsSensitive    from classifyOriginSensitivity
  * @param {boolean} [state.landingIsIdp]        is the landing a known identity provider
  * @param {Excursion | null} [state.excursion]  in-flight excursion, if any
+ * @param {number} [state.excursionsUsed]       how many this actor has opened
  * @param {number} [state.now]                  injected clock
  * @returns {LandingVerdict}
  */
 export const decideLanding = (state) => {
   const {
     mode, ownedOrigin = null, landing, landingIsSensitive,
-    landingIsIdp = false, excursion = null, now = 0,
+    landingIsIdp = false, excursion = null, excursionsUsed = 0, now = 0,
   } = state;
 
-  const landingOrigin = normalizeApiOrigin(landing);
+  // FAIL CLOSED on an unrecognized mode. why this is not paranoia: an actor
+  // record predating the field, a chrome.storage.session JSON round-trip, or a
+  // typo in the SW's ctx rebuild would otherwise fall through every branch to a
+  // permissive default and silently disable this entire core with no error.
+  if (mode !== 'roaming' && mode !== 'bound') {
+    return { action: 'end', reason: 'this helper is in an unknown state, so it was stopped' };
+  }
 
-  // A tab that is nowhere usable — blank, about:, an extension page, junk.
-  // Not a violation and not a place to work: let the caller's own null-tab
-  // handling deal with it rather than ending an actor over a transient state.
-  if (!landingOrigin) return { action: 'continue', reason: 'no page loaded' };
+  const { kind, origin: landingOrigin } = locate(landing);
+
+  // Nowhere in particular. Transient; not a violation. Carry any excursion
+  // through UNCHANGED — a blank read mid-sign-in must not discharge it, because
+  // absence of the field means "cleared" to the caller.
+  if (kind === 'none') {
+    return { action: 'continue', reason: 'no page loaded', ...(excursion ? { excursion } : {}) };
+  }
 
   if (mode === 'roaming') {
-    // THE NO-ENTRY RULE. A roaming actor holds no credentials and must not
-    // acquire any by walking into a site where the user has an identity.
-    if (landingIsSensitive) {
+    // An unnameable host is never classified sensitive (the classifier refuses
+    // it too), so roaming treats it as ordinary — consistent, and roaming holds
+    // nothing to lose either way.
+    if (kind === 'named' && landingIsSensitive) {
       return {
         action: 'handoff',
-        handoffTo: landingOrigin,
+        handoffTo: /** @type {string} */ (landingOrigin),
         reason: 'this is a site you have an account on, so its own helper should do the work',
       };
     }
@@ -112,48 +188,71 @@ export const decideLanding = (state) => {
   }
 
   // ── bound ────────────────────────────────────────────────────────────────
-  // First landing after mint DEFINES what this actor owns. Mirrors the API
-  // actor, whose origin is fixed at mint; a bound actor starts on a blank tab
-  // and cannot know its origin before it arrives.
-  if (!ownedOrigin) return { action: 'continue', reason: 'first landing defines the owned site' };
+  // First landing after mint DEFINES what this actor owns, and the verdict says
+  // WHAT to adopt so the caller never re-derives it differently.
+  if (!ownedOrigin) {
+    return kind === 'named'
+      ? { action: 'continue', reason: 'first landing defines the owned site', adoptOrigin: /** @type {string} */ (landingOrigin) }
+      : { action: 'end', reason: 'this page has no address peerd can pin work to' };
+  }
+
+  // A real page we cannot name is FOREIGN to a bound actor: it is provably not
+  // the owned origin (which is nameable by construction).
+  if (kind === 'unnamed') {
+    return { action: 'end', reason: 'the tab moved to a page peerd cannot verify, so this task was stopped' };
+  }
 
   if (sameOrigin(landingOrigin, ownedOrigin)) {
-    // Home. Any excursion that was running is over, successfully — this is the
-    // ONLY way an excursion ends well, which is what makes it bounded rather
-    // than a hole.
+    // Home. Any excursion is over, successfully — the only good ending, and the
+    // omission of `excursion` here is what discharges it.
     return { action: 'continue', reason: 'still on the owned site' };
   }
 
   // Off-origin. The only survivable case is an auth excursion still in credit.
   if (excursion) {
-    const expired = now > excursion.deadline;
-    const spent = excursion.budget <= 0;
-    if (expired || spent) {
-      return {
-        action: 'end',
-        reason: expired
-          ? 'the sign-in step took too long, so this task was stopped'
-          : 'the sign-in step went further than expected, so this task was stopped',
-      };
+    if (now > excursion.deadline) {
+      return { action: 'end', reason: 'the sign-in step took too long, so this task was stopped' };
     }
-    // Still travelling. Decrement and carry on.
+    // Where may a sign-in actually go? The IdP that opened it, and pages with
+    // no identity of their own (interstitials, CDNs). NOT another credentialed
+    // site: an open corridor must not become a window onto your mail or your
+    // bank just because a sign-in started. why not "refuse every sensitive
+    // hop": an IdP is definitionally a password-field origin, so the learned
+    // signal will mark it — hence the openedAt exemption rather than a blanket
+    // rule.
+    const atOpener = sameOrigin(landingOrigin, excursion.openedAt);
+    if (landingIsSensitive && !atOpener) {
+      return { action: 'end', reason: 'the sign-in step led to another site you have an account on, so this task was stopped' };
+    }
+    // Spend budget only on an actual MOVE. This function runs per tool call,
+    // not per navigation; without this a single-page login would burn the
+    // budget standing still.
+    const moved = !sameOrigin(landingOrigin, excursion.lastLanding);
+    if (!moved) return { action: 'continue', reason: 'signing in', excursion };
+    if (excursion.budget <= 0) {
+      return { action: 'end', reason: 'the sign-in step went further than expected, so this task was stopped' };
+    }
     return {
       action: 'continue',
       reason: 'signing in',
-      excursion: { ...excursion, budget: excursion.budget - 1 },
+      excursion: { ...excursion, lastLanding: /** @type {string} */ (landingOrigin), budget: excursion.budget - 1 },
     };
   }
 
-  // No excursion running. Landing on a known IdP OPENS one — this is the OAuth
-  // solve, and it is deliberately narrow: only a bound actor, only toward a
-  // known IdP, only with a budget and a deadline, and it can only be discharged
-  // by returning to the owned origin.
+  // No excursion running. Landing on a known IdP OPENS one — deliberately
+  // narrow: bound actors only, toward a known IdP only, with a budget, a
+  // deadline, a recorded opener, and a lifetime cap.
   if (landingIsIdp) {
+    if (excursionsUsed >= MAX_EXCURSIONS) {
+      return { action: 'end', reason: 'this task has already signed in as many times as peerd allows, so it was stopped' };
+    }
     return {
       action: 'continue',
       reason: 'signing in',
       excursion: {
         returnTo: ownedOrigin,
+        openedAt: /** @type {string} */ (landingOrigin),
+        lastLanding: /** @type {string} */ (landingOrigin),
         budget: EXCURSION_BUDGET,
         deadline: now + EXCURSION_MS,
       },
@@ -161,10 +260,7 @@ export const decideLanding = (state) => {
   }
 
   // Anywhere else: the environment this actor owned is not where it is.
-  // Whether a redirect, a hijack, or the user driving the tab themselves, the
-  // answer is the same and the caller reports which via environment_changed.
-  return {
-    action: 'end',
-    reason: 'this helper works only on one site, and the tab left it',
-  };
+  // Redirect, hijack, or the user driving the tab — same answer; the caller
+  // reports which via environment_changed.
+  return { action: 'end', reason: 'this helper works only on one site, and the tab left it' };
 };

--- a/extension/peerd-runtime/actor/origin-sensitivity.js
+++ b/extension/peerd-runtime/actor/origin-sensitivity.js
@@ -1,0 +1,153 @@
+// @ts-check
+// peerd-runtime/actor — is this origin one where the user has an IDENTITY?
+// (issue #251, the classifier half.)
+//
+// PURE (values in -> verdict out), so the policy is testable without a browser,
+// a vault, or a storage layer. Every input is passed in; nothing is imported
+// that reaches IO.
+//
+// WHAT THIS DECIDES. A web actor is either ROAMING (browses freely, holds no
+// authority) or BOUND (owns exactly one credentialed origin, like an API
+// actor). This function is what sorts origins into those two worlds: a
+// sensitive origin is one a roaming actor may NOT enter and a bound actor may
+// NOT leave.
+//
+// why "sensitive" is about IDENTITY, not danger: a hijacked actor loose on the
+// open web is a nuisance — everything it can reach it could already reach, and
+// everything it read was public. The damage is entirely in the sites where it
+// acts AS THE USER. So the line is drawn at "do you have an account here",
+// which is also why the signals below are all about accounts and none of them
+// are about how sketchy a site looks.
+//
+// FAIL-OPEN, deliberately, and the consequence is named: an origin we don't
+// know about is treated as ordinary, so a roaming actor may enter it. A
+// missed classification does NOT open a hole in an existing protection — it
+// declines to add one. The learned signals exist to shrink that gap with use
+// rather than to make the seed list exhaustive, which it never could be.
+//
+// WHAT IS NOT HERE. The store (peerd-egress), the observation points that feed
+// it (the DOM walk, the confirm path), and the enforcement (gates,
+// resolveTargetTab) all live elsewhere. This file only answers the question.
+
+import { normalizeApiOrigin } from './web-actor.js';
+
+/**
+ * Why an origin was classified sensitive. Rendered in the handoff notice and
+ * the audit trail, so the user can see WHICH signal fired rather than being
+ * told a site is special with no account of it.
+ * @typedef {'ugc-zone' | 'vault-secret' | 'password-field' | 'confirmed-write'} SensitivityReason
+ */
+
+/**
+ * @typedef {object} SensitivityVerdict
+ * @property {boolean} sensitive
+ * @property {SensitivityReason} [reason]   present only when sensitive
+ * @property {string} [origin]              the normalized origin that matched
+ */
+
+/** why frozen: a verdict is passed around and rendered; nothing downstream should edit it. */
+const ORDINARY = Object.freeze({ sensitive: false });
+
+/**
+ * The LEARNED signals, in the order they are trusted. Both are byproducts of
+ * ordinary use — neither asks the user anything, and neither needs a
+ * permission we don't already hold.
+ *
+ * why these two and not "does it have cookies": we have no `cookies`
+ * permission and adding one is a broad ask on a store-reviewed extension (the
+ * same reasoning that kept `webNavigation` out — see the SW's tabs.onUpdated
+ * comment). These two are observable from data we already collect.
+ *
+ *   password-field   A password input was seen in the DOM walk on this origin.
+ *                    Nothing else on the web means "this site has accounts"
+ *                    as reliably, and we already walk the DOM for the snapshot.
+ *   confirmed-write  The user approved a web:write on this origin. They
+ *                    affirmed acting there under their own name.
+ *
+ * KNOWN OVER-TRIGGER (jonybur flagged the shape): a newsletter modal with a
+ * password field on a marketing page would mark the whole origin. Accepted for
+ * now — the failure mode is a site being treated as MORE protected than it
+ * needs to be, which costs a handoff, not a breach. If it proves noisy the fix
+ * is to require the field to be in a form that also carries an identifier
+ * input, not to drop the signal.
+ * @type {readonly SensitivityReason[]}
+ */
+export const LEARNED_REASONS = Object.freeze(['password-field', 'confirmed-write']);
+
+/**
+ * Classify an origin.
+ *
+ * Order is deliberate: the two SEEDS are checked before the learned set,
+ * because a seed carries a stronger provenance (a curated registry entry, or a
+ * credential the user typed in themselves) and makes for a better explanation
+ * in the handoff notice than "we saw a password box once".
+ *
+ * @param {unknown} input                   a URL or bare host
+ * @param {object} deps
+ * @param {(origin: string) => boolean} [deps.isUgcZone]  is it in the #242 UGC registry.
+ *   INJECTED rather than imported: the registry is a separate concern that
+ *   lands on its own schedule (#242 / PR #250), and taking it as a signal keeps
+ *   this classifier independently testable and free of a hard dependency on
+ *   which registry happens to exist. It is a signal here, not a special case.
+ * @param {(origin: string) => boolean} [deps.hasVaultSecret]  is there an `origin:` secret for it
+ * @param {ReadonlySet<string> | ReadonlyMap<string, SensitivityReason>} [deps.learned]
+ *   the learned set, keyed by normalized origin. A Map carries WHICH signal
+ *   fired; a Set is accepted so callers with no provenance still work.
+ * @returns {SensitivityVerdict}
+ */
+export const classifyOriginSensitivity = (input, deps = {}) => {
+  const { isUgcZone, hasVaultSecret, learned } = deps;
+  const origin = normalizeApiOrigin(input);
+  // Not a usable public origin at all (a blank tab, an extension page, an IP,
+  // localhost, junk). Nothing to be signed in to.
+  if (!origin) return ORDINARY;
+
+  // SEED 1 — a curated UGC zone (#242). These are exactly "you have an identity
+  // here AND strangers author the content", the worst combination, and the
+  // registry is already reviewed. Classified on the ORIGIN, not the path: the
+  // #242 rule is path-scoped because it gates one WRITE, whereas an actor being
+  // bound is about the whole site's session.
+  if (isUgcZone?.(origin) === true) {
+    return { sensitive: true, reason: 'ugc-zone', origin };
+  }
+
+  // SEED 2 — the user stored a credential for it. Definitionally credentialed:
+  // they authored the fact.
+  if (hasVaultSecret?.(origin) === true) {
+    return { sensitive: true, reason: 'vault-secret', origin };
+  }
+
+  // LEARNED — grown from ordinary use.
+  if (learned) {
+    if (learned instanceof Map) {
+      const reason = learned.get(origin);
+      if (reason) return { sensitive: true, reason, origin };
+    } else if (learned.has(origin)) {
+      // Provenance wasn't retained; report the weaker of the two rather than
+      // claiming a signal we can't substantiate.
+      return { sensitive: true, reason: 'password-field', origin };
+    }
+  }
+
+  return ORDINARY;
+};
+
+/**
+ * Do two URLs sit on the same origin? The comparison the landing rule runs on
+ * every tool call, so it is here rather than open-coded at the call sites.
+ *
+ * why not a string compare of `.origin`: both sides go through
+ * normalizeApiOrigin first, so `HTTPS://GitHub.com:443` and `https://github.com`
+ * agree, and a non-origin input (blank tab, `about:`, junk) yields null rather
+ * than a string that could accidentally equal another null-ish value.
+ *
+ * @param {unknown} a
+ * @param {unknown} b
+ * @returns {boolean} false if EITHER side isn't a usable origin — an unknown
+ *   location is never "the same as" a known one.
+ */
+export const sameOrigin = (a, b) => {
+  const x = normalizeApiOrigin(a);
+  const y = normalizeApiOrigin(b);
+  return x !== null && y !== null && x === y;
+};

--- a/extension/peerd-runtime/index.js
+++ b/extension/peerd-runtime/index.js
@@ -142,6 +142,13 @@ export {
   makeWebActorTabBindings, makeWebActorRegistry, WEB_ACTOR_SUMMARY_PROMPT, fenceWebActorSummary,
   makeApiActorBindings, normalizeApiOrigin, API_ACTOR_SUMMARY_PROMPT, fenceApiActorSummary,
 } from './actor/web-actor.js';
+// issue 251: authority segmented by origin. A web actor is ROAMING (browses
+// freely, holds nothing) or BOUND (owns one credentialed origin, like the API
+// actor above). Two pure cores: which origins the user has an identity on, and
+// what happens when a tab LANDS somewhere. Exported here because the enforcement
+// points that will consume them live outside this module (background/).
+export { classifyOriginSensitivity, sameOrigin, LEARNED_REASONS } from './actor/origin-sensitivity.js';
+export { decideLanding, EXCURSION_BUDGET, EXCURSION_MS } from './actor/landing-rule.js';
 // DESIGN-19: site clients — per-origin derived API clients. The pure core
 // (validation, confirm-gated proposal, staleness header, fenced dossier, URL pin),
 // the two-tier store, and the capture digester. See site-clients/index.js.

--- a/extension/peerd-runtime/index.js
+++ b/extension/peerd-runtime/index.js
@@ -148,7 +148,7 @@ export {
 // what happens when a tab LANDS somewhere. Exported here because the enforcement
 // points that will consume them live outside this module (background/).
 export { classifyOriginSensitivity, sameOrigin, LEARNED_REASONS } from './actor/origin-sensitivity.js';
-export { decideLanding, EXCURSION_BUDGET, EXCURSION_MS } from './actor/landing-rule.js';
+export { decideLanding, EXCURSION_BUDGET, EXCURSION_MS, MAX_EXCURSIONS } from './actor/landing-rule.js';
 // DESIGN-19: site clients — per-origin derived API clients. The pure core
 // (validation, confirm-gated proposal, staleness header, fenced dossier, URL pin),
 // the two-tier store, and the capture digester. See site-clients/index.js.

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -87,7 +87,7 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // 505/506 → 510: the #119 (page bridge + OM2W eval) and #187 (fetch content
 // pipeline) file sets merge — both ledgers above are kept; the union floor.
 // 510 → 511: the Z.ai GLM provider adapter (peerd-provider/adapters/glm.js).
-const COVERED_FLOOR = 530;
+const COVERED_FLOOR = 532;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/tests/peerd-runtime/actor/landing-rule.test.ts
+++ b/tests/peerd-runtime/actor/landing-rule.test.ts
@@ -10,7 +10,7 @@
 // got there, because the rule genuinely cannot tell and must not need to.
 
 import { describe, test, expect } from 'bun:test';
-import { decideLanding, EXCURSION_BUDGET, EXCURSION_MS } from '../../../extension/peerd-runtime/actor/landing-rule.js';
+import { decideLanding, EXCURSION_BUDGET, EXCURSION_MS, MAX_EXCURSIONS } from '../../../extension/peerd-runtime/actor/landing-rule.js';
 
 const OWNED = 'https://app.test';
 const bound = (over: any = {}) => decideLanding({ mode: 'bound', ownedOrigin: OWNED, landingIsSensitive: false, now: 1_000, ...over });
@@ -69,42 +69,128 @@ describe('bound — the origin lock', () => {
   test('a blank/unusable location is not a violation', () => {
     // Transient (a tab mid-load, about:blank). Ending an actor over it would
     // be a self-inflicted flake; the caller's null-tab handling owns this.
-    for (const l of ['about:blank', '', 'chrome-extension://x/p.html']) {
+    for (const l of ['about:blank', '', 'chrome-extension://x/p.html', 'data:text/html,hi', 'javascript:0']) {
       expect(bound({ landing: l }).action).toBe('continue');
     }
+  });
+
+  // REGRESSION, and it was the worst bug in the first draft of this file.
+  // normalizeApiOrigin's host rule exists so an ADDRESSED origin can't collide
+  // with the literal 'web' or a numeric tabId — it is not a "where is this tab"
+  // predicate. Reusing it as one folded every host below into "no page loaded"
+  // and told a bound actor to CONTINUE on an attacker-controlled page. These all
+  // load fine in a browser.
+  test.each([
+    ['https://evil.com./pwn'],        // trailing-dot FQDN
+    ['http://192.168.1.9/admin'],     // IPv4 literal
+    ['https://[2001:db8::1]/'],       // IPv6 literal
+    ['http://localhost:8888/lab'],    // loopback
+    ['https://intranet/'],            // single-label intranet host
+    ['https://evil_x.com/'],          // underscore label
+  ])('a real page we cannot canonicalize (%s) is FOREIGN, not "no page"', (landing) => {
+    expect(bound({ landing }).action).toBe('end');
+  });
+
+  test('an unnameable FIRST landing cannot be adopted as an owned origin', () => {
+    // Otherwise a bound actor could be pinned to something the rule that later
+    // judges it is unable to express.
+    const v = decideLanding({ mode: 'bound', ownedOrigin: null, landing: 'http://192.168.1.9/', landingIsSensitive: false });
+    expect(v.action).toBe('end');
+  });
+
+  test('the first landing REPORTS what to adopt, so the caller never re-derives it', () => {
+    // The obvious helper over there (originOfUrl) canonicalizes differently on
+    // exactly the hosts above; a caller deriving its own would disagree with
+    // the rule that later judges it.
+    const v = decideLanding({ mode: 'bound', ownedOrigin: null, landing: 'HTTPS://App.test:443/x', landingIsSensitive: true });
+    expect(v.adoptOrigin).toBe('https://app.test');
+  });
+});
+
+describe('fail-closed on a bad mode', () => {
+  test.each([[undefined], ['Bound'], ['web'], [null], [42]])('mode %p ends the actor', (mode) => {
+    // An actor record predating the field, a storage.session JSON round-trip, or
+    // a typo in the SW ctx rebuild must not silently disable this whole core.
+    const v = decideLanding({ mode: mode as any, landing: 'https://bank.test', landingIsSensitive: true });
+    expect(v.action).toBe('end');
   });
 });
 
 describe('auth excursions — the OAuth solve', () => {
+  const IDP = 'https://accounts.google.com';
+  const inFlight = (over: any = {}) => ({ returnTo: OWNED, openedAt: IDP, lastLanding: IDP, budget: 2, deadline: 99_999, ...over });
+
   test('landing on a known IdP opens a bounded excursion instead of ending', () => {
-    const v = bound({ landing: 'https://accounts.google.com', landingIsSensitive: true, landingIsIdp: true });
+    const v = bound({ landing: IDP, landingIsSensitive: true, landingIsIdp: true });
     expect(v.action).toBe('continue');
-    expect(v.excursion).toEqual({ returnTo: OWNED, budget: EXCURSION_BUDGET, deadline: 1_000 + EXCURSION_MS });
+    expect(v.excursion).toEqual({
+      returnTo: OWNED, openedAt: IDP, lastLanding: IDP,
+      budget: EXCURSION_BUDGET, deadline: 1_000 + EXCURSION_MS,
+    });
   });
 
-  test('an in-flight excursion spends budget on each further hop', () => {
-    const ex = { returnTo: OWNED, budget: 2, deadline: 99_999 };
-    const v = bound({ landing: 'https://idp-step2.test', excursion: ex });
+  test('an in-flight excursion spends budget when it actually MOVES', () => {
+    const v = bound({ landing: 'https://idp-step2.test', excursion: inFlight() });
     expect(v.action).toBe('continue');
     expect(v.excursion?.budget).toBe(1);
   });
 
-  test('an exhausted budget ends the actor', () => {
-    const v = bound({ landing: 'https://idp-step9.test', excursion: { returnTo: OWNED, budget: 0, deadline: 99_999 } });
+  test('repeated calls on the SAME page do not spend budget', () => {
+    // This function runs per tool call (resolveTargetTab is on every DOM tool),
+    // not per navigation. A single-page login — snapshot, type, click, snapshot
+    // — would otherwise burn the budget standing still and end the actor
+    // mid-sign-in. The budget is denominated in navigations, so it must only
+    // decrement on one.
+    const v = bound({ landing: IDP, landingIsSensitive: true, excursion: inFlight() });
+    expect(v.excursion?.budget).toBe(2);
+  });
+
+  test('an exhausted budget ends the actor on the next move', () => {
+    const v = bound({ landing: 'https://idp-step9.test', excursion: inFlight({ budget: 0 }) });
     expect(v.action).toBe('end');
   });
 
   test('an expired deadline ends the actor even with budget left', () => {
-    // why both: budget only decrements on navigation, so a tab parked
-    // mid-excursion would otherwise hold the exception open indefinitely.
-    const v = bound({ landing: 'https://idp.test', excursion: { returnTo: OWNED, budget: 9, deadline: 500 }, now: 1_000 });
+    const v = bound({ landing: 'https://idp.test', excursion: inFlight({ budget: 9, deadline: 500 }), now: 1_000 });
     expect(v.action).toBe('end');
   });
 
   test('returning to the owned origin discharges it — the only good ending', () => {
-    const v = bound({ landing: OWNED, excursion: { returnTo: OWNED, budget: 1, deadline: 99_999 } });
+    const v = bound({ landing: OWNED, excursion: inFlight({ budget: 1 }) });
     expect(v.action).toBe('continue');
     expect(v.excursion).toBeUndefined();          // cleared, not carried
+  });
+
+  test('a blank read mid-excursion carries it through rather than discharging it', () => {
+    // Absence of the field means "cleared" to the caller, so a tab caught
+    // mid-load must not silently end a sign-in in progress.
+    const ex = inFlight();
+    expect(bound({ landing: 'about:blank', excursion: ex }).excursion).toEqual(ex);
+  });
+
+  test('an open corridor is NOT a window onto other credentialed sites', () => {
+    // The bound path ignoring landingIsSensitive was the design gap: a docs-site
+    // actor could be bounced onto an IdP, then walked to mail or a bank for four
+    // free hops. A roaming actor — which holds nothing — gets a hard handoff on
+    // its first sensitive landing, so the actor that DOES carry authority must
+    // not get a softer rule.
+    const v = bound({ landing: 'https://bank.test/transfer', landingIsSensitive: true, excursion: inFlight() });
+    expect(v.action).toBe('end');
+  });
+
+  test('...but the IdP that opened it stays reachable, because an IdP is credentialed by nature', () => {
+    // Which is why the exemption is keyed on openedAt rather than a blanket
+    // "refuse every sensitive hop" that would break every real sign-in.
+    const v = bound({ landing: `${IDP}/signin/step2`, landingIsSensitive: true, excursion: inFlight() });
+    expect(v.action).toBe('continue');
+  });
+
+  test('the lifetime cap survives discharge, so the corridor cannot be refreshed', () => {
+    // Discharging at home clears the corridor, so a per-leg budget alone lets a
+    // hostile page loop home → IdP → hops → home forever, buying a fresh budget
+    // and deadline every two navigations. Bounded per leg, unbounded per task.
+    const v = bound({ landing: IDP, landingIsSensitive: true, landingIsIdp: true, excursionsUsed: MAX_EXCURSIONS });
+    expect(v.action).toBe('end');
   });
 
   test('an excursion cannot be opened toward a NON-IdP', () => {

--- a/tests/peerd-runtime/actor/landing-rule.test.ts
+++ b/tests/peerd-runtime/actor/landing-rule.test.ts
@@ -1,0 +1,136 @@
+// issue 251 — the landing rule. What happens when a web actor's tab is
+// somewhere.
+//
+// The property this file exists to pin, and the reason the rule is shaped the
+// way it is: it judges WHERE THE TAB IS, never what was asked for. An
+// args.url check catches only a navigation the actor made, and is defeated by
+// any 302 — which is not theoretical, because navigate.js re-stamps the pin to
+// the landing origin, laundering an open redirect into an owned one. Every
+// test below therefore describes a LANDING, with no reference to how the tab
+// got there, because the rule genuinely cannot tell and must not need to.
+
+import { describe, test, expect } from 'bun:test';
+import { decideLanding, EXCURSION_BUDGET, EXCURSION_MS } from '../../../extension/peerd-runtime/actor/landing-rule.js';
+
+const OWNED = 'https://app.test';
+const bound = (over: any = {}) => decideLanding({ mode: 'bound', ownedOrigin: OWNED, landingIsSensitive: false, now: 1_000, ...over });
+const roaming = (over: any = {}) => decideLanding({ mode: 'roaming', landingIsSensitive: false, ...over });
+
+describe('roaming — the no-entry rule', () => {
+  test('an ordinary page is fine; browsing is the whole point of roaming', () => {
+    expect(roaming({ landing: 'https://blog.test/post' }).action).toBe('continue');
+  });
+
+  test('a credentialed site is REFUSED and handed off', () => {
+    // The core of #251. A roaming actor holds no authority and must not
+    // acquire any by walking into a site where the user has an identity.
+    // Note what this is NOT: a confirm. An earlier draft let the actor in and
+    // leaned on #242's prompt, which makes user attention the boundary.
+    const v = roaming({ landing: 'https://github.com/acme/x', landingIsSensitive: true });
+    expect(v.action).toBe('handoff');
+    expect(v.handoffTo).toBe('https://github.com');
+  });
+
+  test('the handoff names the successor origin, normalized', () => {
+    // The orchestrator routes on this value, so a path or a port must not ride along.
+    expect(roaming({ landing: 'HTTPS://GitHub.com:443/a?b=c', landingIsSensitive: true }).handoffTo)
+      .toBe('https://github.com');
+  });
+
+  test('a roaming actor has no owned origin to leave, so nothing else can end it', () => {
+    const v = roaming({ landing: 'https://elsewhere.test', ownedOrigin: OWNED });
+    expect(v.action).toBe('continue');
+  });
+});
+
+describe('bound — the origin lock', () => {
+  test('on its own site it continues', () => {
+    expect(bound({ landing: `${OWNED}/deep/page` }).action).toBe('continue');
+  });
+
+  test('off its own site it ENDS — regardless of how it got there', () => {
+    const v = bound({ landing: 'https://evil.test/x' });
+    expect(v.action).toBe('end');
+  });
+
+  test('an off-origin landing ends it even when the destination looks harmless', () => {
+    // The rule is about leaving, not about the destination's reputation.
+    // A benign-looking open-redirect target is the whole attack.
+    expect(bound({ landing: 'https://cdn.test/asset' }).action).toBe('end');
+  });
+
+  test('the FIRST landing defines what it owns', () => {
+    // A bound actor starts on a blank tab and cannot know its origin before
+    // arriving — same as an API actor, whose origin is fixed at mint.
+    const v = decideLanding({ mode: 'bound', ownedOrigin: null, landing: 'https://app.test', landingIsSensitive: true });
+    expect(v.action).toBe('continue');
+  });
+
+  test('a blank/unusable location is not a violation', () => {
+    // Transient (a tab mid-load, about:blank). Ending an actor over it would
+    // be a self-inflicted flake; the caller's null-tab handling owns this.
+    for (const l of ['about:blank', '', 'chrome-extension://x/p.html']) {
+      expect(bound({ landing: l }).action).toBe('continue');
+    }
+  });
+});
+
+describe('auth excursions — the OAuth solve', () => {
+  test('landing on a known IdP opens a bounded excursion instead of ending', () => {
+    const v = bound({ landing: 'https://accounts.google.com', landingIsSensitive: true, landingIsIdp: true });
+    expect(v.action).toBe('continue');
+    expect(v.excursion).toEqual({ returnTo: OWNED, budget: EXCURSION_BUDGET, deadline: 1_000 + EXCURSION_MS });
+  });
+
+  test('an in-flight excursion spends budget on each further hop', () => {
+    const ex = { returnTo: OWNED, budget: 2, deadline: 99_999 };
+    const v = bound({ landing: 'https://idp-step2.test', excursion: ex });
+    expect(v.action).toBe('continue');
+    expect(v.excursion?.budget).toBe(1);
+  });
+
+  test('an exhausted budget ends the actor', () => {
+    const v = bound({ landing: 'https://idp-step9.test', excursion: { returnTo: OWNED, budget: 0, deadline: 99_999 } });
+    expect(v.action).toBe('end');
+  });
+
+  test('an expired deadline ends the actor even with budget left', () => {
+    // why both: budget only decrements on navigation, so a tab parked
+    // mid-excursion would otherwise hold the exception open indefinitely.
+    const v = bound({ landing: 'https://idp.test', excursion: { returnTo: OWNED, budget: 9, deadline: 500 }, now: 1_000 });
+    expect(v.action).toBe('end');
+  });
+
+  test('returning to the owned origin discharges it — the only good ending', () => {
+    const v = bound({ landing: OWNED, excursion: { returnTo: OWNED, budget: 1, deadline: 99_999 } });
+    expect(v.action).toBe('continue');
+    expect(v.excursion).toBeUndefined();          // cleared, not carried
+  });
+
+  test('an excursion cannot be opened toward a NON-IdP', () => {
+    // Otherwise "off-origin" would be self-authorizing and the lock would be
+    // a suggestion.
+    expect(bound({ landing: 'https://evil.test', landingIsIdp: false }).action).toBe('end');
+  });
+
+  test('a roaming actor never needs an excursion — most SSO happens there', () => {
+    const v = roaming({ landing: 'https://accounts.google.com', landingIsSensitive: false, landingIsIdp: true });
+    expect(v.action).toBe('continue');
+    expect(v.excursion).toBeUndefined();
+  });
+});
+
+describe('the reasons are for humans', () => {
+  test('every reason is plain prose with no identifiers', () => {
+    const verdicts = [
+      roaming({ landing: 'https://github.com', landingIsSensitive: true }),
+      bound({ landing: 'https://evil.test' }),
+      bound({ landing: 'https://x.test', excursion: { returnTo: OWNED, budget: 0, deadline: 9e9 } }),
+      bound({ landing: 'https://x.test', excursion: { returnTo: OWNED, budget: 9, deadline: 1 } }),
+    ];
+    for (const v of verdicts) {
+      expect(v.reason.length).toBeGreaterThan(10);
+      expect(v.reason).not.toMatch(/[_{}();]|actor[A-Z]|null|undefined/);
+    }
+  });
+});

--- a/tests/peerd-runtime/actor/origin-sensitivity.test.ts
+++ b/tests/peerd-runtime/actor/origin-sensitivity.test.ts
@@ -1,0 +1,117 @@
+// issue 251 — the sensitivity classifier: is this an origin the user has an
+// identity on?
+//
+// The security property under test is NOT "does it catch every credentialed
+// site" — it cannot, and it fails open by design. It is:
+//   - the two SEEDS (curated registry, user-authored vault secret) always win,
+//     and win in that order, so the handoff notice cites the strongest signal
+//   - the LEARNED set works, and carries provenance when it has it
+//   - a non-origin (blank tab, extension page, IP, localhost) is never
+//     sensitive — there is nothing to be signed in to
+//   - it never throws on junk, because it runs on every landing
+
+import { describe, test, expect } from 'bun:test';
+import { classifyOriginSensitivity, sameOrigin, LEARNED_REASONS } from '../../../extension/peerd-runtime/actor/origin-sensitivity.js';
+
+const ugcOnly = { isUgcZone: (o: string) => o === 'https://github.com' };
+
+describe('sensitivity — the seeds', () => {
+  test('a UGC-registry origin is sensitive, attributed to the registry', () => {
+    const v = classifyOriginSensitivity('https://github.com', ugcOnly);
+    expect(v.sensitive).toBe(true);
+    expect(v.reason).toBe('ugc-zone');
+    expect(v.origin).toBe('https://github.com');
+  });
+
+  test('the UGC signal is INJECTED, not imported — absent means simply not that signal', () => {
+    // why this matters: the registry lands on its own schedule (#242 / PR #250).
+    // The classifier must be usable, and testable, without it.
+    expect(classifyOriginSensitivity('https://github.com').sensitive).toBe(false);
+  });
+
+  test('an origin the user stored a credential for is sensitive', () => {
+    const v = classifyOriginSensitivity('https://api.stripe.com', {
+      hasVaultSecret: (o) => o === 'https://api.stripe.com',
+    });
+    expect(v.reason).toBe('vault-secret');
+  });
+
+  test('classification is on the ORIGIN, not the path', () => {
+    // #242 gates one write and is path-scoped; being BOUND is about the whole
+    // site's session, so a repo root is as sensitive as an issue page.
+    expect(classifyOriginSensitivity('https://github.com/acme/widget', ugcOnly).sensitive).toBe(true);
+  });
+
+  test('a seed outranks the learned set, so the notice cites the stronger signal', () => {
+    const v = classifyOriginSensitivity('https://github.com', {
+      ...ugcOnly,
+      learned: new Map([['https://github.com', 'password-field' as const]]),
+    });
+    expect(v.reason).toBe('ugc-zone');
+  });
+});
+
+describe('sensitivity — the learned set', () => {
+  test('a learned origin is sensitive and keeps its provenance', () => {
+    const v = classifyOriginSensitivity('https://bank.test', {
+      learned: new Map([['https://bank.test', 'confirmed-write' as const]]),
+    });
+    expect(v.sensitive).toBe(true);
+    expect(v.reason).toBe('confirmed-write');
+  });
+
+  test('a bare Set works, reporting the weaker signal rather than claiming one', () => {
+    const v = classifyOriginSensitivity('https://bank.test', {
+      learned: new Set(['https://bank.test']),
+    });
+    expect(v.sensitive).toBe(true);
+    expect(LEARNED_REASONS).toContain(v.reason as any);
+  });
+
+  test('the learned set is keyed on the NORMALIZED origin', () => {
+    // The store writes normalized keys; a lookup that didn't normalize would
+    // silently miss and hand a roaming actor into a credentialed site.
+    const v = classifyOriginSensitivity('HTTPS://Bank.test:443/login', {
+      learned: new Set(['https://bank.test']),
+    });
+    expect(v.sensitive).toBe(true);
+  });
+});
+
+describe('sensitivity — nothing to be signed in to', () => {
+  test.each([
+    ['about:blank'], ['chrome-extension://abc/page.html'], ['http://localhost:3000'],
+    ['http://127.0.0.1'], ['javascript:alert(1)'], ['data:text/html,hi'], [''],
+  ])('%s is never sensitive', (input) => {
+    expect(classifyOriginSensitivity(input, ugcOnly).sensitive).toBe(false);
+  });
+
+  test.each([[null], [undefined], [42], [{}], [[]]])('junk input %p does not throw', (input) => {
+    expect(() => classifyOriginSensitivity(input as any, ugcOnly)).not.toThrow();
+    expect(classifyOriginSensitivity(input as any, ugcOnly).sensitive).toBe(false);
+  });
+
+  test('a host that merely CONTAINS a sensitive one is not it', () => {
+    // The normalize step is the same one the egress boundary uses, so
+    // github.com.evil.test cannot borrow github's classification.
+    expect(classifyOriginSensitivity('https://github.com.evil.test', ugcOnly).sensitive).toBe(false);
+  });
+});
+
+describe('sameOrigin', () => {
+  test('normalizes both sides — case, default port, path', () => {
+    expect(sameOrigin('HTTPS://GitHub.com:443/a/b', 'https://github.com')).toBe(true);
+  });
+
+  test('different origins are different', () => {
+    expect(sameOrigin('https://github.com', 'https://evil.test')).toBe(false);
+    expect(sameOrigin('https://github.com', 'http://github.com')).toBe(false);   // scheme counts
+  });
+
+  test('an unusable origin is never "the same as" anything, including another unusable one', () => {
+    // why: two nulls must not compare equal, or a blank tab would read as
+    // "still on the owned site" and the landing rule would wave it through.
+    expect(sameOrigin('about:blank', 'about:blank')).toBe(false);
+    expect(sameOrigin('about:blank', 'https://github.com')).toBe(false);
+  });
+});


### PR DESCRIPTION
## In plain terms

A web actor today drives a tab anywhere — searching, following links, then acting on your GitHub with your login, all as the same thing. A page that hijacks it inherits every site you're signed into.

This splits it in two:

- **A roaming actor** browses. Follows links, reads pages, hops between sites. That's what you have today and it doesn't change.
- **A bound actor** works on *one* credentialed site and cannot leave it.

**A roaming actor can't enter a credentialed site.** If browsing leads somewhere you have an account, it stops and hands the work to that site's actor. So a hijacked roaming actor has nothing worth stealing, and never reaches anything that does.

This PR is the two **pure cores** only — no consumer yet, exactly like #245/#246/#247/#249. Enforcement is the follow-up.

## What's here

**`origin-sensitivity.js`** — which origins you have an identity on. Two seeds: the #242 UGC registry (**injected**, not imported, so this doesn't depend on #250's merge order) and any origin with a vault `origin:` secret, which you authored. Two learned signals that are byproducts of ordinary use and need no new permission: a password field seen in the DOM walk, and an approved `web:write`.

**`landing-rule.js`** — judge the **landing**, never the request. A tab's origin changes three ways: the actor navigates, that navigation 302s, or the page redirects itself. Only the first is a tool call, so an `args.url` check is defeated by any open redirect — and that isn't hypothetical, because `navigate.js:145-165` re-stamps the pin to wherever the tab landed, laundering the change into an owned origin. Testing where the tab *actually is* collapses all three into one check no redirect chain can walk around.

**Auth excursions** are the OAuth answer: a bound actor landing on a known IdP opens a bounded exception — navigation budget, deadline, recorded opener, lifetime cap — dischargeable only by returning home. Roaming actors need none, which is where most SSO happens.

## Reviewed by a skeptical swarm — and it found a hole I'd introduced

Four lenses (bypass / design-gap / elegance / integration), every finding adversarially verified. **7 survived, 9 refuted**, plus two the lenses missed and the synthesis pass caught. Verdict: LAND-WITH-FIXES. The second commit is that pass. All six were in `landing-rule.js`; the classifier came back clean.

The worst one is worth stating plainly, because it inverted the file's only invariant:

> **`normalizeApiOrigin` is not a "where is this tab" predicate.** Its host rule exists so an *addressed* origin can't collide with the literal `'web'` or a numeric tabId — its own comment says so. Reusing it as a location test folded IP literals, IPv6, trailing-dot FQDNs, underscore labels, loopback and single-label intranet hosts into "no page loaded". A bound actor 302'd to `https://evil.com./pwn` was told to **continue**. Those pages load fine.

Unlike the classifier's fail-open — which declines to *add* a protection — that **removed** one. Now three location classes, with "a real page we cannot canonicalize" treated as foreign.

The other five: an unvalidated `mode` that fell through permissively (turning the whole core into an unconditional `continue`); an open excursion that never re-checked its destination, giving a bound actor four free hops onto your mail or bank; a corridor that refreshed by bouncing home, making it bounded per leg but unbounded per task; a budget documented in navigations but spent per *invocation*, which would have killed a six-call single-page login against a budget of four; and a first-landing branch that decided an adoption without returning anything to adopt.

## Checklist

- [x] Gates green — bun **3144**, typecheck, lint, `check:boundary`, `check:tscheck` (floor 530 → 532)
- [x] Only original code — no copyleft
- [x] Tests added — **68** cases across both cores, including the six unnameable-host regressions, the bad-mode table, corridor-refresh and same-page-budget
- [x] No hand-edited generated files
- [x] **Danger zone: the actor authority boundary.** Pure core, no consumer yet — see below.

## Notes for reviewers

**Not wired.** These decide; nothing calls them. The enforcement points (`resolveTargetTab`, `navigate.js`'s pin re-stamp, `gates.js`) are the follow-up PR, which also owns the handoff routing and the learned-signal writes.

**One rule the core cannot enforce, and the wiring must.** `decideLanding` returns `handoffTo`, but the requirement that the **orchestrator re-authors the goal** — never forwarding the roaming actor's text — lives in the unbuilt wiring. If an implementer just forwards it, a hijacked roaming actor writes its own payload into the handoff and the segmentation is decorative. That has to be a hard gate.

**Fail-open is real and named.** An unlisted credentialed site — a bank, webmail, an internal tool — gets roaming treatment until a learned signal fires, so the *first* visit to any such site is roaming by construction. The learned set shrinks that with use rather than pretending a seed list could be complete.

**Sequencing.** Independent of #250 by construction (the UGC signal is injected). Design and open questions live in #251.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRfeF2q9Nw7Goiudk6PwQ8)_