### PR TITLE
fix(ui): render the origin-lock events in Activity

### DIFF
--- a/extension/options/sections/activity.js
+++ b/extension/options/sections/activity.js
@@ -42,6 +42,15 @@ const EVENT_META = {
   memory_suggestion_dismissed:{ label: 'memory suggestion dismissed', level: 'info' },
   trim_summary_enriched:      { label: 'history summary updated', level: 'info' },
   cheap_call_skipped:         { label: 'background call skipped', level: 'info' },
+  // The origin lock (#255). These are the entries that answer "why did peerd
+  // refuse to open that site" - the exact question the learned set makes a user
+  // ask - and without a label they rendered as a bare `origin_learned_sensitive`
+  // slug with no origin attached. `origin_unlearned_sensitive` is written by the
+  // Settings un-learn (#262); labelling it here is harmless before that lands,
+  // since unknown types already fall back to a raw-label row.
+  origin_learned_sensitive:   { label: 'site treated as yours',  level: 'info' },
+  origin_unlearned_sensitive: { label: 'site no longer yours',   level: 'warn' },
+  actor_origin_stop:          { label: 'web helper stopped',     level: 'warn' },
   // dweb (preview-only) — the high-signal, user-facing events. Internal
   // mesh/gossip diagnostics carry the dweb_ prefix too and fall back to a
   // raw-label/info row (the `?? { label: e.type, level: 'info' }` below).
@@ -75,6 +84,9 @@ const detailLine = (entry) => {
   // way denylist events show their pattern.
   if (d.id) bits.push(d.id);
   if (d.gate) bits.push(`gate=${d.gate}`);
+  // The origin leads: on an origin-lock row it IS the content ("site treated as
+  // yours" says nothing without it), and elsewhere it reads as the subject.
+  if (d.origin) bits.push(d.origin);
   if (d.reason) bits.push(d.reason);
   if (d.provider) bits.push(d.provider);
   if (d.primitive) bits.push(d.primitive);
@@ -93,6 +105,14 @@ const detailLine = (entry) => {
       bits.push(d.tier ? `${d.mode}/${d.tier}` : d.mode);
     }
   }
+  // why: an origin-lock row without its origin is unreadable - "site treated as
+  // yours" tells you nothing about WHICH site, and that is the whole content of
+  // the event. `to` is already narrowed to an origin phrase by the report layer
+  // (origin-lock-report.js originPhrase), so no path leaks in here.
+  if (d.handoffTo) bits.push(`→ ${d.handoffTo}`);
+  else if (d.to) bits.push(`→ ${d.to}`);
+  if (d.action) bits.push(d.action);
+  if (typeof d.count === 'number') bits.push(`${d.count} site(s)`);
   if (typeof d.durationMs === 'number') bits.push(`${d.durationMs}ms`);
   return bits.join(' · ');
 };

--- a/extension/tests/index.js
+++ b/extension/tests/index.js
@@ -99,6 +99,7 @@ import './unit/sidepanel/attachments.test.js';
 import './unit/sidepanel/message-list.test.js';
 import './unit/sidepanel/failure-chip.test.js';
 import './unit/sidepanel/confirm-note.test.js';
+import './unit/options/activity-origin-events.test.js';
 
 // --- home (chassis): the full-tab Library page ---
 import './unit/home/library-section.test.js';

