### PR TITLE
fix(security): close prompt-injection blast-radius gaps found in audit

### DIFF
--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -262,15 +262,25 @@ Code: `peerd-distributed/content/manifest.js`, `identity/keypair.js`,
 An inbound (peer-originated) turn can never make the agent delegate, and an actor
 spawned by an inbound or injected turn is tainted for its whole subtree. Forged,
 severed, foreign-rooted, and cyclic lineages fail closed. A poisoned mesh op (bad
-method or args) is rejected, and signing as the user requires per-target consent.
+method or args) is rejected, and signing as the user requires per-target consent. The
+wall covers EVERY door to delegation, not only the direct `message_actor` tool: the
+`script` tool's `actors.send`/`actors.ask` surface reaches the same `messageActor`, so
+it is refused mint on an inbound turn (`tools/defs/script.js` gates `actorsOn` on
+`ctx.inbound !== true` — the trusted turn signal folded SW-side; the untrusted worker
+never echoes it).
 Code: `peerd-runtime/actor/delegation-lineage.js` (`mayMessageActor`,
-`buildAncestry`), `actor/a2a-api.js`. Red-team: scenario 05.
+`buildAncestry`), `tools/defs/script.js`, `actor/a2a-api.js`. Red-team: scenario 05.
 
 <a id="inv-6"></a>
 ### INV-6. Sandboxed code is confined to an audited bridge
 In a Notebook or headless worker realm, every raw network channel throws, the native
 `fetch` is deleted off the prototype chain, and the bridge is pinned non-writable and
-non-configurable so in-realm sabotage cannot unseat it. No fresh un-sealed realm can
+non-configurable so in-realm sabotage cannot unseat it. Same-origin durable stores are
+sealed too — `indexedDB` (the sealed worker runs at the extension origin, so an unsealed
+IDBFactory would reach the `peerd` database: the vault blob, always-loaded memory,
+sessions, grants, and audit) and the Cache API are both replaced with throwing stubs and
+deleted off the prototype chain, so the audited postMessage bridge and the per-instance
+OPFS root remain the only outward edges. No fresh un-sealed realm can
 be created, and OPFS import paths collapse `..` inside the instance root. A wasm32-wasi
 module run in that realm via the `peerd:wasi` builtin holds strictly less than the realm
 itself: its only imports are the vendored shim's WASI preview1 syscalls, and every
@@ -294,10 +304,14 @@ with the real-realm proof in
 ### INV-7. No egress to private, loopback, link-local, or metadata hosts
 `webFetch` refuses a host classified as private, loopback, link-local, `.local`, or
 metadata by `isPrivateOrLocalHost`, across decimal, hex, octal, and short-form IPv4 and
-IPv4-mapped and NAT64 IPv6 encodings, before any network call, ahead of the denylist,
-and fails closed on redirects so a public host cannot pivot to an internal one.
-Code: `peerd-egress/fetch/private-network.js`, `fetch/web-fetch.js`. Red-team:
-scenario 07.
+IPv4-mapped and NAT64 IPv6 encodings — plus the RFC 6598 shared/CGNAT (`100.64.0.0/10`),
+benchmarking (`198.18.0.0/15`), and reserved/broadcast (`240.0.0.0/4`) ranges that are
+internal-use on real deployments — before any network call, ahead of the denylist,
+and fails closed on redirects so a public host cannot pivot to an internal one. The same
+redirect refusal is applied by `read_pdf`'s byte fetch (`offscreen/pdf-extract.js`,
+`redirect:'manual'`), which previously validated only the pre-redirect host.
+Code: `peerd-egress/fetch/private-network.js`, `fetch/web-fetch.js`,
+`offscreen/pdf-extract.js`. Red-team: scenario 07.
 
 <a id="inv-8"></a>
 ### INV-8. Injected instructions cannot reach a capability
@@ -316,9 +330,15 @@ the side-by-side comparison.
 ### INV-12. What the model reads is what a human could have seen
 Page bytes that are invisible to a person but legible to a model — zero-width and
 soft-hyphen runs, bidi overrides, the Unicode Tags block, variation-selector
-sequences, HTML comments — are removed before the text reaches the model. The strip
-runs at both read boundaries and inside the untrusted-data fence itself, so a new
-web-sourced tool cannot forget it, and it runs TWICE around HTML extraction, because
+sequences, the combining grapheme joiner (`U+034F`, a `gc=Mn` invisible the `\p{Cf}`
+sweep cannot reach), HTML comments — are removed before the text reaches the model. The
+strip runs at both read boundaries and inside the untrusted-data fence itself, so a new
+web-sourced tool cannot forget it, and it also runs at the two boundaries where
+page-derived text becomes DURABLE trusted context rather than a transient tool result:
+the `/init` active-tab probe that seeds always-loaded project memory
+(`memory/init-orchestrator.js`) and the skill descriptions rendered into the system
+prompt at startup (`skills/registry.js`) — a covert channel there would persist,
+invisible at the approval gate, and it runs TWICE around HTML extraction, because
 extraction parses the document and turns `&#8203;` — seven ordinary ASCII characters
 on the way in — into a real zero-width byte on the way out. Legitimate content is
 LARGELY not collateral: the LETTERS of every script survive, including the ZWNJ that
