### PR TITLE
chore(release): 0.4.0 — changelog, version bump, feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,59 @@ and storage formats may move until the surface stabilizes.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-01
+
+### Added
+- **The toolbar button opens the side panel.** Clicking peerd used to
+  take over a whole tab with the full-page home, so the first click of
+  a session landed on a full-tab vault gate instead of next to the page
+  you were already on. It now opens the side panel (the sidebar on
+  Firefox) by default, and Settings, Behavior, Toolbar button switches
+  it back to the full-page home. On Chrome the choice is mirrored into
+  the browser's own action-click behavior, so the panel opens natively
+  before the service worker even wakes and the default can never race a
+  cold start. One consequence of that native path: for panel users the
+  icon becomes a toggle, which is the platform convention. The keyboard
+  shortcut still always toggles the panel, whichever default you pick.
+- **You can see which tab peerd is driving, and what it is doing in
+  it.** The driven page joins a collapsible peerd tab group for as long
+  as peerd owns it, so a glance at the tab strip says which tab is not
+  yours to touch right now. Inside that page, a small corner pill names
+  the current action, shows the origin, and carries a Stop button,
+  softening to "Thinking..." between calls so a slow step never reads
+  as a hang. The pill is invisible to peerd itself, by three
+  independent measures, and its wording comes from a fixed vocabulary:
+  never the text being typed, never page-authored labels or selectors,
+  and only the host of a navigation rather than the full URL.
+- **The orchestrator can wait for a delegation when it needs the
+  answer to speak.** `message_actor` takes an opt-in `await`, which
+  resolves the actor's fenced reply into the tool result so peerd
+  answers in the same turn instead of ending on "I'll report back".
+  Delegation stays async by default, which is still the only shape that
+  fans out. The wait is bounded: past a wall-clock cap it degrades back
+  to the ordinary later-turn reply without cancelling the actor, so a
+  slow delegation is never a lost one. Stop still ends delegated work,
+  and steering mid-wait now keeps the actor running and lands its reply
+  on the turn you steered into, rather than discarding the work.
+
+### Changed
+- **The visual gallery is Markdown and rides every pull request.**
+  GitHub serves a committed `.html` file as source text, so the gallery
+  was unreadable in the one place people actually browse the repo. It
+  is now `scripts/cdp/GALLERY.md`, which renders natively, and the
+  visual job posts a single sticky comment on every PR linking it with
+  a drift verdict, rather than speaking up only when the render broke.
+  Contributor-facing only; nothing in the extension changes.
+
+### Fixed
+- The in-page activity pill is taken down at the end of an actor turn
+  on Firefox too, where turns run in the service worker rather than an
+  offscreen worker. It previously outlived the turn there, parked on
+  "Thinking..." indefinitely.
+- peerd's system prompt described delegation as always asynchronous,
+  which contradicted the new opt-in wait on the same decision and left
+  the model with two conflicting statements of the delegation contract.
+
 ## [0.3.0] - 2026-07-31
 
 ### Added

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "peerd (dev)",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "An AI assistant that automates tasks in your browser. Local-first: your own API key, no account, no servers, no tracking.",
   "side_panel": {
     "default_path": "sidepanel/sidepanel.html"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "peerd",
   "private": true,
   "type": "module",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Browser-native AI agent harness. Solo dev — Bun is for tests + one-shot vendor scripts only; the extension itself runs no build step.",
   "license": "Apache-2.0",
   "homepage": "https://peerd.ai",

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -96,7 +96,11 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // 548 → 549: the in-page activity indicator's two checked cores (#259) —
 // actor/activity-label.js and background/page-activity.js. The injected
 // overlay body itself is ES5 and exempt, so it does not count.
-const COVERED_FLOOR = 549;
+// 549 → 551: ratchet hygiene at the 0.4.0 release, not new annotation work.
+// The 548 and 549 steps were each derived from a conflicting base rather than
+// from a fresh scan, so the floor was left trailing the real count by two.
+// Taking the reported number locks the existing gain in.
+const COVERED_FLOOR = 551;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/scripts/cdp/run-e2e-verify.mjs
+++ b/scripts/cdp/run-e2e-verify.mjs
@@ -102,10 +102,17 @@ const makeRecorder = (ctx, state) => {
     },
     // The same dual-theme capture for an arbitrary WIDE page (full-tab surfaces:
     // the home SPA, options) opened via openWidePage — the large in-browser view.
-    async visualPage(name, page, opts = {}) {
+    // beforeShot(page, theme) runs after the theme switch and before the shot,
+    // for a page that is still CHANGING while we capture it. why per-theme and
+    // not once per state: the two captures are ~100ms apart, so a state that
+    // normalises something time-varying (vm-tab-failed pins its boot-log clock)
+    // has to re-normalise for the second one — otherwise whatever moved in that
+    // window lands in the dark shot only, and the state flaps on dark forever.
+    async visualPage(name, page, { beforeShot, ...opts } = {}) {
       for (const theme of THEMES) {
         await setEmulatedTheme(page, theme);
         await sleep(80);
+        if (beforeShot) await beforeShot(page, theme);
         this._record(`${name}.${theme}`, name, theme, await capturePage(page), opts);
       }
     },

--- a/scripts/cdp/states.mjs
+++ b/scripts/cdp/states.mjs
@@ -18,7 +18,7 @@
 // screenshot to look at and a structured pass/fail with the "why".
 
 import { createServer } from 'node:http';
-import { rpc, evalIn, waitFor, sseText, sseToolCall, openWidePage, PASSPHRASE } from './e2e-harness.mjs';
+import { rpc, evalIn, waitFor, sseText, sseToolCall, openWidePage, sleep, PASSPHRASE } from './e2e-harness.mjs';
 
 // A compact transcript probe shared by the functional states.
 const probe = (ctx) => evalIn(ctx.page, `(() => {
@@ -917,7 +917,7 @@ export const STATES = [
         // presence and position are part of what the baseline should guard, its
         // value is not. (The harness's UTC timezone override does not help: the
         // problem is the time advancing, not the zone.)
-        await evalIn(page, `(() => {
+        const pinClock = () => evalIn(page, `(() => {
           for (const el of document.querySelectorAll('#boot-log, #boot-log *')) {
             for (const n of el.childNodes) {
               if (n.nodeType === 3) n.textContent = n.textContent.replace(/\\d{2}:\\d{2}:\\d{2}/g, '00:00:00');
@@ -925,7 +925,34 @@ export const STATES = [
           }
           return true;
         })()`);
-        await rec.visualPage('vm-tab-failed', page);
+
+        // TWO different nondeterminisms live in this one card, and pinning only
+        // ever addressed the first:
+        //
+        //   the VALUE of each timestamp — pinClock above; and
+        //   HOW MANY lines exist when we shoot. `ready` fires on the failed
+        //   boot-card, but the boot keeps appending for a little longer, so the
+        //   capture could catch N or N+1 lines depending on runner speed.
+        //
+        // The second is what actually made this state flap on main (a dark-only
+        // drift, because dark is the SECOND capture — a line landing between the
+        // two shots reached dark alone, carrying an unpinned clock with it).
+        // So: wait for the log to stop growing before shooting anything, and
+        // re-pin before EACH theme via beforeShot, which closes the window
+        // between the two captures rather than just the one before the first.
+        // waitFor returns null on budget exhaustion rather than throwing. That is
+        // the right shape here: a log that never settles should still produce a
+        // shot (and a visible diff) rather than failing the whole state with a
+        // timeout that says nothing about the render.
+        const logLength = () => evalIn(page, `document.getElementById('boot-log')?.textContent?.length ?? 0`);
+        await waitFor(async () => {
+          const a = await logLength();
+          await sleep(120);
+          return a === await logLength();
+        }, { budgetMs: 5000 });
+
+        await pinClock();
+        await rec.visualPage('vm-tab-failed', page, { beforeShot: pinClock });
       } finally { try { page.close(); } catch { /* */ } }
     },
   },

--- a/update-feeds/chrome-preview.xml
+++ b/update-feeds/chrome-preview.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gupdate xmlns="http://www.google.com/update2/response" protocol="2.0">
   <app appid="lpdkhfeldihoejbbfonnbekpjclkknoc">
-    <updatecheck codebase="https://github.com/NotASithLord/peerd/releases/download/v0.3.0/peerd-preview-chrome.crx" version="0.3.0"/>
+    <updatecheck codebase="https://github.com/NotASithLord/peerd/releases/download/v0.4.0/peerd-preview-chrome.crx" version="0.4.0"/>
   </app>
 </gupdate>

--- a/update-feeds/firefox-preview.json
+++ b/update-feeds/firefox-preview.json
@@ -3,8 +3,8 @@
     "peerd-preview@peerd.ai": {
       "updates": [
         {
-          "version": "0.3.0",
-          "update_link": "https://github.com/NotASithLord/peerd/releases/download/v0.3.0/peerd-preview-firefox.xpi",
+          "version": "0.4.0",
+          "update_link": "https://github.com/NotASithLord/peerd/releases/download/v0.4.0/peerd-preview-firefox.xpi",
           "applications": {
             "gecko": {
               "strict_min_version": "121.0"


### PR DESCRIPTION
## What & why

Release prep for **0.4.0**, cut after the jony PR merge sweep (#272, #260, #259, #203 all landed on `main` today). Bumps `package.json` to 0.4.0, writes the changelog section the release notes are extracted from, regenerates the manifest and the update feeds, and locks the `// @ts-check` ratchet to its real count.

Minor rather than patch: three of the four merges are user-facing features, and the front door changes what the toolbar button does by default.

Closes #

## Checklist

- [x] `bun run preflight` passes (tests, typecheck, lint, in-browser, dweb-boundary, no manifest drift)
- [x] Only original or permissively-licensed code — **no GPL / AGPL / copyleft**
- [x] Tests added or updated (or N/A) — N/A, no source change in this PR
- [x] No hand-edited generated files (`manifest.json`, `shared/channel-config.js`) — regenerated via `bun run gen:dev`
- [x] Called out below if this touches a **danger zone** (egress / vault / gates / runner & sandbox boundaries / dweb) — none touched here

## Notes for reviewers

**What ran green on this head**

| gate | result |
|---|---|
| `bun run preflight` | OK |
| bun tests | 3507 pass / 0 fail |
| in-browser (CDP, headless) | 662 pass / 0 fail |
| `bun run test:e2e` | 21 states, **128/128** checks |
| `bun run package:all` | all four artifacts at v0.4.0; both store packages verify zero dweb traces |
| typecheck / lint / boundary / imports / tscheck / gen-drift | clean |

**The tscheck floor moves 549 → 551.** Not new annotation work — ratchet hygiene. The 548 and 549 steps were each derived from a conflicting rebase base rather than a fresh scan, so the floor had been trailing the real count by two and the check was emitting its "consider bumping" warning. Taking the reported number locks the existing gain in.

**Feeds** are regenerated (`bun run feeds`) so they are in the tree before the tag rather than after it, mirroring step 5 of `packaging/release.ts`. Their download URLs point at v0.4.0 assets, which exist once the release is cut.

**What this PR deliberately does not do — the release itself.** `bun run release` needs signing credentials that only exist on your machine and in CI (`key.pem` for the Chrome `.crx`, `AMO_JWT_ISSUER`/`AMO_JWT_SECRET` for the Firefox `.xpi`), and it pushes a tag. `package:all` here warned `UNSIGNED` on both preview artifacts for exactly that reason. So everything up to the irreversible step is done and the tag is yours to cut:

```
git checkout main && git pull        # after this merges
bun run release -- --dry-run         # package + sign + feeds, then stop
bun run release                      # tag v0.4.0, push, publish, deploy feeds
```

`release.ts` re-runs preflight and re-derives the feeds itself, so a re-run of either is idempotent against what is committed here.

**One judgment call worth your eye:** the version number. 0.4.0 assumes the front-door default change (the toolbar button now opens the side panel rather than the full-page home) reads as a milestone. If you would rather ship these as 0.3.1, it is a one-line change to `package.json` plus the changelog heading, and `bun run gen:dev` picks the rest up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHWBQdU9tySEwLAjbC4bmw

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHWBQdU9tySEwLAjbC4bmw)_