### PR TITLE
feat(front-door): toolbar click opens the side panel by default; frontDoorView setting

### DIFF
--- a/extension/background/panel-affordance.js
+++ b/extension/background/panel-affordance.js
@@ -8,13 +8,17 @@
 // answer comes back as a plain tag the imperative shell in service-worker.js
 // acts on. Pure ⇒ unit-testable without a browser (panel-affordance.test.ts).
 //
-// The model (DESIGN-12, owner 2026-06-20): the toolbar icon is peerd's FRONT
-// DOOR. With no home up yet it opens the full-page home — peerd should feel
-// first-party, not a bolted-on sidebar. Once home IS up, the icon COMPLEMENTS
-// by pulling the chat into the window-global side panel (Chrome) / sidebar
-// (Firefox) so it follows you onto any tab. The keyboard command is the
-// dedicated twin: it TOGGLES the panel — pulls it in, or closes it if it's
-// already open (the icon never closes; it's the front door, not a switch).
+// The model (DESIGN-12, owner 2026-06-20; amended 2026-07-29): the toolbar
+// icon is peerd's FRONT DOOR, and WHICH surface it opens is the user's
+// `frontDoorView` setting. 'panel' (the default) pulls the chat straight into
+// the window-global side panel (Chrome) / sidebar (Firefox), next to the page
+// the user is on — landing them in a full-tab takeover (often straight into
+// the vault gate) read as heavyweight. 'home' restores the original model:
+// the full-page home first, the panel once home is already up (peerd as a
+// first-party surface, not a bolted-on sidebar). Either way the keyboard
+// command is the dedicated twin: it TOGGLES the panel — pulls it in, or
+// closes it if it's already open (the icon never closes; it's the front
+// door, not a switch).
 
 /**
  * @param {Object} p
@@ -24,21 +28,36 @@
  * @param {boolean} p.hasSidePanel   is browser.sidePanel.open available? (Chrome)
  * @param {boolean} p.hasSidebar     is browser.sidebarAction.open available? (Firefox)
  * @param {boolean} [p.fromShortcut] true when invoked from the keyboard command
- *   (toggle the panel) rather than the toolbar icon (home-first, open-only).
+ *   (toggle the panel) rather than the toolbar icon (open-only).
+ * @param {'panel'|'home'} [p.frontDoorView] the user's default front-door
+ *   surface (the `frontDoorView` setting): 'panel' (default) opens the side
+ *   panel / sidebar directly; 'home' keeps the full-page-home-first model.
+ * @param {boolean} [p.nativePanelMirror] true when the browser natively opens
+ *   the panel on icon click (Chrome, via the setPanelBehavior mirror in
+ *   tab-affordances.js). An icon click reaching us AT ALL then implies the
+ *   mirror is off — the user chose 'home' — and that inference, not the
+ *   setting, is what survives an SW cold start: the settings store serves
+ *   channel defaults until its async hydration lands, and the waking click
+ *   can beat it.
  * @returns {'panel'|'sidebar'|'close'|'home'}
  *   'panel'   → open the Chrome side panel for the current window
  *   'sidebar' → open the Firefox sidebar
  *   'close'   → close the open side panel / sidebar
  *   'home'    → open (focus-or-create) the full-page home
  */
-export const decidePullIn = ({ homeOpen, panelOpen = false, hasSidePanel, hasSidebar, fromShortcut = false }) => {
+export const decidePullIn = ({ homeOpen, panelOpen = false, hasSidePanel, hasSidebar, fromShortcut = false, frontDoorView = 'panel', nativePanelMirror = false }) => {
   // The shortcut toggles: an open panel closes. (The icon ignores panelOpen —
   // re-opening an already-open panel is a harmless focus, and "front door"
   // shouldn't double as a dismiss.)
   if (fromShortcut && panelOpen && (hasSidePanel || hasSidebar)) return 'close';
-  // The shortcut is the dedicated "pull in peerd"; the icon only complements
+  // Icon + native mirror ⇒ the browser already handles 'panel' clicks itself,
+  // so this dispatch means 'home' regardless of the (possibly un-hydrated)
+  // setting value. The shortcut never rides the inference — it is always the
+  // dedicated "pull in peerd".
+  const view = (!fromShortcut && nativePanelMirror) ? 'home' : frontDoorView;
+  // The icon opens the panel by default; under 'home' it only complements
   // once home is already the user's anchor.
-  const wantPanel = fromShortcut || homeOpen;
+  const wantPanel = fromShortcut || homeOpen || view !== 'home';
   if (wantPanel && hasSidePanel) return 'panel';
   if (wantPanel && hasSidebar) return 'sidebar';
   return 'home';

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -2386,10 +2386,13 @@ const closeSidePanel = async () => {
 // calls noteAgentTab/scheduleWebTabHint/broadcastAgentTab/showWebTabHint from
 // its tool-context + port wiring, and setTabAnchor from the actor-turn start.
 const {
-  noteAgentTab, broadcastAgentTab, scheduleWebTabHint, showWebTabHint, setTabAnchor, isHomeOpen, focusAgentTab,
+  noteAgentTab, broadcastAgentTab, scheduleWebTabHint, showWebTabHint, setTabAnchor, isHomeOpen, focusAgentTab, syncFrontDoorBehavior,
 } = makeTabAffordances({
   browser, uiPorts, denylistStore, closeSidePanel,
   isWatchOn: () => settingsStore.get().watchAgentTab === true,
+  // Sync read (no await) — the front-door decision must run inside the
+  // click gesture or sidePanel.open() drops its activation.
+  getFrontDoorView: () => (settingsStore.get().frontDoorView === 'home' ? 'home' : 'panel'),
 });
 
 // Confirmation coordinator. The dispatcher's async confirmation step
@@ -3780,6 +3783,10 @@ const onSettingsChanged = (/** @type {any} */ patch) => {
   // long-dead agent tab. normalizeSettingsPatch only emits keys the caller actually
   // sent, so the key's PRESENCE here is exactly "the user just touched the toggle".
   if (patch?.watchAgentTab === true) focusAgentTab();
+  // Front door: re-mirror the choice into Chrome's native action-click
+  // behavior the moment it changes (key PRESENCE = the user just touched it —
+  // normalizeSettingsPatch only emits keys the caller actually sent).
+  if (patch?.frontDoorView) syncFrontDoorBehavior();
 };
 // The base host tore down (master OFF) → every room closed, incl. the inbox, so
 // clear the SW-side membership flag for a clean re-join on the next start.
@@ -4917,11 +4924,16 @@ browser.runtime.onMessage.addListener(/** @type {any} */ (makeDispatcher({
   ...(/** @type {any} */ (siteClientRoutes)),
 })));
 
-// The toolbar icon + Alt+Shift+P front door (open home, or pull the chat panel
-// in) lives in background/tab-affordances.js alongside the agent-tab card and
-// web-tab hint — it owns the sync-gesture pull-in and its listeners.
+// The toolbar icon + Alt+Shift+P front door (open the panel or home, per the
+// frontDoorView setting) lives in background/tab-affordances.js alongside the
+// agent-tab card and web-tab hint — it owns the sync-gesture pull-in and its
+// listeners.
 loadUserEndpoints();
-loadSettings();
+// why the chained mirror: it must apply AFTER hydration (the store serves
+// channel defaults until load() lands), and Chrome persists the behavior
+// browser-side, so by the time a click wakes a future cold SW the native
+// open already reflects the user's real choice.
+loadSettings().then(() => syncFrontDoorBehavior()).catch(() => {});
 
 // SW boot logging — we want a clear timeline of when the SW comes up
 // (cold start, extension reload, idle respawn). The console clears

--- a/extension/background/settings-patch.js
+++ b/extension/background/settings-patch.js
@@ -126,6 +126,12 @@ export const normalizeSettingsPatch = (patch, {
     // this flips on; each later agent tab touch follows while it stays on.
     next.watchAgentTab = patch.watchAgentTab;
   }
+  // The front door: which surface the toolbar icon opens — 'panel' (side
+  // panel / sidebar, the default) or 'home' (the original full-page-first
+  // model). Only these two; anything else is ignored (defaults win → 'panel').
+  if (patch.frontDoorView === 'panel' || patch.frontDoorView === 'home') {
+    next.frontDoorView = patch.frontDoorView;
+  }
   if (typeof patch.confirmWebWrites === 'boolean') {
     // #53: anti-exfil gate. When OFF, non-GET web egress (fetch_url + the WebVM
     // bridge) is auto-approved (risk-acknowledged); ON (default) confirms.

--- a/extension/background/tab-affordances.js
+++ b/extension/background/tab-affordances.js
@@ -35,8 +35,9 @@ const AGENT_TAB_COLORS = ['#00B7EB', '#EF4444', '#F59E0B', '#22C55E', '#D946EF']
  * @param {{ patterns: () => any }} deps.denylistStore
  * @param {() => Promise<any>} deps.closeSidePanel
  * @param {() => boolean} [deps.isWatchOn]  live read of the watchAgentTab setting (default off)
+ * @param {() => ('panel'|'home')} [deps.getFrontDoorView]  live read of the frontDoorView setting (default 'panel')
  */
-export const makeTabAffordances = ({ browser, uiPorts, denylistStore, closeSidePanel, isWatchOn = () => false }) => {
+export const makeTabAffordances = ({ browser, uiPorts, denylistStore, closeSidePanel, isWatchOn = () => false, getFrontDoorView = () => 'panel' }) => {
   const HOME_URL = browser.runtime.getURL('home/home.html');
 
   // ── 1. the agent-tab card ──────────────────────────────────────────────────
@@ -225,12 +226,13 @@ export const makeTabAffordances = ({ browser, uiPorts, denylistStore, closeSideP
   browser.tabs?.onRemoved?.addListener((/** @type {number} */ tabId) => { peerdWebTabs.delete(tabId); });
 
   // ── 3. the front door — toolbar icon + Alt+Shift+P ──────────────────────────
-  // The toolbar icon is peerd's FRONT DOOR. With no home up yet it opens the
-  // full-page home — peerd should feel first-party, not a bolted-on sidebar
-  // (DESIGN-12). Once home IS up, the icon COMPLEMENTS: it pulls the chat into the
-  // window-global side panel (Chrome) / sidebar (Firefox) so the chat follows you
-  // onto ANY tab. The Alt+Shift+P command is the dedicated twin: it ALWAYS pulls
-  // the panel in, from anywhere.
+  // The toolbar icon is peerd's FRONT DOOR, and which surface it opens is the
+  // user's `frontDoorView` setting (Settings → Behavior): 'panel' (default)
+  // pulls the chat into the window-global side panel (Chrome) / sidebar
+  // (Firefox) so it sits next to the page and follows you onto ANY tab;
+  // 'home' restores the original full-page-first model (DESIGN-12) — home
+  // with no home up yet, the panel once home IS up. The Alt+Shift+P command
+  // is the dedicated twin: it ALWAYS pulls the panel in, from anywhere.
   //
   // Hard constraint: sidePanel.open()/sidebarAction.open() must run SYNCHRONOUSLY
   // inside the click/keystroke gesture — no await before them or the activation is
@@ -278,6 +280,29 @@ export const makeTabAffordances = ({ browser, uiPorts, denylistStore, closeSideP
     if (!none) lastFocusedWindowId = winId;
   });
 
+  // Mirror the front-door choice into Chrome's NATIVE action-click behavior.
+  // With openPanelOnActionClick:true the browser opens the side panel itself —
+  // before the SW even wakes — so the default 'panel' front door can never
+  // race cold-start settings hydration (the store serves channel defaults
+  // until its async load lands, and the click that WAKES the worker beats it).
+  // Consequence: action.onClicked then only fires for 'home' users, which is
+  // the inference decidePullIn's nativePanelMirror leg rides. Chrome persists
+  // the behavior browser-side; re-applying at boot + on a frontDoorView write
+  // (both SW-wired) keeps it true to the setting. Native semantics also make
+  // the icon a panel TOGGLE for 'panel' users — the platform convention for
+  // side-panel extensions. Firefox has no equivalent, so its icon path keeps
+  // the sync settings read (a 'home' opt-in there can still see one
+  // panel-open on a cold event-page wake — accepted residual).
+  const syncFrontDoorBehavior = async () => {
+    try {
+      await (/** @type {any} */ (browser)).sidePanel?.setPanelBehavior?.({
+        openPanelOnActionClick: getFrontDoorView() === 'panel',
+      });
+    } catch (e) {
+      console.warn('[sw] setPanelBehavior failed', e);
+    }
+  };
+
   // The pull-in itself — open() runs synchronously (no await before it) to keep the
   // gesture; a failed/declined open falls back to home so the icon never dead-ends.
   const pullInPeerd = (/** @type {number} */ windowId, { fromShortcut = false } = {}) => {
@@ -287,6 +312,8 @@ export const makeTabAffordances = ({ browser, uiPorts, denylistStore, closeSideP
       hasSidePanel: !!(/** @type {any} */ (browser)).sidePanel?.open,
       hasSidebar: !!browser.sidebarAction?.open,
       fromShortcut,
+      frontDoorView: getFrontDoorView(),
+      nativePanelMirror: !!(/** @type {any} */ (browser)).sidePanel?.setPanelBehavior,
     });
     // Toggle-closed (shortcut only) — close needs no gesture, so fire and forget.
     if (target === 'close') { closeSidePanel(); return; }
@@ -317,5 +344,5 @@ export const makeTabAffordances = ({ browser, uiPorts, denylistStore, closeSideP
     pullInPeerd(/** @type {number} */ (tab?.windowId ?? lastFocusedWindowId), { fromShortcut: true });
   });
 
-  return { noteAgentTab, broadcastAgentTab, scheduleWebTabHint, showWebTabHint, setTabAnchor, isHomeOpen, focusAgentTab };
+  return { noteAgentTab, broadcastAgentTab, scheduleWebTabHint, showWebTabHint, setTabAnchor, isHomeOpen, focusAgentTab, syncFrontDoorBehavior };
 };

--- a/extension/background/watch-mode.js
+++ b/extension/background/watch-mode.js
@@ -23,7 +23,8 @@
  *    becoming a standing licence to grab focus.
  *
  *  - `panelOpen` — a SIDE-PANEL port specifically. why not "any peerd surface":
- *    the full-page home is peerd's front door (the toolbar icon opens it) and its
+ *    the full-page home is a primary parked surface (the toolbar icon still
+ *    opens it under frontDoorView:'home') and its
  *    port SELF-RECONNECTS after every service-worker respawn, so a home tab parked
  *    in a background window keeps "a surface is open" true forever — which is the
  *    resting state for lots of users, and would have let an unattended 3am Routine

--- a/extension/home/home.js
+++ b/extension/home/home.js
@@ -8,8 +8,10 @@
 // "Pop to the side" hands the chat to the window-global side panel so it
 // follows you across tabs while the agent drives the browser.
 //
-// Opened from the side-panel header (▦) or the toolbar icon. Settings is a link
-// from the rail (configuration stays distinct from the home surface).
+// Opened from the side-panel header (▦) — or the toolbar icon, when the
+// frontDoorView setting is 'home' (the default front door is the side panel).
+// Settings is a link from the rail (configuration stays distinct from the
+// home surface).
 
 import m from '/vendor/mithril/mithril.js';
 import browser from '/vendor/browser-polyfill.js';

--- a/extension/options/sections/behavior.js
+++ b/extension/options/sections/behavior.js
@@ -25,6 +25,35 @@ export const BehaviorSection = {
     const confirmsOn = state.session?.permission?.confirmActions === true;
 
     return m('div', [
+      // The front door (background/panel-affordance.js): which surface the
+      // toolbar icon opens. 'panel' is the default — the chat lands next to
+      // the page you're on instead of taking over a whole tab.
+      m('h3', 'Toolbar button'),
+      (() => {
+        const frontDoor = state.settings?.frontDoorView === 'home' ? 'home' : 'panel';
+        return [
+          m('p', frontDoor === 'panel'
+            ? 'Clicking the peerd toolbar button opens the chat in the side panel (sidebar on Firefox), next to the page you\'re on. The full-page home is still there — open it from the panel, or switch the default below.'
+            : 'Clicking the peerd toolbar button opens the full-page home tab. Once home is open, the button pulls the chat into the side panel instead. Switch the default below to open the side panel directly.'),
+          m('.input-row', [
+            m('label', { for: 'front-door-view' }, 'Opens'),
+            m('select', {
+              id: 'front-door-view',
+              value: frontDoor,
+              onchange: async (/** @type {{ target: HTMLSelectElement }} */ e) => {
+                await send({ type: 'settings/update', patch: { frontDoorView: e.target.value } });
+                m.redraw();
+              },
+            }, [
+              ['panel', 'side panel — default'],
+              ['home', 'full-page home'],
+            ].map(([value, label]) => m('option', { value }, label))),
+          ]),
+          m('p.hint', 'The keyboard shortcut (Cmd+Shift+P on Mac, Alt+Shift+P elsewhere) always toggles the side panel, whichever default you pick.'),
+        ];
+      })(),
+
+      m('.settings-divider'),
       // peerd ACTS by default (acting on the browser is the point). This
       // is the optional seatbelt: flip it on to confirm each side-effect.
       m('h3', 'Confirm before actions'),
@@ -409,6 +438,7 @@ export const BehaviorSection = {
       })(),
 
       resetRow(send, [
+        'frontDoorView',
         'reasoningEnabled', 'reasoningEffort', 'confirmWebWrites', 'schemaValidatedReplies',
         'advancedAutomationEnabled', 'devMode',
         'autoResumeInterruptedTurns', 'providerFailoverEnabled', 'providerFallbacks',

--- a/extension/shared/channel-config.js
+++ b/extension/shared/channel-config.js
@@ -32,6 +32,7 @@ export const CHANNEL_DEFAULTS = Object.freeze({
   openrouterModels: [],
   advancedAutomationEnabled: true,
   watchAgentTab: false,
+  frontDoorView: "panel",
   runnerModel: "",
   prewalkEnabled: false,
   enginePrewalkEnabled: false,

--- a/extension/sidepanel/components/app.js
+++ b/extension/sidepanel/components/app.js
@@ -192,10 +192,11 @@ const TopBar = {
           title: 'Settings',
           onclick: () => openOptions(),
         }, icon('set')),
-        // Close the panel. The toolbar action now opens Home rather than
-        // toggling the panel shut, so the panel needs its own dismiss — this
-        // reuses the SW's sidepanel/close (disable+re-arm; Chrome-only, no-op
-        // on Firefox's sidebar). Lock moved to the Home rail.
+        // Close the panel. The toolbar action OPENS peerd (the side panel by
+        // default, or Home via the frontDoorView setting) — only Chrome's
+        // native action-click toggle ever closes it — so the panel keeps its
+        // own dismiss; this reuses the SW's sidepanel/close (disable+re-arm;
+        // Chrome-only, no-op on Firefox's sidebar). Lock moved to the Home rail.
         m('button.icon', {
           title: 'Close panel',
           onclick: () => send({ type: 'sidepanel/close' }),

--- a/packaging/default-settings.mjs
+++ b/packaging/default-settings.mjs
@@ -133,6 +133,15 @@ export const defaults = {
   // channels: watching is a per-moment choice, not a default posture.
   watchAgentTab: { store: false, preview: false },
 
+  // Which surface the toolbar icon opens — peerd's front door
+  // (background/panel-affordance.js). 'panel' (owner call, 2026-07-29): the
+  // chat pulls into the side panel / sidebar NEXT TO the page the user is on;
+  // the full-page home taking over a whole tab on first click (often straight
+  // into the vault gate) read as heavyweight. 'home' restores the original
+  // full-page-first model (DESIGN-12): home first, panel once home is open.
+  // A friction preference, not a safety posture — identical on both channels.
+  frontDoorView: { store: 'panel', preview: 'panel' },
+
   // Web actor model override. '' is NO override — the web actor resolves to
   // the active provider's fast default (Haiku on Anthropic via
   // adapter.defaultRunnerModel; resolveRunnerModel), NOT the chat model. So out

--- a/tests/background/panel-affordance.test.ts
+++ b/tests/background/panel-affordance.test.ts
@@ -2,29 +2,51 @@ import { describe, test, expect } from 'bun:test';
 import { decidePullIn } from '../../extension/background/panel-affordance.js';
 
 describe('decidePullIn', () => {
-  describe('toolbar icon (fromShortcut: false)', () => {
-    test('opens home when no home surface is open (Chrome)', () => {
+  describe('toolbar icon (fromShortcut: false) — default front door (panel)', () => {
+    test('opens the side panel directly, even with no home open (Chrome)', () => {
       expect(decidePullIn({ homeOpen: false, hasSidePanel: true, hasSidebar: false }))
-        .toBe('home');
+        .toBe('panel');
     });
 
-    test('complements with the side panel when home is already open (Chrome)', () => {
+    test('opens the sidebar directly, even with no home open (Firefox)', () => {
+      expect(decidePullIn({ homeOpen: false, hasSidePanel: false, hasSidebar: true }))
+        .toBe('sidebar');
+    });
+
+    test('still opens the panel when home is already open (Chrome)', () => {
       expect(decidePullIn({ homeOpen: true, hasSidePanel: true, hasSidebar: false }))
         .toBe('panel');
     });
 
+    test('an explicit frontDoorView: "panel" behaves like the default', () => {
+      expect(decidePullIn({ homeOpen: false, hasSidePanel: true, hasSidebar: false, frontDoorView: 'panel' }))
+        .toBe('panel');
+    });
+  });
+
+  describe('toolbar icon (fromShortcut: false) — frontDoorView: "home" (the original model)', () => {
+    test('opens home when no home surface is open (Chrome)', () => {
+      expect(decidePullIn({ homeOpen: false, hasSidePanel: true, hasSidebar: false, frontDoorView: 'home' }))
+        .toBe('home');
+    });
+
+    test('complements with the side panel when home is already open (Chrome)', () => {
+      expect(decidePullIn({ homeOpen: true, hasSidePanel: true, hasSidebar: false, frontDoorView: 'home' }))
+        .toBe('panel');
+    });
+
     test('opens home when no home surface is open (Firefox)', () => {
-      expect(decidePullIn({ homeOpen: false, hasSidePanel: false, hasSidebar: true }))
+      expect(decidePullIn({ homeOpen: false, hasSidePanel: false, hasSidebar: true, frontDoorView: 'home' }))
         .toBe('home');
     });
 
     test('complements with the sidebar when home is already open (Firefox)', () => {
-      expect(decidePullIn({ homeOpen: true, hasSidePanel: false, hasSidebar: true }))
+      expect(decidePullIn({ homeOpen: true, hasSidePanel: false, hasSidebar: true, frontDoorView: 'home' }))
         .toBe('sidebar');
     });
   });
 
-  describe('keyboard command (fromShortcut: true) — toggle', () => {
+  describe('keyboard command (fromShortcut: true) — toggle, regardless of front door', () => {
     test('pulls the side panel in when closed, even with no home open (Chrome)', () => {
       expect(decidePullIn({ homeOpen: false, panelOpen: false, hasSidePanel: true, hasSidebar: false, fromShortcut: true }))
         .toBe('panel');
@@ -44,6 +66,36 @@ describe('decidePullIn', () => {
       expect(decidePullIn({ homeOpen: false, panelOpen: true, hasSidePanel: false, hasSidebar: true, fromShortcut: true }))
         .toBe('close');
     });
+
+    test('frontDoorView: "home" never changes the shortcut — it still pulls the panel in', () => {
+      expect(decidePullIn({ homeOpen: false, panelOpen: false, hasSidePanel: true, hasSidebar: false, fromShortcut: true, frontDoorView: 'home' }))
+        .toBe('panel');
+    });
+
+    test('frontDoorView: "home" never changes the shortcut — an open panel still toggles closed', () => {
+      expect(decidePullIn({ homeOpen: false, panelOpen: true, hasSidePanel: true, hasSidebar: false, fromShortcut: true, frontDoorView: 'home' }))
+        .toBe('close');
+    });
+  });
+
+  describe('the native-mirror inference (Chrome setPanelBehavior)', () => {
+    test('icon + mirror ⇒ home-first, even when the (pre-hydration) setting says panel', () => {
+      // The cold-start case the mirror exists for: the settings store still
+      // serves the channel default 'panel', but onClicked firing at all means
+      // the browser-side behavior was off — the user chose 'home'.
+      expect(decidePullIn({ homeOpen: false, hasSidePanel: true, hasSidebar: false, frontDoorView: 'panel', nativePanelMirror: true }))
+        .toBe('home');
+    });
+
+    test('icon + mirror still complements with the panel once home is open', () => {
+      expect(decidePullIn({ homeOpen: true, hasSidePanel: true, hasSidebar: false, frontDoorView: 'panel', nativePanelMirror: true }))
+        .toBe('panel');
+    });
+
+    test('the shortcut never rides the inference — it pulls the panel in regardless', () => {
+      expect(decidePullIn({ homeOpen: false, panelOpen: false, hasSidePanel: true, hasSidebar: false, fromShortcut: true, nativePanelMirror: true }))
+        .toBe('panel');
+    });
   });
 
   describe('toolbar icon never closes — only the shortcut toggles', () => {
@@ -57,6 +109,8 @@ describe('decidePullIn', () => {
     expect(decidePullIn({ homeOpen: true, hasSidePanel: false, hasSidebar: false, fromShortcut: true }))
       .toBe('home');
     expect(decidePullIn({ homeOpen: false, hasSidePanel: false, hasSidebar: false }))
+      .toBe('home');
+    expect(decidePullIn({ homeOpen: false, hasSidePanel: false, hasSidebar: false, frontDoorView: 'panel' }))
       .toBe('home');
   });
 

--- a/tests/background/settings-patch.test.ts
+++ b/tests/background/settings-patch.test.ts
@@ -53,6 +53,12 @@ describe('normalizeSettingsPatch — booleans + enums', () => {
     expect(norm({ reasoningEffort: 'high' })).toEqual({ reasoningEffort: 'high' });
     expect(norm({ reasoningEffort: 'ultra' })).toEqual({});
   });
+  test('frontDoorView gated to panel|home; anything else dropped', () => {
+    expect(norm({ frontDoorView: 'panel' })).toEqual({ frontDoorView: 'panel' });
+    expect(norm({ frontDoorView: 'home' })).toEqual({ frontDoorView: 'home' });
+    expect(norm({ frontDoorView: 'popup' })).toEqual({});
+    expect(norm({ frontDoorView: true })).toEqual({});
+  });
 });
 
 describe('normalizeSettingsPatch — providers + models', () => {


### PR DESCRIPTION
**Why**

Clicking the peerd toolbar icon opened the full-page home, so the first click of a session landed on a full-tab vault gate rather than next to the page you were on. (This commit was stranded on `feat/redesign`, whose PR #232 already merged - re-cut onto current main.)

**What**

- The toolbar icon now opens the side panel (sidebar on Firefox) by default; a new `frontDoorView` setting in Settings → Behavior switches it back to the full-page home.
- On Chrome the choice is mirrored into `sidePanel.setPanelBehavior`, so the default opens natively - before the service worker even wakes - and can't race cold-start settings hydration. One consequence: the icon becomes a panel toggle for those users, the platform convention.
- Firefox keeps the explicit open path; a `home` opt-in there can still see one panel-open on a cold event-page wake (documented in the code).
- The keyboard shortcut still always toggles the panel, whichever default is set.

**How**

- Gates green on the rebased base: 3434 bun tests, 631 in-browser, typecheck, lint, imports, no gen drift.
- 8 new `decidePullIn` cases incl. the native-mirror inference; `frontDoorView` patch validation.
- Live-verified the picker renders and flips on the current main (screenshot).