--- a/extension/tests/unit/options/activity-origin-events.test.js
+++ b/extension/tests/unit/options/activity-origin-events.test.js
@@ -1,0 +1,76 @@
+// @ts-check
+// Options → Activity: the origin-lock events must be readable.
+//
+// The #255 arc writes `origin_learned_sensitive` and `actor_origin_stop`, and
+// those entries exist to answer the one question the learned set makes a user
+// ask - "why did peerd refuse to open that site". Before this, neither type was
+// in EVENT_META, so both rendered as a bare slug, and `detailLine` never read
+// `details.origin` - so the row did not even say WHICH site.
+
+import m from '/vendor/mithril/mithril.js';
+import { describe, it, expect } from '../../framework.js';
+import { ActivityView } from '/options/sections/activity.js';
+
+/** @param {any[]} entries */
+const mount = (entries) => {
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  const send = async (/** @type {any} */ msg) => (msg.type === 'audit/list'
+    ? { ok: true, entries, total: entries.length }
+    : { ok: true });
+  m.mount(root, { view: () => m(ActivityView, { send }) });
+  return { root, unmount: () => { m.mount(root, null); root.remove(); } };
+};
+
+const settle = () => new Promise((r) => setTimeout(r, 0)).then(() => m.redraw.sync?.() ?? m.redraw());
+
+describe('options.activity — origin-lock events', () => {
+  it('labels a learned origin and names the site', async () => {
+    const { root, unmount } = mount([
+      { id: '1', when: 1, type: 'origin_learned_sensitive', details: { origin: 'https://bank.test', reason: 'password-field' } },
+    ]);
+    try {
+      await settle();
+      const text = root.textContent ?? '';
+      expect(text.includes('origin_learned_sensitive')).toBe(false);   // no raw slug
+      expect(text.includes('site treated as yours')).toBe(true);
+      expect(text.includes('https://bank.test')).toBe(true);           // WHICH site
+      expect(text.includes('password-field')).toBe(true);              // and why
+    } finally { unmount(); }
+  });
+
+  it('labels a helper stop and names where it was stopped', async () => {
+    const { root, unmount } = mount([
+      { id: '2', when: 2, type: 'actor_origin_stop', details: { action: 'handoff', to: 'https://bank.test', handoffTo: 'https://bank.test' } },
+    ]);
+    try {
+      await settle();
+      const text = root.textContent ?? '';
+      expect(text.includes('web helper stopped')).toBe(true);
+      expect(text.includes('https://bank.test')).toBe(true);
+      expect(text.includes('handoff')).toBe(true);
+    } finally { unmount(); }
+  });
+
+  it('labels an un-learn, and reads louder than the learn', async () => {
+    // Removing a protection is the noisier event - same posture as the denylist
+    // rows, where disabling a built-in pattern is a warn.
+    const { root, unmount } = mount([
+      { id: '3', when: 3, type: 'origin_unlearned_sensitive', details: { origin: 'https://shop.test' } },
+    ]);
+    try {
+      await settle();
+      const text = root.textContent ?? '';
+      expect(text.includes('site no longer yours')).toBe(true);
+      expect(text.includes('https://shop.test')).toBe(true);
+    } finally { unmount(); }
+  });
+
+  it('an unknown type still renders rather than blanking the row', async () => {
+    const { root, unmount } = mount([{ id: '4', when: 4, type: 'brand_new_event', details: {} }]);
+    try {
+      await settle();
+      expect((root.textContent ?? '').includes('brand_new_event')).toBe(true);
+    } finally { unmount(); }
+  });
+});

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -90,7 +90,7 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // 530 → 534: the security-boundary arc's four pure cores —
 // actor/reply-schema.js (#241), actor/ugc-registry.js (#242),
 // tools/egress-heuristics.js (#243), dom/cdr.js (#244).
-const COVERED_FLOOR = 544;
+const COVERED_FLOOR = 545;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.


### PR DESCRIPTION
**Why**

The #255 arc writes `origin_learned_sensitive` and `actor_origin_stop` so a user can answer "why did peerd refuse to open that site". Neither type was in `EVENT_META`, so both rendered as a bare slug - and `detailLine` never read `details.origin`, so the row didn't even say which site. ARC-TESTING.md flags this gap.

**What**

- Labels the three origin-lock event types (`origin_unlearned_sensitive` rides in ahead of #262 - harmless, unknown types already fall back to a raw-label row).
- The detail line now leads with the origin, then the handoff target and action. The origin leads because on these rows it *is* the content.
- Un-learning reads as `warn`, matching how disabling a built-in denylist pattern reads - removing a protection is the louder event.

**How**

- 4 in-browser tests mounting the real view: each type renders its label and its site, and an unknown type still renders rather than blanking the row. Revert-proven - all three fail with the labels removed.
- Gates green: 3424 bun, 635 in-browser, typecheck, lint, imports, tscheck (floor 545).
- Live-checked the rendered page (no regression to existing rows).
