### PR TITLE
fix(security): scope the spill cache to its owner, declare the site-client origin (#275, #274)

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -603,7 +603,7 @@ let webCacheSeq = 0;
 const webCache = {
   /** Mint a new time-ordered cache key. */
   key: () => `wc-${Date.now().toString(36)}-${(webCacheSeq += 1).toString(36)}`,
-  /** @param {{ key: string, url?: string, format?: string, text: string, storedAt?: number }} record */
+  /** @param {{ key: string, url?: string, format?: string, text: string, storedAt?: number, ownerSessionId?: string | null }} record */
   put: async (record) => {
     await idb.put(WEB_EXTRACT_CACHE_STORE, { storedAt: Date.now(), ...record });
     // Best-effort eviction: keys sort chronologically (time-prefixed), so

--- a/extension/peerd-runtime/tools/defs/fetch-url.js
+++ b/extension/peerd-runtime/tools/defs/fetch-url.js
@@ -203,7 +203,14 @@ export const fetchUrlTool = {
       if (truncated && webCache?.key && webCache?.put) {
         const cacheKey = webCache.key();
         try {
-          await webCache.put({ key: cacheKey, url: res.finalUrl || args.url, format, text: workingBody });
+          // Stamp the OWNER. The spill store is one service-worker-level map keyed
+          // by an opaque handle, so without this any actor holding a key could page
+          // back bytes a different actor fetched - credentialed, from an origin it
+          // is itself locked out of. read_web_cache checks this before slicing.
+          await webCache.put({
+            key: cacheKey, url: res.finalUrl || args.url, format, text: workingBody,
+            ownerSessionId: ctx.session?.sessionId ?? null,
+          });
           footer = ex
             ? excerptFooter({ key: cacheKey, total: ex.total, passagesShown: ex.passagesShown, passagesTotal: ex.passagesTotal, query })
             : pagingFooter({ key: cacheKey, total: win.total, headChars: win.headChars, tailChars: win.tailChars });

--- a/extension/peerd-runtime/tools/defs/read-web-cache.js
+++ b/extension/peerd-runtime/tools/defs/read-web-cache.js
@@ -46,10 +46,20 @@ export const readWebCacheTool = {
   origins: () => [],
   execute: async (args, ctx) => {
     if (typeof args?.key !== 'string' || !args.key) return { ok: false, error: 'key_required' };
-    const webCache = /** @type {{ get?: (key: string) => Promise<{ key: string, url?: string, format?: string, text: string } | undefined> } | undefined} */ (
+    const webCache = /** @type {{ get?: (key: string) => Promise<{ key: string, url?: string, format?: string, text: string, ownerSessionId?: string | null } | undefined> } | undefined} */ (
       /** @type {any} */ (ctx).webCache);
     if (!webCache?.get) return { ok: false, error: 'web_cache_unavailable' };
     const rec = await webCache.get(args.key).catch(() => undefined);
+    // The key is the ONLY thing standing between a caller and these bytes, and the
+    // store is global to the service worker - so a key that leaked into another
+    // actor's context (a reply, a shared transcript) would hand it a credentialed
+    // fetch from an origin its own lock refuses. Scope the read to whoever spilled
+    // it. why not fail-closed on an UNSTAMPED record: entries written before this
+    // check exist in live profiles and page-out within 40 spills; refusing them
+    // would break paging mid-turn on upgrade for no attacker-reachable gain.
+    if (rec && rec.ownerSessionId != null && rec.ownerSessionId !== (ctx.session?.sessionId ?? null)) {
+      return { ok: false, error: `not_your_cache_entry: ${args.key} was spilled by a different actor. Re-run the read yourself (fetch_url) rather than paging someone else's fetch.` };
+    }
     if (!rec || typeof rec.text !== 'string') {
       return { ok: false, error: `no_such_key: ${args.key} — the cache entry may have been evicted; re-run the read that produced it (fetch_url, or read_page mode:'content' for a tab you've already rendered — don't fetch_url a page you can still see).` };
     }

--- a/extension/peerd-runtime/tools/defs/site-client-read.js
+++ b/extension/peerd-runtime/tools/defs/site-client-read.js
@@ -27,7 +27,15 @@ export const siteClientReadTool = {
     },
   },
   sideEffect: 'read',
-  origins: () => [],
+  // Declare the target origin so the gates that already exist actually fire on it:
+  // `origins: () => []` told the denylist hook there was nothing to check, so a
+  // site client for a denylisted origin could be read/written while every other
+  // path to that origin was refused. site_client_run already declared it - these
+  // two had drifted.
+  origins: (args) => {
+    const o = normalizeSiteOrigin(args?.origin);
+    return o ? [o] : [];
+  },
   execute: async (args, ctx) => {
     const origin = normalizeSiteOrigin(args?.origin);
     if (!origin) return { ok: false, error: `bad_origin: ${args?.origin}` };

--- a/extension/peerd-runtime/tools/defs/site-client-write.js
+++ b/extension/peerd-runtime/tools/defs/site-client-write.js
@@ -59,7 +59,15 @@ export const siteClientWriteTool = {
   sideEffect: 'write',
   // IDB write, no web origin touched here — the origin/egress gates have nothing
   // to check. The safety is the confirm round-trip below.
-  origins: () => [],
+  // Declare the target origin so the gates that already exist actually fire on it:
+  // `origins: () => []` told the denylist hook there was nothing to check, so a
+  // site client for a denylisted origin could be read/written while every other
+  // path to that origin was refused. site_client_run already declared it - these
+  // two had drifted.
+  origins: (args) => {
+    const o = normalizeSiteOrigin(args?.origin);
+    return o ? [o] : [];
+  },
 
   execute: async (args, ctx) => {
     const origin = normalizeSiteOrigin(args?.origin);
@@ -107,7 +115,9 @@ export const siteClientWriteTool = {
       summary: `${proposal.op} site client ${origin} — persists ${proposal.bodyBytesAfter}B of `
         + `RUNNABLE JS (was ${proposal.bodyBytesBefore}B) + ${proposal.dossier.endpoints.length} endpoint(s) `
         + `(+${proposal.endpointDelta.added}/−${proposal.endpointDelta.removed}). Review the module before allowing.`,
-      origins: [],
+      // Name the origin on the card: a confirm that lists no origin cannot be
+      // audited against one, and this write persists runnable JS for that site.
+      origins: [origin],
       sessionId: ctx.session?.sessionId ?? null,
     });
     if (ans !== 'yes_once' && ans !== 'yes_session' && ans !== true) {

--- a/tests/peerd-runtime/tools/cache-and-client-scope.test.ts
+++ b/tests/peerd-runtime/tools/cache-and-client-scope.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect } from 'bun:test';
+import { readWebCacheTool } from '../../../extension/peerd-runtime/tools/defs/read-web-cache.js';
+import { siteClientReadTool } from '../../../extension/peerd-runtime/tools/defs/site-client-read.js';
+import { siteClientWriteTool } from '../../../extension/peerd-runtime/tools/defs/site-client-write.js';
+
+// Two tools that took a caller-supplied handle and consulted no gate:
+//
+//   read_web_cache - the spill store is one service-worker-level map keyed by an
+//     opaque handle, so a key that leaked into another actor's context paged back
+//     bytes that actor never fetched (possibly credentialed, from an origin its
+//     own lock refuses).
+//   site_client_read/_write - declared `origins: () => []`, so the denylist hook
+//     had nothing to check. site_client_run already declared its origin.
+
+const cacheCtx = (rec: any, sessionId: string | null) => ({
+  webCache: { get: async () => rec },
+  session: sessionId ? { sessionId } : undefined,
+} as any);
+
+const REC = { key: 'wc-1', url: 'https://bank.test/statement', format: 'raw', text: 'BALANCE 42' };
+
+describe('read_web_cache is scoped to the actor that spilled it', () => {
+  test('the owner can page its own entry', async () => {
+    const res: any = await readWebCacheTool.execute({ key: 'wc-1' }, cacheCtx({ ...REC, ownerSessionId: 'actor-a' }, 'actor-a'));
+    expect(res.ok).toBe(true);
+    expect(res.content).toContain('BALANCE 42');
+  });
+
+  test('a DIFFERENT actor holding the key is refused', async () => {
+    const res: any = await readWebCacheTool.execute({ key: 'wc-1' }, cacheCtx({ ...REC, ownerSessionId: 'actor-a' }, 'actor-b'));
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain('not_your_cache_entry');
+    // and the bytes do not ride along in the refusal
+    expect(JSON.stringify(res)).not.toContain('BALANCE 42');
+  });
+
+  test('an UNSTAMPED legacy entry is still readable', async () => {
+    // Entries written before the stamp exist in live profiles and age out within
+    // 40 spills; refusing them would break paging mid-turn on upgrade.
+    const res: any = await readWebCacheTool.execute({ key: 'wc-1' }, cacheCtx(REC, 'actor-b'));
+    expect(res.ok).toBe(true);
+  });
+});
+
+describe('site_client read/write declare the origin they touch', () => {
+  test('read declares the normalized origin so the denylist hook can see it', () => {
+    expect(siteClientReadTool.origins({ origin: 'https://bank.test/anything' }, {} as any)).toEqual(['https://bank.test']);
+  });
+
+  test('write declares it too', () => {
+    expect(siteClientWriteTool.origins({ origin: 'https://bank.test' }, {} as any)).toEqual(['https://bank.test']);
+  });
+
+  test('a junk origin declares nothing rather than a bogus entry', () => {
+    expect(siteClientReadTool.origins({ origin: 'not a url' }, {} as any)).toEqual([]);
+    expect(siteClientWriteTool.origins({}, {} as any)).toEqual([]);
+  });
+});


### PR DESCRIPTION
**Why**

Two tools took a caller-supplied handle and consulted no gate. `read_web_cache` reads a spill store that is one service-worker-level map keyed by an opaque handle, so a key reaching another actor's context paged back bytes that actor never fetched - possibly credentialed, from an origin its own lock refuses (#275). `site_client_read/_write` declared `origins: () => []`, which told the denylist hook there was nothing to check (#274).

**What**

- `fetch_url` stamps the owning session on each spill; `read_web_cache` refuses a mismatch. An unstamped legacy entry stays readable - those exist in live profiles, age out within 40 spills, and refusing them would break paging mid-turn on upgrade for no attacker-reachable gain.
- `site_client_read/_write` now declare the normalized target origin, so the denylist gate fires. `site_client_run` already did; these two had drifted.
- The write confirmation card names the origin - a card listing none can't be audited against one.

**How**

- 6 new tests: owner reads, a different actor is refused (and the bytes don't ride along in the refusal), legacy entries still page, both tools declare the origin, junk declares nothing.
- Revert-proven: each fix's tests fail with it removed.
- Gates green: 3430 bun, 631 in-browser, typecheck, lint, boundary, imports, tscheck, e2e 128/128.

Note: the origin-lock question in #274 is **not** settled here - this only makes the gates that already exist fire.
