### PR TITLE
test(visual): compute the missing 'before' for newly added visual states

### DIFF
--- a/.github/workflows/package-and-release.yml
+++ b/.github/workflows/package-and-release.yml
@@ -318,6 +318,27 @@ jobs:
         id: render
         run: bun run test:e2e:visual
 
+      # A state ADDED by this PR has no committed baseline, so the step above can
+      # only seed it — it passes trivially and the PR reports "no visual drift"
+      # for a screen nobody ever photographed. This computes that missing
+      # "before" by rendering the same state definitions against the MERGE-BASE
+      # build (peerd has no build step, so that is a checkout and a render).
+      #
+      # Non-gating on purpose: it reports what changed, it does not decide. The
+      # committed baselines remain the approved-look record, and the human
+      # checkpoint that comes with reseeding them.
+      - name: Compute before/after for states with no baseline
+        if: always() && github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          CHROME_PATH: ${{ steps.cft.outputs.chrome-path }}
+        id: newstates
+        run: |
+          # The merge-base needs main's history; the PR checkout is shallow.
+          git fetch --no-tags --depth=50 origin main || true
+          bun scripts/cdp/new-state-before-after.mjs > "$RUNNER_TEMP/new-states.md" || true
+          cat "$RUNNER_TEMP/new-states.md"
+
       - name: Write the render report to the job summary
         if: always()
         run: |
@@ -327,6 +348,7 @@ jobs:
             bun scripts/cdp/visual-report.mjs
             echo
             echo "Before / after / diff PNGs are attached to this run as the \`visual-diff-…\` artifact."
+            if [ -s "$RUNNER_TEMP/new-states.md" ]; then echo; cat "$RUNNER_TEMP/new-states.md"; fi
             echo
             echo "If the change is INTENDED: re-run this workflow on your branch with"
             echo "**update_visual_baselines** checked, download \`visual-baselines-linux-x64\`,"

