### PR TITLE
feat(egress): a declarativeNetRequest backstop for the denylist

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,7 +51,13 @@ Understanding the boundaries helps you scope a report:
 - **Egress chokepoint.** All network calls route through
   `peerd-egress/fetch/`: `safeFetch` (a hardcoded provider allowlist for
   model calls) and `webFetch` (SSRF guard + a denylist of sensitive
-  origins, no redirects). There is no other egress path.
+  origins, no redirects). There is no other egress path. The denylist also
+  has a network-level backstop (`peerd-egress/denylist/dnr-rules.js` +
+  `background/denylist-net-guard.js`): a `declarativeNetRequest` rule that
+  blocks denylisted domains inside the tabs peerd is currently driving —
+  and only those, never your own browsing — so a page that navigates
+  ITSELF onto a sensitive site is refused below the page, where no
+  decision-time gate can see it.
 - **Untrusted-content boundary (the heap split).** The main agent never
   sees raw page content: page/DOM work is delegated to a per-tab **web
   actor** — a separate agent loop that, on Chrome, runs in its OWN Worker

--- a/extension/background/denylist-net-guard.js
+++ b/extension/background/denylist-net-guard.js
@@ -59,10 +59,10 @@ export const makeDenylistNetGuard = ({ dnr, getPatterns, getTabIds, buildUpdate,
     // why fingerprint rather than always call: tab lifecycle churn (open, close,
     // re-bind, re-bind again) fires many syncs that describe the SAME rule, and
     // updateSessionRules is a real IPC round trip. Cleared on failure so a retry
-    // is never skipped.
-    const fingerprint = rule
-      ? `${rule.condition.requestDomains.join(',')}|${rule.condition.tabIds.join(',')}`
-      : '';
+    // is never skipped. Over the WHOLE addRules array, not just the block rule —
+    // the IdP allow rule rides alongside it, and a fingerprint blind to a rule is
+    // a fingerprint that can skip a write that rule needed.
+    const fingerprint = JSON.stringify(update.addRules);
     if (applied === fingerprint) return;
     try {
       await dnr.updateSessionRules(update);

--- a/extension/background/denylist-net-guard.js
+++ b/extension/background/denylist-net-guard.js
@@ -1,0 +1,108 @@
+// @ts-check
+// background/denylist-net-guard.js — the imperative shell around the denylist's
+// declarativeNetRequest backstop (peerd-egress/denylist/dnr-rules.js holds the
+// pure rule math; read the why there).
+//
+// One job: keep exactly one session-scoped DNR rule in sync with
+// (the live denylist × the tabs peerd is currently driving). Everything it
+// needs is injected — the DNR namespace, the two live getters, audit — so the
+// whole thing is exercisable from Bun with a fake API.
+//
+// Three properties this file is responsible for:
+//
+//   1. NEVER browser-wide. The rule is dropped entirely when the driven-tab
+//      set is empty (dnr-rules refuses to build an unscoped rule), so a bug
+//      here degrades to "no backstop", never to "the user can't reach their
+//      bank".
+//   2. SERIALIZED. Syncs fire from tab lifecycle events and denylist edits,
+//      which interleave freely; overlapping updateSessionRules calls on one
+//      rule id would race to a nondeterministic winner. Every sync queues
+//      behind the last.
+//   3. NEVER FATAL. DNR support varies (Firefox's implementation is partial,
+//      and `tabIds` conditions are session-rule-only), so an unsupported or
+//      failing API must leave the JS gates — which are the actual
+//      specification — running exactly as before. Failures log once per
+//      distinct message and audit once; they never reject into a caller and
+//      never permanently disarm the guard.
+
+// Imports nothing: the rule math (peerd-egress's denylistSessionRuleUpdate) is
+// INJECTED like every other collaborator here, so this file stays Bun-importable
+// — pulling /peerd-egress/index.js in transitively drags the browser polyfill,
+// which throws outside an extension. Same posture as denylist-store.js.
+
+/**
+ * @param {Object} deps
+ * @param {any} deps.dnr  the chrome.declarativeNetRequest namespace (or a fake)
+ * @param {() => readonly string[]} deps.getPatterns  live denylist patterns
+ * @param {() => readonly number[]} deps.getTabIds    tabs peerd is driving right now
+ * @param {(input: { patterns: readonly string[], tabIds: readonly number[] }) =>
+ *   { removeRuleIds: number[], addRules: any[] }} deps.buildUpdate
+ *   peerd-egress's denylistSessionRuleUpdate (pure).
+ * @param {(entry: { type: string, details?: Record<string, any> }) => any} [deps.audit]
+ * @param {Pick<Console, 'warn'>} [deps.console]
+ */
+export const makeDenylistNetGuard = ({ dnr, getPatterns, getTabIds, buildUpdate, audit, console: log = console }) => {
+  const supported = typeof dnr?.updateSessionRules === 'function';
+  /** Serialization lane — every sync chains onto the previous one. */
+  let queue = Promise.resolve();
+  /** Fingerprint of the last successfully applied rule; null = unknown/dirty. */
+  let applied = /** @type {string | null} */ (null);
+  /** Distinct failure messages already logged (so a stuck API isn't a log flood). */
+  const loggedFailures = new Set();
+  let lastError = /** @type {string | null} */ (null);
+  let ruleDomains = 0;
+  let ruleTabs = /** @type {number[]} */ ([]);
+
+  const apply = async () => {
+    const update = buildUpdate({ patterns: getPatterns() ?? [], tabIds: getTabIds() ?? [] });
+    const rule = /** @type {any} */ (update.addRules[0]);
+    // why fingerprint rather than always call: tab lifecycle churn (open, close,
+    // re-bind, re-bind again) fires many syncs that describe the SAME rule, and
+    // updateSessionRules is a real IPC round trip. Cleared on failure so a retry
+    // is never skipped.
+    const fingerprint = rule
+      ? `${rule.condition.requestDomains.join(',')}|${rule.condition.tabIds.join(',')}`
+      : '';
+    if (applied === fingerprint) return;
+    try {
+      await dnr.updateSessionRules(update);
+      applied = fingerprint;
+      lastError = null;
+      ruleDomains = rule ? rule.condition.requestDomains.length : 0;
+      ruleTabs = rule ? [...rule.condition.tabIds] : [];
+    } catch (e) {
+      applied = null;
+      lastError = e instanceof Error ? e.message : String(e);
+      if (!loggedFailures.has(lastError)) {
+        loggedFailures.add(lastError);
+        log.warn('[denylist-net-guard] session rule update failed —',
+          'the network backstop is off; the denylist gates in the dispatcher and webFetch still apply:', lastError);
+        try { audit?.({ type: 'denylist_net_guard_failed', details: { reason: lastError } }); }
+        catch { /* audit is best-effort; never let it mask the original failure */ }
+      }
+    }
+  };
+
+  return {
+    /**
+     * Reconcile the rule with current state. Safe to call on every lifecycle
+     * event, including ones that changed nothing. Resolves when this sync's
+     * turn in the queue has run (callers that must not race a navigation can
+     * await it); never rejects.
+     * @returns {Promise<void>}
+     */
+    sync() {
+      if (!supported) return queue;
+      queue = queue.then(apply, apply);
+      return queue;
+    },
+
+    /** Is a usable DNR session-rule API present? (false → this guard is a no-op.) */
+    supported: () => supported,
+
+    /** Diagnostics for the audit/inspect surfaces. No authority. */
+    state: () => ({
+      supported, domains: ruleDomains, tabs: [...ruleTabs], lastError,
+    }),
+  };
+};

--- a/extension/background/routes/denylist.js
+++ b/extension/background/routes/denylist.js
@@ -12,7 +12,11 @@
  * @returns {Record<string, (msg?: any) => Promise<any>>}
  */
 export const makeDenylistRoutes = (deps) => {
-  const { denylistStore, auditLog } = deps;
+  // denylistNetGuard: the denylist's NETWORK-level backstop (a DNR rule built
+  // from the list — background/denylist-net-guard.js). An edit changes what that
+  // rule must block, so both mutating routes resync it. Injected like every other
+  // collaborator; this file still imports nothing.
+  const { denylistStore, auditLog, denylistNetGuard } = deps;
 
   // The shared { patterns, added, disabled } reply every denylist route returns.
   const snapshot = () => {
@@ -30,6 +34,7 @@ export const makeDenylistRoutes = (deps) => {
     'denylist/add': async ({ pattern }) => {
       const r = await denylistStore.add(pattern);
       if (!r.ok) return r;
+      denylistNetGuard.sync();
       auditLog.append({ type: 'denylist_added', details: { pattern: r.pattern, seed: r.seed } }).catch(() => {});
       return snapshot();
     },
@@ -40,6 +45,7 @@ export const makeDenylistRoutes = (deps) => {
     'denylist/remove': async ({ pattern }) => {
       const r = await denylistStore.remove(pattern);
       if (!r.ok) return r;
+      denylistNetGuard.sync();
       auditLog.append({ type: 'denylist_removed', details: { pattern: r.pattern, seed: r.seed } }).catch(() => {});
       return snapshot();
     },

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -260,7 +260,7 @@ import {
   // live — the state store, the judge, the synchronous credential-scope
   // narrowing, and the report a stop turns into.
   makeOriginStateStore, makeLearnedOrigins, makeJudgeLanding, makeCredentialScope,
-  isKnownIdp, knownIdpSeeds, describeLandingStop, originPhrase, isUgcHost,
+  isKnownIdp, knownIdpDomains, describeLandingStop, originPhrase, isUgcHost,
   finalAssistantText,
   // The debug surface: the bundle assembler + the delegation-tree walk the
   // session/debugBundle route runs (pure; the SW supplies the reads).
@@ -835,17 +835,10 @@ const drivenTabIds = () => {
   }
   return [...ids];
 };
-// The IdP registry as bare domains for the allow rule: the vendor SUFFIXES
-// verbatim (requestDomains already means "this domain and its subdomains", which
-// is exactly what a per-customer `acme.okta.com` needs) plus the hostname of
-// each exact origin. Computed once — the registry is a frozen constant.
-const idpExemptDomains = (() => {
-  const seeds = knownIdpSeeds();
-  const hosts = seeds.origins
-    .map((origin) => { try { return new URL(origin).hostname; } catch { return null; } })
-    .filter((host) => typeof host === 'string');
-  return [...new Set([...seeds.suffixes, .../** @type {string[]} */ (hosts)])];
-})();
+// The IdP registry as bare domains for the allow rule — derived NEXT TO the
+// registry (knownIdpDomains) so a registry edit moves the excursion rule and
+// this carve-out together. Computed once; the registry is a frozen constant.
+const idpExemptDomains = knownIdpDomains();
 
 const denylistNetGuard = makeDenylistNetGuard({
   dnr: /** @type {any} */ (globalThis).chrome?.declarativeNetRequest,
@@ -1226,6 +1219,14 @@ const buildToolContext = async (/** @type {any} */ { sessionId: overrideSessionI
   // rejects) — it cannot hang the turn. Every dispatch path (main turn, direct
   // dispatch, spawned actors) routes through here, so all are covered.
   await denylistReady;
+  // Same shape, one layer down: never dispatch a tool while the DNR backstop
+  // trails the driven-tab set. Most binding paths kick the sync without awaiting
+  // it (bind() is a sync callback), so an actor's FIRST tool call could
+  // otherwise race the rule landing — adoptWebTab awaits, but the site-actor
+  // path (addressing an existing tab) did not. Awaiting here closes every such
+  // race structurally. Cheap: a no-change sync short-circuits on the
+  // fingerprint, and the promise never rejects.
+  await denylistNetGuard.sync();
   // why: the override lets the actor orchestrator build a context
   // bound to a CHILD session id instead of the chat's current one. With
   // no override this is identical to the original behaviour (the active

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -260,7 +260,7 @@ import {
   // live — the state store, the judge, the synchronous credential-scope
   // narrowing, and the report a stop turns into.
   makeOriginStateStore, makeLearnedOrigins, makeJudgeLanding, makeCredentialScope,
-  isKnownIdp, describeLandingStop, originPhrase, isUgcHost,
+  isKnownIdp, knownIdpSeeds, describeLandingStop, originPhrase, isUgcHost,
   finalAssistantText,
   // The debug surface: the bundle assembler + the delegation-tree walk the
   // session/debugBundle route runs (pure; the SW supplies the reads).
@@ -835,9 +835,29 @@ const drivenTabIds = () => {
   }
   return [...ids];
 };
+// The IdP registry as bare domains for the allow rule: the vendor SUFFIXES
+// verbatim (requestDomains already means "this domain and its subdomains", which
+// is exactly what a per-customer `acme.okta.com` needs) plus the hostname of
+// each exact origin. Computed once — the registry is a frozen constant.
+const idpExemptDomains = (() => {
+  const seeds = knownIdpSeeds();
+  const hosts = seeds.origins
+    .map((origin) => { try { return new URL(origin).hostname; } catch { return null; } })
+    .filter((host) => typeof host === 'string');
+  return [...new Set([...seeds.suffixes, .../** @type {string[]} */ (hosts)])];
+})();
+
 const denylistNetGuard = makeDenylistNetGuard({
   dnr: /** @type {any} */ (globalThis).chrome?.declarativeNetRequest,
-  buildUpdate: denylistSessionRuleUpdate,
+  // The IdP carve-out. The origin lock lets a bound actor's tab leave its owned
+  // origin exactly once, for a sign-in, and several identity providers are also
+  // denylist entries — an overlap both halves intend (the denylist stops the
+  // AGENT driving a login box; the excursion keeps the tab usable so the PERSON
+  // can finish signing in and the actor can resume). A blanket network block
+  // would break that, so the rule pair exempts exactly the IdP registry — which
+  // stays the single authority on what counts as one. No authority is granted:
+  // isDenylistedTab still refuses every DOM tool on such a tab.
+  buildUpdate: (/** @type {any} */ input) => denylistSessionRuleUpdate({ ...input, exemptDomains: idpExemptDomains }),
   getPatterns: () => denylistStore.patterns(),
   getTabIds: drivenTabIds,
   audit: (/** @type {any} */ entry) => { auditLog.append(entry).catch(() => {}); },

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -267,7 +267,7 @@ import {
   assembleDebugBundle, childSessionIdsOf,
 } from '/peerd-runtime/index.js';
 
-import { flattenCategorisedDenylist, normalizeDenylistPattern } from '/peerd-egress/index.js';
+import { flattenCategorisedDenylist, normalizeDenylistPattern, denylistSessionRuleUpdate } from '/peerd-egress/index.js';
 
 import { createVmClient } from './vm-client.js';
 import { createVmTabTracker } from './vm-tab-tracker.js';
@@ -314,6 +314,7 @@ import { createDebuggerPool } from './debugger-pool.js';
 import { normalizeSettingsPatch } from './settings-patch.js';
 import { makeSettingsStore } from './settings-store.js';
 import { makeDenylistStore } from './denylist-store.js';
+import { makeDenylistNetGuard } from './denylist-net-guard.js';
 import { makeSessionState } from './session-state.js';
 import { makeLocalModelState } from './local-model-state.js';
 import { makeProfileState } from './profile-state.js';
@@ -794,9 +795,53 @@ const loadDenylist = async () => {
   }
   await denylistStore.load(seed);
   console.log('[sw] denylist loaded —', denylistStore.patterns().length, 'patterns');
+  // The backstop's rule set is derived from the list, so it has to be rebuilt
+  // the moment the list exists (a live SW restart can find tabs already driven).
+  denylistNetGuard.sync();
 };
 /** @type {Promise<void>} */
 const denylistReady = loadDenylist();
+
+// ── the denylist's NETWORK-level backstop ──────────────────────────────────
+//
+// The gates above are decision-time: they judge a URL the agent hands us. They
+// cannot see what a page does on its OWN initiative — a driven tab that
+// `location =`s onto a bank reaches the bank's DOM through a tool call that
+// never named the bank, so no gate ever got a URL to refuse. Same gap in an App
+// sandbox, whose agent-authored code reaches the network without passing
+// webFetch at all. declarativeNetRequest closes it below the page: one
+// session-scoped rule, blocking denylisted domains in the tabs peerd is
+// CURRENTLY DRIVING and nowhere else. See background/denylist-net-guard.js and
+// peerd-egress/denylist/dnr-rules.js.
+//
+// Deliberately a BACKSTOP, not a replacement: the JS gates still produce the
+// refusal the model reads and the audit entry the user sees. Where DNR is
+// unavailable (Firefox's partial implementation) the guard is a no-op and
+// behavior is exactly what it was before.
+const drivenTabIds = () => {
+  /** @type {Set<number>} */
+  const ids = new Set();
+  // Tabs a web actor owns — the ones it navigates and reads the DOM of.
+  for (const [tabId] of webActorTabBindings.entries()) ids.add(tabId);
+  // Engine tabs. The WebVM's network already proxies through webFetch and the
+  // Notebook worker is sealed, so App tabs are the ones with a real un-gated
+  // network edge — but scoping all three keeps the rule uniform and costs a
+  // rule condition entry, not a check per request.
+  for (const tracker of [vmTabTracker, jsTabTracker, appTabTracker]) {
+    for (const instanceId of tracker.listLive()) {
+      const tabId = tracker.getTabId(instanceId);
+      if (typeof tabId === 'number') ids.add(tabId);
+    }
+  }
+  return [...ids];
+};
+const denylistNetGuard = makeDenylistNetGuard({
+  dnr: /** @type {any} */ (globalThis).chrome?.declarativeNetRequest,
+  buildUpdate: denylistSessionRuleUpdate,
+  getPatterns: () => denylistStore.patterns(),
+  getTabIds: drivenTabIds,
+  audit: (/** @type {any} */ entry) => { auditLog.append(entry).catch(() => {}); },
+});
 
 // ---------------------------------------------------------------------------
 // issue 251 — the origin lock, made live.
@@ -2712,19 +2757,24 @@ browser.runtime.onMessage.addListener((/** @type {any} */ msg, /** @type {any} *
 // chrome.tabs.onRemoved.
 browser.runtime.onMessage.addListener((/** @type {any} */ msg, /** @type {any} */ sender) => {
   if (!isTrustedSender(sender)) return false;
+  // Each tab-ready is a new tabId entering the driven set, so each one resyncs
+  // the denylist network backstop (idempotent; a no-op when nothing moved).
   if (msg?.type === 'vm/tab-ready') {
     if (typeof msg.vmId !== 'string' || sender?.tab?.id == null) return false;
     vmTabTracker.onTabReady(msg.vmId, sender.tab.id);
+    denylistNetGuard.sync();
     return false;
   }
   if (msg?.type === 'js/tab-ready') {
     if (typeof msg.notebookId !== 'string' || sender?.tab?.id == null) return false;
     jsTabTracker.onTabReady(msg.notebookId, sender.tab.id);
+    denylistNetGuard.sync();
     return false;
   }
   if (msg?.type === 'app/tab-ready') {
     if (typeof msg.appId !== 'string' || sender?.tab?.id == null) return false;
     appTabTracker.onTabReady(msg.appId, sender.tab.id);
+    denylistNetGuard.sync();
     return false;
   }
   return false;
@@ -2747,6 +2797,10 @@ browser.tabs.onRemoved.addListener((tabId) => {
   // its next op (the clients ensureTab internally); the binding persists.
   // Drop any DOM-nav refs for the closed tab.
   domRefs.clear(tabId);
+  // ...and drop it out of the network backstop's tab scope. Tab ids are REUSED
+  // within a browser session, so a stale entry would silently apply the block
+  // to whatever unrelated tab inherits the id.
+  denylistNetGuard.sync();
 });
 
 // Invalidate a tab's DOM-nav refs when it starts navigating — the
@@ -3153,16 +3207,28 @@ const mintActor = async (/** @type {{ reg: any, kind: string }} */ entry, /** @t
 // one of these is a routing cache whose durable truth lives on the session record.
 const persistRegistry = (/** @type {string} */ key, /** @type {{ entries: () => any }} */ registry) =>
   () => { sessionCache.sessionSet(key, registry.entries()).catch(() => {}); };
-const hydrateRegistry = (/** @type {string} */ key, /** @type {{ load: (e: any) => void }} */ registry) => {
+// Returns the load promise (never rejects) so a caller whose state DEPENDS on
+// the rehydrated entries — the net guard's driven-tab set — can chain onto it
+// instead of guessing at the timing.
+const hydrateRegistry = (/** @type {string} */ key, /** @type {{ load: (e: any) => void }} */ registry) =>
   Promise.resolve(sessionCache.sessionGet(key))
     .then((e) => { if (Array.isArray(e)) registry.load(/** @type {any} */ (e)); })
     .catch(() => {});
-};
 
 const webActorTabBindings = makeWebActorTabBindings();
 const WEB_BINDINGS_KEY = 'webActorTabBindings';
-const persistWebBindings = persistRegistry(WEB_BINDINGS_KEY, webActorTabBindings);
-hydrateRegistry(WEB_BINDINGS_KEY, webActorTabBindings);
+const persistWebBindingsOnly = persistRegistry(WEB_BINDINGS_KEY, webActorTabBindings);
+// why compose the net-guard sync in HERE rather than at each call site: every
+// mutation of the tab bindings — bind, drop, re-bind, the onRemoved prune —
+// already funnels through persistWebBindings, so this is the one place that
+// sees the driven-tab set change. A sync is idempotent and skips when nothing
+// moved, so the extra call on a no-op mutation costs nothing.
+const persistWebBindings = () => { persistWebBindingsOnly(); denylistNetGuard.sync(); };
+// Rehydration restores bindings without going through persistWebBindings (an
+// SW restart finds tabs still being driven), so the guard is told once the load
+// lands — not before, or it would re-derive the same empty set it started with.
+hydrateRegistry(WEB_BINDINGS_KEY, webActorTabBindings)
+  .then(() => denylistNetGuard.sync());
 
 // The chat→web-actor registry — the 0-or-1-tab web actor (addressed by `to:'web'`,
 // the SINGLE entry point for web work). Separate from webActorTabBindings because
@@ -4240,6 +4306,10 @@ const adoptWebTab = async (/** @type {string} */ actorSessionId) => {
   if (typeof tabId !== 'number') throw new Error('adopt_web_tab: no tab id');
   webActorTabBindings.bind(tabId, actorSessionId);
   persistWebBindings();
+  // AWAIT the network backstop before handing the tab back: the caller's very
+  // next act is to navigate it. persistWebBindings already kicked the sync off;
+  // this only waits for its turn in the queue, and it never rejects.
+  await denylistNetGuard.sync();
   noteAgentTab(tabId, { kind: 'web', opened: true }).catch(() => {});
   return { tabId, windowId: created?.windowId };
 };
@@ -4878,7 +4948,10 @@ browser.runtime.onMessage.addListener(/** @type {any} */ (makeDispatcher({
     uiPorts, loadUserEndpoints, inspectImport, applyImport, settingsStore, saveUserHook,
     CHANNEL, DEFAULT_SETTINGS, ExportPassphraseError,
   }),
-  ...makeDenylistRoutes({ denylistStore, auditLog }),
+  // denylistNetGuard: an edit changes what the network backstop blocks, so the
+  // rule is rebuilt on every edit — including the removal path, where a stale
+  // rule would keep blocking a site the user just unblocked.
+  ...makeDenylistRoutes({ denylistStore, auditLog, denylistNetGuard }),
   // The settings view of the LEARNED origin set (+ the only un-learn path).
   // Settings-surface only: routes are unreachable from the tool dispatcher, so
   // no agent or page-fed actor can erase its own containment.
@@ -5084,6 +5157,9 @@ ensureOffscreen().catch((e) => console.error('[sw] boot ensureOffscreen failed',
     await appTabTracker.bootstrap();
     console.log('[sw] instance registries initialized — live tabs:',
       { vm: vmTabTracker.listLive(), js: jsTabTracker.listLive(), app: appTabTracker.listLive() });
+    // An SW restart re-adopts engine tabs that never stopped running, so the
+    // network backstop's tab scope has to be rebuilt from what bootstrap found.
+    denylistNetGuard.sync();
   } catch (e) {
     console.error('[sw] instance init failed', e);
   }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -26,6 +26,7 @@
     "offscreen",
     "notifications",
     "alarms",
+    "declarativeNetRequest",
     "debugger"
   ],
   "host_permissions": [

--- a/extension/peerd-egress/denylist/dnr-rules.js
+++ b/extension/peerd-egress/denylist/dnr-rules.js
@@ -1,0 +1,143 @@
+// @ts-check
+// Denylist → declarativeNetRequest rules. The NETWORK-level half of the
+// denylist; the pure core, so it is testable without a browser.
+//
+// why a second enforcement point at all — the JS gates already check the
+// denylist in three places (the dispatcher's origin gate, webFetch, and the
+// tab-affordance hint). All three are DECISION-TIME checks: they judge a URL
+// the agent hands us, BEFORE the request. What none of them can see is what
+// the page does next. Once a peerd-driven tab is on a page, that page can
+// navigate itself anywhere — `location =`, a meta refresh, a form POST, an
+// iframe, an OAuth bounce — and nothing in peerd is on that path. The agent
+// then reads a bank's DOM through a tool call that never named the bank, so
+// no gate ever got a URL to refuse. Same hole in an App sandbox: agent-authored
+// code in an opaque-origin iframe reaches the network directly, not through
+// webFetch.
+//
+// declarativeNetRequest closes it at the layer the page cannot argue with. The
+// rules are SESSION-scoped and TAB-scoped: they apply only to tabs peerd is
+// currently driving, never to the user's own browsing. Blocking the user's bank
+// tab would be a bug, not a feature — the denylist says "the agent may not go
+// here", not "this browser may not go here".
+//
+// This is a BACKSTOP, not the primary control. The JS gates stay exactly as
+// they are: they produce the refusal the model can read and the audit entry the
+// user can see. DNR produces a dead socket and no explanation. Where they
+// disagree, the JS gates are the specification.
+//
+// The mapping is deliberately COARSER than the JS matcher, in the strict
+// direction. DNR's `requestDomains` matches a domain AND its subdomains; there
+// is no subdomain-only form short of a regex rule. So `*.okta.com` maps to the
+// domain `okta.com`, which also blocks the apex the JS matcher would allow.
+// Over-blocking one apex inside an agent-driven tab is the cheap side of that
+// trade — and every seed entry that has an apex lists it explicitly anyway.
+
+import { normalizeDenylistPattern } from './denylist.js';
+
+/**
+ * The session rule id the denylist block rule occupies. ONE rule carries every
+ * domain and every protected tab, so a resync is a single remove+add and the id
+ * can be a constant. why one rule: `requestDomains` and `tabIds` are both lists
+ * on a single condition, so per-domain or per-tab rules would buy nothing but
+ * bookkeeping (and rule-count pressure against the session-rule cap).
+ */
+export const DENYLIST_RULE_ID = 1;
+
+/**
+ * Resource types the block rule covers. Enumerated EXPLICITLY rather than left
+ * to the default: implementations differ on whether an omitted `resourceTypes`
+ * includes `main_frame`, and main_frame is the one that matters most here. The
+ * set is restricted to types that predate DNR (the MV2 webRequest enum) so a
+ * strict validator on either browser can't reject the whole rule over a value
+ * it doesn't know.
+ */
+export const DENYLIST_RESOURCE_TYPES = Object.freeze([
+  'main_frame', 'sub_frame', 'stylesheet', 'script', 'image', 'font',
+  'object', 'xmlhttprequest', 'ping', 'media', 'websocket', 'other',
+]);
+
+/**
+ * Is `host` equal to, or a subdomain of, `base`? (Label-boundary aware — the
+ * same care denylist.js takes: `evilchase.com` is not under `chase.com`.)
+ * @param {string} host
+ * @param {string} base
+ */
+const isUnder = (host, base) => host === base || host.endsWith(`.${base}`);
+
+/**
+ * Reduce denylist patterns to the set of domains a DNR `requestDomains`
+ * condition should carry.
+ *
+ * Three reductions, in order:
+ *   1. normalize + drop anything the JS matcher itself wouldn't accept (the one
+ *      source of truth for pattern validity is normalizeDenylistPattern);
+ *   2. strip the leading `*.` — `requestDomains` already covers subdomains;
+ *   3. drop entries a broader entry already covers (`mail.proton.me` under
+ *      `proton.me`), so the list carries no redundancy.
+ *
+ * Pure; returns a stable (sorted) array so a resync with unchanged input
+ * produces an identical rule.
+ *
+ * @param {readonly string[]} patterns
+ * @returns {string[]}
+ */
+export const denylistBlockDomains = (patterns) => {
+  const bases = new Set();
+  for (const raw of patterns ?? []) {
+    const normalized = normalizeDenylistPattern(raw);
+    if (!normalized) continue;
+    bases.add(normalized.startsWith('*.') ? normalized.slice(2) : normalized);
+  }
+  const all = [...bases];
+  return all
+    .filter((host) => !all.some((other) => other !== host && isUnder(host, other)))
+    .sort();
+};
+
+/**
+ * Build the block rule for a set of driven tabs, or null when there is nothing
+ * to enforce (no domains, or no tab is currently being driven). Null means
+ * "remove the rule" — an unscoped rule would be a browser-wide block, which is
+ * exactly the outcome this module must never produce, so the tab list is
+ * REQUIRED, not defaulted.
+ *
+ * @param {Object} input
+ * @param {readonly string[]} input.domains  from denylistBlockDomains
+ * @param {readonly number[]} input.tabIds   tabs peerd is currently driving
+ * @param {number} [input.ruleId]
+ * @returns {object | null}
+ */
+export const buildDenylistBlockRule = ({ domains, tabIds, ruleId = DENYLIST_RULE_ID }) => {
+  const tabs = [...new Set((tabIds ?? []).filter((t) => Number.isInteger(t) && t >= 0))];
+  if (!domains?.length || !tabs.length) return null;
+  return {
+    id: ruleId,
+    // Priority is only meaningful against our OWN other rules; we ship one.
+    priority: 1,
+    action: { type: 'block' },
+    condition: {
+      requestDomains: [...domains],
+      tabIds: tabs,
+      resourceTypes: [...DENYLIST_RESOURCE_TYPES],
+    },
+  };
+};
+
+/**
+ * The full `updateSessionRules` argument for the current state. Always removes
+ * the rule id first so the call is idempotent and self-healing: whatever the
+ * previous state was (stale tab list, stale domains, nothing at all), applying
+ * this leaves exactly one correct rule, or none.
+ *
+ * @param {Object} input
+ * @param {readonly string[]} input.patterns  the live denylist
+ * @param {readonly number[]} input.tabIds
+ * @param {number} [input.ruleId]
+ * @returns {{ removeRuleIds: number[], addRules: object[] }}
+ */
+export const denylistSessionRuleUpdate = ({ patterns, tabIds, ruleId = DENYLIST_RULE_ID }) => {
+  const rule = buildDenylistBlockRule({
+    domains: denylistBlockDomains(patterns ?? []), tabIds, ruleId,
+  });
+  return { removeRuleIds: [ruleId], addRules: rule ? [rule] : [] };
+};

--- a/extension/peerd-egress/denylist/dnr-rules.js
+++ b/extension/peerd-egress/denylist/dnr-rules.js
@@ -44,6 +44,31 @@ import { normalizeDenylistPattern } from './denylist.js';
 export const DENYLIST_RULE_ID = 1;
 
 /**
+ * The companion ALLOW rule's id, at a higher priority than the block — the
+ * sign-in corridor.
+ *
+ * why it exists: the origin lock (peerd-runtime/actor/landing-rule.js) lets a
+ * BOUND actor's tab leave its owned origin exactly once, for an identity
+ * provider, on a budgeted excursion. Several of those providers — okta.com,
+ * auth0.com, duosecurity.com, appleid.apple.com — are also denylist entries, and
+ * that overlap is deliberate on both sides: the denylist stops the AGENT from
+ * driving a login box, while the excursion rule keeps the tab usable so the
+ * SIGN-IN can still happen and the actor can resume when the tab comes home.
+ *
+ * A blanket network block would collapse that distinction — the login page would
+ * not render at all, so not even the person at the keyboard could complete it.
+ * The allow rule keeps the corridor open at the network layer ONLY. It grants
+ * the agent nothing: `isDenylistedTab` still refuses every DOM tool on such a
+ * tab and the origin gate still refuses a navigate to it, so what the agent may
+ * DO on an IdP page is unchanged — only whether the bytes arrive for the human.
+ *
+ * The exempt set is INJECTED (peerd-runtime owns the IdP registry, and egress
+ * sits below runtime — it must not reach up for it). Widening that registry is a
+ * security decision that belongs in one place, and this file is not it.
+ */
+export const DENYLIST_ALLOW_RULE_ID = 2;
+
+/**
  * Resource types the block rule covers. Enumerated EXPLICITLY rather than left
  * to the default: implementations differ on whether an omitted `resourceTypes`
  * includes `main_frame`, and main_frame is the one that matters most here. The
@@ -124,20 +149,60 @@ export const buildDenylistBlockRule = ({ domains, tabIds, ruleId = DENYLIST_RULE
 };
 
 /**
+ * Build the ALLOW rule that keeps the sign-in corridor open (see
+ * DENYLIST_ALLOW_RULE_ID). Same tab scoping as the block rule, one priority
+ * step above it, so it wins wherever the two overlap.
+ *
+ * Only ever emitted alongside a block rule — an allow rule on its own would be
+ * a no-op, and emitting one anyway would put a rule in front of a user who has
+ * no block in effect.
+ *
+ * @param {Object} input
+ * @param {readonly string[]} input.domains  exempt domains (the IdP registry)
+ * @param {readonly number[]} input.tabIds
+ * @param {number} [input.ruleId]
+ * @returns {object | null}
+ */
+export const buildIdpAllowRule = ({ domains, tabIds, ruleId = DENYLIST_ALLOW_RULE_ID }) => {
+  const tabs = [...new Set((tabIds ?? []).filter((t) => Number.isInteger(t) && t >= 0))];
+  const exempt = [...new Set((domains ?? []).filter((d) => typeof d === 'string' && d.includes('.')))].sort();
+  if (!exempt.length || !tabs.length) return null;
+  return {
+    id: ruleId,
+    priority: 2,
+    action: { type: 'allow' },
+    condition: {
+      requestDomains: exempt,
+      tabIds: tabs,
+      resourceTypes: [...DENYLIST_RESOURCE_TYPES],
+    },
+  };
+};
+
+/**
  * The full `updateSessionRules` argument for the current state. Always removes
- * the rule id first so the call is idempotent and self-healing: whatever the
+ * both rule ids first so the call is idempotent and self-healing: whatever the
  * previous state was (stale tab list, stale domains, nothing at all), applying
- * this leaves exactly one correct rule, or none.
+ * this leaves a correct pair of rules, or none.
  *
  * @param {Object} input
  * @param {readonly string[]} input.patterns  the live denylist
  * @param {readonly number[]} input.tabIds
+ * @param {readonly string[]} [input.exemptDomains]  IdP domains that stay
+ *   reachable inside a driven tab — injected, see DENYLIST_ALLOW_RULE_ID.
  * @param {number} [input.ruleId]
+ * @param {number} [input.allowRuleId]
  * @returns {{ removeRuleIds: number[], addRules: object[] }}
  */
-export const denylistSessionRuleUpdate = ({ patterns, tabIds, ruleId = DENYLIST_RULE_ID }) => {
-  const rule = buildDenylistBlockRule({
+export const denylistSessionRuleUpdate = ({
+  patterns, tabIds, exemptDomains = [], ruleId = DENYLIST_RULE_ID, allowRuleId = DENYLIST_ALLOW_RULE_ID,
+}) => {
+  const block = buildDenylistBlockRule({
     domains: denylistBlockDomains(patterns ?? []), tabIds, ruleId,
   });
-  return { removeRuleIds: [ruleId], addRules: rule ? [rule] : [] };
+  const allow = block ? buildIdpAllowRule({ domains: exemptDomains, tabIds, ruleId: allowRuleId }) : null;
+  return {
+    removeRuleIds: [ruleId, allowRuleId],
+    addRules: [block, allow].filter((rule) => rule !== null),
+  };
 };

--- a/extension/peerd-egress/index.js
+++ b/extension/peerd-egress/index.js
@@ -70,6 +70,16 @@ export {
   flattenCategorisedDenylist,
   normalizeDenylistPattern,
 } from './denylist/denylist.js';
+// The denylist's NETWORK-level backstop: the pure denylist →
+// declarativeNetRequest rule mapping. The imperative half (keeping the rule in
+// sync with the driven-tab set) is background/denylist-net-guard.js.
+export {
+  denylistBlockDomains,
+  buildDenylistBlockRule,
+  denylistSessionRuleUpdate,
+  DENYLIST_RULE_ID,
+  DENYLIST_RESOURCE_TYPES,
+} from './denylist/dnr-rules.js';
 
 // --- confirm protocol ---------------------------------------------------
 export { makeConfirmCoordinator } from './confirm/protocol.js';

--- a/extension/peerd-runtime/actor/idp-registry.js
+++ b/extension/peerd-runtime/actor/idp-registry.js
@@ -105,3 +105,33 @@ export const knownIdpSeeds = () => Object.freeze({
   origins: Object.freeze([...IDP_ORIGINS]),
   suffixes: IDP_SUFFIXES,
 });
+
+/**
+ * The registry as bare DOMAINS, for a consumer whose match primitive is
+ * "this domain and its subdomains" — today the denylist's DNR backstop, whose
+ * `requestDomains` semantics are exactly that. Suffixes pass through verbatim
+ * (a per-customer `acme.okta.com` is a subdomain of `okta.com`); exact origins
+ * contribute their hostname.
+ *
+ * why here and not derived at the consumer: this list is the sign-in corridor's
+ * NETWORK-layer carve-out — an entry keeps an identity provider reachable
+ * inside an agent-driven tab that the denylist otherwise blocks. Deriving it
+ * next to the registry keeps ONE membership decision feeding every layer: a
+ * registry edit moves the excursion rule and the carve-out together, and the
+ * corridor test (denylist × registry) pins that they cannot drift apart.
+ *
+ * NOTE the deliberate widening this consumer accepts: `isKnownIdp` refuses
+ * http and non-default ports; a domain grant cannot express either refinement.
+ * Both refusals are about what the AGENT may treat as a sign-in landing —
+ * network reachability for the human is the coarser question, and coarser is
+ * safe here because reachable-but-refused is exactly the pre-DNR posture.
+ *
+ * @returns {string[]} deduped, sorted
+ */
+export const knownIdpDomains = () => {
+  const domains = new Set(IDP_SUFFIXES);
+  for (const origin of IDP_ORIGINS) {
+    try { domains.add(new URL(origin).hostname); } catch { /* registry is static; unreachable */ }
+  }
+  return [...domains].sort();
+};

--- a/extension/peerd-runtime/index.js
+++ b/extension/peerd-runtime/index.js
@@ -164,7 +164,7 @@ export { makeLearnedOrigins, MAX_LEARNED } from './actor/learned-origins.js';
 // A UGC host is by construction a site people have accounts on; that is what
 // made its content attacker-authorable in the first place.
 export { isUgcHost } from './actor/ugc-registry.js';
-export { isKnownIdp, knownIdpSeeds } from './actor/idp-registry.js';
+export { isKnownIdp, knownIdpSeeds, knownIdpDomains } from './actor/idp-registry.js';
 export { describeLandingStop, originPhrase } from './actor/origin-lock-report.js';
 // DESIGN-19: site clients — per-origin derived API clients. The pure core
 // (validation, confirm-gated proposal, staleness header, fenced dossier, URL pin),

--- a/manifests/base.json
+++ b/manifests/base.json
@@ -30,6 +30,7 @@
     "offscreen",
     "notifications",
     "alarms",
+    "declarativeNetRequest",
     "debugger"
   ],
 

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -100,7 +100,10 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // The 548 and 549 steps were each derived from a conflicting base rather than
 // from a fresh scan, so the floor was left trailing the real count by two.
 // Taking the reported number locks the existing gain in.
-const COVERED_FLOOR = 551;
+// 551 → 553: the denylist's declarativeNetRequest backstop adds two checked
+// files — peerd-egress/denylist/dnr-rules.js (the pure patterns → rule mapping)
+// and background/denylist-net-guard.js (the session-rule sync shell).
+const COVERED_FLOOR = 553;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/tests/background/denylist-net-guard.test.ts
+++ b/tests/background/denylist-net-guard.test.ts
@@ -51,7 +51,7 @@ describe('denylist-net-guard — rule sync', () => {
     const { guard } = guardOver(dnr, ['chase.com'], []);
     await guard.sync();
     expect(dnr.calls[0].addRules).toEqual([]);
-    expect(dnr.calls[0].removeRuleIds).toHaveLength(1);
+    expect(dnr.calls[0].removeRuleIds).toHaveLength(2);   // block + the IdP allow rule
   });
 
   test('a repeat sync with unchanged state does not re-call the API', async () => {

--- a/tests/background/denylist-net-guard.test.ts
+++ b/tests/background/denylist-net-guard.test.ts
@@ -1,0 +1,161 @@
+import { describe, test, expect } from 'bun:test';
+import { makeDenylistNetGuard } from '../../extension/background/denylist-net-guard.js';
+import { denylistSessionRuleUpdate } from '../../extension/peerd-egress/denylist/dnr-rules.js';
+
+// The imperative half of the denylist's DNR backstop: does it keep exactly one
+// correct session rule, and does it stay harmless when the API isn't there?
+
+const makeDnr = (opts: { fail?: () => Error | null } = {}) => {
+  const calls: any[] = [];
+  return {
+    calls,
+    updateSessionRules: async (update: any) => {
+      const err = opts.fail?.();
+      if (err) throw err;
+      calls.push(update);
+    },
+  };
+};
+
+const guardOver = (dnr: any, patterns: string[], tabs: number[], audit?: any) => {
+  let livePatterns = patterns;
+  let liveTabs = tabs;
+  const guard = makeDenylistNetGuard({
+    dnr,
+    buildUpdate: denylistSessionRuleUpdate,
+    getPatterns: () => livePatterns,
+    getTabIds: () => liveTabs,
+    audit,
+    console: { warn: () => {} } as any,
+  });
+  return {
+    guard,
+    setPatterns: (p: string[]) => { livePatterns = p; },
+    setTabs: (t: number[]) => { liveTabs = t; },
+  };
+};
+
+describe('denylist-net-guard — rule sync', () => {
+  test('a driven tab gets a tab-scoped block rule', async () => {
+    const dnr = makeDnr();
+    const { guard } = guardOver(dnr, ['chase.com', '*.chase.com'], [12]);
+    await guard.sync();
+    expect(dnr.calls).toHaveLength(1);
+    expect(dnr.calls[0].addRules[0].condition).toMatchObject({
+      requestDomains: ['chase.com'], tabIds: [12],
+    });
+  });
+
+  test('no driven tabs → the rule is removed, never left unscoped', async () => {
+    const dnr = makeDnr();
+    const { guard } = guardOver(dnr, ['chase.com'], []);
+    await guard.sync();
+    expect(dnr.calls[0].addRules).toEqual([]);
+    expect(dnr.calls[0].removeRuleIds).toHaveLength(1);
+  });
+
+  test('a repeat sync with unchanged state does not re-call the API', async () => {
+    const dnr = makeDnr();
+    const { guard } = guardOver(dnr, ['chase.com'], [12]);
+    await guard.sync();
+    await guard.sync();
+    await guard.sync();
+    expect(dnr.calls).toHaveLength(1);
+  });
+
+  test('a tab closing rescopes the rule', async () => {
+    const dnr = makeDnr();
+    const { guard, setTabs } = guardOver(dnr, ['chase.com'], [12, 13]);
+    await guard.sync();
+    setTabs([13]);
+    await guard.sync();
+    expect(dnr.calls).toHaveLength(2);
+    expect(dnr.calls[1].addRules[0].condition.tabIds).toEqual([13]);
+  });
+
+  test('a denylist edit rebuilds the rule', async () => {
+    const dnr = makeDnr();
+    const { guard, setPatterns } = guardOver(dnr, ['chase.com'], [12]);
+    await guard.sync();
+    setPatterns(['chase.com', 'irs.gov']);
+    await guard.sync();
+    expect(dnr.calls[1].addRules[0].condition.requestDomains).toEqual(['chase.com', 'irs.gov']);
+  });
+
+  test('un-denylisting the last pattern removes the rule', async () => {
+    const dnr = makeDnr();
+    const { guard, setPatterns } = guardOver(dnr, ['chase.com'], [12]);
+    await guard.sync();
+    setPatterns([]);
+    await guard.sync();
+    expect(dnr.calls[1].addRules).toEqual([]);
+  });
+
+  test('concurrent syncs never overlap on the single rule id', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const calls: any[] = [];
+    const dnr = {
+      updateSessionRules: async (u: any) => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((r) => setTimeout(r, 2));
+        calls.push(u);
+        inFlight -= 1;
+      },
+    };
+    const { guard, setTabs } = guardOver(dnr, ['chase.com'], [1]);
+    const first = guard.sync();
+    await new Promise((r) => setTimeout(r, 0));   // let the first apply get going
+    setTabs([2]);
+    const second = guard.sync();
+    await Promise.all([first, second]);
+    expect(maxInFlight).toBe(1);
+    expect(calls.map((c) => c.addRules[0].condition.tabIds)).toEqual([[1], [2]]);
+  });
+
+  test('syncs that queue before the first runs COALESCE (state is read at apply time)', async () => {
+    const dnr = makeDnr();
+    const { guard, setTabs } = guardOver(dnr, ['chase.com'], [1]);
+    const first = guard.sync();
+    setTabs([2]);                                  // changed before any apply ran
+    const second = guard.sync();
+    await Promise.all([first, second]);
+    // Both applies see the same (final) state, so only one write reaches the API.
+    expect(dnr.calls).toHaveLength(1);
+    expect(dnr.calls[0].addRules[0].condition.tabIds).toEqual([2]);
+  });
+});
+
+describe('denylist-net-guard — degrades, never breaks', () => {
+  test('no declarativeNetRequest API → a silent no-op that still resolves', async () => {
+    const { guard } = guardOver(undefined, ['chase.com'], [12]);
+    expect(guard.supported()).toBe(false);
+    await guard.sync();               // must not reject
+    expect(guard.state().domains).toBe(0);
+  });
+
+  test('an API failure is swallowed, audited once, and retried on the next sync', async () => {
+    const audited: any[] = [];
+    let failing = true;
+    const dnr = makeDnr({ fail: () => (failing ? new Error('tabIds unsupported') : null) });
+    const { guard } = guardOver(dnr, ['chase.com'], [12], (e: any) => audited.push(e));
+    await guard.sync();
+    await guard.sync();
+    expect(audited).toHaveLength(1);
+    expect(audited[0].type).toBe('denylist_net_guard_failed');
+    expect(guard.state().lastError).toContain('tabIds');
+    // The failure did NOT latch the fingerprint, so a later sync re-attempts.
+    failing = false;
+    await guard.sync();
+    expect(dnr.calls).toHaveLength(1);
+    expect(guard.state().lastError).toBeNull();
+  });
+
+  test('a throwing audit sink cannot break the guard', async () => {
+    const dnr = makeDnr({ fail: () => new Error('nope') });
+    const { guard } = guardOver(dnr, ['chase.com'], [12], () => { throw new Error('audit down'); });
+    await guard.sync();               // must not reject
+    expect(guard.state().lastError).toBe('nope');
+  });
+});

--- a/tests/background/routes-denylist.test.ts
+++ b/tests/background/routes-denylist.test.ts
@@ -7,6 +7,7 @@ import { makeDenylistRoutes } from '../../extension/background/routes/denylist.j
 
 const makeDeps = (over: any = {}) => {
   const audits: any[] = [];
+  const syncs: boolean[] = [];
   const deps = {
     denylistStore: {
       patterns: () => ['a.com'],
@@ -16,8 +17,10 @@ const makeDeps = (over: any = {}) => {
       ...over.denylistStore,
     },
     auditLog: { append: async (e: any) => { audits.push(e); } },
+    // The DNR backstop's resync — an edit changes what the rule blocks.
+    denylistNetGuard: { sync: () => { syncs.push(true); } },
   };
-  return { deps, audits };
+  return { deps, audits, syncs };
 };
 
 describe('denylist routes', () => {
@@ -50,5 +53,21 @@ describe('denylist routes', () => {
     const { deps, audits } = makeDeps({ denylistStore: { remove: async () => ({ ok: false, error: 'not-found' }) } });
     expect(await makeDenylistRoutes(deps)['denylist/remove']({ pattern: 'ghost' })).toEqual({ ok: false, error: 'not-found' });
     expect(audits).toEqual([]);
+  });
+
+  // The DNR backstop's rule is derived from the list, so an accepted edit has to
+  // resync it — the remove path especially, where a stale rule would keep
+  // blocking a site the user just unblocked.
+  test('an accepted add or remove resyncs the network backstop', async () => {
+    const { deps, syncs } = makeDeps();
+    await makeDenylistRoutes(deps)['denylist/add']({ pattern: 'x.com' });
+    await makeDenylistRoutes(deps)['denylist/remove']({ pattern: 'b.com' });
+    expect(syncs).toHaveLength(2);
+  });
+
+  test('a rejected edit does not resync', async () => {
+    const { deps, syncs } = makeDeps({ denylistStore: { add: async () => ({ ok: false, error: 'invalid-pattern' }) } });
+    await makeDenylistRoutes(deps)['denylist/add']({ pattern: '' });
+    expect(syncs).toEqual([]);
   });
 });

--- a/tests/meta/denylist-idp-corridor.test.ts
+++ b/tests/meta/denylist-idp-corridor.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect } from 'bun:test';
+import { flattenCategorisedDenylist } from '../../extension/peerd-egress/denylist/denylist.js';
+import {
+  denylistBlockDomains,
+  denylistSessionRuleUpdate,
+} from '../../extension/peerd-egress/denylist/dnr-rules.js';
+import { knownIdpDomains, knownIdpSeeds } from '../../extension/peerd-runtime/actor/idp-registry.js';
+import seed from '../../extension/peerd-egress/denylist/default.json';
+
+// The sign-in corridor, asserted ACROSS module boundaries over the REAL data.
+//
+// why this file exists (and why in meta/): the seed denylist and the IdP
+// registry deliberately OVERLAP — okta.com, auth0.com, duosecurity.com,
+// appleid.apple.com are in both — because the two lists gate different
+// parties: the denylist stops the AGENT driving a login box, the excursion
+// rule keeps the TAB usable so the human can sign in. That intent lived only
+// in two file headers, so nothing executable failed when the DNR backstop's
+// first draft blanket-blocked IdPs in driven tabs and silently broke the
+// excursion. Each module's unit tests passed; the bug lived in their
+// COMPOSITION. These tests make the coupling an artifact: whichever side
+// drifts (a registry edit, a seed edit, a rule-shape change), the invariant
+// is re-checked against the other.
+
+const patterns = flattenCategorisedDenylist(seed as any);
+const idpDomains = knownIdpDomains();
+
+/** requestDomains semantics: does `domain` cover `host` (itself or a subdomain)? */
+const covers = (host: string, domain: string) => host === domain || host.endsWith(`.${domain}`);
+
+describe('denylist × IdP registry — the sign-in corridor', () => {
+  test('the overlap exists (the coupling these tests protect is live, not vestigial)', () => {
+    const blocked = denylistBlockDomains(patterns);
+    const overlap = idpDomains.filter((idp) => blocked.some((b) => covers(idp, b)));
+    // If this goes empty, the identity category left the seed (or the registry
+    // emptied) and the corridor machinery below is guarding nothing — that is a
+    // design change to make knowingly, not by drift.
+    expect(overlap.length).toBeGreaterThan(0);
+    expect(overlap).toContain('okta.com');
+  });
+
+  test('every IdP registry entry stays network-reachable inside a driven tab', () => {
+    const update: any = denylistSessionRuleUpdate({
+      patterns, tabIds: [7], exemptDomains: idpDomains,
+    });
+    const block = update.addRules.find((r: any) => r.action.type === 'block');
+    const allow = update.addRules.find((r: any) => r.action.type === 'allow');
+    expect(block).toBeDefined();
+    // The real seed denylists IdP vendors, so the carve-out MUST ride along...
+    expect(allow).toBeDefined();
+    // ...and outrank the block, or it decides nothing.
+    expect(allow.priority).toBeGreaterThan(block.priority);
+    // The decisive check, per registry entry: any entry the block rule would
+    // catch is also caught by the allow rule — DNR resolves same-match
+    // conflicts by priority, so allow-covered means reachable. This is the
+    // exact property the first draft violated.
+    for (const idp of idpDomains) {
+      const blockedBy = block.condition.requestDomains.filter((d: string) => covers(idp, d));
+      if (blockedBy.length === 0) continue;   // not denylisted — nothing to carve
+      const allowedBy = allow.condition.requestDomains.filter((d: string) => covers(idp, d));
+      expect({ idp, blockedBy, allowedBy: allowedBy.length > 0 }).toEqual(
+        { idp, blockedBy, allowedBy: true },
+      );
+    }
+  });
+
+  test('the carve-out grants reachability to registry entries ONLY', () => {
+    const update: any = denylistSessionRuleUpdate({
+      patterns, tabIds: [7], exemptDomains: idpDomains,
+    });
+    const allow = update.addRules.find((r: any) => r.action.type === 'allow');
+    // Every allow-rule domain traces back to the registry — the corridor cannot
+    // quietly widen past the one file that owns IdP membership.
+    for (const domain of allow.condition.requestDomains) {
+      expect(idpDomains).toContain(domain);
+    }
+  });
+
+  test('knownIdpDomains covers the whole registry (derivation cannot drop entries)', () => {
+    const seeds = knownIdpSeeds();
+    for (const suffix of seeds.suffixes) expect(idpDomains).toContain(suffix);
+    for (const origin of seeds.origins) {
+      const host = new URL(origin).hostname;
+      expect(idpDomains.some((d) => covers(host, d))).toBe(true);
+    }
+  });
+});

--- a/tests/peerd-egress/denylist-dnr.test.ts
+++ b/tests/peerd-egress/denylist-dnr.test.ts
@@ -2,8 +2,10 @@ import { describe, test, expect } from 'bun:test';
 import {
   denylistBlockDomains,
   buildDenylistBlockRule,
+  buildIdpAllowRule,
   denylistSessionRuleUpdate,
   DENYLIST_RULE_ID,
+  DENYLIST_ALLOW_RULE_ID,
   DENYLIST_RESOURCE_TYPES,
 } from '../../extension/peerd-egress/denylist/dnr-rules.js';
 
@@ -74,13 +76,46 @@ describe('buildDenylistBlockRule — never unscoped', () => {
 describe('denylistSessionRuleUpdate — idempotent reconcile', () => {
   test('always removes the rule id first, so applying it is self-healing', () => {
     const update = denylistSessionRuleUpdate({ patterns: ['chase.com'], tabIds: [1] });
-    expect(update.removeRuleIds).toEqual([DENYLIST_RULE_ID]);
+    expect(update.removeRuleIds).toEqual([DENYLIST_RULE_ID, DENYLIST_ALLOW_RULE_ID]);
     expect(update.addRules).toHaveLength(1);
   });
   test('with no driven tabs it is a pure removal', () => {
     const update = denylistSessionRuleUpdate({ patterns: ['chase.com'], tabIds: [] });
-    expect(update).toEqual({ removeRuleIds: [DENYLIST_RULE_ID], addRules: [] });
+    expect(update).toEqual({ removeRuleIds: [DENYLIST_RULE_ID, DENYLIST_ALLOW_RULE_ID], addRules: [] });
   });
+  test('exempt IdP domains ride along as a higher-priority allow rule', () => {
+    const update: any = denylistSessionRuleUpdate({
+      patterns: ['*.okta.com', 'chase.com'], tabIds: [4], exemptDomains: ['okta.com'],
+    });
+    expect(update.removeRuleIds).toEqual([DENYLIST_RULE_ID, DENYLIST_ALLOW_RULE_ID]);
+    const [block, allow] = update.addRules;
+    expect(block.action.type).toBe('block');
+    expect(allow.action.type).toBe('allow');
+    // The corridor only works if allow OUTRANKS block where they overlap.
+    expect(allow.priority).toBeGreaterThan(block.priority);
+    expect(allow.condition.requestDomains).toEqual(['okta.com']);
+    expect(allow.condition.tabIds).toEqual([4]);
+    // The block rule is NOT narrowed — the allow rule is what carves it out, so
+    // the denylist entry still exists for every other consumer to reason about.
+    expect(block.condition.requestDomains).toContain('okta.com');
+  });
+
+  test('no exempt domains → no allow rule (nothing extra in front of the user)', () => {
+    const update = denylistSessionRuleUpdate({ patterns: ['chase.com'], tabIds: [4] });
+    expect(update.addRules).toHaveLength(1);
+  });
+
+  test('an allow rule is never emitted without a block rule to carve out', () => {
+    // No driven tabs → no block; the allow rule must not appear on its own.
+    expect(denylistSessionRuleUpdate({ patterns: ['chase.com'], tabIds: [], exemptDomains: ['okta.com'] }).addRules)
+      .toEqual([]);
+    // No denylist at all → same.
+    expect(denylistSessionRuleUpdate({ patterns: [], tabIds: [4], exemptDomains: ['okta.com'] }).addRules)
+      .toEqual([]);
+    expect(buildIdpAllowRule({ domains: ['okta.com'], tabIds: [] })).toBeNull();
+    expect(buildIdpAllowRule({ domains: [], tabIds: [4] })).toBeNull();
+  });
+
   test('the real seed denylist collapses to a workable domain count', async () => {
     const seed = await Bun.file('extension/peerd-egress/denylist/default.json').json();
     const patterns: string[] = Object.values(seed.categories).flat() as string[];

--- a/tests/peerd-egress/denylist-dnr.test.ts
+++ b/tests/peerd-egress/denylist-dnr.test.ts
@@ -126,6 +126,11 @@ describe('denylistSessionRuleUpdate — idempotent reconcile', () => {
     // comfortably inside one rule's condition.
     expect(domains.length).toBeLessThan(patterns.length);
     expect(domains).toContain('chase.com');
+    // okta.com IS in the blocked set — the IdP registry's carve-out restores its
+    // reachability via the higher-priority allow rule, not by narrowing this
+    // list. The composition invariant lives in tests/meta/denylist-idp-corridor:
+    // an earlier revision of THIS test pinned the bare containment with no
+    // carve-out anywhere, i.e. encoded the broken sign-in corridor as expected.
     expect(domains).toContain('okta.com');
   });
 });

--- a/tests/peerd-egress/denylist-dnr.test.ts
+++ b/tests/peerd-egress/denylist-dnr.test.ts
@@ -1,0 +1,96 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  denylistBlockDomains,
+  buildDenylistBlockRule,
+  denylistSessionRuleUpdate,
+  DENYLIST_RULE_ID,
+  DENYLIST_RESOURCE_TYPES,
+} from '../../extension/peerd-egress/denylist/dnr-rules.js';
+
+// The denylist's network-level backstop, pure half. The property that matters
+// most is negative: this must never produce a rule that isn't scoped to peerd's
+// own driven tabs, because that rule would block the USER's browsing.
+
+describe('denylistBlockDomains — patterns → requestDomains', () => {
+  test('apex and its wildcard collapse to one domain', () => {
+    expect(denylistBlockDomains(['chase.com', '*.chase.com'])).toEqual(['chase.com']);
+  });
+  test('a wildcard-only pattern maps to the base domain (deliberately stricter)', () => {
+    // requestDomains has no subdomain-only form; blocking okta.com's apex too
+    // is the safe direction of that imprecision. See dnr-rules.js.
+    expect(denylistBlockDomains(['*.okta.com'])).toEqual(['okta.com']);
+  });
+  test('domains already covered by a broader entry are dropped', () => {
+    expect(denylistBlockDomains(['proton.me', 'mail.proton.me', '*.proton.me']))
+      .toEqual(['proton.me']);
+  });
+  test('a look-alike is NOT treated as covered (label boundary)', () => {
+    expect(denylistBlockDomains(['chase.com', 'evilchase.com']))
+      .toEqual(['chase.com', 'evilchase.com']);
+  });
+  test('patterns the JS matcher would reject are dropped, not passed through', () => {
+    expect(denylistBlockDomains(['not a host', 'nodot', 'ev*il.com', '', 'ok.com']))
+      .toEqual(['ok.com']);
+  });
+  test('a pasted URL normalizes like it does in the matcher', () => {
+    expect(denylistBlockDomains(['https://chase.com/login?x=1'])).toEqual(['chase.com']);
+  });
+  test('output is sorted and deduped (stable across resyncs)', () => {
+    const a = denylistBlockDomains(['b.com', 'a.com', 'b.com']);
+    const b = denylistBlockDomains(['a.com', 'b.com']);
+    expect(a).toEqual(['a.com', 'b.com']);
+    expect(a).toEqual(b);
+  });
+  test('empty input is empty output, not a throw', () => {
+    expect(denylistBlockDomains([])).toEqual([]);
+  });
+});
+
+describe('buildDenylistBlockRule — never unscoped', () => {
+  test('no tabs → no rule (an unscoped rule would block the user\'s own browsing)', () => {
+    expect(buildDenylistBlockRule({ domains: ['chase.com'], tabIds: [] })).toBeNull();
+  });
+  test('no domains → no rule', () => {
+    expect(buildDenylistBlockRule({ domains: [], tabIds: [7] })).toBeNull();
+  });
+  test('the built rule blocks, is tab-scoped, and covers main_frame', () => {
+    const rule: any = buildDenylistBlockRule({ domains: ['chase.com'], tabIds: [7, 9] });
+    expect(rule.id).toBe(DENYLIST_RULE_ID);
+    expect(rule.action).toEqual({ type: 'block' });
+    expect(rule.condition.requestDomains).toEqual(['chase.com']);
+    expect(rule.condition.tabIds).toEqual([7, 9]);
+    expect(rule.condition.resourceTypes).toContain('main_frame');
+    expect(rule.condition.resourceTypes).toContain('sub_frame');
+    expect(rule.condition.resourceTypes).toEqual([...DENYLIST_RESOURCE_TYPES]);
+  });
+  test('tab ids are deduped and non-integers dropped', () => {
+    const rule: any = buildDenylistBlockRule({
+      domains: ['a.com'], tabIds: [3, 3, -1, 4.5, 8] as any,
+    });
+    expect(rule.condition.tabIds).toEqual([3, 8]);
+  });
+});
+
+describe('denylistSessionRuleUpdate — idempotent reconcile', () => {
+  test('always removes the rule id first, so applying it is self-healing', () => {
+    const update = denylistSessionRuleUpdate({ patterns: ['chase.com'], tabIds: [1] });
+    expect(update.removeRuleIds).toEqual([DENYLIST_RULE_ID]);
+    expect(update.addRules).toHaveLength(1);
+  });
+  test('with no driven tabs it is a pure removal', () => {
+    const update = denylistSessionRuleUpdate({ patterns: ['chase.com'], tabIds: [] });
+    expect(update).toEqual({ removeRuleIds: [DENYLIST_RULE_ID], addRules: [] });
+  });
+  test('the real seed denylist collapses to a workable domain count', async () => {
+    const seed = await Bun.file('extension/peerd-egress/denylist/default.json').json();
+    const patterns: string[] = Object.values(seed.categories).flat() as string[];
+    const domains = denylistBlockDomains(patterns);
+    // Every pattern maps to something (nothing silently dropped as invalid)...
+    expect(domains.length).toBeGreaterThan(0);
+    // ...and apex+wildcard pairing means the rule carries roughly half the list,
+    // comfortably inside one rule's condition.
+    expect(domains.length).toBeLessThan(patterns.length);
+    expect(domains).toContain('chase.com');
+    expect(domains).toContain('okta.com');
+  });
+});


### PR DESCRIPTION
## What & why

Adds a **network-level backstop for the denylist** using `declarativeNetRequest`: one session-scoped rule, rebuilt from the live denylist, blocking denylisted domains **inside the tabs peerd is currently driving** — and nowhere else.

Why it's worth having: the denylist is checked in three places today (the dispatcher's origin gate, `webFetch`, the tab-strip hint) and all three are *decision-time* checks — they judge a URL the agent hands us, before the request. None of them can see what a page does on its **own** initiative. A driven tab that `location =`s onto a bank lands there through a tool call that never named the bank, so no gate ever got a URL to refuse. Same gap in an App sandbox, whose agent-authored code reaches the network without passing `webFetch` at all. DNR closes it below the page, where the page can't argue.

The user's own browsing is untouched. The denylist means "the agent may not go here", not "this browser may not go here", so the rule is tab-scoped and is dropped entirely when the driven-tab set is empty (`buildDenylistBlockRule` refuses to build an unscoped rule — a bug here degrades to *no backstop*, never to *the user can't reach their bank*).

It's a **backstop, not a replacement**: the JS gates still produce the refusal the model reads and the audit entry the user sees. DNR produces a dead socket and no explanation. Where they disagree, the JS gates are the specification.

Closes #

## Checklist

- [x] `bun run preflight` passes (tests, typecheck, lint, in-browser, dweb-boundary, no manifest drift)
- [x] Only original or permissively-licensed code — **no GPL / AGPL / copyleft**
- [x] Tests added or updated (or N/A)
- [x] No hand-edited generated files (`manifest.json`, `shared/channel-config.js`) — regenerated via `bun run gen:dev` after adding the permission to `manifests/base.json`
- [x] Called out below — this touches the **egress** danger zone

## Notes for reviewers

**Danger-zone rationale.** This only ever *adds* blocking; no existing gate is relaxed or removed. Three properties are the review surface, and each has tests:

1. **Never browser-wide.** No tabs → no rule. `tests/peerd-egress/denylist-dnr.test.ts`, `tests/background/denylist-net-guard.test.ts`.
2. **Serialized.** Syncs fire from tab lifecycle events and denylist edits, which interleave; overlapping `updateSessionRules` calls on one rule id would race. Every sync queues behind the last.
3. **Never fatal.** DNR support varies (Firefox's implementation is partial; `tabIds` conditions are session-rule-only), so a missing or failing API leaves behavior exactly as it was — logs once, audits once (`denylist_net_guard_failed`), retries on the next sync, never rejects into a caller.

**The origin-lock interaction — the sign-in corridor (second commit).** The origin lock's excursion rule lets a *bound* actor's tab leave its owned origin exactly once, for an identity provider — and several IdP registry entries (okta.com, auth0.com, duosecurity.com, appleid.apple.com) are **also denylist entries**. That overlap is intended on both sides: the denylist stops the *agent* from driving a login box; the excursion keeps the *tab* usable so the person can sign in and the actor can resume. A blanket block rule would have made the IdP page fail to render inside a driven tab, breaking the sign-in even for the human. So the block rule ships with a companion **allow rule one priority step above it**, same tab scope, carrying exactly the IdP registry (injected — `peerd-runtime` stays the single authority on what counts as an IdP; egress never reaches up for it). No agent authority changes: `isDenylistedTab` still refuses every DOM tool on such a tab and the origin gate still refuses navigating to it — only whether the bytes render for the human. The allow rule is never emitted without a block rule to carve out.

**One deliberate imprecision.** `requestDomains` matches a domain *and* its subdomains, with no subdomain-only form short of a regex rule — so `*.okta.com` maps to `okta.com` and also blocks the apex that the JS matcher would allow. Over-blocking one apex inside an agent-driven tab is the cheap side of that trade, and every seed entry with a real apex lists it explicitly anyway. Documented at the mapping.

**The DNR semantics were verified against real Chrome**, not just the docs — a throwaway extension applying the exact rule pair this code produces, with `--host-resolver-rules` pointing fake hosts at a local server:

| navigation | result |
|---|---|
| protected tab → `denied.test` | **blocked** (main_frame nav refused) |
| protected tab → `sub.denied.test` | **blocked** (confirms the subdomain collapse) |
| protected tab → `idp.denied.test` (exempted) | served — **allow beats block, even nested under a blocked domain** |
| protected tab → `allowed.test` | served — no over-blocking |
| unprotected (user) tab → `denied.test` | served — **tab scoping holds** |

**Files.**
- `peerd-egress/denylist/dnr-rules.js` — the pure mapping. Reuses `normalizeDenylistPattern` as the single authority on pattern validity, collapses apex+wildcard pairs, drops entries a broader one covers, emits a stable sorted list. Also builds the IdP allow rule.
- `background/denylist-net-guard.js` — the sync shell. Imports nothing (rule math injected) so it stays Bun-importable, like `denylist-store.js`. Fingerprints the whole `addRules` array so a skipped write can't strand either rule.
- Wiring: every point the driven-tab set or the list can move — bind/drop (through `persistWebBindings`), engine tab-ready, `tabs.onRemoved`, the denylist edit routes, and boot (seed load, binding rehydrate, tracker bootstrap). `adoptWebTab` **awaits** the sync before handing the tab back, since the caller's next act is to navigate it.
- `manifests/base.json` gains `declarativeNetRequest` (all channels; no user-facing install warning, unlike `declarativeNetRequestFeedback`). Firefox keeps it — its DNR is partial, and the guard feature-detects.

**Coverage note.** `tabs.onRemoved` resyncs because **tab ids are reused** within a browser session; a stale entry would apply the block to whatever unrelated tab inherits the id.

**Not covered** (deliberate, worth a follow-up conversation, not this PR): extension-initiated requests (`webFetch`'s own path) aren't DNR-scoped — there's no reliable way to condition on the extension as initiator, and `webFetch` already checks the denylist in JS.

**No UI surface changed**, so the visual/e2e-verify loop had nothing new to snapshot — but `bun run test:e2e` was run against the real unpacked extension to prove the SW still boots with the new permission and wiring: **21 states, 128/128 checks**.