@@ -330,7 +350,8 @@ are ordinary visible characters. The comment-removal pass is applied
 only where a comment is genuinely a comment (markup), never to JSON or plain text
 where `<!--` is visible content.
 Code: `peerd-runtime/dom/cdr.js`, wired at `tools/prompt-wrap.js`,
-`tools/defs/fetch-url.js`, `tools/defs/read-page.js`. Red-team: scenario 09.
+`tools/defs/fetch-url.js`, `tools/defs/read-page.js`, `memory/init-orchestrator.js`,
+`skills/registry.js`. Red-team: scenario 09.
 
 ### INV-13. Borrowing the user's identity on a page strangers wrote takes the user
 An authenticated write on an origin where third parties author the content (issue
@@ -402,16 +423,26 @@ evaluating peerd should know. Each cites where it lives in the code.
   falls back to a keyless in-service-worker loop where the boundary is a prompt
   boundary rather than a memory boundary, which is the pre-heap-split posture. The
   memory boundary is not universal. (`background/service-worker.js` offscreen fallback.)
-- R2. Memory poisoning. The auto-memory digest excludes tool results and synthetic
-  messages, but still includes raw assistant text, which can echo attacker-paraphrased
-  content, and an approved note persists into every future prompt. Approval is the trust
-  boundary. A user who approves a poisoned note owns the consequence.
-  (`peerd-runtime/memory/auto-memory.js`.)
-- R3. A skill body is trusted instructions by design. Skill install fetches through
-  `webFetch` (denylist and caps), and the frontmatter parser refuses unknown keys, but
-  the skill body loads into context as trusted instructions with no untrusted-content
-  fence. A malicious shared skill is a direct instruction-injection vector. Installing a
-  skill runs its author's prompt. (`peerd-runtime/skills/`.)
+- R2 (narrowed). Memory poisoning. The auto-memory digest excludes tool results and
+  synthetic messages, but still includes raw assistant text, which can echo
+  attacker-paraphrased content, and an approved note persists into every future prompt.
+  Approval is the trust boundary. A user who approves a poisoned note owns the
+  consequence. Narrowed: the `/init` seed of always-loaded project memory now
+  CDR-strips its page-derived probe (`memory/init-orchestrator.js`, INV-12), so an
+  INVISIBLE-Unicode instruction can no longer ride into durable memory beneath the
+  approval gate — the note the user reviews is the note the model reads. The residual is
+  the visible channel: content the model paraphrases into ordinary assistant text.
+  (`peerd-runtime/memory/auto-memory.js`, `memory/init-orchestrator.js`.)
+- R3 (narrowed). A skill body is trusted instructions by design. Skill install fetches
+  through `webFetch` (denylist and caps), and the frontmatter parser refuses unknown
+  keys, but the skill body loads into context as trusted instructions with no
+  untrusted-content fence. A malicious shared skill is a direct instruction-injection
+  vector. Installing a skill runs its author's prompt. Narrowed: the skill name and
+  description rendered into the startup prompt — the one skill field shown before any
+  `load_skill` — are now CDR-stripped (`skills/registry.js`, INV-12), so the description
+  the user reviewed in the skills UI is the description the model reads; a covert
+  invisible-Unicode channel in that field is closed. The BODY remains trusted-by-design.
+  (`peerd-runtime/skills/`.)
 - R4 (narrowed). The audit log is tamper-EVIDENT, not tamper-proof. Every entry
   extends a SHA-256 hash chain and a head record pins the newest link, so a rewritten
   entry, a deleted middle entry, a truncated tail, or an inserted record fails
@@ -481,6 +512,14 @@ evaluating peerd should know. Each cites where it lives in the code.
   `read_web_cache` or `site_client_*` in the window before a DOM tool re-enters the
   chokepoint. (`peerd-runtime/actor/landing-rule.js`, `origin-lock.js`,
   `tools/defs/dom-helpers.js`; driven end to end by the `origin-lock` e2e state.)
+  The #251 arc hardened the TAB actor's `site_client_*` path but left its API-actor
+  sibling: the `site-fetch/call` relay's `backing:'api'` branch pinned credentials to the
+  MODEL-supplied `origin` argument, so an API actor bound to one origin could name a
+  DIFFERENT origin and spend that origin's stored key + cookies — a cross-origin
+  credential escalation past the "an API actor owns one origin" containment (DESIGN-18).
+  Closed: the branch now pins to the actor's own bound origin (`instanceId`) and refuses a
+  cross-origin target, mirroring `fetch_url`'s API pin. (`background/service-worker.js`
+  `siteFetchCallRoute`.)
 - R13. The egress tripwire does not scan the query string or fragment, so the canonical
   exfil GET is uncovered. `attacker.test/?d=<blob>` is not inspected, because that is
   where legitimate long high-entropy values live — OIDC `id_token`s, SAML requests,