--- a/scripts/cdp/new-state-before-after.mjs
+++ b/scripts/cdp/new-state-before-after.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env bun
+// new-state-before-after — the one comparison the pixel gate structurally cannot make.
+//
+// THE HOLE. A baseline only exists once someone commits one. So a PR that ADDS a
+// visual state has nothing to compare against: the state is seeded from that same
+// branch and passes trivially, and the PR reports "no visual drift" for a screen
+// nobody had ever photographed. That is not a hypothetical — PR #294 rebuilt the
+// whole Behavior and Denylist pages (7–23% of pixels) and the gate reported no
+// drift, correctly and uselessly, because neither page had a baseline.
+//
+// THE FIX. For states with no committed baseline, compute the "before" instead of
+// reading it: render the SAME state definitions against the merge-base's
+// extension code. peerd has no build step, so "check out the base and render it"
+// is a checkout plus a harness run — cheap enough to do per PR, and impossible in
+// a project that has to compile first.
+//
+// why the merge-base and not origin/main: main moves. Diffing against its HEAD
+// attributes everything that landed while you were branched to your PR.
+//
+// This does NOT replace the committed baselines. Those stay the approved-look
+// record (and the gallery), and they carry the human checkpoint a computed
+// baseline cannot: with main-as-truth, a bad render that lands silently becomes
+// the new correct. This only covers the case where there is no record yet.
+//
+// Usage:
+//   bun scripts/cdp/new-state-before-after.mjs [--base <ref>] [--force <state,…>]
+// Writes <state>.<theme>.{before,after,diff}.png + new-state-report.json into
+// scripts/cdp/artifacts/, and prints a markdown table on stdout.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { launchPeerd, unlockAndReady, resetSession, setEmulatedTheme, capturePage, THEMES, sleep, log } from './e2e-harness.mjs';
+import { STATES } from './states.mjs';
+import { BASELINES_ROOT, VISUAL_AUTHORITY, decodePng, comparePixels, writeDiffImage } from './visual.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '..', '..');
+const ARTIFACTS = join(HERE, 'artifacts');
+
+const arg = (flag) => {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 ? process.argv[i + 1] : null;
+};
+const forced = new Set((arg('--force') || '').split(',').map((s) => s.trim()).filter(Boolean));
+
+// A state is "new" when THE AUTHORITY has no committed PNG for it — deliberately
+// not the local platform's dir. Only linux-x64 baselines are committed, so
+// checking the local platform would call every state new on a dev machine and
+// render the entire suite twice.
+const AUTHORITY_DIR = join(BASELINES_ROOT, VISUAL_AUTHORITY);
+const isNew = (name) => forced.has(name)
+  || THEMES.some((t) => !existsSync(join(AUTHORITY_DIR, `${name}.${t}.png`)));
+
+const visualStates = STATES.filter((s) => s.kind === 'visual');
+const newStates = visualStates.filter((s) => isNew(s.name));
+
+if (newStates.length === 0) {
+  log('no new visual states — every state has a committed baseline, nothing to compute');
+  process.exit(0);
+}
+log(`new visual state(s) with no baseline: ${newStates.map((s) => s.name).join(', ')}`);
+
+// ── the "before" build ───────────────────────────────────────────────────────
+// A detached worktree at the merge-base. The STATE DEFINITIONS come from this
+// branch (they have to — the base does not know these states exist); only the
+// EXTENSION under test comes from the base. That separation is the whole trick.
+const baseRef = arg('--base') || execFileSync('git', ['merge-base', 'origin/main', 'HEAD'], { cwd: ROOT, encoding: 'utf8' }).trim();
+const baseTree = join(ARTIFACTS, `base-${baseRef.slice(0, 8)}`);
+mkdirSync(ARTIFACTS, { recursive: true });
+if (!existsSync(baseTree)) {
+  log(`materialising the base build at ${baseRef.slice(0, 8)}`);
+  execFileSync('git', ['worktree', 'add', '--detach', baseTree, baseRef], { cwd: ROOT, stdio: 'pipe' });
+  // The manifest is generated, not committed in a runnable state for every
+  // channel — regenerate it inside the base tree so it can be loaded unpacked.
+  try { execFileSync('bun', ['run', 'gen:dev'], { cwd: baseTree, stdio: 'pipe' }); }
+  catch (e) { log(`gen:dev in the base tree failed (continuing): ${e?.message ?? e}`); }
+}
+
+/**
+ * Capture-only recorder. The real one compares against baselines; here there is
+ * nothing to compare against yet, so it just writes PNGs under a given suffix.
+ */
+const captureRecorder = (ctx, suffix) => ({
+  check: () => {},
+  shot: async () => {},
+  async visual(name) {
+    for (const theme of THEMES) {
+      await setEmulatedTheme(ctx.page, theme);
+      await sleep(80);
+      writeFileSync(join(ARTIFACTS, `${name}.${theme}.${suffix}.png`), await ctx.screenshot());
+    }
+    await setEmulatedTheme(ctx.page, 'light');
+  },
+  async visualPage(name, page) {
+    for (const theme of THEMES) {
+      await setEmulatedTheme(page, theme);
+      await sleep(80);
+      writeFileSync(join(ARTIFACTS, `${name}.${theme}.${suffix}.png`), await capturePage(page));
+    }
+  },
+});
+
+/** Render the given states against one extension build. */
+const renderAgainst = async (extensionDir, suffix) => {
+  const ctx = await launchPeerd({ modelResponder: () => ({ sse: '' }), extensionDir });
+  try {
+    await unlockAndReady(ctx.page);
+    const rec = captureRecorder(ctx, suffix);
+    for (const state of newStates) {
+      if (state.responder) ctx.setModelResponder(state.responder);
+      await resetSession(ctx).catch(() => {});
+      try { await state.run(ctx, rec); }
+      catch (e) { log(`  ${state.name} threw on the ${suffix} build: ${e?.message ?? e}`); }
+    }
+  } finally { ctx.close(); }
+};
+
+log('rendering the BEFORE (merge-base build)…');
+await renderAgainst(join(baseTree, 'extension'), 'before');
+log('rendering the AFTER (this branch)…');
+await renderAgainst(join(ROOT, 'extension'), 'after');
+
+// ── compare ─────────────────────────────────────────────────────────────────
+const rows = [];
+for (const state of newStates) {
+  for (const theme of THEMES) {
+    const b = join(ARTIFACTS, `${state.name}.${theme}.before.png`);
+    const a = join(ARTIFACTS, `${state.name}.${theme}.after.png`);
+    if (!existsSync(a)) continue;
+    if (!existsSync(b)) {
+      // The route did not exist on the base at all — a genuinely new screen, as
+      // opposed to a new PHOTOGRAPH of an existing one. Say which it is; they
+      // read identically in a diff report and mean opposite things to a reviewer.
+      rows.push({ state: state.name, theme, verdict: 'new screen (absent on base)', ratio: null });
+      continue;
+    }
+    const before = decodePng(readFileSync(b));
+    const after = decodePng(readFileSync(a));
+    if (before.width !== after.width || before.height !== after.height) {
+      rows.push({ state: state.name, theme, verdict: `resized ${before.width}×${before.height} → ${after.width}×${after.height}`, ratio: null });
+      continue;
+    }
+    const { ratio } = comparePixels(before, after);
+    if (ratio > 0) writeDiffImage(before, after, join(ARTIFACTS, `${state.name}.${theme}.diff.png`));
+    rows.push({ state: state.name, theme, verdict: ratio > 0 ? 'changed' : 'identical', ratio });
+  }
+}
+
+writeFileSync(join(ARTIFACTS, 'new-state-report.json'), JSON.stringify({ baseRef, rows }, null, 2));
+
+console.log(`### New visual states — before/after vs \`${baseRef.slice(0, 8)}\`\n`);
+console.log('These states had no committed baseline, so the pixel gate could not compare them.');
+console.log('The "before" is the same state rendered against the merge-base build.\n');
+console.log('| state | theme | result |');
+console.log('|---|---|---|');
+for (const r of rows) {
+  const pct = r.ratio == null ? '—' : `${(r.ratio * 100).toFixed(2)}% of pixels`;
+  console.log(`| \`${r.state}\` | ${r.theme} | ${r.verdict}${r.ratio ? ` · ${pct}` : ''} |`);
+}
+
+// Housekeeping: the base worktree is a build artifact, not state worth keeping.
+try { execFileSync('git', ['worktree', 'remove', '--force', baseTree], { cwd: ROOT, stdio: 'pipe' }); }
+catch { try { rmSync(baseTree, { recursive: true, force: true }); } catch { /* best effort */ } }


### PR DESCRIPTION
**Why**

A baseline only exists once someone commits one, so a PR that **adds** a visual state has nothing to compare against — the state is seeded from that same branch, passes trivially, and the PR reports "no visual drift" for a screen nobody ever photographed.

Not hypothetical: #294 rebuilt the Behavior and Denylist pages (8% and 31% of pixels changed) and the visual gate reported no drift — correctly, and uselessly, because neither page had a baseline. The before/after had to be produced by hand to review it.

**What**

- `scripts/cdp/new-state-before-after.mjs`: for states the **authority** has no PNG for, render the same state definitions against the **merge-base** build and diff. peerd has no build step, so that's a checkout and a render.
- Merge-base, not main's HEAD — otherwise everything that landed while you were branched is attributed to your PR.
- One non-gating CI step in the `visual` job, `continue-on-error`, folded into the job summary. It reports; it doesn't decide.
- Distinguishes "new photograph of an existing screen" from "screen absent on base" — they diff identically and mean opposite things to a reviewer.

**How**

- Forced onto #294's two states it reproduces the real deltas: 8.10 / 25.95 / 30.59 / 30.61%.
- On a branch that adds no states (this one) it exits without rendering anything.
- Lint clean; workflow parsed to confirm the step lands in the `visual` job, after the render and before the summary.

Deliberately **not** a replacement for committed baselines. Those stay the approved-look record and carry the human checkpoint a computed baseline can't: with main as truth, a bad render that lands silently becomes the new correct.
