### PR TITLE
ci(security): make dependency review gate now that Dependency graph is on

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,11 +3,8 @@
 #
 #   codeql            semantic analysis of the extension + tooling JS/TS
 #   osv               known-vulnerability scan of the resolved dependency tree
-#   dependency-review ADVISORY until the repository's Dependency graph setting is
-#                     enabled (the action errors "not supported" without it, which
-#                     is not a finding). Reports a new dependency carrying a known
-#                     advisory or a copyleft license; flip off continue-on-error
-#                     to make it gate once the setting is on.
+#   dependency-review the PR-time diff gate: a new dependency carrying a known
+#                     advisory (or a copyleft license) fails the PR
 #   invariants        peerd-SPECIFIC architectural rules that no generic scanner
 #                     knows about (packaging/check-invariants.ts)
 #
@@ -84,14 +81,15 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # Soft until the repo's Dependency graph is switched on (Settings →
-      # Code security): without it the API this action needs returns "not
-      # supported" and the step errors for a REASON THAT IS NOT A FINDING —
-      # which would train everyone to ignore a red security job. Flip
-      # continue-on-error off once the setting is enabled and this has a green
-      # run; the OSV job above covers the same tree unconditionally meanwhile.
+      # GATING. This ran continue-on-error while the repo's Dependency graph
+      # setting was off, because without it the action errors "not supported" —
+      # red for a reason that is not a finding, which is how people learn to
+      # ignore a security job. The setting is on now, so the softener is gone and
+      # a PR that introduces an advisory-carrying or copyleft dependency fails.
+      # why it is worth gating even though OSV also scans: OSV reads the resolved
+      # lockfile for KNOWN VULNERABILITIES; this reads the PR's dependency DIFF and
+      # is the only control enforcing the license policy at all.
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
-        continue-on-error: true
         with:
           fail-on-severity: moderate
           # Mirrors the PR checklist's "no GPL / AGPL / copyleft" line — the

--- a/docs/security/HARDENING-ROADMAP.md
+++ b/docs/security/HARDENING-ROADMAP.md
@@ -38,9 +38,11 @@ For orientation — enforced by CI, not by this prose:
   (`packaging/check-invariants.ts`): it pins the generated manifest surface for
   store, preview AND dev, every dynamic-code site, and every `runtime.onMessage`
   listener against a blessed baseline, and hard-refuses `content_scripts` /
-  `externally_connectable` in any channel. PR dependency review runs alongside
-  but is ADVISORY (`continue-on-error`) until the repository's Dependency graph
-  setting is enabled — so the copyleft denylist reports without gating today.
+  `externally_connectable` in any channel. PR dependency review gates alongside
+  it (the repository's Dependency graph is enabled), failing a PR that
+  introduces a dependency carrying a known advisory or a copyleft license —
+  the only control enforcing the license policy at all, since OSV reads the
+  resolved lockfile for vulnerabilities rather than the PR's dependency diff.
 - The actor relay sender-pin + grant, the actor-lane spend preflight + cost fold,
   and keyless custody on the spawned-child fallback — see P0-1..3 below, which
   record precisely what shipped and what remains.


### PR DESCRIPTION
## What & why

Follow-up to #292. The `dependency-review` job shipped as `continue-on-error` because the action errors *"Dependency review is not supported on this repository"* without the repo's Dependency graph setting — red for a reason that is not a finding, which is how people learn to ignore a security job. That setting is on now, so the softener comes off and the job gates: a PR introducing a dependency that carries a known advisory, or a copyleft license, fails.

Worth gating even though OSV also scans the tree — they cover different things:

- **OSV** reads the *resolved lockfile* for known vulnerabilities, on every push and weekly.
- **Dependency review** reads the *PR's dependency diff*, and is the only control enforcing the license policy at all (the `deny-licenses` list mirrors the PR checklist's "no GPL / AGPL / copyleft" line).

The roadmap's shipped list is corrected in the same commit — it had been deliberately careful to say "advisory, not gating", and would now understate what CI actually does.

**This PR is its own test.** If the setting somehow isn't fully propagated, the `Dependency review (PR diff)` job on this PR fails with the "not supported" error rather than a finding, and the right move is to revert the flip rather than merge it.

Also noted while rebasing onto main: Dependabot's first run (#297) landed correctly — it bumped `actions/checkout` to `3d3c42e5…` with the `# v7.0.1` comment intact, which is exactly the SHA-pin maintenance the config was added for. Verified that SHA is genuinely `refs/tags/v7.0.1`.

Closes #

## Checklist

- [x] `bun run preflight` passes — no source changed; YAML validated and `check:docpaths` re-run against the edited roadmap
- [x] Only original or permissively-licensed code — **no GPL / AGPL / copyleft**
- [x] Tests added or updated (or N/A) — N/A, CI configuration only; the gate verifies itself on this PR
- [x] No hand-edited generated files (`manifest.json`, `shared/channel-config.js`)
- [x] Called out below if this touches a **danger zone** (egress / vault / gates / runner & sandbox boundaries / dweb)

## Notes for reviewers

- No extension code changes — two files, both CI/docs.
- The remaining settings-only follow-up from #292 is required reviewers on the `release` environment.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnAR8QTVNHC3mnAkUKH3tp

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnAR8QTVNHC3mnAkUKH3tp)_