--- a/extension/background/dweb-inbound-rate-cap.js
+++ b/extension/background/dweb-inbound-rate-cap.js
@@ -21,7 +21,8 @@
 export const makeDwebInboundRateCap = ({ now = Date.now, perDidPerMinute = 3, perHourGlobal = 30 } = {}) => {
   /** @type {Map<string, number[]>} per-did wake timestamps (sliding minute) */
   const byDid = new Map();
-  let hour = { windowStart: 0, count: 0 };
+  /** @type {number[]} global wake timestamps (sliding hour) */
+  let globalTimes = [];
 
   /** Admit an inbound wake from `did`? Records the wake when it returns true.
    *  @param {string} did @returns {boolean} */
@@ -29,11 +30,16 @@ export const makeDwebInboundRateCap = ({ now = Date.now, perDidPerMinute = 3, pe
     const nowMs = now();
     const times = (byDid.get(did) ?? []).filter((t) => nowMs - t < 60_000);
     if (times.length >= perDidPerMinute) return false;             // per-did minute cap
-    if (nowMs - hour.windowStart > 3_600_000) hour = { windowStart: nowMs, count: 0 };
-    if (hour.count >= perHourGlobal) return false;                 // global hour cap
+    // why a SLIDING hour, not a fixed window: a fixed [windowStart, +1h) counter
+    // resets abruptly, so ~perHourGlobal admits in the final seconds plus another
+    // full perHourGlobal right after the reset = a ~2x burst across the boundary
+    // (a Sybil peer mints free did:keys to realize it). A sliding filter caps the
+    // TRUE rate at perHourGlobal per any rolling hour, closing the boundary burst.
+    globalTimes = globalTimes.filter((t) => nowMs - t < 3_600_000);
+    if (globalTimes.length >= perHourGlobal) return false;         // global sliding-hour cap
     times.push(nowMs);
     byDid.set(did, times);
-    hour.count += 1;
+    globalTimes.push(nowMs);
     // Sweep dids whose timestamps have all aged out, so the map can't grow
     // without limit on the long-lived SW.
     for (const [k, ts] of byDid) {

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -3475,7 +3475,20 @@ const siteFetchCallRoute = {
     // the owned origin; the worker never holds a credential.
     let scopedFetch;
     if (owner.backing === 'api') {
-      scopedFetch = withApiCredentials(webFetch, () => pin, {
+      // An API actor OWNS ONE origin (its instanceId), and fetch_url pins its
+      // credentials to that FIXED origin (see the actorBacking==='api' branch in
+      // buildToolContext). This relay must pin the SAME way — `pin` here is
+      // MODEL-supplied (site_client_run's `origin` arg), so without this check a
+      // hijacked API actor bound to origin A could name origin B and spend B's
+      // stored vault key + B's cookies: the cross-origin credential escalation the
+      // "an API actor owns one origin" containment (DESIGN-18) exists to prevent.
+      // Refuse when the named origin is not the actor's owned origin. why this is
+      // the API sibling of the tab branch below: #251 scoped the tab path to the
+      // tab's LIVE origin via the lock and origin-lock.js flagged site_client_* as
+      // uncovered — that fix landed for tab actors; this closes it for API actors.
+      const owned = typeof owner.instanceId === 'string' ? normalizeApiOrigin(owner.instanceId) : null;
+      if (!owned || pin !== owned) return { ok: false, error: 'site_fetch_cross_origin' };
+      scopedFetch = withApiCredentials(webFetch, () => owned, {
         getSecret: (/** @type {string} */ name) => vault.getSecret(name),
         audit: (/** @type {any} */ e) => auditLog.append(e),
       });
@@ -4140,6 +4153,13 @@ const actorsCallRoute = async (/** @type {{ method?: string, args?: any, ownerSe
     if (!owner || owner.kind === 'actor' || owner.kind === 'spawned') {
       return { ok: false, error: 'actors: only a chat session holds the script delegation surface' };
     }
+    // why no inbound re-check HERE: the inbound (untrusted-origin) wall for this
+    // path is enforced at the trusted MINT — script.js refuses to expose the
+    // `actors` surface at all when ctx.inbound === true (folded SW-side by the
+    // turn driver), so an inbound turn never reaches this route with an actors
+    // op. inbound is a per-TURN property the untrusted worker cannot be trusted
+    // to echo, so the mint is the only sound enforcement point; do NOT accept an
+    // inbound flag off the relay message here.
     const { op, args } = actorsCallToOp({ method: msg.method, args: msg.args });
     if (op === 'list') {
       // The roster through the normal tool gates — actor_list with the owner's

--- a/extension/engine-tabs/notebook-tab/notebook-neutralizers.js
+++ b/extension/engine-tabs/notebook-tab/notebook-neutralizers.js
@@ -219,4 +219,28 @@ export function applyRealmSeal(global) {
     open: cacheBlocked, match: cacheBlocked, has: cacheBlocked,
     delete: cacheBlocked, keys: cacheBlocked,
   }));
+
+  // IndexedDB: a DURABLE, same-origin edge — NOT network, so it slips the
+  // "every egress channel is sealed" framing above, yet it is the single most
+  // dangerous one. The sealed worker is minted from a blob: URL inside an
+  // ORDINARY extension page (the Notebook tab / the offscreen host — only
+  // engine-tabs/app-tab/runner.html is in manifest `sandbox.pages`), so it
+  // inherits the extension origin chrome-extension://<id>. That is the SAME
+  // origin whose one IDB database `peerd` (peerd-egress/storage/idb.js) holds
+  // the vault blob, agents_memory (durable, always-loaded into the trusted
+  // orchestrator prompt), every session + session_messages, tool_grants, and
+  // the audit log — none of it partitioned from a same-origin worker. Without
+  // this seal, model-authored code the keyless web actor runs here (page-code
+  // REPL) or a Notebook run could POISON agents_memory('user') — a persistent,
+  // highest-authority prompt injection that re-enters the orchestrator across
+  // the B1 memory boundary the whole design rests on — FORGE a tool_grants
+  // record to pre-approve a side-effecting tool, or read the vault blob and
+  // full history out for exfil (the js_notebook lane ships egress). The
+  // sandbox's sanctioned durable store is OPFS, rooted per-instance by the
+  // host; IDB is never a sanctioned edge, so replace the whole IDBFactory with
+  // throwing stubs (open/deleteDatabase/databases/cmp), same shape as caches.
+  const idbBlocked = () => fail('IndexedDB (indexedDB)');
+  seal(global, 'indexedDB', /** @type {any} */ ({
+    open: idbBlocked, deleteDatabase: idbBlocked, databases: idbBlocked, cmp: idbBlocked,
+  }));
 }

--- a/extension/offscreen/pdf-extract.js
+++ b/extension/offscreen/pdf-extract.js
@@ -203,9 +203,19 @@ const fetchPdfBytes = async (/** @type {{ url?: string, bytesB64?: string }} */ 
   }
   let res;
   try {
-    res = await fetch(url);
+    // redirect:'manual' — the SW validated only the INITIAL host (denylist +
+    // isPrivateOrLocalHost in read-pdf.js). A default follow-mode fetch would
+    // let a public host 302 this request onto a loopback / LAN / link-local /
+    // metadata / denylisted host that no decision-time gate re-checks — the same
+    // SSRF pivot webFetch closes by refusing 3xx (INV-7). Mirror that here: a
+    // redirect returns an opaqueredirect (status 0) that we reject rather than
+    // follow, so the byte fetch can never reach an origin the guard never saw.
+    res = await fetch(url, { redirect: 'manual' });
   } catch (e) {
     throw new PdfFetchError(`could not fetch PDF: ${(/** @type {{ message?: string }} */ (e))?.message ?? e}`);
+  }
+  if (res.type === 'opaqueredirect' || res.status === 0) {
+    throw new PdfFetchError('PDF url redirected; redirects are refused to prevent SSRF to internal hosts');
   }
   if (!res.ok) throw new PdfFetchError(`HTTP ${res.status} fetching PDF`, { status: res.status });
   const buf = await res.arrayBuffer();

--- a/extension/peerd-egress/fetch/private-network.js
+++ b/extension/peerd-egress/fetch/private-network.js
@@ -61,7 +61,13 @@ const isPrivateIpv4 = ([a, b]) =>
   || a === 127     // 127.0.0.0/8 loopback
   || (a === 169 && b === 254)            // 169.254.0.0/16 link-local
   || (a === 172 && b >= 16 && b <= 31)   // 172.16.0.0/12
-  || (a === 192 && b === 168);           // 192.168.0.0/16
+  || (a === 192 && b === 168)            // 192.168.0.0/16
+  // Non-routable / internal-use ranges an SSRF guard must also refuse — these
+  // are reachable as INTERNAL space on real deployments, so an actor fetch to
+  // them is the same LAN-pivot risk as 10/8 or 192.168/16.
+  || (a === 100 && b >= 64 && b <= 127)  // 100.64.0.0/10 RFC 6598 shared/CGNAT (mobile/ISP LAN)
+  || (a === 198 && (b === 18 || b === 19)) // 198.18.0.0/15 RFC 2544 benchmarking
+  || a >= 240;                            // 240.0.0.0/4 reserved, incl. 255.255.255.255 broadcast
 
 // Expand an IPv6 string into its 8 16-bit hextets. Handles `::` zero-run
 // compression and an optional trailing dotted-IPv4 tail (IPv4-in-IPv6).

--- a/extension/peerd-runtime/dom/cdr.js
+++ b/extension/peerd-runtime/dom/cdr.js
@@ -173,11 +173,22 @@ const VARIATION_SELECTOR_RE = new RegExp(
   'gu',
 );
 
+// A few INVISIBLE marks are General_Category=Mn (a combining mark), NOT Format,
+// so the \p{Cf} catch-all below structurally cannot reach them — and unlike the
+// variation selectors handled above they carry no legitimate emoji/CJK role to
+// preserve. COMBINING GRAPHEME JOINER (U+034F) renders as nothing yet the model
+// reads it: splice it between letters to smuggle a token boundary the human
+// never sees (the same class of covert channel as ZWSP, a different category).
+// why NOT the Mongolian free variation selectors (U+180B-180D/180F, also Mn):
+// like ZWNJ they do orthographic glyph-selection work in Mongolian text, so
+// stripping them would change the word — accepted collateral, left in place.
+const INVISIBLE_MARKS = '\\u034F';
+
 // The invisible-format sweep: the named ranges above UNION \p{Cf}, minus ZWJ
 // (already handled). why: `v`-flag set subtraction is the only way to say
 // "all format chars EXCEPT the one that doubles as an emoji joiner".
 const INVISIBLES_RE = new RegExp(
-  `[[${ZERO_WIDTH}${BIDI_CONTROLS}${TAG_BLOCK}\\p{Cf}]--[\\u200D\\u200C]]`,
+  `[[${ZERO_WIDTH}${BIDI_CONTROLS}${TAG_BLOCK}${INVISIBLE_MARKS}\\p{Cf}]--[\\u200D\\u200C]]`,
   'gv',
 );
 

--- a/extension/peerd-runtime/memory/init-orchestrator.js
+++ b/extension/peerd-runtime/memory/init-orchestrator.js
@@ -16,6 +16,9 @@
 // (the DI rule).
 
 import { draftAgentsMd, deriveChecklist, resolveWorkspaceKey } from './initializer.js';
+// disarmText is PURE (not an IO surface), so importing it directly does not
+// break the module's dependency-injection rule.
+import { disarmText } from '../dom/cdr.js';
 
 /**
  * @param {Object} deps
@@ -44,7 +47,15 @@ export const makeInitOrchestrator = (deps) => {
       if (!tab?.id || !tab.url || /^(chrome|about|devtools|edge):/.test(tab.url)) {
         return tab?.url ? { url: tab.url, title: tab.title } : null;
       }
-      let probe = { url: tab.url, title: tab.title };
+      // why disarmText here: this page-derived probe (title, headings, body
+      // snippet) is composed by draftAgentsMd into ALWAYS-LOADED project memory,
+      // which re-enters the TRUSTED orchestrator system prompt every future
+      // session. It is a read boundary INV-12 must cover — invisible-Unicode /
+      // bidi instructions smuggled in a heading or the body would persist as a
+      // durable injection, and be invisible both at the confirm gate and in the
+      // Memory tab. Strip at the source, exactly as read_page / fetch_url do.
+      /** @type {{ url?: string, title?: string, headings?: string[], textSnippet?: string }} */
+      let probe = { url: tab.url, title: disarmText(tab.title) };
       try {
         const [res] = await scripting.executeScript({
           target: { tabId: tab.id },
@@ -55,7 +66,14 @@ export const makeInitOrchestrator = (deps) => {
             return { headings, textSnippet: text };
           },
         });
-        if (res?.result) probe = { ...probe, ...res.result };
+        if (res?.result) {
+          const r = res.result;
+          probe = {
+            ...probe,
+            headings: Array.isArray(r.headings) ? r.headings.map((/** @type {unknown} */ h) => disarmText(String(h))) : r.headings,
+            textSnippet: typeof r.textSnippet === 'string' ? disarmText(r.textSnippet) : r.textSnippet,
+          };
+        }
       } catch { /* inject blocked — keep url/title only */ }
       return probe;
     } catch {

--- a/extension/peerd-runtime/skills/registry.js
+++ b/extension/peerd-runtime/skills/registry.js
@@ -22,6 +22,7 @@
 // text the model may later read.
 
 import { parseSkillMd, SkillParseError } from './parse.js';
+import { disarmText } from '../dom/cdr.js';
 
 export { SkillParseError };
 
@@ -110,7 +111,7 @@ export const createSkillRegistry = ({ store, audit }) => {
   const describeForPrompt = async () => {
     const enabled = (await list()).filter((s) => s.enabled);
     if (enabled.length === 0) return '';
-    const lines = enabled.map((s) => `  ${s.name} — ${oneLine(s.description)}`);
+    const lines = enabled.map((s) => `  ${disarmText(s.name)} — ${oneLine(s.description)}`);
     return [
       '──── skills ───────────────────────────────────────────────────────────',
       '',
@@ -202,10 +203,17 @@ export const createSkillRegistry = ({ store, audit }) => {
 
 /**
  * Collapse a description to a single prompt line; clamp runaway length.
+ * why disarmText first: a skill description is rendered verbatim into the
+ * TRUSTED system prompt at every startup (describeForPrompt) with no
+ * untrusted-content fence — R3 names a malicious shared skill as a direct
+ * instruction-injection vector. Stripping invisible-Unicode / bidi here means
+ * the description the user reviewed in the skills UI is the description the
+ * model reads; a covert channel smuggled past review is removed. Disarm BEFORE
+ * the whitespace collapse so any newline vector inside it is also flattened.
  * @param {string} s
  */
 const oneLine = (s) => {
-  const flat = String(s).replace(/\s+/g, ' ').trim();
+  const flat = disarmText(String(s)).replace(/\s+/g, ' ').trim();
   return flat.length > 300 ? `${flat.slice(0, 297)}…` : flat;
 };
 

--- a/extension/peerd-runtime/tools/defs/script.js
+++ b/extension/peerd-runtime/tools/defs/script.js
@@ -105,7 +105,7 @@ export const scriptTool = {
     }
     // why: jsOffscreenClient/scriptRuns/messageActor ride the opaque ctx
     // contract (not on ToolContext); narrow to what this tool touches.
-    const c = /** @type {{ jsOffscreenClient?: { execHeadless?: (code: string, opts: object) => Promise<RunResult>, abortHeadless?: (runId: string) => Promise<void> }, scriptRuns?: { mintRunId: (sid: string) => string, register: (runId: string, signal?: any, owner?: string) => void, abort: (runId: string) => void, release: (runId: string) => void, opsFor?: (runId: string) => Array<any> }, runCache?: { put?: (record: object) => Promise<void> }, messageActor?: unknown, abortSignal?: { aborted: boolean, addEventListener: Function, removeEventListener?: Function }, toolUseId?: string }} */ (
+    const c = /** @type {{ jsOffscreenClient?: { execHeadless?: (code: string, opts: object) => Promise<RunResult>, abortHeadless?: (runId: string) => Promise<void> }, scriptRuns?: { mintRunId: (sid: string) => string, register: (runId: string, signal?: any, owner?: string) => void, abort: (runId: string) => void, release: (runId: string) => void, opsFor?: (runId: string) => Array<any> }, runCache?: { put?: (record: object) => Promise<void> }, messageActor?: unknown, inbound?: boolean, abortSignal?: { aborted: boolean, addEventListener: Function, removeEventListener?: Function }, toolUseId?: string }} */ (
       /** @type {unknown} */ (ctx));
     const jsOffscreenClient = c.jsOffscreenClient;
     if (!jsOffscreenClient || typeof jsOffscreenClient.execHeadless !== 'function') {
@@ -125,8 +125,20 @@ export const scriptTool = {
     //     30s compute wall-clock, not inherit the ~5-minute delegation one.
     // The SW actors/call route re-verifies the owner per op regardless.
     const sessionKind = /** @type {{ kind?: string } | undefined} */ (ctx.session)?.kind;
+    // why ctx.inbound !== true: an inbound (untrusted-origin) turn — a synthetic
+    // async-actor reintegration wake or the dweb agent's trickle-up, both fenced
+    // attacker-derived bytes — is refused a DIRECT message_actor by the sender
+    // gate's Wall 1 (mayMessageActor: inbound === true → false). The script tool's
+    // actors.send/ask reach the SAME messageActor through the actors/call relay,
+    // so minting that surface on an inbound turn would be a SECOND, ungated door
+    // through the inbound wall (the relay never carried the flag). Fail closed at
+    // the mint — no surface advertised — and thread the flag to the SW route below
+    // (defense-in-depth: the route re-checks, consistent with "SW re-verifies
+    // every op"). Direct message_actor already gates on c.inbound the same way.
+    const inbound = c.inbound === true;
     const actorsOn = typeof c.messageActor === 'function' && !!c.scriptRuns && !!sid
       && sessionKind !== 'spawned' && sessionKind !== 'actor'
+      && !inbound
       && /\bactors\b/.test(args.code);
     // The durable workspace is a CHAT-SESSION surface: a spawned/actor child's
     // session is ephemeral and never archived (archive is the only teardown

--- a/tests/background/dweb-inbound-rate-cap.test.ts
+++ b/tests/background/dweb-inbound-rate-cap.test.ts
@@ -56,6 +56,27 @@ describe('makeDwebInboundRateCap — global hour cap', () => {
     c.advance(3_600_001);
     expect(cap.allow('did:x')).toBe(true);
   });
+
+  test('SLIDING window — no ~2x burst across the hour boundary (fixed-window weakness)', () => {
+    // Regression for the audit finding: a FIXED window admits perHourGlobal in
+    // the last seconds AND another full perHourGlobal right after an abrupt
+    // reset. A sliding window caps the TRUE rate at perHourGlobal per rolling
+    // hour, so straddling the boundary must NOT double the admits.
+    const c = clock();
+    const cap = makeDwebInboundRateCap({ now: c.now });
+    // Fill the window near the end of the first hour.
+    for (let i = 0; i < 30; i += 1) expect(cap.allow(`did:a${i}`)).toBe(true);
+    expect(cap.allow('did:a-extra')).toBe(false);
+    // Advance PAST a fixed 1h window edge but keep the earlier admits inside a
+    // rolling hour (only +30s). A fixed window would reset and admit 30 more.
+    c.advance(30_000);
+    let burst = 0;
+    for (let i = 0; i < 30; i += 1) if (cap.allow(`did:b${i}`)) burst += 1;
+    expect(burst).toBe(0); // sliding window: the earlier 30 still count
+    // Once the earliest admits truly age out (>1h), capacity returns normally.
+    c.advance(3_600_001);
+    expect(cap.allow('did:c')).toBe(true);
+  });
 });
 
 describe('makeDwebInboundRateCap — eviction', () => {

--- a/tests/engine-tabs/notebook-tab/notebook-neutralizers.test.ts
+++ b/tests/engine-tabs/notebook-tab/notebook-neutralizers.test.ts
@@ -29,6 +29,15 @@ const freshGlobal = () => {
       open: () => 'NATIVE-CACHE-OPEN', match: () => undefined,
       has: () => false, delete: () => false, keys: () => [],
     },
+    // indexedDB is an IDBFactory on WorkerGlobalScope.prototype. It is NOT a
+    // network channel but a same-origin DURABLE edge: the sealed worker inherits
+    // the extension origin (blob: worker of an ordinary extension page), so an
+    // unsealed indexedDB reaches the `peerd` DB — vault blob, durable memory,
+    // sessions, tool_grants, audit. The seal must block it like caches.
+    indexedDB: {
+      open: () => 'NATIVE-IDB-OPEN', deleteDatabase: () => 'NATIVE-IDB-DELETE',
+      databases: () => [], cmp: () => 0,
+    },
   };
   const g: any = Object.create(proto);
   g.XMLHttpRequest = function XMLHttpRequest() {};
@@ -99,6 +108,19 @@ describe('realm seal — raw channels are hard-blocked', () => {
     expect(() => g.caches.match('x')).toThrow('peerd.egress.fetch');
     // the native CacheStorage is gone from the prototype chain, not just shadowed
     expect(Object.getOwnPropertyDescriptor(proto, 'caches')).toBeUndefined();
+  });
+
+  test('IndexedDB is sealed — the same-origin durable store cannot be reached', () => {
+    // The seal's escape the audit found: indexedDB is not a network channel, so
+    // it slipped the egress-only framing, but the sealed worker runs at the
+    // extension origin and would otherwise read/write the `peerd` DB (vault blob,
+    // agents_memory poisoning, tool_grants forgery, audit). It must throw like
+    // caches, and the native IDBFactory must be gone from the prototype chain.
+    const { g, proto } = freshGlobal();
+    applyRealmSeal(g);
+    expect(() => g.indexedDB.open('peerd')).toThrow('peerd.egress.fetch');
+    expect(() => g.indexedDB.deleteDatabase('peerd')).toThrow('peerd.egress.fetch');
+    expect(Object.getOwnPropertyDescriptor(proto, 'indexedDB')).toBeUndefined();
   });
 
   test('survives a navigator with no sendBeacon, and no navigator at all', () => {

--- a/tests/peerd-runtime/dom/cdr.test.ts
+++ b/tests/peerd-runtime/dom/cdr.test.ts
@@ -64,6 +64,15 @@ describe('disarmText — strips invisible injection vectors', () => {
     expect(disarmText(`hello${TAG_A}world`)).toBe('helloworld');
   });
 
+  test('COMBINING GRAPHEME JOINER (U+034F) is stripped — a gc=Mn invisible the Cf sweep misses', () => {
+    // CGJ renders as nothing but the model reads it; splicing it between letters
+    // smuggles a token boundary the human never sees. It is General_Category=Mn,
+    // NOT Format, so \p{Cf} cannot reach it — a separate strip covers it.
+    const CGJ = cp(0x034F);
+    expect(disarmText(`pass${CGJ}word`)).toBe('password');
+    expect(disarmText(`ignore${CGJ} all${CGJ} rules`)).toBe('ignore all rules');
+  });
+
   test('variation-selector smuggling (VS Supplement) is stripped to the base', () => {
     // The 2024 VS-smuggling channel: append VS code points to a base char to
     // encode arbitrary bytes with zero visual footprint. Category Mn, NOT Cf,

--- a/tests/red-team/scenarios/07-ssrf-private-network.ts
+++ b/tests/red-team/scenarios/07-ssrf-private-network.ts
@@ -48,6 +48,9 @@ const SSRF_TARGETS: { label: string; url: string }[] = [
 const EVASION_HOSTS = [
   '169.254.169.254', '0x7f000001', '0177.0.0.1', '127.1',
   '::ffff:7f00:1', '::ffff:a9fe:a9fe', '64:ff9b::a9fe:a9fe', 'foo.localhost',
+  // Non-routable / internal-use ranges an SSRF guard must also refuse (RFC 6598
+  // shared/CGNAT is real internal LAN space on mobile/ISP deployments).
+  '100.64.0.1', '100.127.255.255', '198.18.0.5', '255.255.255.255', '240.0.0.1',
 ];
 
 export const scenario: Scenario = {


### PR DESCRIPTION
## What & why

A focused security audit stress-tested peerd's containment invariants (INV-1…INV-13) against the actual code, with the central question: **where can a prompt-injected/untrusted context still reach durable authority** — the vault, another instance, egress/exfil, persistent memory, or host escape?

**The core architecture held.** The memory boundary (keyless offscreen actor heaps), the SW-gated relays (tool ctx rebuilt from the persisted session record, not worker args; session identity host-closure-bound), the exact-origin credentialed allowlist, the sender/lineage gate, and bundle/signature integrity all resisted attack. This PR fixes the gaps that did **not** hold — each verified against source, then fixed and probed:

- **CRITICAL (INV-6) — realm seal omitted `indexedDB`.** The seal blocked every network channel but not IndexedDB. The sealed Notebook/headless worker is a `blob:` worker of an ordinary extension page, so it runs at the extension origin and could `indexedDB.open('peerd')` — reaching the vault blob, **always-loaded memory (persistent prompt-injection), `tool_grants` (confirm-gate forgery), audit**. Now sealed like `caches`.
- **HIGH (INV-5) — inbound wall bypass via the `script` tool.** An inbound (untrusted-origin) turn is refused a direct `message_actor`, but `script`'s `actors.send/ask` reached the same `messageActor` with no inbound flag. Fixed by failing closed at the **trusted mint** (`actorsOn` gates on `ctx.inbound`; the untrusted worker never echoes it).
- **HIGH (DESIGN-18) — API-actor cross-origin credential escalation.** The `site-fetch/call` relay's `backing:'api'` branch pinned credentials to the **model-supplied** origin, so an API actor bound to origin A could name origin B and spend B's stored key + cookies. Now pinned to the actor's own `instanceId` with a cross-origin refusal, mirroring `fetch_url`.
- **MEDIUM (INV-7) — `read_pdf` SSRF pivot.** Its offscreen byte fetch followed redirects, so a public host could 302 onto a private/denylisted host the SW-side guard never re-checked. Now `redirect:'manual'` + reject 3xx.
- **LOW** — SSRF guard extended with RFC 6598 CGNAT / benchmarking / reserved ranges; dweb inbound global rate cap made a sliding window (no ~2× boundary burst); CDR now strips the combining grapheme joiner (U+034F, a `gc=Mn` invisible the `\p{Cf}` sweep missed).
- **Persistence (R2/R3)** — CDR-strip the `/init` active-tab probe before it seeds always-loaded project memory, and skill names/descriptions before they render into the startup prompt, closing invisible-Unicode channels that would persist beneath the approval gate.

One reported finding was **not** reproduced and is documented as such: the "variation-selector smuggling slips CDR" claim is a false positive — `disarmText` already applies a dedicated variation-selector pass; only the CGJ codepoint was genuinely uncovered.

Closes #

## Checklist

- [ ] `bun run preflight` passes — **partial:** `bun test ./tests` (3861 pass / 0 fail), `tsc` typecheck, `eslint`, dweb-boundary, source-hygiene, doc-paths, and tscheck-floor all pass locally. The in-browser CDP suite and visual lane were **not** run here (no Chrome in this environment) — they run in CI.
- [x] Only original code — no GPL / AGPL / copyleft
- [x] Tests added or updated — new probes for the IndexedDB seal, the CGNAT SSRF ranges, the CGJ strip, and the rate-cap boundary
- [x] No hand-edited generated files
- [x] Touches **danger zones** — see below

## Notes for reviewers

**Danger zones touched:** egress (`private-network.js`, `pdf-extract.js`), gates/delegation (`script.js` actors mint, `service-worker.js` `siteFetchCallRoute`), runner & sandbox boundary (`notebook-neutralizers.js` seal), dweb (`dweb-inbound-rate-cap.js`), and the untrusted-content fence (`cdr.js`, `init-orchestrator.js`, `skills/registry.js`).

- The `script`→actors fix is deliberately enforced **only** at the mint (`ctx.inbound`, trusted, folded SW-side) rather than threaded through the worker relay — the worker is untrusted and would spoof the flag, so the mint is the sound enforcement point. A pointer comment records this at `siteFetchCallRoute`.
- The API-actor credential pin uses `owner.instanceId` as the owned origin, consistent with how `fetch_url` derives it for `backing:'api'`.
- `THREAT-MODEL.md` is updated in the same change per its stated change policy: INV-5, INV-6, INV-7, INV-12 amended; R2, R3, and the R12 family narrowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdHLokSYxamtwjhqq9MsRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdHLokSYxamtwjhqq9MsRj)_