### PR TITLE
feat(ui): show which tab peerd is driving, and what it is doing in there

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -349,6 +349,7 @@ export default [
   {
     files: [
       'extension/peerd-runtime/dom/walk-injected.js',
+      'extension/peerd-runtime/dom/activity-overlay-injected.js',
       'extension/peerd-runtime/dom/framework-state.js',
       'extension/peerd-runtime/dom/pull-in-hint-injected.js',
       'extension/peerd-runtime/dom/fetch-tap-injected.js',

--- a/extension/background/page-activity.js
+++ b/extension/background/page-activity.js
@@ -1,0 +1,211 @@
+// @ts-check
+// page-activity — make it obvious WHICH tab peerd is driving and WHAT it is
+// doing in there, from inside the browser rather than only from the side panel.
+//
+// Two surfaces, one lifecycle:
+//   TAB STRIP   the driven tab joins the collapsible "peerd" tab group, the same
+//               group the engine tabs already use (background/tab-tracker.js), so
+//               a glance at the strip says which tab is not the user's to touch.
+//   IN PAGE     a small corner pill (dom/activity-overlay-injected.js) naming the
+//               current action, with a Stop button.
+//
+// why both and not one: they answer different questions. The group answers
+// "which tab", visible even when the tab is in the background. The pill answers
+// "is it working, or has it hung" — the complaint that prompted this — and it is
+// only visible where the user is actually looking when peerd is mid-task.
+//
+// IO IS INJECTED (tabs / tabGroups / scripting), so the whole lifecycle is
+// testable without a browser and the in-browser tests can drive it with stubs —
+// the same posture tab-tracker.js takes.
+//
+// EVERYTHING HERE IS BEST-EFFORT. A failure to decorate a tab must never fail
+// the tool call that triggered it: the user asked peerd to do something on a
+// page, and losing that to a cosmetic error would be a strictly worse bug than
+// the one this fixes. Every entry point swallows. On Firefox, `tabGroups` is
+// absent and the group half no-ops while the pill still works.
+
+import { activityOverlayInjected, clearActivityOverlayInjected } from '/peerd-runtime/index.js';
+
+/**
+ * The tab group the driven tab joins. Deliberately the SAME title the engine
+ * tabs use (app-client.js APP_TAB_GROUP_TITLE), so peerd owns one group in the
+ * strip rather than sprouting one per subsystem.
+ */
+export const ACTIVITY_GROUP_TITLE = 'peerd';
+
+/** @typedef {{ tabs: any, tabGroups?: any, scripting: any }} ActivityDeps */
+
+/**
+ * Put a tab into peerd's tab group.
+ *
+ * why remember nothing about the previous group: a tab the user had already
+ * grouped is a case we cannot restore faithfully (tabGroups has no "put it back
+ * where it was" and re-grouping would move it again), so release UNGROUPS and
+ * leaves it loose. Stated here because it IS a behaviour change to the user's
+ * strip and the honest answer is that it is imperfect, not that it is invisible.
+ *
+ * @param {number} tabId
+ * @param {ActivityDeps} deps
+ * @returns {Promise<boolean>} whether the tab ended up grouped
+ */
+export const groupDrivenTab = async (tabId, deps) => {
+  const { tabs, tabGroups } = deps;
+  if (!tabGroups || typeof tabs?.group !== 'function') return false;   // Firefox
+  try {
+    const tab = await tabs.get(tabId);
+    const existing = await tabGroups.query({ title: ACTIVITY_GROUP_TITLE, windowId: tab.windowId });
+    const groupId = existing?.[0]?.id;
+    if (groupId == null) {
+      const created = await tabs.group({ tabIds: [tabId] });
+      await tabGroups.update(created, { title: ACTIVITY_GROUP_TITLE, color: 'orange', collapsed: false });
+    } else {
+      await tabs.group({ tabIds: [tabId], groupId });
+    }
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Take a tab back out of peerd's group.
+ * @param {number} tabId
+ * @param {ActivityDeps} deps
+ * @returns {Promise<boolean>}
+ */
+export const ungroupDrivenTab = async (tabId, deps) => {
+  const { tabs } = deps;
+  if (typeof tabs?.ungroup !== 'function') return false;
+  try {
+    await tabs.ungroup([tabId]);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Show (or update) the in-page pill.
+ *
+ * why re-inject on every call rather than holding a port: the pill dies with the
+ * document, and the actor navigates constantly. A per-call injection is
+ * self-healing — the first action after a navigation rebuilds it — where a port
+ * would need reconnect bookkeeping to reach the same place.
+ *
+ * @param {number} tabId
+ * @param {string} label   the phrase from describeToolActivity
+ * @param {string} origin  the origin being driven, shown under the phrase
+ * @param {ActivityDeps} deps
+ * @returns {Promise<boolean>}
+ */
+export const showPageActivity = async (tabId, label, origin, deps) => {
+  try {
+    await deps.scripting.executeScript({
+      target: { tabId },
+      func: activityOverlayInjected,
+      args: [String(label ?? ''), String(origin ?? '')],
+    });
+    return true;
+  } catch {
+    // A restricted page (chrome://, the Web Store, a PDF viewer) refuses
+    // injection. Nothing to do — the tab-group marking still stands.
+    return false;
+  }
+};
+
+/**
+ * Remove the in-page pill.
+ * @param {number} tabId
+ * @param {ActivityDeps} deps
+ * @returns {Promise<boolean>}
+ */
+export const clearPageActivity = async (tabId, deps) => {
+  try {
+    await deps.scripting.executeScript({
+      target: { tabId },
+      func: clearActivityOverlayInjected,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Build the activity reporter the tool dispatcher calls around every
+ * `primitive:'tab'` call.
+ *
+ * The returned object is what gets threaded onto the tool context as
+ * `onToolActivity`. It is stateful in one small way — it remembers which tabs it
+ * has grouped — so release can ungroup exactly those and leave every other tab
+ * alone.
+ *
+ * THE TWO LIFETIMES, which are deliberately different because they answer
+ * different questions:
+ *
+ *   THE GROUP lasts as long as peerd OWNS the tab — across turns, through the
+ *   thinking gaps, until the binding drops. "This tab is not yours right now."
+ *   THE PILL lasts only while a turn is actually running. "It is working, here,
+ *   on this, and here is Stop."
+ *
+ * Collapsing them was the first design and it was wrong in both directions: a
+ * pill that outlived the turn says peerd is busy when it is idle, and a group
+ * that ended with the turn would shuffle the tab in and out of the strip on
+ * every exchange.
+ *
+ * @param {ActivityDeps} deps
+ * @returns {{
+ *   begin: (tabId: number, label: string, origin: string) => Promise<void>,
+ *   end: (tabId: number) => Promise<void>,
+ *   idle: (tabId: number) => Promise<void>,
+ *   release: (tabId: number) => Promise<void>,
+ *   markedTabs: () => number[],
+ * }}
+ */
+export const createPageActivityReporter = (deps) => {
+  /** Tabs this reporter grouped, so release only undoes its own work. */
+  const marked = new Set();
+
+  return {
+    /** A tab tool is starting: mark the tab and name the action. */
+    begin: async (tabId, label, origin) => {
+      if (typeof tabId !== 'number') return;
+      if (!marked.has(tabId)) {
+        marked.add(tabId);
+        await groupDrivenTab(tabId, deps);
+      }
+      await showPageActivity(tabId, label, origin, deps);
+    },
+
+    // why the pill SURVIVES the end of a call: the gap between two tool calls is
+    // the model thinking, which is most of the wall-clock the user is waiting
+    // through — and it is exactly when a disappearing indicator would read as
+    // "it finished" and invite them to grab the keyboard. The phrase softens to
+    // "Thinking…" instead; idle() is what takes the pill down, at turn end.
+    end: async (tabId) => {
+      if (typeof tabId !== 'number' || !marked.has(tabId)) return;
+      await showPageActivity(tabId, 'Thinking…', '', deps);
+    },
+
+    /**
+     * The TURN is over. Take the pill down — peerd is not doing anything right
+     * now — but keep the group: it still owns the tab and will be back.
+     */
+    idle: async (tabId) => {
+      if (typeof tabId !== 'number' || !marked.has(tabId)) return;
+      await clearPageActivity(tabId, deps);
+    },
+
+    /**
+     * Peerd no longer OWNS the tab — the binding dropped, the tab closed, or the
+     * origin lock handed it back. Undo everything, including the grouping.
+     */
+    release: async (tabId) => {
+      if (typeof tabId !== 'number' || !marked.delete(tabId)) return;
+      await clearPageActivity(tabId, deps);
+      await ungroupDrivenTab(tabId, deps);
+    },
+
+    markedTabs: () => [...marked],
+  };
+};

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -4551,7 +4551,18 @@ const actorMessaging = makeActorMessaging({
     // oneShot: the loop synthesizes the reply from the first clean tool round and
     // stops (no summarize inference) — finalAssistantText below reads that synthetic
     // assistant message exactly like a normal reply, so nothing else changes here.
-    await runAgentTurn({ sessionId: actorSessionId, userText: deliveredMessage, synthetic: false, activeTabId: actorTabId, display, oneShot: oneShot === true });
+    try {
+      await runAgentTurn({ sessionId: actorSessionId, userText: deliveredMessage, synthetic: false, activeTabId: actorTabId, display, oneShot: oneShot === true });
+    } finally {
+      // why here too: runActorTurnOffscreen takes the pill down in its own
+      // finally, but this is the IN-SW fallback the offscreen path returns null
+      // for (Firefox has no offscreen API). Without it the pill outlives the
+      // turn on Firefox and sits on "Thinking…" forever — peerd saying it is
+      // working while nothing is happening, the exact misreading the indicator
+      // exists to prevent. The GROUP still stays; only the pill comes down.
+      const drivenTabId = webActorTabBindings.tabFor(actorSessionId);
+      if (typeof drivenTabId === 'number') pageActivity.idle(drivenTabId).catch(() => {});
+    }
     const s = await sessions.get(actorSessionId);
     const fresh = finalAssistantText(/** @type {any} */ ({ messages: (s?.messages ?? []).slice(before) }));
     return withLandingStop(fresh

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -282,6 +282,7 @@ import { makeOffscreenPdfClient } from './offscreen-pdf-client.js';
 import { makeOffscreenWebClient } from './offscreen-web-client.js';
 import { makeUiPorts } from './ui-ports.js';
 import { createAppClient, APP_TAB_GROUP_TITLE } from './app-client.js';
+import { createPageActivityReporter } from './page-activity.js';
 import { createAppTabTracker } from './app-tab-tracker.js';
 import {
   createVmRegistry,
@@ -1005,6 +1006,10 @@ const originLockFor = (/** @type {string | null | undefined} */ actorSessionId) 
         if (current) {
           const parkedTab = webActorTabBindings.tabFor(actorSessionId);
           if (typeof parkedTab === 'number' && webActorTabBindings.drop(parkedTab)) persistWebBindings();
+          // The stop hands this tab back to the user (they may want to look at
+          // it), so peerd's group + pill come off with the binding. Without this
+          // a refused tab stays in peerd's group forever, still looking driven.
+          if (typeof parkedTab === 'number') pageActivity.release(parkedTab).catch(() => {});
           // A SITE actor whose very first landing was refused is a dead handle:
           // its owned origin is one the site does not actually serve, and the
           // binding is durable, so retrying the same handle resumed the same
@@ -1139,6 +1144,16 @@ const todoChains = new Map();
  * provider + vault state so tools see a consistent view during a
  * single dispatch.
  */
+// The in-page activity indicator, one per service worker. Holds the set of tabs
+// it has marked so release() only ever undoes its own grouping — a tab the user
+// grouped themselves is none of its business. Best-effort throughout; on Firefox
+// browser.tabGroups is undefined and the group half quietly no-ops.
+const pageActivity = createPageActivityReporter({
+  tabs: browser.tabs,
+  tabGroups: /** @type {any} */ (browser).tabGroups,
+  scripting: browser.scripting,
+});
+
 const buildToolContext = async (/** @type {any} */ { sessionId: overrideSessionId, activeTabId, exposure, synthetic, trusted, actorInstanceId, actorType, actorBacking, actorSurface } = {}) => {
   // SECURITY: never build a tool context against an unloaded denylist. The seed
   // loads async; this await closes the cold-start race so the origin gate always
@@ -1315,6 +1330,13 @@ const buildToolContext = async (/** @type {any} */ { sessionId: overrideSessionI
     // action confirms. { mode: 'plan'|'act', confirmActions: boolean }.
     permission,
     activeTab,
+    // The in-page activity indicator (background/page-activity.js). The
+    // dispatcher calls begin/end around every `primitive:'tab'` call, so the
+    // tab peerd is driving marks itself in the tab strip and says what it is
+    // doing. Threaded here rather than imported by the dispatcher so the IO
+    // stays injected and every non-SW dispatch path (tests, the offscreen
+    // worker's own ctx) simply has no indicator.
+    onToolActivity: pageActivity,
     // why: the bound actor orchestrator. The actor_create tool calls
     // ctx.spawnActor(...) to decompose a task into a child session
     // that runs the same loop. Wired below; see makeSpawnActor.
@@ -4229,6 +4251,11 @@ const adoptWebTab = async (/** @type {string} */ actorSessionId) => {
 // so the two concerns stay independent.
 browser.tabs?.onRemoved?.addListener((/** @type {number} */ tabId) => {
   if (webActorTabBindings.drop(tabId)) persistWebBindings();
+  // The tab is gone, so both halves of the indicator are moot — but the
+  // reporter still holds the id in its marked set, and tab ids are reused
+  // within a session. Release drops it so a LATER tab that inherits the id
+  // isn't mistaken for one peerd already grouped.
+  pageActivity.release(tabId).catch(() => {});
 });
 
 // Heap-split phase 2: run an ENGINE actor's loop (vm/notebook/app) in its own
@@ -4352,6 +4379,13 @@ const runActorTurnOffscreen = async (/** @type {any} */ { actorSessionId, messag
     return r.finalText ? { result: r.finalText } : { result: 'the actor turn was stopped before it produced a reply.', stopped: true };
   } finally {
     release();
+    // The turn is over, so the pill comes down — leaving it up through the idle
+    // gap would say "peerd is working" while nothing is happening, which is the
+    // same misreading in the opposite direction. The tab GROUP stays: the actor
+    // still owns this tab and will be back on the next turn, and shuffling it in
+    // and out of the strip every exchange would be its own annoyance.
+    const drivenTabId = webActorTabBindings.tabFor(actorSessionId);
+    if (typeof drivenTabId === 'number') pageActivity.idle(drivenTabId).catch(() => {});
   }
 };
 

--- a/extension/peerd-runtime/actor/activity-label.js
+++ b/extension/peerd-runtime/actor/activity-label.js
@@ -1,0 +1,122 @@
+// @ts-check
+// peerd-runtime/actor — what to SAY the agent is doing, in the page it drives.
+//
+// PURE (tool name + args in → one short phrase out), so the wording is testable
+// without a browser and the imperative shell (background/page-activity.js) only
+// decides WHEN to show something, never WHAT it says.
+//
+// why a phrase and not the tool name: this is read by the person whose browser
+// is being driven, mid-task, out of the corner of their eye, while they decide
+// whether it is safe to touch the keyboard. "type" is jargon and "running tool:
+// type" is worse. "Typing…" is the thing they actually need.
+//
+// WHAT IS DELIBERATELY NOT IN THE PHRASE, and why — this is the part to keep
+// when editing:
+//
+//   1. NEVER the typed text. `type` carries the value going into the field,
+//      which is exactly where a password, a card number or a 2FA code lives.
+//      Painting it into an on-screen banner would put secrets on the user's
+//      monitor (and into any screen recording or shared window) that the page
+//      itself was masking. The phrase says "Typing…", never what.
+//
+//   2. NEVER page-derived text — no click selectors, no element labels, no
+//      titles. "Clicking Submit" reads better, but a selector is chosen from
+//      content the page authored, so echoing it lets a hostile page write the
+//      sentence the user reads while deciding whether to intervene. That is the
+//      same reasoning the origin-lock handoff report uses when it names an
+//      ORIGIN and never a path (actor/origin-lock-report.js).
+//
+//   3. Only the HOST of a navigation, never the full URL. Same rule: the host
+//      is what tells the user where they are going; the path and query are
+//      attacker-shaped and carry no extra meaning at a glance.
+//
+// So every phrase this returns is drawn from a FIXED vocabulary, with at most a
+// hostname interpolated. Nothing the model or the page writes reaches the user's
+// screen through this surface.
+
+/**
+ * Hostname of a URL, or null when it isn't a parseable absolute URL.
+ * why not a regex: `new URL` is the same parse the navigation itself will do, so
+ * the phrase can never name a host the browser would disagree about.
+ * @param {unknown} value
+ * @returns {string | null}
+ */
+const hostOf = (value) => {
+  try {
+    const { hostname } = new URL(String(value ?? ''));
+    return hostname || null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * The fixed vocabulary. Anything acting on the page gets an entry; a tool absent
+ * from this map and not `primitive:'tab'` gets no indicator at all.
+ * @type {Readonly<Record<string, string>>}
+ */
+const PHRASES = Object.freeze({
+  click: 'Clicking',
+  type: 'Typing',
+  page_keys: 'Pressing keys',
+  read_page: 'Reading the page',
+  read_pdf: 'Reading a PDF',
+  snapshot: 'Looking at the page',
+  query_dom: 'Looking at the page',
+  read_state: 'Looking at the page',
+  watch_changes: 'Watching for changes',
+  page_exec: 'Running a script on the page',
+  page_eval: 'Running a script on the page',
+});
+
+/** What the indicator says when a tab tool has no specific phrase. */
+export const GENERIC_ACTIVITY = 'Working on the page';
+
+/**
+ * The origin, as the pill's second line should read it: host only.
+ *
+ * why strip the scheme: the line above it already names hosts bare ("Opening
+ * github.com"), and `https://` on every pill is eight characters of noise on a
+ * surface whose whole job is to be readable at a glance in peripheral vision. A
+ * NON-https scheme is kept, because "http" on a page being driven with your
+ * session is worth seeing.
+ *
+ * @param {unknown} origin  a canonical origin, e.g. https://github.com
+ * @returns {string}  '' when there is nothing usable to show
+ */
+export const displayOrigin = (origin) => {
+  const raw = String(origin ?? '').trim();
+  if (!raw) return '';
+  try {
+    const url = new URL(raw);
+    return url.protocol === 'https:' ? url.host : `${url.protocol}//${url.host}`;
+  } catch {
+    return raw;
+  }
+};
+
+/**
+ * Describe one tool call as a phrase for the in-page indicator.
+ *
+ * @param {string} name   the tool name
+ * @param {Record<string, unknown> | null} [args]  the tool's arguments
+ * @param {{ isTabTool?: boolean }} [opts]
+ *   isTabTool marks a `primitive:'tab'` call the map doesn't name, so a tool
+ *   added later still shows SOMETHING rather than silently going dark. why it is
+ *   passed in rather than looked up: this file stays pure and free of the tool
+ *   registry, which reaches IO.
+ * @returns {string | null}  the phrase, or null when nothing should be shown
+ */
+export const describeToolActivity = (name, args = null, opts = {}) => {
+  const tool = String(name ?? '');
+
+  // Navigation names its destination host — the one thing worth interpolating.
+  if (tool === 'navigate' || tool === 'open_tab') {
+    const host = hostOf(/** @type {Record<string, unknown>} */ (args ?? {}).url);
+    return host ? `Opening ${host}` : 'Opening a page';
+  }
+
+  const phrase = Object.hasOwn(PHRASES, tool) ? PHRASES[tool] : null;
+  if (phrase) return phrase;
+  return opts.isTabTool === true ? GENERIC_ACTIVITY : null;
+};

--- a/extension/peerd-runtime/dom/activity-overlay-injected.js
+++ b/extension/peerd-runtime/dom/activity-overlay-injected.js
@@ -1,0 +1,197 @@
+// peerd-runtime/dom — the in-page "peerd is doing something here" indicator.
+//
+// A small pill in the bottom-right corner of the tab the web actor is driving:
+// the brand orb, one short phrase (actor/activity-label.js decides the words),
+// and a Stop button. It answers the two questions a person has when their own
+// browser starts moving on its own — "is this thing working, or stuck?" and
+// "how do I make it stop?" — in the place they are already looking, which is the
+// page, not the side panel.
+//
+// INVISIBLE TO PEERD ITSELF. This is the constraint that shapes the whole file.
+// The agent reads the page it is driving, so an indicator built naively becomes
+// something the agent SEES, describes back to the user, and can click. Three
+// independent measures keep it out, because any one of them could be undone by
+// a later edit and the failure is silent:
+//
+//   1. `aria-hidden="true"` on the host. walk-injected.js's isHidden() treats an
+//      aria-hidden element as hidden and `continue`s, which skips the element
+//      AND its subtree; the CDP a11y-tree path drops it for the same reason.
+//   2. A CLOSED shadow root. walk-injected.js descends `el.shadowRoot`, which is
+//      null for a closed root, so the walk cannot reach the contents even if
+//      measure 1 is removed.
+//   3. Closed shadow content is not part of the host's `textContent`, so
+//      read_page's text mode cannot pick the phrase up either.
+//
+// Measure 2 is also why the root is stashed on a global rather than re-read from
+// the element: a closed root is unreachable from the outside by design, so the
+// updater has to hold its own reference. Same isolated-world-global trick
+// walk-injected.js uses for walk ids, and it dies with the document for the same
+// reason — which is exactly the lifetime we want, since a navigation should
+// leave no stale pill behind.
+//
+// STYLING IS SELF-CONTAINED AND HARD-CODED. It cannot use the side panel's CSS
+// custom properties (different document) and must not inherit the host page's
+// (a page that sets `* { font-family: Comic Sans }` should not restyle this).
+// The shadow root gives isolation in both directions; `all: initial` on the
+// wrapper closes the inheritance the shadow boundary does not.
+//
+// Deliberately ES5 and self-contained: chrome.scripting serializes this source
+// and re-evaluates it in the target page, so it can close over nothing. See the
+// header of dom-helpers.js. The `// why:` comments here matter more than usual
+// because none of it can be refactored into shared helpers.
+
+/**
+ * The host element's id. Exported so tests can assert the pill's presence and
+ * absence by the same name the injected bodies hard-code (they cannot import it
+ * — see the header on why they close over nothing).
+ */
+export const ACTIVITY_OVERLAY_ID = 'peerd-activity-overlay';
+
+/**
+ * Create or update the in-page activity pill.
+ *
+ * Idempotent: called once per tool call, it builds the pill the first time and
+ * only swaps the phrase afterwards, so the spinner does not restart mid-task and
+ * the pill never flickers between two actions.
+ *
+ * @param {string} label  the phrase to show (from describeToolActivity)
+ * @param {string} originLabel  the origin being driven, shown under the phrase
+ * @returns {boolean} true when the pill is present afterwards
+ */
+export function activityOverlayInjected(label, originLabel) {
+  'use strict';
+  try {
+    var ID = 'peerd-activity-overlay';
+    var host = document.getElementById(ID);
+    var root = globalThis.__peerdActivityRoot;
+
+    // why re-create when the global is gone but the host is not: the isolated
+    // world is rebuilt on navigation while a cached host element could survive a
+    // same-document rewrite. Trust the pair, not either half.
+    if (host && !root) { host.remove(); host = null; }
+
+    if (!host) {
+      host = document.createElement('div');
+      host.id = ID;
+      // Measure 1 — see the header. Also keeps it out of the CDP a11y tree.
+      host.setAttribute('aria-hidden', 'true');
+      host.style.setProperty('all', 'initial', 'important');
+      host.style.setProperty('position', 'fixed', 'important');
+      host.style.setProperty('inset', 'auto 16px 16px auto', 'important');
+      // why the maximum: the pill has to sit above the page's own overlays, and
+      // a page that outbids this is a page whose modal we would be hiding behind.
+      host.style.setProperty('z-index', '2147483647', 'important');
+      // The host is a positioning shell only; the pill inside takes the clicks.
+      host.style.setProperty('pointer-events', 'none', 'important');
+
+      // Measure 2 — CLOSED, so nothing outside this function can read it.
+      root = host.attachShadow({ mode: 'closed' });
+      globalThis.__peerdActivityRoot = root;
+
+      var style = document.createElement('style');
+      style.textContent = [
+        ':host, * { box-sizing: border-box; }',
+        '.pill {',
+        '  all: initial;',
+        '  pointer-events: auto;',
+        '  display: flex; align-items: center; gap: 10px;',
+        '  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;',
+        '  font-size: 12px; line-height: 1.35;',
+        '  color: #F5F5F5; background: #16181C;',
+        '  border: 1px solid rgba(255,255,255,.14); border-radius: 10px;',
+        '  padding: 9px 11px; max-width: 320px;',
+        '  box-shadow: 0 8px 28px rgba(0,0,0,.34), 0 2px 6px rgba(0,0,0,.22);',
+        '}',
+        // The brand orb, matching the side panel's .peerd-spinner exactly —
+        // same conic gradient, same mask, same 0.85s cadence (the brand-wide
+        // spinner cadence). This is the ONE place colour is allowed here; the
+        // rest of the pill is monochrome, per the brand rule.
+        '.orb {',
+        '  flex: none; width: 14px; height: 14px; border-radius: 50%;',
+        '  background: conic-gradient(from 0deg, #00B7EB, #D946EF, #F59E0B, #22C55E, #EF4444, #00B7EB);',
+        '  -webkit-mask: radial-gradient(closest-side, transparent 58%, #000 60%);',
+        '          mask: radial-gradient(closest-side, transparent 58%, #000 60%);',
+        '  animation: peerd-act-spin 0.85s linear infinite;',
+        '}',
+        '@keyframes peerd-act-spin { to { transform: rotate(360deg); } }',
+        '@media (prefers-reduced-motion: reduce) { .orb { animation: none; } }',
+        '.text { display: flex; flex-direction: column; min-width: 0; }',
+        '.label { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }',
+        '.origin { color: #9AA0A6; font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }',
+        '.stop {',
+        '  all: initial; cursor: pointer; flex: none;',
+        '  font-family: inherit; font-size: 11px; color: #F5F5F5;',
+        '  background: rgba(255,255,255,.08);',
+        '  border: 1px solid rgba(255,255,255,.18); border-radius: 6px;',
+        '  padding: 4px 8px; margin-left: 2px;',
+        '}',
+        '.stop:hover { background: rgba(255,255,255,.16); }',
+      ].join('\n');
+
+      var pill = document.createElement('div');
+      pill.className = 'pill';
+
+      var orb = document.createElement('div');
+      orb.className = 'orb';
+
+      var text = document.createElement('div');
+      text.className = 'text';
+      var labelEl = document.createElement('div');
+      labelEl.className = 'label';
+      var originEl = document.createElement('div');
+      originEl.className = 'origin';
+      text.appendChild(labelEl);
+      text.appendChild(originEl);
+
+      var stop = document.createElement('button');
+      stop.className = 'stop';
+      stop.type = 'button';
+      stop.textContent = 'Stop';
+      stop.addEventListener('click', function () {
+        // why fire-and-forget with a guard: the pill lives in a page that may
+        // outlive the extension context (an unloaded SW, a disabled extension).
+        // A throw here would surface as a page console error on a button the
+        // user pressed in good faith, so failure is silent and the pill stays —
+        // the side panel's Stop is always the backstop.
+        try {
+          if (typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.sendMessage) {
+            chrome.runtime.sendMessage({ type: 'agent/stop' });
+          }
+        } catch (e) { /* extension context gone; side-panel Stop still works */ }
+        labelEl.textContent = 'Stopping…';
+      });
+
+      pill.appendChild(orb);
+      pill.appendChild(text);
+      pill.appendChild(stop);
+      root.appendChild(style);
+      root.appendChild(pill);
+      (document.body || document.documentElement).appendChild(host);
+    }
+
+    var l = root.querySelector('.label');
+    var o = root.querySelector('.origin');
+    if (l) l.textContent = String(label == null ? '' : label);
+    if (o) o.textContent = String(originLabel == null ? '' : originLabel);
+    return true;
+  } catch (e) {
+    // An indicator must never break the page it is annotating.
+    return false;
+  }
+}
+
+/**
+ * Remove the pill. Safe to call when it was never shown.
+ * @returns {boolean} true when nothing is left behind
+ */
+export function clearActivityOverlayInjected() {
+  'use strict';
+  try {
+    var host = document.getElementById('peerd-activity-overlay');
+    if (host) host.remove();
+    globalThis.__peerdActivityRoot = undefined;
+    return true;
+  } catch (e) {
+    return false;
+  }
+}

--- a/extension/peerd-runtime/dom/index.js
+++ b/extension/peerd-runtime/dom/index.js
@@ -19,6 +19,15 @@ export { summarizeMutations } from './action-result.js';
 // (walk-injected.js) — same serializer, same ref contract.
 export { captureSnapshot, describeSource } from './capture.js';
 export { domWalkInjected } from './walk-injected.js';
+
+// The in-page activity indicator injected into the tab the web actor drives.
+// Exported from the module surface because the SW-side shell that schedules it
+// (background/page-activity.js) lives outside peerd-runtime.
+export {
+  activityOverlayInjected,
+  clearActivityOverlayInjected,
+  ACTIVITY_OVERLAY_ID,
+} from './activity-overlay-injected.js';
 // The "pull peerd in" reminder injected into a regular web page peerd opens
 // (informational only — no SW route; docs/PULL-IN-PEERD-WEB-SCOPE.md).
 export { pullInHintInjected } from './pull-in-hint-injected.js';

--- a/extension/peerd-runtime/index.js
+++ b/extension/peerd-runtime/index.js
@@ -358,6 +358,9 @@ export {
   captureSnapshot,
   describeSource,
   domWalkInjected,
+  activityOverlayInjected,
+  clearActivityOverlayInjected,
+  ACTIVITY_OVERLAY_ID,
   pullInHintInjected,
   // DESIGN-19 Tap B — the MAIN-world fetch/XHR tap for site-client capture.
   installFetchTapInjected,

--- a/extension/peerd-runtime/tools/dispatcher.js
+++ b/extension/peerd-runtime/tools/dispatcher.js
@@ -18,6 +18,7 @@ import { GATES } from './gates.js';
 import { listHooks } from './hooks/registry.js';
 import { runPreToolUse, runPostToolUse } from './hooks/runner.js';
 import { ugcWriteConfirm } from '../actor/ugc-registry.js';
+import { describeToolActivity, displayOrigin } from '../actor/activity-label.js';
 import {
   decideAction,
   DEFAULT_CONFIRM_ACTIONS,
@@ -115,6 +116,10 @@ const liveTabUrl = async (ctx) => {
  * @typedef {ToolContext & {
  *   hooks?: import('./hooks/runner.js').Hook[],
  *   permission?: { mode?: string, confirmActions?: boolean },
+ *   onToolActivity?: {
+ *     begin: (tabId: number, label: string, origin: string) => unknown,
+ *     end: (tabId: number) => unknown,
+ *   } | null,
  * }} DispatchContext
  */
 
@@ -353,10 +358,33 @@ export const dispatchToolCall = async (call, ctx) => {
   // to its own stream entry; without an id the chunks have no anchor
   // and the renderer drops them.
   const execCtx = { ...ctx, toolUseId: call.id };
+
+  // ---- In-page activity indicator ----------------------------------------
+  // why here and not in each tab tool: this is the one place every page-acting
+  // call passes through, on every path (main turn, bound actor, the offscreen
+  // actor relay whose ctx the SW rebuilds). Wiring it per-tool would mean a tool
+  // added later silently going dark.
+  //
+  // why FIRE-AND-FORGET rather than awaited: `begin` is an executeScript round
+  // trip into a page that may be busy, unresponsive, or refusing injection. The
+  // user asked for the action, not for the decoration — a cosmetic surface must
+  // never delay it, and must never be able to fail it. Both calls swallow.
+  const activity = tool.primitive === 'tab' ? ctx.onToolActivity : null;
+  const activityTabId = typeof args?.tabId === 'number' ? args.tabId : ctx.activeTab?.id;
+  if (activity && typeof activityTabId === 'number') {
+    const phrase = describeToolActivity(call.name, args, { isTabTool: true });
+    if (phrase) {
+      Promise.resolve(activity.begin(activityTabId, phrase, displayOrigin(ctx.activeTab?.origin))).catch(() => {});
+    }
+  }
+
   const start = performance.now();
   try {
     const result = await tool.execute(args, execCtx);
     const durationMs = Math.round(performance.now() - start);
+    if (activity && typeof activityTabId === 'number') {
+      Promise.resolve(activity.end(activityTabId)).catch(() => {});
+    }
     ctx.audit({
       type: 'tool_executed',
       details: { tool: call.name, primitive: tool.primitive, dispatch: tool.dispatch, durationMs },
@@ -388,6 +416,12 @@ export const dispatchToolCall = async (call, ctx) => {
     return enriched;
   } catch (e) {
     const durationMs = Math.round(performance.now() - start);
+    // why the failure path settles the indicator too: a tool that throws would
+    // otherwise leave the pill frozen on "Typing…" forever, which reads as a
+    // hang — the exact misreading this whole surface exists to prevent.
+    if (activity && typeof activityTabId === 'number') {
+      Promise.resolve(activity.end(activityTabId)).catch(() => {});
+    }
     const message = /** @type {{ message?: string }} */ (e)?.message ?? String(e);
     ctx.audit({
       type: 'tool_failed',

--- a/extension/tests/index.js
+++ b/extension/tests/index.js
@@ -40,6 +40,7 @@ import './unit/peerd-runtime/dispatcher.test.js';
 import './unit/peerd-runtime/introspection-tools.test.js';
 import './unit/peerd-runtime/query-dom.test.js';
 import './unit/peerd-runtime/dom-walk.test.js';
+import './unit/peerd-runtime/activity-overlay.test.js';
 import './unit/peerd-runtime/page-eval.test.js';
 import './unit/peerd-runtime/page-exec.test.js';
 import './unit/peerd-runtime/page-keys.test.js';

--- a/extension/tests/unit/peerd-runtime/activity-overlay.test.js
+++ b/extension/tests/unit/peerd-runtime/activity-overlay.test.js
@@ -1,0 +1,137 @@
+// @ts-check
+// The in-page activity pill, against a REAL DOM.
+//
+// The wording is covered by the pure test (tests/peerd-runtime/actor/
+// activity-label.test.ts). What needs a browser is the property the whole design
+// is built around: the pill must be INVISIBLE TO PEERD ITSELF. The agent reads
+// the page it is driving, so an indicator it can see is one it will describe
+// back to the user, and one it can click.
+//
+// That invisibility rests on three independent measures (aria-hidden, a CLOSED
+// shadow root, and closed-shadow content being outside textContent). Each is
+// asserted separately, because they can be broken one at a time and the failure
+// is silent — the pill keeps looking right while quietly entering the agent's
+// context.
+
+import { describe, it, expect } from '../../framework.js';
+import { domWalkInjected } from '/peerd-runtime/index.js';
+import {
+  activityOverlayInjected,
+  clearActivityOverlayInjected,
+  ACTIVITY_OVERLAY_ID,
+} from '/peerd-runtime/dom/activity-overlay-injected.js';
+
+/**
+ * Run `fn` with a page fixture mounted, always tearing the pill down after.
+ * @param {(host: HTMLDivElement) => void | Promise<void>} fn
+ */
+const withPage = async (fn) => {
+  const host = document.createElement('div');
+  host.id = 'activity-fixture';
+  host.innerHTML = '<h1>Checkout</h1><p>Card number</p><button id="pay">Pay now</button>';
+  document.body.appendChild(host);
+  try { await fn(host); }
+  finally { clearActivityOverlayInjected(); host.remove(); }
+};
+
+const overlay = () => document.getElementById(ACTIVITY_OVERLAY_ID);
+
+describe('activity overlay — lifecycle', () => {
+  it('mounts a pill and reports success', async () => {
+    await withPage(() => {
+      expect(overlay()).toBe(null);
+      expect(activityOverlayInjected('Typing', 'https://acme.test')).toBe(true);
+      expect(!!overlay()).toBe(true);
+    });
+  });
+
+  it('is idempotent — a second call updates in place, it does not stack', async () => {
+    await withPage(() => {
+      activityOverlayInjected('Typing', 'https://acme.test');
+      const first = overlay();
+      activityOverlayInjected('Clicking', 'https://acme.test');
+      expect(document.querySelectorAll(`#${ACTIVITY_OVERLAY_ID}`).length).toBe(1);
+      // why identity and not just the count: re-creating the host would restart
+      // the spinner animation on every tool call, which reads as a stutter.
+      expect(overlay() === first).toBe(true);
+    });
+  });
+
+  it('clear removes it, and is safe when nothing is mounted', async () => {
+    await withPage(() => {
+      activityOverlayInjected('Typing', 'https://acme.test');
+      expect(clearActivityOverlayInjected()).toBe(true);
+      expect(overlay()).toBe(null);
+      expect(clearActivityOverlayInjected()).toBe(true);   // no-op, still true
+    });
+  });
+
+  it('never throws, whatever it is handed', async () => {
+    await withPage(() => {
+      // An indicator must not be able to break the page it annotates.
+      expect(activityOverlayInjected(/** @type {any} */ (null), /** @type {any} */ (undefined))).toBe(true);
+      expect(activityOverlayInjected(/** @type {any} */ ({}), /** @type {any} */ (123))).toBe(true);
+    });
+  });
+});
+
+describe('activity overlay — invisible to peerd itself', () => {
+  it('measure 1: the host is aria-hidden', async () => {
+    await withPage(() => {
+      activityOverlayInjected('Typing', 'https://acme.test');
+      expect(/** @type {Element} */ (overlay()).getAttribute('aria-hidden')).toBe('true');
+    });
+  });
+
+  it('measure 2: the shadow root is CLOSED (unreachable from outside)', async () => {
+    await withPage(() => {
+      activityOverlayInjected('Typing', 'https://acme.test');
+      // An open root would hand the walk a way in via el.shadowRoot.
+      expect(/** @type {Element} */ (overlay()).shadowRoot).toBe(null);
+    });
+  });
+
+  it('measure 3: its text is NOT in the page textContent (read_page cannot see it)', async () => {
+    await withPage(() => {
+      activityOverlayInjected('Typing the card number', 'https://acme.test');
+      const text = document.body.textContent || '';
+      expect(text.includes('Typing the card number')).toBe(false);
+      expect(text.includes('Stop')).toBe(false);
+      // The real page content is of course still there.
+      expect(text.includes('Card number')).toBe(true);
+    });
+  });
+
+  it('the DOM walk does not emit a node for it', async () => {
+    await withPage(() => {
+      const before = domWalkInjected();
+      activityOverlayInjected('Typing the card number', 'https://acme.test');
+      const after = domWalkInjected();
+
+      const serialized = JSON.stringify(after.nodes);
+      expect(serialized.includes('Typing the card number')).toBe(false);
+      expect(serialized.includes('peerd-activity-overlay')).toBe(false);
+      // Load-bearing: the pill has a BUTTON in it. If the walk could see through
+      // the shadow boundary, the agent would find a clickable "Stop" that is not
+      // part of the page — and could click its own off switch.
+      /** @param {ReturnType<typeof domWalkInjected>} out */
+      const buttons = (out) => /** @type {any[]} */ (out.nodes)
+        .filter((n) => n.role?.value === 'button')
+        .map((n) => n.name?.value);
+      expect(buttons(after).includes('Stop')).toBe(false);
+      expect(JSON.stringify(buttons(after))).toBe(JSON.stringify(buttons(before)));
+    });
+  });
+
+  it('the walk is otherwise UNCHANGED by the pill being up', async () => {
+    // The strongest form of the claim: same page, same walk, pill or no pill.
+    await withPage(() => {
+      const before = domWalkInjected();
+      activityOverlayInjected('Clicking', 'https://acme.test');
+      const after = domWalkInjected();
+      /** @param {ReturnType<typeof domWalkInjected>} out */
+      const names = (out) => /** @type {any[]} */ (out.nodes).map((n) => n.name?.value ?? null);
+      expect(JSON.stringify(names(after))).toBe(JSON.stringify(names(before)));
+    });
+  });
+});

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -93,7 +93,10 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // 545/547 → 548: the learned-origins un-learn surface (#262) and the Activity
 // origin-lock rows (#282) land together — both ledgers are kept and the floor
 // is their union, the same shape as the 505/506 → 510 merge above.
-const COVERED_FLOOR = 548;
+// 548 → 549: the in-page activity indicator's two checked cores (#259) —
+// actor/activity-label.js and background/page-activity.js. The injected
+// overlay body itself is ES5 and exempt, so it does not count.
+const COVERED_FLOOR = 549;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/packaging/tscheck-coverage.ts
+++ b/packaging/tscheck-coverage.ts
@@ -13,6 +13,7 @@ import { EXTENSION_DIR, REPO_ROOT } from './lib.ts';
 export const ES5_INJECTED = new Set<string>([
   'peerd-runtime/dom/walk-injected.js',
   'peerd-runtime/dom/framework-state.js',
+  'peerd-runtime/dom/activity-overlay-injected.js',
   'peerd-runtime/dom/pull-in-hint-injected.js',
   'background/debugger-pool.js',
   'peerd-runtime/tools/defs/watch-changes.js',

--- a/packaging/web-target.ts
+++ b/packaging/web-target.ts
@@ -97,6 +97,12 @@ export const KNOWN_BROWSER_TOUCHES = new Set<string>([
   'shared/peer-notifications.js|browser.runtime?.onMessage?.addListener((/** @type {unknown} */ raw) => {',
   'shared/open-options.js|browser.runtime.openOptionsPage();',
   'shared/open-options.js|browser.tabs.create({',
+  // The in-page activity pill's Stop button. Guarded by a `typeof chrome` check
+  // and wrapped in try/catch at the call site, so on the web target — where
+  // there is no extension runtime to message — the button simply does nothing
+  // and the pill stays up. The side panel's Stop is the backstop there, exactly
+  // as it is when the extension's own SW has been evicted.
+  "peerd-runtime/dom/activity-overlay-injected.js|chrome.runtime.sendMessage({ type: 'agent/stop' });",
 ]);
 
 // The web shell: a MINIMAL smoke page + the build-stamped service worker.

--- a/tests/peerd-runtime/actor/activity-label.test.ts
+++ b/tests/peerd-runtime/actor/activity-label.test.ts
@@ -1,0 +1,142 @@
+// The words the in-page activity pill puts on the user's screen.
+//
+// Most of this file is not about wording, it is about what must NEVER reach that
+// surface. The pill is rendered into the page the agent is driving, which means
+// it is on the user's monitor, in front of whoever is looking over their
+// shoulder, and inside any screen share or recording. Two classes of input reach
+// it — the model's tool args and, through them, page-authored content — and both
+// are pinned shut here.
+
+import { describe, test, expect } from 'bun:test';
+import { describeToolActivity, displayOrigin, GENERIC_ACTIVITY } from '../../../extension/peerd-runtime/actor/activity-label.js';
+
+describe('activity-label — the wording', () => {
+  test('navigation names the destination HOST', () => {
+    expect(describeToolActivity('navigate', { url: 'https://github.com/anthropics/x' }))
+      .toBe('Opening github.com');
+    expect(describeToolActivity('open_tab', { url: 'https://en.wikipedia.org/wiki/Cat' }))
+      .toBe('Opening en.wikipedia.org');
+  });
+
+  test('an unparseable or missing url degrades to a generic phrase', () => {
+    expect(describeToolActivity('navigate', { url: 'not a url' })).toBe('Opening a page');
+    expect(describeToolActivity('navigate', {})).toBe('Opening a page');
+    expect(describeToolActivity('navigate', null)).toBe('Opening a page');
+  });
+
+  test('each page action gets a plain-language phrase', () => {
+    expect(describeToolActivity('type', { selector: '#a', text: 'x' })).toBe('Typing');
+    expect(describeToolActivity('click', { selector: '#b' })).toBe('Clicking');
+    expect(describeToolActivity('read_page', {})).toBe('Reading the page');
+    expect(describeToolActivity('snapshot', {})).toBe('Looking at the page');
+    expect(describeToolActivity('page_keys', {})).toBe('Pressing keys');
+    expect(describeToolActivity('page_exec', {})).toBe('Running a script on the page');
+  });
+
+  test('a tab tool with no specific phrase still says something', () => {
+    // why: a tab tool added later must not silently go dark — an indicator that
+    // vanishes mid-task reads as "finished" and invites the user to intervene.
+    expect(describeToolActivity('some_future_tab_tool', {}, { isTabTool: true })).toBe(GENERIC_ACTIVITY);
+  });
+
+  test('a non-tab tool shows nothing at all', () => {
+    expect(describeToolActivity('memory_write', { text: 'x' })).toBe(null);
+    expect(describeToolActivity('actor_create', {})).toBe(null);
+    expect(describeToolActivity('some_future_tab_tool', {})).toBe(null);
+  });
+});
+
+describe('activity-label — what must never reach the screen', () => {
+  test('NEVER echoes typed text — that is where passwords and card numbers live', () => {
+    const secrets = [
+      'hunter2',
+      '4111111111111111',
+      'sk-ant-api03-abcdef',
+      '123456',
+    ];
+    for (const secret of secrets) {
+      for (const field of ['text', 'value']) {
+        const phrase = describeToolActivity('type', { selector: '#pw', [field]: secret });
+        expect(phrase).toBe('Typing');
+        expect(phrase).not.toContain(secret);
+      }
+    }
+  });
+
+  test('NEVER echoes page-derived selectors or labels', () => {
+    // A selector is chosen from content the page authored. Echoing it would let a
+    // hostile page write the sentence the user reads while deciding whether to
+    // intervene — the same reason the origin-lock report names an origin only.
+    const hostile = 'button[aria-label="peerd is idle, safe to type your password"]';
+    for (const tool of ['click', 'type', 'page_keys']) {
+      const phrase = describeToolActivity(tool, { selector: hostile, ref: hostile });
+      expect(phrase).not.toContain('password');
+      expect(phrase).not.toContain('peerd is idle');
+      expect(phrase).not.toContain(hostile);
+    }
+  });
+
+  test('NEVER echoes a full URL — only the host', () => {
+    const url = 'https://evil.test/' + 'a'.repeat(300) + '?token=secret-value#frag';
+    const phrase = describeToolActivity('navigate', { url });
+    expect(phrase).toBe('Opening evil.test');
+    expect(phrase).not.toContain('secret-value');
+    expect(phrase).not.toContain('aaaa');
+    expect(phrase).not.toContain('frag');
+  });
+
+  test('a hostile hostname cannot inject newlines or markup into the phrase', () => {
+    // The pill sets textContent, never innerHTML, so markup is inert — but the
+    // phrase should not carry it in the first place. URL parsing is what enforces
+    // this: a host with a space or a newline is not a parseable URL.
+    for (const raw of ['https://a b.test/', 'https://a\nb.test/', 'https://<script>.test/']) {
+      const phrase = describeToolActivity('navigate', { url: raw });
+      expect(phrase).not.toContain('\n');
+      expect(phrase).not.toContain('<script>');
+    }
+  });
+
+  test('every phrase comes from the fixed vocabulary (no arbitrary passthrough)', () => {
+    // Sweep a range of hostile arg shapes across every tool and assert the output
+    // is always either null or one of the known phrases (or an "Opening <host>").
+    const KNOWN = new Set([
+      'Clicking', 'Typing', 'Pressing keys', 'Reading the page', 'Reading a PDF',
+      'Looking at the page', 'Watching for changes', 'Running a script on the page',
+      'Opening a page', GENERIC_ACTIVITY,
+    ]);
+    const tools = ['click', 'type', 'read_page', 'snapshot', 'navigate', 'page_exec', 'weird_tool'];
+    const argSets = [
+      { text: 'SECRET', selector: 'SECRET', value: 'SECRET', url: 'https://ok.test/SECRET' },
+      { url: 'SECRET' },
+      {},
+      null,
+    ];
+    for (const t of tools) {
+      for (const a of argSets) {
+        const phrase = describeToolActivity(t, a, { isTabTool: true });
+        if (phrase === null) continue;
+        const ok = KNOWN.has(phrase) || phrase === 'Opening ok.test';
+        expect(ok).toBe(true);
+        expect(phrase).not.toContain('SECRET');
+      }
+    }
+  });
+});
+
+describe('activity-label — the origin line', () => {
+  test('https is shown host-only, matching the phrase above it', () => {
+    expect(displayOrigin('https://github.com')).toBe('github.com');
+    expect(displayOrigin('https://mail.google.com')).toBe('mail.google.com');
+  });
+
+  test('a non-https scheme is KEPT — driving an http page with your session is worth seeing', () => {
+    expect(displayOrigin('http://acme.localhost:8080')).toBe('http://acme.localhost:8080');
+  });
+
+  test('empty / unusable input degrades to something harmless', () => {
+    expect(displayOrigin(null)).toBe('');
+    expect(displayOrigin('')).toBe('');
+    expect(displayOrigin('   ')).toBe('');
+    expect(displayOrigin('not a url')).toBe('not a url');
+  });
+});


### PR DESCRIPTION
**Why**

You cannot tell which tab peerd is driving, so you risk typing into it - and a slow action gives no sign it is working.

**What**

- Puts the driven page in a collapsible `peerd` tab group while peerd owns it; ungroups on release or close (no-op on Firefox).
- Adds an in-page pill while a turn runs - action (`Opening github.com`), origin, Stop - softening to "Thinking…" between calls; hidden from the agent by `aria-hidden` + a closed shadow root.
- Both hang off `dispatchToolCall` fire-and-forget, so no tool is delayed and a failure still settles the pill. Wording is fixed, never typed text or page labels.
- Website half only; the side panel is unchanged, and this was tested headless.

**How**

- `bun run preflight` passes.
- New tests: in-browser `activity-overlay.test.js`; bun `activity-label.test.ts` sweeps hostile args over every tool.
- Live page: pill visible, its text absent from `innerText`.
