### PR TITLE
fix(visual): stop home-fulltab racing the first-run seed install

### DIFF
--- a/scripts/cdp/states.mjs
+++ b/scripts/cdp/states.mjs
@@ -871,6 +871,23 @@ export const STATES = [
         await waitFor(() => evalIn(page,
           `!!document.querySelector('.home-shell, .home-rail, .empty-state--home, .path-menu--home')`),
           { budgetMs: 15_000, pollMs: 80 }).catch(() => {});
+        // …and then past the FIRST-RUN SEED INSTALL, which is what made this
+        // state flaky. home.js seeds the commons app on first unlock and the
+        // Library re-renders when it lands, so the camera raced it: some runs
+        // photographed "1 app", others "No apps yet", and the 0.78% diff read as
+        // a UI regression when it was a lifecycle race. The seed is a PACKAGED
+        // asset, not a network fetch, so waiting for it is deterministic — it
+        // always arrives; the only question was whether we waited for it.
+        //
+        // Bounded and swallowed on purpose: a build with the dweb pruned (the
+        // store channel) installs nothing, and there an empty Library IS the
+        // settled state. Falling through then is correct, not a miss.
+        //
+        // Known residual: the card carries a relative timestamp ("just now").
+        // It is stable for anything under a minute, which every run is, but a
+        // pathologically slow runner would drift it.
+        await waitFor(() => evalIn(page, `document.querySelectorAll('.library-grid > *').length > 0`),
+          { budgetMs: 10_000, pollMs: 100 }).catch(() => {});
         await rec.visualPage('home-fulltab', page);
       } finally { try { page.close(); } catch { /* */ } }
     },


### PR DESCRIPTION
**Why**

`home-fulltab` photographed the Library as soon as the shell mounted, but `home.js` installs the commons seed app on first unlock and the Library re-renders when it lands. The camera raced it: some runs captured "1 app", others "No apps yet", and the resulting 0.78% diff reads as a UI regression when it's a lifecycle race.

Seen for real: a branch whose only change was a CI script red'd the visual gate on this state, and a re-run with no code change went green. A gate that fails at random trains people to re-run rather than read it — which is what it costs.

**What**

- Wait for the Library to settle before capturing.
- The seed is a **packaged asset**, not a network fetch, so waiting is deterministic — it always arrives; the only question was whether we waited.
- Bounded and swallowed, so a build with the dweb pruned (store channel) still captures its empty Library, which is that build's settled state.

**How**

- Ran the state three times: pixel-identical, **0.0000%** apart.
- **No reseed needed** — it settles on the same seeded render the committed baseline already holds.
- One residual noted in the code: the card carries a relative timestamp ("just now"), stable under a minute but not forever.
