### PR TITLE
fix(security): don't learn an origin from a signup form's password field

### DIFF
--- a/extension/peerd-runtime/dom/walk-injected.js
+++ b/extension/peerd-runtime/dom/walk-injected.js
@@ -222,9 +222,35 @@ export function domWalkInjected() {
   // Known miss: querySelector does not pierce shadow roots, so a login form
   // inside a closed or open shadow tree is invisible here. Fail-open, same as
   // the classifier it feeds.
+  //
+  // why `new-password` is EXCLUDED: that autocomplete token means "this field
+  // CREATES a password", i.e. a registration form — which is evidence the user
+  // does NOT have an account here, the exact opposite of what this signal is
+  // asking. Measured: the whole Stack Exchange network ships a hidden signup
+  // modal (action="/users/signup", autocomplete="new-password") in its page
+  // chrome, so reading ONE answer permanently marked stackoverflow.com,
+  // superuser.com, serverfault.com, askubuntu.com and math.stackexchange.com as
+  // sites the user has an identity on — after which a roaming helper could never
+  // drive a tab there again, with no UI to see or undo it.
+  //
+  // why not filter on VISIBILITY instead (the first thing that suggests itself):
+  // it would undo the deliberate choice above. A closed sign-in modal is hidden
+  // AND is a real signal; that case is the reason this reads the document rather
+  // than the walk. `new-password` separates the two without touching it.
+  //
+  // Checked against real pages: this clears 6/7 of the observed false positives
+  // and keeps 7/7 real sign-in pages firing (they use `current-password` or no
+  // autocomplete at all). The one origin still marked, instagram.com, is a
+  // genuine login form on its front page — a correct classification.
   var hasPasswordField = false;
   try {
-    hasPasswordField = !!document.querySelector('input[type="password"]');
+    var pwFields = document.querySelectorAll('input[type="password"]');
+    for (var pwIndex = 0; pwIndex < pwFields.length; pwIndex++) {
+      var pwAutocomplete = pwFields[pwIndex].getAttribute('autocomplete');
+      if (String(pwAutocomplete == null ? '' : pwAutocomplete).toLowerCase() === 'new-password') continue;
+      hasPasswordField = true;
+      break;
+    }
   } catch (e) {
     hasPasswordField = false;
   }
@@ -302,14 +328,23 @@ export function domWalkInjected() {
  *
  * Deliberately ES5 and self-contained: chrome.scripting serializes this source
  * and re-evaluates it in the page's classic-script world, so it can close over
- * nothing. See the header of dom-helpers.js.
+ * nothing. See the header of dom-helpers.js. That is also why the
+ * `new-password` rule is spelled out again here instead of shared — an injected
+ * body closes over nothing, so the two copies must each stand alone. Keep them
+ * in step; the walk copy carries the full rationale.
  *
  * @returns {boolean}
  */
 export function hasPasswordFieldInjected() {
   'use strict';
   try {
-    return !!document.querySelector('input[type="password"]');
+    var fields = document.querySelectorAll('input[type="password"]');
+    for (var i = 0; i < fields.length; i++) {
+      var autocomplete = fields[i].getAttribute('autocomplete');
+      // A registration field is evidence the user has NO account here.
+      if (String(autocomplete == null ? '' : autocomplete).toLowerCase() !== 'new-password') return true;
+    }
+    return false;
   } catch (e) {
     return false;
   }

--- a/extension/tests/unit/peerd-runtime/dom-walk.test.js
+++ b/extension/tests/unit/peerd-runtime/dom-walk.test.js
@@ -13,6 +13,7 @@
 
 import { describe, it, expect } from '../../framework.js';
 import { domWalkInjected, createRefRegistry } from '/peerd-runtime/index.js';
+import { hasPasswordFieldInjected } from '/peerd-runtime/dom/walk-injected.js';
 import { snapshotTool, clickTool, typeTool } from '/peerd-runtime/tools/defs/index.js';
 
 /** @typedef {import('/shared/tool-types.js').ToolContext} ToolContext */
@@ -253,6 +254,111 @@ describe('snapshot → click/type over walk refs — full chain', () => {
       expect(r.ok).toBe(true);
       expect(contentOf(r)).toContain('~ ');                 // Send changed state
       expect(contentOf(r)).toContain('- link "Help"');
+    });
+  });
+});
+
+// The password-field signal (issue 251) — the ONE bit the walk reports to the
+// origin classifier, and the only input to "does the user have an account here"
+// that the DOM can supply. Both entry points are covered because they are
+// separate ES5 copies by necessity (an injected body closes over nothing), so
+// they can drift apart silently.
+//
+// The load-bearing case is `new-password`. Measured on the live web, the Stack
+// Exchange network ships a hidden SIGNUP modal on every page; treating that as
+// "you have an account here" locked a roaming helper out of stackoverflow.com
+// after a single ordinary read, permanently and invisibly.
+describe('dom walk — the password-field signal', () => {
+  /**
+   * A fixture with NO password field of its own, so each test controls exactly
+   * what is in the document. why its own helper: the shared FIXTURE_HTML above
+   * carries `#dw-secret`, which would make every case below trivially true.
+   * @param {string} html
+   * @param {(host: HTMLElement) => Promise<void> | void} fn
+   */
+  const withInputs = async (html, fn) => {
+    const host = document.createElement('div');
+    host.id = 'pw-signal-fixture';
+    host.innerHTML = html;
+    document.body.appendChild(host);
+    try { await fn(host); }
+    finally { host.remove(); }
+  };
+
+  it('no password field anywhere: both entry points say false', async () => {
+    await withInputs('<input type="text" name="q">', () => {
+      expect(domWalkInjected().hasPasswordField).toBe(false);
+      expect(hasPasswordFieldInjected()).toBe(false);
+    });
+  });
+
+  it('a bare password field marks the origin', async () => {
+    await withInputs('<input type="password" name="pass">', () => {
+      expect(domWalkInjected().hasPasswordField).toBe(true);
+      expect(hasPasswordFieldInjected()).toBe(true);
+    });
+  });
+
+  it('autocomplete="current-password" marks the origin — that IS a sign-in box', async () => {
+    await withInputs('<input type="password" autocomplete="current-password">', () => {
+      expect(domWalkInjected().hasPasswordField).toBe(true);
+      expect(hasPasswordFieldInjected()).toBe(true);
+    });
+  });
+
+  it('a HIDDEN sign-in box still marks the origin (the deliberate case)', async () => {
+    // why this test exists: the obvious fix for the signup false positive is to
+    // skip fields that are not rendered, and it would break this — a login modal
+    // behind a button is hidden AND is a real signal. It is the reason the signal
+    // reads the document rather than the walk.
+    await withInputs('<div style="display:none"><input type="password" autocomplete="current-password"></div>', () => {
+      expect(domWalkInjected().hasPasswordField).toBe(true);
+      expect(hasPasswordFieldInjected()).toBe(true);
+    });
+  });
+
+  it('autocomplete="new-password" ALONE does NOT mark the origin — it is a signup form', async () => {
+    // The shipped Stack Exchange shape, reduced: a hidden signup modal whose
+    // password field is for CREATING an account the user does not have.
+    await withInputs(
+      '<form action="/users/signup" style="visibility:hidden">'
+      + '<input type="email" name="email">'
+      + '<input type="password" name="password" autocomplete="new-password">'
+      + '</form>',
+      () => {
+        expect(domWalkInjected().hasPasswordField).toBe(false);
+        expect(hasPasswordFieldInjected()).toBe(false);
+      },
+    );
+  });
+
+  it('an identifier sibling does NOT rescue a signup form', async () => {
+    // why called out: requiring the password field to sit in a form that also has
+    // an identifier input was the mitigation origin-sensitivity.js weighed and did
+    // not take. It would NOT have fixed this — the signup form has an email field.
+    await withInputs(
+      '<form><input type="text" name="email"><input type="password" autocomplete="new-password"></form>',
+      () => {
+        expect(domWalkInjected().hasPasswordField).toBe(false);
+      },
+    );
+  });
+
+  it('a signup form ALONGSIDE a sign-in box still marks the origin', async () => {
+    await withInputs(
+      '<input type="password" autocomplete="new-password">'
+      + '<input type="password" autocomplete="current-password">',
+      () => {
+        expect(domWalkInjected().hasPasswordField).toBe(true);
+        expect(hasPasswordFieldInjected()).toBe(true);
+      },
+    );
+  });
+
+  it('the token is matched case-insensitively', async () => {
+    await withInputs('<input type="password" autocomplete="NEW-PASSWORD">', () => {
+      expect(domWalkInjected().hasPasswordField).toBe(false);
+      expect(hasPasswordFieldInjected()).toBe(false);
     });
   });
 });


### PR DESCRIPTION
**Why**

The learned password-field signal was a bare `querySelector('input[type="password"]')`, so any password input anywhere permanently marked the origin as one the user has an account on - with no UI to clear it. Found dog-fooding #255; context #251.

**What**

- Ignore password inputs with `autocomplete="new-password"` - that token means a signup form, i.e. no account.
- Applied in both ES5 copies in `dom/walk-injected.js` (injected bodies cannot share code).
- Clears 6 of 7 observed false positives (all 5 Stack Exchange sites + Pinterest); 7 of 7 real sign-in pages still fire.
- Existing installs keep origins already marked - clearing those needs the learned-origins list + clear UI.

**How**

- 8 in-browser tests in `extension/tests/unit/peerd-runtime/dom-walk.test.js`, covering both entry points.
- `bun run preflight` passes.
- e2e `origin-lock` passes unchanged - its fixture uses a bare password input.
