### PR TITLE
docs: bring CLAUDE.md current with the security-boundary arc (#255)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,9 @@ exists today:
    addressable handle), and replies re-enter it fenced on a later
    turn — it never blocks. The web actor (`actor/web-actor.js`) is
    the single entry point for web work: it picks between a sessionless,
-   denylist-gated `fetch_url` and opening + driving a tab. Dweb tools
+   denylist-gated `fetch_url` and opening + driving a tab, and it is
+   ORIGIN-SEGMENTED — roaming or bound to one origin, under the origin
+   lock (see the security-boundary bullet below). Dweb tools
    are invisible where `DWEB_ENABLED` is false. Plus sessions, clock
    (temporal grounding), actor orchestrator, voice (Moonshine WASM
    + Web Speech fallback).
@@ -355,6 +357,32 @@ gotchas to know going in:
   audit. The legacy permission-mode axis was REMOVED
   2026-06-12 — Plan/Act + the denylist carry the safety weight; Plan
   permits pure URL loads only, never clicks (enforced in `gates.js`).
+- The security boundary around web work — the web actor is
+  **origin-segmented**. Every web actor is either ROAMING (browses
+  freely, holds no credentialed authority) or BOUND to exactly one
+  origin it may not leave; the orchestrator addresses a bound one as
+  `site:<origin>`. The lock judges the URL the tab ACTUALLY LANDED ON,
+  never the one something asked for, so an unobserved redirect cannot
+  smuggle a roaming actor onto a credentialed origin — a roaming actor
+  that lands on a sensitive origin STOPS and reports a handoff instead
+  of continuing. Which origins count as sensitive is part curated seed,
+  part LEARNED from ordinary use (a walked password field, an approved
+  write, any origin with a stored key). Credential scope is derived,
+  never model-named, and can only narrow. Pure cores in
+  `peerd-runtime/actor/` (`landing-rule.js`, `origin-lock.js`,
+  `origin-sensitivity.js`, `learned-origins.js`, `ugc-registry.js`,
+  `reply-schema.js`); enforcement at the DOM chokepoint in the
+  dispatcher and the SW's site-fetch/call routes. Alongside it: **CDR
+  disarm** (`peerd-runtime/dom/cdr.js`) strips zero-width runs, bidi
+  overrides and Unicode tag characters from page text before the model
+  reads it, leaving Persian/Urdu/Indic intact; a **UGC-zone** forced
+  confirmation on acting-as-the-user on pages strangers wrote, which
+  fires even with confirmations off; and an **exfil-shaped-URL
+  tripwire** (`tools/egress-heuristics.js`) on both navigations and the
+  actor's own fetch. All of it is best-effort ABOVE the real
+  containment, which is still the offscreen heap fence — the residuals
+  are written down honestly in `docs/security/THREAT-MODEL.md`, and
+  `docs/security/RED-TEAM-RESULTS.md` is generated, not hand-maintained.
 - The feature buildout — memory, edit + checkpoints, Plan/Act,
   composer (slash commands + @-refs), goal mode (autonomous loop), cost
   telemetry, skills, review actor, and hooks — all integrated.


### PR DESCRIPTION
## What & why

#255 shipped a new user-visible posture and refreshed `SECURITY.md` and `docs/security/THREAT-MODEL.md`, but `CLAUDE.md` — the file the project tells every session to read first — said nothing about any of it. Nothing was structurally wrong, since the arc's new files sit inside already-described directories, but the orientation was stale on exactly the part of the system a session is most likely to touch.

This adds a "What's shipped" bullet for the boundary (origin-segmented web actors and the origin lock, learned sensitive origins, derived-not-model-named credential scope, CDR disarm, the UGC forced confirm, the exfil tripwire) and notes the segmentation in the layer-5 web-actor description, which previously described the web actor as picking between `fetch_url` and driving a tab with no mention that it is now origin-bound.

Found by the skeptical review swarm that gated the arc's merge — it was the one gap none of #245–#254 closed.

## Checklist

- [x] `bun run preflight` passes (tests, typecheck, lint, in-browser, dweb-boundary, no manifest drift)
- [x] Only original or permissively-licensed code — **no GPL / AGPL / copyleft**
- [x] Tests added or updated (or N/A) — N/A, prose only
- [x] No hand-edited generated files (`manifest.json`, `shared/channel-config.js`)
- [x] Called out below if this touches a **danger zone** (egress / vault / gates / runner & sandbox boundaries / dweb)

Gates run rather than assumed: `bun run lint` clean, `bun run check:docpaths` OK, `bun run check:boundary` OK. (`eslint extension packaging` reports one pre-existing `prefer-template` error in `packaging/templates/browser-polyfill.web.js`; it is on `main` already and outside what the `lint` script covers.)

## Notes for reviewers

This describes a danger zone (gates / egress) but changes no code — prose only, one file.

Written to the docs-defer-to-code convention, which is the main thing worth checking: it gives the **shape** and cites files rather than transcribing anything that drifts. No curated-origin list, no IdP list, no tripwire thresholds, no test counts. The honest-residuals pointer goes to `THREAT-MODEL.md` rather than restating R14–R17 inline, and `RED-TEAM-RESULTS.md` is explicitly flagged as generated so nobody hand-edits it. `check:docpaths` verifies every path cited resolves, so this stays enforced.

One judgement call worth a second opinion: I described the lock as judging "the URL the tab ACTUALLY LANDED ON, never the one something asked for." That is the invariant the arc's tests pin, and it is the part most likely to be mis-remembered by a future session as "checks the requested URL" — which is why it is stated in caps rather than left to the code. If you'd rather CLAUDE.md stay shorter and defer the whole mechanism to `origin-lock.js`, the bullet compresses to about three lines without losing the pointer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ed15hKHSrQU5Tq4wsQer6C)_