### PR TITLE
feat(doc): read Word/Excel/PowerPoint/ODF/RTF/EPUB/CSV as Markdown (read_doc)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -273,10 +273,15 @@ export default [
   // as voice/model-store — DATA verified by SRI, not a provider API call.
   // offscreen/pdf-extract fetches the PDF bytes for the read_pdf tool (the
   // target is denylist-checked at the tool boundary before we get here).
+  // offscreen/doc-extract is the exact same posture for read_doc: the office
+  // document's bytes, whose target read-doc.js denylist- and SSRF-checked
+  // before dispatching, fetched with redirect:'manual' so a 3xx cannot pivot
+  // the request onto a host no gate saw.
   {
     files: [
       'extension/peerd-runtime/pdf/ocr-store.js',
       'extension/offscreen/pdf-extract.js',
+      'extension/offscreen/doc-extract.js',
     ],
     rules: { 'no-restricted-globals': 'off' },
   },

--- a/extension/background/offscreen-doc-client.js
+++ b/extension/background/offscreen-doc-client.js
@@ -1,0 +1,38 @@
+// @ts-check
+// background/offscreen-doc-client.js — SW-side client for document conversion.
+//
+// The read_doc tool runs in the SW; the bytes are fetched and converted in the
+// offscreen document (offscreen/doc-extract.js). This client ensures the
+// offscreen doc exists and dispatches the job. Dependencies are injected
+// (ensureOffscreen + sendMessage) so it stays a pure, testable shell — the
+// same shape as offscreen-pdf-client.js.
+//
+// why the error is REPACKED rather than thrown as a string: the conversion's
+// failures are the interesting part of its API (a legacy .doc, a PDF behind a
+// document link, an encrypted archive) and each has a different next move. The
+// tool turns `code` into that sentence, so the code must survive the hop.
+
+/**
+ * @param {Object} deps
+ * @param {() => Promise<void>} deps.ensureOffscreen   create the offscreen doc if absent
+ * @param {(msg: object) => Promise<any>} deps.sendMessage   runtime.sendMessage → offscreen
+ */
+export const makeOffscreenDocClient = ({ ensureOffscreen, sendMessage }) => ({
+  /**
+   * @param {{ url?: string, bytesB64?: string, name?: string, contentType?: string }} source
+   * @param {{ format?: string }} [opts]
+   * @returns {Promise<{ doc: import('/peerd-runtime/doc/model.js').Document, bytes: number, sniffedVia: string }>}
+   */
+  extract: async (source, opts = {}) => {
+    await ensureOffscreen();
+    const reply = await sendMessage({ type: 'doc/extract', source, opts });
+    if (!reply?.ok) {
+      const error = /** @type {Error & { code?: string, detail?: string, format?: string }} */ (
+        new Error(reply?.detail ?? reply?.error ?? 'document conversion failed'));
+      error.code = reply?.error ?? 'doc_extract_failed';
+      error.format = reply?.format;
+      throw error;
+    }
+    return reply.result;
+  },
+});

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -307,6 +307,7 @@ import { createContextSnapshots } from './context-snapshots.js';
 import { confirmGrantKey } from './confirm-grant-key.js';
 import { makeOffscreenActorClient } from './offscreen-actor-client.js';
 import { makeOffscreenPdfClient } from './offscreen-pdf-client.js';
+import { makeOffscreenDocClient } from './offscreen-doc-client.js';
 import { makeOffscreenWebClient } from './offscreen-web-client.js';
 import { makeUiPorts } from './ui-ports.js';
 import { createAppClient, APP_TAB_GROUP_TITLE } from './app-client.js';
@@ -1601,6 +1602,11 @@ const buildToolContext = async (/** @type {any} */ { sessionId: overrideSessionI
     // read_pdf — PDF text extraction in the offscreen doc (pdf.js needs a
     // Worker the SW can't host). Defined after ensureOffscreen below.
     pdfOffscreenClient,
+    // read_doc — office/publishing formats (Word/Excel/PowerPoint/ODF/RTF/EPUB/
+    // CSV) converted to Markdown in the offscreen doc. Defined after
+    // ensureOffscreen below. NOT in spawn.js CAPABILITY_CONSUMERS (like
+    // pdfOffscreenClient), so it survives the web actor's capability strip.
+    docOffscreenClient,
     // fetch_url's clean-content extraction — HTML -> markdown in the offscreen
     // doc (Readability needs a DOM Document the SW can't build). Defined after
     // ensureOffscreen below. NOT in spawn.js CAPABILITY_CONSUMERS (like
@@ -2553,6 +2559,15 @@ const actorClient = offscreenAvailable ? makeOffscreenActorClient({
 // The PDF-extraction client (the read_pdf tool). ensureOffscreen, then a
 // 'pdf/extract' message to offscreen/pdf-extract.js (pdf.js in a Worker).
 const pdfOffscreenClient = offscreenAvailable ? makeOffscreenPdfClient({
+  ensureOffscreen,
+  sendMessage: (m) => browser.runtime.sendMessage(m),
+}) : null;
+
+// The office-document conversion client (the read_doc tool). ensureOffscreen,
+// then a 'doc/extract' message to offscreen/doc-extract.js. The conversion
+// itself is pure (peerd-runtime/doc) — it runs offscreen so the multi-megabyte
+// byte buffer, and the untrusted document behind it, stay out of the SW.
+const docOffscreenClient = offscreenAvailable ? makeOffscreenDocClient({
   ensureOffscreen,
   sendMessage: (m) => browser.runtime.sendMessage(m),
 }) : null;

--- a/extension/offscreen/doc-extract.js
+++ b/extension/offscreen/doc-extract.js
@@ -1,0 +1,138 @@
+// @ts-check
+// offscreen/doc-extract.js — convert an office/publishing document in the
+// OFFSCREEN document. The read_doc tool (SW) calls in via
+// background/offscreen-doc-client.js → a 'doc/extract' message → here.
+//
+// Why here and not the SW: not because the conversion needs a DOM (it does not
+// — peerd-runtime/doc is pure and would run anywhere), but because of what
+// happens BEFORE it. The bytes have to be fetched, and a document is routinely
+// tens of megabytes; holding that in the service worker fights the MV3
+// lifecycle, and it is exactly the buffer the SW should not be sitting on when
+// it is also the context that holds the vault DK. The offscreen document is
+// where peerd already puts untrusted heavy parsing (pdf.js, Readability, the
+// sealed worker), so a hostile .docx lands in the same place a hostile PDF does
+// rather than in a new one.
+//
+// SECURITY: the bytes are UNTRUSTED web content, and the conversion is entirely
+// declarative — a ZIP index read, an XML tokenizer, and string building. There
+// is no eval, no scripting engine, no DOM insertion, and no external entity
+// resolution (xml.js SKIPS doctypes and never resolves an entity it did not
+// define — so XXE and billion-laughs have no surface here). A hostile document
+// can at worst make the parse fail, which is surfaced as an error. The text
+// crosses back wrapped in <untrusted_web_content> by the read_doc tool.
+
+import browser from '/vendor/browser-polyfill.js';
+import { base64ToBytes } from '/shared/util.js';
+import { isTrustedSender } from '/shared/messaging.js';
+import {
+  convertToDocument, sniffDocFormat,
+  DocFetchError, DocParseError, UnsupportedDocFormatError, LegacyDocFormatError, ZipError,
+} from '/peerd-runtime/index.js';
+
+// A hard ceiling on the bytes we will pull. Lower than the PDF reader's 75MB:
+// a PDF is often a scan whose size is pixels, whereas a .docx or .xlsx that
+// large is overwhelmingly embedded media we are going to discard anyway, and
+// the ZIP index read touches the whole buffer.
+const MAX_BYTES = 40 * 1024 * 1024;
+
+/**
+ * Fetch the document bytes. Mirrors offscreen/pdf-extract.js exactly, and the
+ * redirect posture is the load-bearing part: the SW validated only the INITIAL
+ * host (denylist + isPrivateOrLocalHost, in read-doc.js). A follow-mode fetch
+ * would let a public host 302 this onto loopback / LAN / link-local / metadata
+ * — the SSRF pivot webFetch closes by refusing 3xx (INV-7). So a redirect
+ * becomes an opaqueredirect we reject rather than follow.
+ *
+ * @param {{ url?: string, bytesB64?: string }} source
+ * @returns {Promise<{ bytes: Uint8Array, contentType: string }>}
+ */
+const fetchDocBytes = async ({ url, bytesB64 } = {}) => {
+  if (bytesB64) return { bytes: base64ToBytes(bytesB64), contentType: '' };
+  if (!url || typeof url !== 'string') throw new DocFetchError('no document url provided');
+  if (url.startsWith('blob:')) {
+    throw new DocFetchError('blob: URLs are not reachable from the extension; use the document\'s http(s) URL');
+  }
+  let res;
+  try {
+    res = await fetch(url, { redirect: 'manual' });
+  } catch (e) {
+    throw new DocFetchError(`could not fetch the document: ${(/** @type {{ message?: string }} */ (e))?.message ?? e}`);
+  }
+  if (res.type === 'opaqueredirect' || res.status === 0) {
+    throw new DocFetchError('the URL redirected; redirects are refused to prevent SSRF to internal hosts');
+  }
+  if (!res.ok) throw new DocFetchError(`HTTP ${res.status} fetching the document`, { status: res.status });
+  const buf = await res.arrayBuffer();
+  if (buf.byteLength > MAX_BYTES) {
+    throw new DocFetchError(`document too large: ${buf.byteLength} bytes (limit ${MAX_BYTES})`);
+  }
+  return { bytes: new Uint8Array(buf), contentType: res.headers.get('content-type') ?? '' };
+};
+
+/**
+ * @param {{ source: any, opts?: { maxChars?: number, format?: string } }} msg
+ */
+const extractDoc = async ({ source, opts = {} }) => {
+  // Stage rides every failure so the returned error pinpoints WHERE it broke.
+  let stage = 'fetch';
+  const where = source?.url ? String(source.url).slice(0, 120) : '(inline bytes)';
+  try {
+    const { bytes, contentType } = await fetchDocBytes(source);
+
+    stage = 'sniff';
+    const hints = {
+      name: source?.name || source?.url || '',
+      // An explicit content-type from the response beats the caller's guess.
+      contentType: contentType || source?.contentType || '',
+      ...(opts.format ? { format: opts.format } : {}),
+    };
+    const sniffed = sniffDocFormat(bytes, hints);
+
+    // PDF has a BETTER reader in this build (pdf.js text layer + opt-in OCR),
+    // so read_doc refuses it by NAME rather than by failure — the agent gets a
+    // route, not a dead end. Same for a URL that served HTML: that is the
+    // ordinary web path, and fetch_url/read_page do it far better.
+    if (sniffed.format === 'pdf') {
+      return { ok: false, error: 'is_pdf', detail: 'This is a PDF. Use read_pdf, which has a text layer and OCR.' };
+    }
+    if (sniffed.format === 'html' || sniffed.format === 'text') {
+      return {
+        ok: false,
+        error: 'is_web_content',
+        detail: `This URL served ${sniffed.format === 'html' ? 'an HTML page' : 'plain text'}, not a document file. `
+          + 'Read it with fetch_url, or open it in a tab. (A login wall commonly does this to a document link.)',
+      };
+    }
+
+    stage = 'convert';
+    const doc = await convertToDocument(bytes, hints);
+    console.debug(`[offscreen/doc-extract] ${where}: ${doc.format}, ${doc.blocks.length} blocks, ${bytes.length} bytes`);
+    return { ok: true, result: { doc, bytes: bytes.length, sniffedVia: sniffed.via } };
+  } catch (e) {
+    const err = /** @type {{ name?: string, message?: string, format?: string }} */ (e);
+    console.error(`[offscreen/doc-extract] FAILED at stage=${stage} for ${where}:`, e);
+    // The typed errors carry the agent's next move, so they cross the wire as
+    // themselves rather than collapsing into one opaque failure string.
+    if (e instanceof LegacyDocFormatError) return { ok: false, error: 'legacy_binary_format', detail: err.message, format: err.format };
+    if (e instanceof UnsupportedDocFormatError) return { ok: false, error: 'unsupported_format', detail: err.message, format: err.format };
+    if (e instanceof ZipError) return { ok: false, error: 'unreadable_container', detail: err.message };
+    if (e instanceof DocParseError) return { ok: false, error: 'parse_failed', detail: err.message, format: err.format };
+    if (e instanceof DocFetchError) return { ok: false, error: 'fetch_failed', detail: err.message };
+    return { ok: false, error: `doc_extract_failed[${stage}]`, detail: `${err?.name ?? 'Error'}: ${err?.message ?? String(e)}` };
+  }
+};
+
+// Message route: SW → offscreen. Gated on isTrustedSender like every sibling
+// handler (pdf/extract, job/run, voice) — fail-closed: externally_connectable
+// is unset today, so this is defense-in-depth, but the gate is what keeps this
+// from being an open fetch proxy if it is ever enabled.
+// why cast: the polyfill's OnMessageListener return type is stricter than this
+// fire-and-respond handler (mirrors the pdf/extract listener).
+browser.runtime.onMessage.addListener(/** @type {any} */ ((/** @type {any} */ msg, /** @type {any} */ sender, /** @type {any} */ sendResponse) => {
+  if (msg?.type !== 'doc/extract') return undefined;
+  if (!isTrustedSender(sender)) { sendResponse({ ok: false, error: 'untrusted-sender' }); return true; }
+  extractDoc(msg)
+    .then((out) => sendResponse(out))
+    .catch((e) => sendResponse({ ok: false, error: e?.name ? `${e.name}: ${e.message}` : (e?.message ?? String(e)) }));
+  return true;     // async sendResponse contract
+}));

--- a/extension/offscreen/doc-extract.js
+++ b/extension/offscreen/doc-extract.js
@@ -88,14 +88,19 @@ const extractDoc = async ({ source, opts = {} }) => {
     };
     const sniffed = sniffDocFormat(bytes, hints);
 
+    // These two redirects are DETECTION-driven, so an explicit opts.format
+    // skips them: overriding a wrong detection is the only reason that
+    // parameter exists, and refusing on the detected format would make the
+    // override unreachable in exactly the case it is for.
+    //
     // PDF has a BETTER reader in this build (pdf.js text layer + opt-in OCR),
     // so read_doc refuses it by NAME rather than by failure — the agent gets a
     // route, not a dead end. Same for a URL that served HTML: that is the
     // ordinary web path, and fetch_url/read_page do it far better.
-    if (sniffed.format === 'pdf') {
+    if (!opts.format && sniffed.format === 'pdf') {
       return { ok: false, error: 'is_pdf', detail: 'This is a PDF. Use read_pdf, which has a text layer and OCR.' };
     }
-    if (sniffed.format === 'html' || sniffed.format === 'text') {
+    if (!opts.format && (sniffed.format === 'html' || sniffed.format === 'text')) {
       return {
         ok: false,
         error: 'is_web_content',

--- a/extension/offscreen/offscreen.js
+++ b/extension/offscreen/offscreen.js
@@ -30,6 +30,11 @@ import { runActor, abortActor } from './actor-runner.js';
 // PDF text extraction (the read_pdf runner tool): pdf.js needs a Worker, which
 // the SW can't host. Self-registers a 'pdf/extract' message handler.
 import './pdf-extract.js';
+// Office/publishing document conversion (the read_doc tool): Word, Excel,
+// PowerPoint, OpenDocument, RTF, EPUB, CSV -> Markdown. Self-registers a
+// 'doc/extract' message handler. Offscreen for the same reason as the PDF
+// reader: the untrusted bytes (tens of MB) never enter the SW.
+import './doc-extract.js';
 // HTML -> markdown extraction (fetch_url's clean-content path): Readability +
 // Turndown need a DOM Document, which the SW can't build. The shell
 // self-registers a 'web/extract' message handler; the headless job runner's

--- a/extension/peerd-runtime/actor/activity-label.js
+++ b/extension/peerd-runtime/actor/activity-label.js
@@ -61,6 +61,7 @@ const PHRASES = Object.freeze({
   page_keys: 'Pressing keys',
   read_page: 'Reading the page',
   read_pdf: 'Reading a PDF',
+  read_doc: 'Reading a document',
   snapshot: 'Looking at the page',
   query_dom: 'Looking at the page',
   read_state: 'Looking at the page',

--- a/extension/peerd-runtime/doc/convert.js
+++ b/extension/peerd-runtime/doc/convert.js
@@ -1,0 +1,97 @@
+// @ts-check
+// bytes → Document. The one entry point that decides WHICH parser runs.
+//
+// Everything reachable from here is pure (the parsers, the ZIP reader, the XML
+// reader) — the only platform primitives are TextDecoder and
+// DecompressionStream, both of which exist in the service worker, a worker, the
+// offscreen document, and Bun. So the whole conversion is context-agnostic and
+// testable from the terminal; the impure part (getting the bytes) stays in the
+// caller.
+
+import { sniffDocFormat, isConvertible, isLegacyBinary } from './sniff.js';
+import { UnsupportedDocFormatError, LegacyDocFormatError } from './errors.js';
+import { parseCsv } from './parse/csv.js';
+import { parseRtf } from './parse/rtf.js';
+import { parseDocx } from './parse/docx.js';
+import { parseXlsx } from './parse/xlsx.js';
+import { parsePptx } from './parse/pptx.js';
+import { parseOdf } from './parse/odf.js';
+import { parseEpub } from './parse/epub.js';
+import { makeDocument, paragraph, finalizeDocument } from './model.js';
+
+/** Which app wrote a legacy OLE2 file, guessed from the name, for the message only. */
+const legacyHint = (/** @type {string} */ name) => {
+  const ext = name.toLowerCase().split('.').pop() ?? '';
+  if (ext === 'doc') return 'Word 97-2003 (.doc)';
+  if (ext === 'xls') return 'Excel 97-2003 (.xls)';
+  if (ext === 'ppt') return 'PowerPoint 97-2003 (.ppt)';
+  return 'a pre-2007 Microsoft Office binary';
+};
+
+/**
+ * Convert document bytes to the unified model.
+ *
+ * @param {Uint8Array} bytes
+ * @param {{ name?: string, contentType?: string, format?: string }} [hints]
+ * @returns {Promise<import('./model.js').Document>}
+ */
+export const convertToDocument = async (bytes, hints = {}) => {
+  // An explicit format overrides the sniffer — the caller may know something
+  // the bytes cannot say (a part extracted from a bigger container).
+  const sniffed = sniffDocFormat(bytes, hints);
+  const format = /** @type {import('./sniff.js').DocFormat} */ (hints.format ?? sniffed.format);
+
+  if (isLegacyBinary(format)) {
+    throw new LegacyDocFormatError(
+      `${legacyHint(hints.name ?? '')} is a binary format this reader cannot open. `
+      + 'Ask the owner for a modern equivalent (.docx / .xlsx / .pptx), or convert it in a WebVM sandbox '
+      + '(vm_import the file, then `libreoffice --headless --convert-to docx`).',
+      { format },
+    );
+  }
+  if (!isConvertible(format)) {
+    throw new UnsupportedDocFormatError(
+      `this reader does not handle ${format === 'unknown' ? 'these bytes' : `.${format} files`}`,
+      { format },
+    );
+  }
+
+  const decodeText = () => new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+  /** @type {import('./model.js').Document} */
+  let doc;
+  switch (format) {
+    case 'csv': case 'tsv':
+      doc = parseCsv(decodeText(), { format, name: hints.name });
+      break;
+    case 'rtf': doc = parseRtf(decodeText(), { name: hints.name }); break;
+    case 'docx': doc = await parseDocx(bytes); break;
+    case 'xlsx': doc = await parseXlsx(bytes); break;
+    case 'pptx': doc = await parsePptx(bytes); break;
+    case 'odt': case 'ods': case 'odp': doc = await parseOdf(bytes, format); break;
+    case 'epub': doc = await parseEpub(bytes); break;
+    default:
+      // Unreachable — isConvertible already gated the set. Kept so adding a
+      // format to CONVERTIBLE without wiring it here fails loudly.
+      throw new UnsupportedDocFormatError(`no parser wired for .${format}`, { format });
+  }
+
+  // Surface a LOW-CONFIDENCE identification. When the bytes themselves named
+  // the format there is nothing to say; when we went on the filename or the
+  // content-type, the reader should know that a wrong guess is possible.
+  if (!hints.format && (sniffed.via === 'extension' || sniffed.via === 'heuristic')) {
+    doc.notes.push(`Format was inferred from the ${sniffed.via === 'extension' ? 'file name' : 'content'}, not from a format signature.`);
+  }
+  return doc;
+};
+
+/**
+ * A Document standing in for content we deliberately did not convert. Used for
+ * the formats that have a better route (PDF → read_pdf) so the caller still
+ * gets a well-formed answer instead of an exception.
+ *
+ * @param {string} format
+ * @param {string} message
+ */
+export const redirectDocument = (format, message) => finalizeDocument(
+  makeDocument({ format, blocks: [paragraph(message)] }),
+);

--- a/extension/peerd-runtime/doc/convert.js
+++ b/extension/peerd-runtime/doc/convert.js
@@ -17,7 +17,6 @@ import { parseXlsx } from './parse/xlsx.js';
 import { parsePptx } from './parse/pptx.js';
 import { parseOdf } from './parse/odf.js';
 import { parseEpub } from './parse/epub.js';
-import { makeDocument, paragraph, finalizeDocument } from './model.js';
 
 /** Which app wrote a legacy OLE2 file, guessed from the name, for the message only. */
 const legacyHint = (/** @type {string} */ name) => {
@@ -83,15 +82,3 @@ export const convertToDocument = async (bytes, hints = {}) => {
   }
   return doc;
 };
-
-/**
- * A Document standing in for content we deliberately did not convert. Used for
- * the formats that have a better route (PDF → read_pdf) so the caller still
- * gets a well-formed answer instead of an exception.
- *
- * @param {string} format
- * @param {string} message
- */
-export const redirectDocument = (format, message) => finalizeDocument(
-  makeDocument({ format, blocks: [paragraph(message)] }),
-);

--- a/extension/peerd-runtime/doc/errors.js
+++ b/extension/peerd-runtime/doc/errors.js
@@ -1,0 +1,61 @@
+// @ts-check
+// Named error subclasses for the document-reading subsystem.
+//
+// House rule (CLAUDE.md): named subclasses, never a bare Error with a message.
+// Each maps to a distinct thing the AGENT should do next, which is why they are
+// separate types rather than one DocError with a code — the read_doc tool turns
+// the type into the "what to try instead" sentence.
+
+/** The bytes could not be fetched (network, HTTP status, refused redirect). */
+export class DocFetchError extends Error {
+  /** @param {string} message @param {{ status?: number }} [meta] */
+  constructor(message, meta = {}) {
+    super(message);
+    this.name = 'DocFetchError';
+    this.status = meta.status ?? 0;
+  }
+}
+
+/** The bytes are not a format this reader knows how to open at all. */
+export class UnsupportedDocFormatError extends Error {
+  /** @param {string} message @param {{ format?: string }} [meta] */
+  constructor(message, meta = {}) {
+    super(message);
+    this.name = 'UnsupportedDocFormatError';
+    this.format = meta.format ?? 'unknown';
+  }
+}
+
+/**
+ * The format IS recognized but this build cannot convert it in-browser — the
+ * legacy OLE2 binaries (.doc/.xls/.ppt) and .xlsb. Distinct from Unsupported
+ * because the answer is different: those have a real escape hatch (convert in
+ * the WebVM), so the tool names it instead of just saying no.
+ */
+export class LegacyDocFormatError extends Error {
+  /** @param {string} message @param {{ format?: string }} [meta] */
+  constructor(message, meta = {}) {
+    super(message);
+    this.name = 'LegacyDocFormatError';
+    this.format = meta.format ?? 'unknown';
+  }
+}
+
+/** The container/markup was recognized but malformed past the point of reading. */
+export class DocParseError extends Error {
+  /** @param {string} message @param {{ format?: string }} [meta] */
+  constructor(message, meta = {}) {
+    super(message);
+    this.name = 'DocParseError';
+    this.format = meta.format ?? 'unknown';
+  }
+}
+
+/** A ZIP container that is encrypted, truncated, or uses an unsupported method. */
+export class ZipError extends Error {
+  /** @param {string} message */
+  constructor(message) {
+    super(message);
+    this.name = 'ZipError';
+  }
+}

--- a/extension/peerd-runtime/doc/format.js
+++ b/extension/peerd-runtime/doc/format.js
@@ -1,0 +1,76 @@
+// @ts-check
+// Document → the body string the read_doc tool returns.
+//
+// Mirrors pdf/extract-format.js: a pure formatter, so the cap-and-render rules
+// are unit-testable without a browser, a network, or a document.
+//
+// The truncation rule is the interesting one. A model that receives a silently
+// cut document will confidently answer questions about the missing half, so a
+// cut is ALWAYS announced, and announced with the numbers needed to decide what
+// to do next (how much was shown, of how much).
+
+import { toMarkdown } from './markdown.js';
+
+/** Default cap on the returned markdown. Roughly 12k tokens of prose. */
+export const DEFAULT_MAX_CHARS = 48_000;
+
+/**
+ * A short provenance header. Kept to one line per fact and omitted entirely
+ * when there is nothing to say — a header longer than the document is a common
+ * converter tax.
+ *
+ * @param {import('./model.js').Document} doc
+ * @returns {string}
+ */
+export const formatHeader = (doc) => {
+  const bits = [`format: ${doc.format}`];
+  if (doc.title) bits.push(`title: ${doc.title}`);
+  for (const [key, value] of Object.entries(doc.meta)) {
+    if (value) bits.push(`${key}: ${value}`);
+  }
+  return bits.join(' · ');
+};
+
+/**
+ * The provenance/notes lines that precede the converted text. Shared so the
+ * read_doc tool can prepend them to a SPILLED window without re-deriving them.
+ *
+ * @param {{ doc: import('./model.js').Document, source?: string }} input
+ * @returns {string}
+ */
+export const formatDocHead = ({ doc, source }) => {
+  const head = [`[${formatHeader(doc)}]`];
+  if (source) head.push(`[source: ${source}]`);
+  if (doc.notes.length) head.push(...doc.notes.map((n) => `[note: ${n}]`));
+  return head.join('\n');
+};
+
+/**
+ * Render a converted document for the model, capped. This is the fallback for
+ * a context with no spill cache — read_doc prefers windowing + paging, which
+ * keeps the whole text reachable instead of discarding the tail.
+ *
+ * @param {{ doc: import('./model.js').Document, maxChars?: number, source?: string }} input
+ * @returns {string}
+ */
+export const formatDocBody = ({ doc, maxChars = DEFAULT_MAX_CHARS, source }) => {
+  const markdown = toMarkdown(doc);
+  const cap = Number.isFinite(maxChars) && maxChars > 0 ? Math.floor(maxChars) : DEFAULT_MAX_CHARS;
+  const head = [formatDocHead({ doc, source })];
+
+  let body = markdown;
+  if (markdown.length > cap) {
+    // Cut at a block boundary when one is near the limit, so the tail is not a
+    // half-sentence or a half-table (a truncated GFM table stops parsing as a
+    // table at all).
+    const window = markdown.slice(0, cap);
+    const boundary = window.lastIndexOf('\n\n');
+    const cut = boundary > cap * 0.8 ? boundary : cap;
+    body = `${markdown.slice(0, cut).trimEnd()}\n\n_… truncated: showing ${cut} of ${markdown.length} characters. `
+      + 'Re-read with a larger maxChars, or ask for a specific section._';
+  }
+  if (!markdown.trim()) {
+    body = '_(this document converted to no text — it may be entirely images, or empty)_';
+  }
+  return `${head.join('\n')}\n\n${body}`;
+};

--- a/extension/peerd-runtime/doc/index.js
+++ b/extension/peerd-runtime/doc/index.js
@@ -1,0 +1,37 @@
+// @ts-check
+// peerd-runtime/doc — public surface of the document-reading subsystem.
+//
+// The sibling of peerd-runtime/pdf, for everything that ISN'T a PDF: the office
+// and publishing formats an agent meets on the open web — Word, Excel,
+// PowerPoint, OpenDocument, RTF, EPUB, and delimited text. One pipeline,
+// modeled on Firecrawl's anydoc:
+//
+//     bytes → sniff → per-format parser → unified Document → GFM Markdown
+//
+// why the shared model in the middle (rather than a converter per format): it
+// is what makes a table from a .docx and a table from a .xlsx come out
+// identical, and it puts every escaping and truncation decision in one file
+// instead of seven.
+//
+// Split across contexts, like pdf:
+//   SW         — the read_doc tool dispatches to the offscreen client
+//   offscreen  — fetches the bytes under the SSRF rules, runs the conversion
+//
+// The conversion core itself is PURE and context-agnostic — it needs only
+// TextDecoder and DecompressionStream — so it is exercised from Bun in
+// tests/doc/*.test.ts. Nothing here is vendored: DEFLATE is the platform's,
+// and the ZIP/XML readers are small enough to own.
+
+export { convertToDocument, redirectDocument } from './convert.js';
+export { formatDocBody, formatDocHead, formatHeader, DEFAULT_MAX_CHARS } from './format.js';
+export { toMarkdown, renderInlines, renderTable } from './markdown.js';
+export {
+  sniffDocFormat, sniffZipFlavor, sniffDelimited, extensionOf,
+  isConvertible, isLegacyBinary, CONVERTIBLE, LEGACY,
+} from './sniff.js';
+export { makeDocument, finalizeDocument, mergeInlines, compactBlocks } from './model.js';
+export { readZipIndex, readZipEntry, readZipText } from './zip.js';
+export { parseXml, findAll, find, elements, textOf, localName, decodeEntities } from './xml.js';
+export {
+  DocFetchError, DocParseError, UnsupportedDocFormatError, LegacyDocFormatError, ZipError,
+} from './errors.js';

--- a/extension/peerd-runtime/doc/index.js
+++ b/extension/peerd-runtime/doc/index.js
@@ -22,7 +22,7 @@
 // tests/doc/*.test.ts. Nothing here is vendored: DEFLATE is the platform's,
 // and the ZIP/XML readers are small enough to own.
 
-export { convertToDocument, redirectDocument } from './convert.js';
+export { convertToDocument } from './convert.js';
 export { formatDocBody, formatDocHead, formatHeader, DEFAULT_MAX_CHARS } from './format.js';
 export { toMarkdown, renderInlines, renderTable } from './markdown.js';
 export {

--- a/extension/peerd-runtime/doc/markdown.js
+++ b/extension/peerd-runtime/doc/markdown.js
@@ -1,0 +1,142 @@
+// @ts-check
+// Document → GitHub-Flavored Markdown. The one place formatting is decided.
+//
+// Two rules govern everything here, and they pull in opposite directions:
+//
+//   1. The output is read by a MODEL, so structure must survive. Headings,
+//      table shape, and list nesting are the document's meaning; losing them
+//      turns a spreadsheet into a word salad.
+//   2. The output costs TOKENS. So no decorative padding, no alignment
+//      whitespace, no empty emphasis markers.
+//
+// Where they conflict, structure wins but pays the minimum: table cells are
+// separated, not aligned into columns (alignment can double a wide table's
+// size for zero information).
+
+/** @typedef {import('./model.js').Document} Document */
+/** @typedef {import('./model.js').Block} Block */
+/** @typedef {import('./model.js').Inline} Inline */
+
+// Characters that would change the STRUCTURE of the markdown if left raw.
+// Deliberately narrow: escaping every `*` and `_` in prose is a common
+// converter mistake that litters the output with backslashes and misleads the
+// reader about what the document actually said.
+const escapeText = (/** @type {string} */ text) => text.replace(/([\\`])/g, '\\$1');
+
+// A pipe inside a cell ends the cell; a newline ends the row. Both must go.
+const escapeCell = (/** @type {string} */ text) => text
+  .replace(/\|/g, '\\|')
+  .replace(/\s*\r?\n\s*/g, ' ')
+  .trim();
+
+/**
+ * Render styled runs. Emphasis markers are placed INSIDE the run's whitespace
+ * (`**bold** ` not `**bold **`) because a marker adjacent to a space does not
+ * bind in CommonMark — the asterisks would render literally.
+ *
+ * @param {Inline[]} inlines
+ * @returns {string}
+ */
+export const renderInlines = (inlines) => inlines.map((run) => {
+  if (!run.text) return '';
+  if (run.code) {
+    // A run containing a backtick needs a longer fence than the longest run
+    // inside it — the CommonMark rule.
+    const longest = (run.text.match(/`+/g) ?? []).reduce((n, s) => Math.max(n, s.length), 0);
+    const fence = '`'.repeat(longest + 1);
+    const pad = run.text.startsWith('`') || run.text.endsWith('`') ? ' ' : '';
+    return `${fence}${pad}${run.text}${pad}${fence}`;
+  }
+  const leading = run.text.match(/^\s*/)?.[0] ?? '';
+  const trailing = run.text.length > leading.length ? (run.text.match(/\s*$/)?.[0] ?? '') : '';
+  const core = run.text.slice(leading.length, run.text.length - trailing.length);
+  if (!core) return run.text;
+
+  let body = escapeText(core);
+  if (run.bold) body = `**${body}**`;
+  if (run.italic) body = `*${body}*`;
+  if (run.href) {
+    // A link whose text IS its target renders as a bare autolink — shorter and
+    // clearer than the duplicated `[url](url)` most converters emit.
+    body = run.href === core ? `<${run.href}>` : `[${body}](${run.href.replace(/[()\s]/g, encodeURIComponent)})`;
+  }
+  return `${leading}${body}${trailing}`;
+}).join('');
+
+/**
+ * A GFM table. Columns are NOT padded to equal width — see the token rule
+ * above. Ragged rows are squared off, because a table with a 3-cell header and
+ * a 5-cell body row does not parse as a table at all.
+ *
+ * @param {string[][]} rows
+ * @param {boolean} header
+ * @returns {string}
+ */
+export const renderTable = (rows, header) => {
+  if (!rows.length) return '';
+  const width = rows.reduce((n, row) => Math.max(n, row.length), 0);
+  if (!width) return '';
+  const square = rows.map((row) => {
+    const cells = Array.from({ length: width }, (_, i) => escapeCell(row[i] ?? ''));
+    return `| ${cells.join(' | ')} |`;
+  });
+  const rule = `|${' --- |'.repeat(width)}`;
+  // GFM has no headerless table: without a header row the body is not
+  // recognized as a table at all. So when the source had none, emit an empty
+  // header rather than silently degrading the structure to paragraphs.
+  return header
+    ? [square[0], rule, ...square.slice(1)].join('\n')
+    : [`|${'  |'.repeat(width)}`, rule, ...square].join('\n');
+};
+
+/**
+ * @param {Block} block
+ * @returns {string}
+ */
+const renderBlock = (block) => {
+  switch (block.type) {
+    case 'heading':
+      return `${'#'.repeat(block.level)} ${renderInlines(block.inlines)}`;
+    case 'paragraph':
+      return renderInlines(block.inlines);
+    case 'quote':
+      return renderInlines(block.inlines).split('\n').map((l) => `> ${l}`).join('\n');
+    case 'divider':
+      return '---';
+    case 'code': {
+      // Fence longer than any backtick run inside, so embedded code fences in
+      // the source cannot break out of the block.
+      const longest = (block.text.match(/`{3,}/g) ?? []).reduce((n, s) => Math.max(n, s.length), 2);
+      const fence = '`'.repeat(longest + 1);
+      return `${fence}${block.lang ?? ''}\n${block.text}\n${fence}`;
+    }
+    case 'list':
+      return block.items.map((item) => {
+        const indent = '  '.repeat(Math.max(0, item.level));
+        const marker = block.ordered ? '1.' : '-';
+        return `${indent}${marker} ${renderInlines(item.inlines)}`;
+      }).join('\n');
+    case 'table': {
+      const body = renderTable(block.rows, block.header);
+      return block.truncatedRows
+        ? `${body}\n\n_… ${block.truncatedRows} more row${block.truncatedRows === 1 ? '' : 's'} not shown._`
+        : body;
+    }
+    default:
+      return '';
+  }
+};
+
+/**
+ * Serialize a document to Markdown. Blocks are separated by a blank line
+ * (which is what makes them separate blocks in Markdown at all).
+ *
+ * @param {Document} doc
+ * @returns {string}
+ */
+export const toMarkdown = (doc) => doc.blocks
+  .map(renderBlock)
+  .filter((s) => s.trim())
+  .join('\n\n')
+  .replace(/\n{3,}/g, '\n\n')
+  .trim();

--- a/extension/peerd-runtime/doc/markdown.js
+++ b/extension/peerd-runtime/doc/markdown.js
@@ -24,7 +24,14 @@
 const escapeText = (/** @type {string} */ text) => text.replace(/([\\`])/g, '\\$1');
 
 // A pipe inside a cell ends the cell; a newline ends the row. Both must go.
+//
+// BACKSLASH FIRST, and the order is the whole point: escaping the pipe alone
+// turns a cell containing `a\|b` into `a\\|b`, where the doubled backslash is
+// itself an escaped backslash — leaving the pipe bare, so the cell splits and
+// every column after it shifts. Escaping backslashes first makes each escape
+// independent. (CodeQL flags exactly this as incomplete string escaping.)
 const escapeCell = (/** @type {string} */ text) => text
+  .replace(/\\/g, '\\\\')
   .replace(/\|/g, '\\|')
   .replace(/\s*\r?\n\s*/g, ' ')
   .trim();

--- a/extension/peerd-runtime/doc/model.js
+++ b/extension/peerd-runtime/doc/model.js
@@ -1,0 +1,173 @@
+// @ts-check
+// The unified Document model — the middle of the pipeline.
+//
+//   bytes → sniff → per-format parser → THIS → Markdown
+//
+// why a shared model rather than each parser emitting Markdown directly: it is
+// the only thing that makes the output CONSISTENT across formats. A table is a
+// table whether it came from a .docx, a sheet in a .xlsx, or a .csv, so the
+// escaping, the column padding, and the truncation rules are written once and
+// every format inherits them. It also keeps the parsers honest — a parser's job
+// is to describe structure, not to make formatting decisions.
+//
+// Deliberately small. This is a model for READING a document as text, not for
+// round-tripping one: styling, geometry, colors, and revision history are
+// dropped on the floor because the consumer is a language model.
+
+/**
+ * @typedef {{ text: string, bold?: boolean, italic?: boolean, code?: boolean, href?: string }} Inline
+ * @typedef {{ type: 'heading', level: number, inlines: Inline[] }} HeadingBlock
+ * @typedef {{ type: 'paragraph', inlines: Inline[] }} ParagraphBlock
+ * @typedef {{ type: 'list', ordered: boolean, items: Array<{ level: number, inlines: Inline[] }> }} ListBlock
+ * @typedef {{ type: 'table', rows: string[][], header: boolean, truncatedRows?: number }} TableBlock
+ * @typedef {{ type: 'code', text: string, lang?: string }} CodeBlock
+ * @typedef {{ type: 'quote', inlines: Inline[] }} QuoteBlock
+ * @typedef {{ type: 'divider' }} DividerBlock
+ * @typedef {HeadingBlock|ParagraphBlock|ListBlock|TableBlock|CodeBlock|QuoteBlock|DividerBlock} Block
+ * @typedef {{
+ *   format: string,
+ *   title: string | null,
+ *   meta: Record<string, string>,
+ *   blocks: Block[],
+ *   notes: string[],
+ * }} Document
+ */
+
+/**
+ * @param {Partial<Document>} [init]
+ * @returns {Document}
+ */
+export const makeDocument = (init = {}) => ({
+  format: init.format ?? 'unknown',
+  title: init.title ?? null,
+  meta: init.meta ?? {},
+  blocks: init.blocks ?? [],
+  notes: init.notes ?? [],
+});
+
+/** @param {string} text @param {Omit<Inline,'text'>} [style] @returns {Inline} */
+export const inline = (text, style = {}) => ({ text, ...style });
+
+/** @param {string} text @returns {Inline[]} */
+export const plain = (text) => (text ? [{ text }] : []);
+
+/** @param {number} level @param {Inline[]|string} content @returns {HeadingBlock} */
+export const heading = (level, content) => ({
+  type: 'heading',
+  // Clamp: a .docx can carry outline level 9, and `#########` is not a heading
+  // in any Markdown renderer.
+  level: Math.min(6, Math.max(1, level)),
+  inlines: typeof content === 'string' ? plain(content) : content,
+});
+
+/** @param {Inline[]|string} content @returns {ParagraphBlock} */
+export const paragraph = (content) => ({
+  type: 'paragraph',
+  inlines: typeof content === 'string' ? plain(content) : content,
+});
+
+/** @param {string[][]} rows @param {{ header?: boolean, truncatedRows?: number }} [opts] @returns {TableBlock} */
+export const table = (rows, opts = {}) => ({
+  type: 'table',
+  rows,
+  header: opts.header ?? true,
+  ...(opts.truncatedRows ? { truncatedRows: opts.truncatedRows } : {}),
+});
+
+/**
+ * Merge adjacent inlines that carry identical styling. Parsers emit one inline
+ * per source run, and office writers split runs on things that do not survive
+ * conversion at all — a spellcheck boundary, a language tag, a tracked-change
+ * marker. Without this pass, `**Hello**` routinely serializes as
+ * `**Hel****lo**`, which renders wrong AND costs extra tokens.
+ *
+ * @param {Inline[]} inlines
+ * @returns {Inline[]}
+ */
+export const mergeInlines = (inlines) => {
+  /** @type {Inline[]} */
+  const out = [];
+  for (const run of inlines) {
+    if (!run || !run.text) continue;
+    const prev = out[out.length - 1];
+    if (prev
+      && !!prev.bold === !!run.bold
+      && !!prev.italic === !!run.italic
+      && !!prev.code === !!run.code
+      && prev.href === run.href) {
+      prev.text += run.text;
+    } else {
+      out.push({ ...run });
+    }
+  }
+  return out;
+};
+
+/**
+ * Drop blocks that carry no content. Every format produces these in bulk —
+ * spacer paragraphs in Word, empty rows in a sheet, blank slide placeholders —
+ * and they are pure token cost with no information.
+ *
+ * A table is NOT emptied by a blank cell (that is data: "this field is
+ * missing"), only by having no non-empty cell at all.
+ *
+ * @param {Block[]} blocks
+ * @returns {Block[]}
+ */
+export const compactBlocks = (blocks) => {
+  const kept = blocks.filter((block) => {
+    switch (block.type) {
+      case 'paragraph':
+      case 'quote':
+        return block.inlines.some((r) => r.text.trim());
+      case 'heading':
+        return block.inlines.some((r) => r.text.trim());
+      case 'list':
+        return block.items.some((it) => it.inlines.some((r) => r.text.trim()));
+      case 'table':
+        return block.rows.some((row) => row.some((cell) => cell.trim()));
+      case 'code':
+        return Boolean(block.text.trim());
+      default:
+        return true;
+    }
+  });
+  // Collapse runs of dividers and strip leading/trailing ones — an artifact of
+  // section breaks in Word and of empty slides in PowerPoint.
+  /** @type {Block[]} */
+  const out = [];
+  for (const block of kept) {
+    if (block.type === 'divider' && (out.length === 0 || out[out.length - 1].type === 'divider')) continue;
+    out.push(block);
+  }
+  while (out.length && out[out.length - 1].type === 'divider') out.pop();
+  return out;
+};
+
+/**
+ * Normalize a finished document: merge runs, drop empties, and lift a title
+ * out of the first heading when the container gave us no metadata title.
+ * Every parser ends with this so the invariants hold in one place.
+ *
+ * @param {Document} doc
+ * @returns {Document}
+ */
+export const finalizeDocument = (doc) => {
+  const blocks = compactBlocks(doc.blocks.map((block) => {
+    if (block.type === 'paragraph' || block.type === 'heading' || block.type === 'quote') {
+      return { ...block, inlines: mergeInlines(block.inlines) };
+    }
+    if (block.type === 'list') {
+      return { ...block, items: block.items.map((it) => ({ ...it, inlines: mergeInlines(it.inlines) })) };
+    }
+    return block;
+  }));
+  let { title } = doc;
+  if (!title) {
+    const first = blocks.find((b) => b.type === 'heading');
+    if (first && first.type === 'heading') {
+      title = first.inlines.map((r) => r.text).join('').trim() || null;
+    }
+  }
+  return { ...doc, blocks, title };
+};

--- a/extension/peerd-runtime/doc/parse/csv.js
+++ b/extension/peerd-runtime/doc/parse/csv.js
@@ -1,0 +1,74 @@
+// @ts-check
+// CSV / TSV → a single table.
+//
+// A real RFC 4180 reader, not a `split(',')`: quoted fields containing the
+// delimiter, embedded newlines, and doubled quotes ("" for a literal ") are all
+// routine in exported data, and getting any of them wrong silently shifts every
+// column after the offending row — the worst kind of failure, because the
+// output still looks like a table.
+
+import { makeDocument, table, finalizeDocument } from '../model.js';
+
+/** Rows past this are summarized rather than rendered — see MAX_TABLE_ROWS. */
+export const MAX_TABLE_ROWS = 500;
+
+/**
+ * Split delimited text into rows of fields.
+ *
+ * @param {string} text
+ * @param {string} delimiter
+ * @returns {string[][]}
+ */
+export const parseDelimited = (text, delimiter) => {
+  /** @type {string[][]} */
+  const rows = [];
+  /** @type {string[]} */
+  let row = [];
+  let field = '';
+  let quoted = false;
+  // A BOM at the head of a Windows-exported CSV would otherwise become part of
+  // the first column's name.
+  const source = text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+
+  for (let i = 0; i < source.length; i += 1) {
+    const ch = source[i];
+    if (quoted) {
+      if (ch !== '"') { field += ch; continue; }
+      // A doubled quote inside a quoted field is one literal quote.
+      if (source[i + 1] === '"') { field += '"'; i += 1; continue; }
+      quoted = false;
+      continue;
+    }
+    if (ch === '"' && !field) { quoted = true; continue; }
+    if (ch === delimiter) { row.push(field); field = ''; continue; }
+    if (ch === '\r') continue;                    // CRLF — the \n does the work
+    if (ch === '\n') { row.push(field); rows.push(row); row = []; field = ''; continue; }
+    field += ch;
+  }
+  // A file with no trailing newline still has a final row.
+  if (field || row.length) { row.push(field); rows.push(row); }
+  // Drop wholly-empty trailing rows (a trailing newline produces one).
+  while (rows.length && rows[rows.length - 1].every((c) => !c.trim())) rows.pop();
+  return rows;
+};
+
+/**
+ * @param {string} text
+ * @param {{ format?: 'csv'|'tsv', name?: string }} [opts]
+ * @returns {import('../model.js').Document}
+ */
+export const parseCsv = (text, opts = {}) => {
+  const format = opts.format ?? 'csv';
+  const rows = parseDelimited(text, format === 'tsv' ? '\t' : ',');
+  const doc = makeDocument({ format, title: opts.name ?? null });
+  if (!rows.length) {
+    doc.notes.push('The file contained no rows.');
+    return finalizeDocument(doc);
+  }
+  const shown = rows.slice(0, MAX_TABLE_ROWS + 1);       // +1 for the header row
+  const dropped = rows.length - shown.length;
+  doc.blocks.push(table(shown, { header: true, truncatedRows: dropped > 0 ? dropped : undefined }));
+  doc.meta.rows = String(rows.length - 1);
+  doc.meta.columns = String(rows[0]?.length ?? 0);
+  return finalizeDocument(doc);
+};

--- a/extension/peerd-runtime/doc/parse/docx.js
+++ b/extension/peerd-runtime/doc/parse/docx.js
@@ -1,0 +1,219 @@
+// @ts-check
+// .docx → Markdown.
+//
+// The body is `word/document.xml`; everything else is lookups:
+//   word/_rels/document.xml.rels  — hyperlink targets (r:id → URL)
+//   word/numbering.xml            — whether a list is bulleted or numbered
+//   docProps/core.xml             — title/author
+//
+// Two structural facts drive the shape of this walker:
+//
+//   * A "list" in Word is not a container. Each list item is an ordinary
+//     paragraph carrying a `w:numPr` (numbering id + indent level), and the
+//     list exists only as a run of consecutive such paragraphs. So list
+//     detection is a GROUPING pass over the paragraph stream, not a descent.
+//   * A table cell contains paragraphs, and those paragraphs can contain
+//     tables. We flatten cell content to a single line, because a GFM cell
+//     cannot hold a block — nesting a real table would produce broken output.
+
+import { parseXml, findAll, elements, textOf, find } from '../xml.js';
+import { readZipIndex, readZipText } from '../zip.js';
+import { makeDocument, heading, paragraph, table, inline, finalizeDocument } from '../model.js';
+import { loadRelationships, loadCoreProperties, headingLevelForStyle } from './ooxml.js';
+import { DocParseError } from '../errors.js';
+
+const MAX_TABLE_ROWS = 500;
+
+/**
+ * Numbering id → whether that list level is ordered. Word stores the format on
+ * the ABSTRACT numbering definition, reached through an indirection: the
+ * paragraph names a `numId`, `w:num` maps that to an `abstractNumId`, and the
+ * per-level `w:numFmt` lives there. Missing pieces fall back to "bulleted",
+ * which is the safer guess — a wrongly-numbered list invents ordering that the
+ * document never claimed.
+ *
+ * @param {string|null} xml
+ * @returns {Map<string, boolean>}   `${numId}:${ilvl}` → ordered
+ */
+export const parseNumbering = (xml) => {
+  /** @type {Map<string, boolean>} */
+  const ordered = new Map();
+  if (!xml) return ordered;
+  try {
+    const root = parseXml(xml);
+    /** @type {Map<string, Map<string, boolean>>} */
+    const abstract = new Map();
+    for (const node of findAll(root, 'abstractNum')) {
+      const id = node.attrs.abstractNumId;
+      if (!id) continue;
+      /** @type {Map<string, boolean>} */
+      const levels = new Map();
+      for (const lvl of findAll(node, 'lvl')) {
+        const fmt = find(lvl, 'numFmt')?.attrs.val ?? 'bullet';
+        levels.set(lvl.attrs.ilvl ?? '0', fmt !== 'bullet' && fmt !== 'none');
+      }
+      abstract.set(id, levels);
+    }
+    for (const num of findAll(root, 'num')) {
+      const numId = num.attrs.numId;
+      const target = find(num, 'abstractNumId')?.attrs.val;
+      if (!numId || target === undefined) continue;
+      const levels = abstract.get(target);
+      if (!levels) continue;
+      for (const [ilvl, isOrdered] of levels) ordered.set(`${numId}:${ilvl}`, isOrdered);
+    }
+  } catch { /* numbering is a nicety — every list falls back to bulleted */ }
+  return ordered;
+};
+
+/**
+ * The styled runs of one `w:p`, resolving hyperlinks through the rels map.
+ *
+ * @param {import('../xml.js').XmlNode} node
+ * @param {Map<string,string>} rels
+ * @returns {import('../model.js').Inline[]}
+ */
+const runsOf = (node, rels) => {
+  /** @type {import('../model.js').Inline[]} */
+  const out = [];
+  /**
+   * @param {import('../xml.js').XmlNode} parent
+   * @param {string|undefined} href
+   */
+  const walk = (parent, href) => {
+    for (const child of parent.children) {
+      if (typeof child === 'string') continue;
+      if (child.local === 'hyperlink') {
+        // An external link resolves through rels; an internal one (anchor) has
+        // no target and degrades to plain text, which is correct — a bookmark
+        // reference means nothing outside the document.
+        const id = child.attrs.id ?? child.attrs.embed;
+        walk(child, id ? rels.get(id) : undefined);
+        continue;
+      }
+      if (child.local === 'r') {
+        const props = find(child, 'rPr');
+        // `w:b` with no val is ON; `w:b val="0"` is OFF. Both appear.
+        const isOn = (/** @type {string} */ local) => {
+          if (!props) return false;
+          const el = elements(props, local)[0];
+          if (!el) return false;
+          const val = el.attrs.val;
+          return val !== '0' && val !== 'false';
+        };
+        const bold = isOn('b');
+        const italic = isOn('i');
+        for (const piece of child.children) {
+          if (typeof piece === 'string') continue;
+          if (piece.local === 't') out.push(inline(textOf(piece), { bold: bold || undefined, italic: italic || undefined, href }));
+          else if (piece.local === 'tab') out.push(inline(' '));
+          else if (piece.local === 'br') out.push(inline('\n'));
+        }
+        continue;
+      }
+      // Structured-document tags (content controls) and smart tags wrap runs;
+      // descend through them rather than losing their text.
+      if (child.local === 'sdt' || child.local === 'sdtContent' || child.local === 'smartTag' || child.local === 'ins') {
+        walk(child, href);
+      }
+    }
+  };
+  walk(node, undefined);
+  return out;
+};
+
+/**
+ * @param {import('../xml.js').XmlNode} node
+ * @returns {{ styleId: string|undefined, numId: string|undefined, ilvl: string, outline: number }}
+ */
+const paragraphProps = (node) => {
+  const props = find(node, 'pPr');
+  if (!props) return { styleId: undefined, numId: undefined, ilvl: '0', outline: 0 };
+  const numPr = find(props, 'numPr');
+  const outlineVal = find(props, 'outlineLvl')?.attrs.val;
+  return {
+    styleId: find(props, 'pStyle')?.attrs.val,
+    // numId 0 is Word's explicit "this paragraph is NOT in a list" — a
+    // formatting removal, not list membership. Treating it as a list produces
+    // stray bullets on ordinary paragraphs.
+    numId: (() => {
+      const id = numPr ? find(numPr, 'numId')?.attrs.val : undefined;
+      return id && id !== '0' ? id : undefined;
+    })(),
+    ilvl: (numPr ? find(numPr, 'ilvl')?.attrs.val : undefined) ?? '0',
+    // outlineLvl is 0-based; 9 means "body text".
+    outline: outlineVal !== undefined && Number(outlineVal) < 9 ? Number(outlineVal) + 1 : 0,
+  };
+};
+
+/** Flatten a table cell to one line — GFM cells cannot hold blocks. */
+const cellText = (/** @type {import('../xml.js').XmlNode} */ cell) => (
+  elements(cell, 'p').map((p) => textOf(p).trim()).filter(Boolean).join(' ')
+  || textOf(cell).trim()
+);
+
+/**
+ * @param {Uint8Array} bytes
+ * @returns {Promise<import('../model.js').Document>}
+ */
+export const parseDocx = async (bytes) => {
+  const index = readZipIndex(bytes);
+  const xml = await readZipText(bytes, index, 'word/document.xml');
+  if (!xml) throw new DocParseError('word/document.xml is missing — not a Word document', { format: 'docx' });
+
+  const [rels, numbering, core] = await Promise.all([
+    loadRelationships(bytes, index, 'word/document.xml'),
+    readZipText(bytes, index, 'word/numbering.xml').catch(() => null).then(parseNumbering),
+    loadCoreProperties(bytes, index),
+  ]);
+
+  const root = parseXml(xml);
+  const body = find(root, 'body');
+  if (!body) throw new DocParseError('the Word document has no body', { format: 'docx' });
+
+  const doc = makeDocument({ format: 'docx', title: core.title, meta: core.meta });
+  /** @type {import('../model.js').ListBlock | null} */
+  let openList = null;
+
+  // Only DIRECT children of the body are the document flow — findAll would
+  // also return the paragraphs nested inside table cells and emit them twice.
+  for (const node of body.children) {
+    if (typeof node === 'string') continue;
+
+    if (node.local === 'p') {
+      const props = paragraphProps(node);
+      const inlines = runsOf(node, rels);
+      if (props.numId) {
+        const level = Number.parseInt(props.ilvl, 10) || 0;
+        const ordered = numbering.get(`${props.numId}:${props.ilvl}`) ?? false;
+        // A change of marker kind ends the list — `1. / - / 1.` is three lists,
+        // not one, and merging them would renumber the source's meaning.
+        if (!openList || openList.ordered !== ordered) {
+          openList = { type: 'list', ordered, items: [] };
+          doc.blocks.push(openList);
+        }
+        openList.items.push({ level, inlines });
+        continue;
+      }
+      openList = null;
+      const level = headingLevelForStyle(props.styleId) || props.outline;
+      doc.blocks.push(level ? heading(level, inlines) : paragraph(inlines));
+      continue;
+    }
+
+    if (node.local === 'tbl') {
+      openList = null;
+      const rows = elements(node, 'tr').map((tr) => elements(tr, 'tc').map(cellText));
+      if (!rows.length) continue;
+      const shown = rows.slice(0, MAX_TABLE_ROWS + 1);
+      const dropped = rows.length - shown.length;
+      doc.blocks.push(table(shown, { header: true, truncatedRows: dropped > 0 ? dropped : undefined }));
+      continue;
+    }
+
+    if (node.local === 'sectPr') continue;         // section properties are layout, not content
+  }
+
+  if (!doc.blocks.length) doc.notes.push('The document contained no readable text.');
+  return finalizeDocument(doc);
+};

--- a/extension/peerd-runtime/doc/parse/epub.js
+++ b/extension/peerd-runtime/doc/parse/epub.js
@@ -1,0 +1,209 @@
+// @ts-check
+// .epub → Markdown.
+//
+// An EPUB is a ZIP of XHTML, so the work is mostly navigation, not parsing:
+//
+//   META-INF/container.xml  → the path of the OPF package document
+//   the OPF                 → metadata, a manifest of parts, and the SPINE
+//   each spine item         → XHTML
+//
+// The spine is the load-bearing piece. The manifest lists every file in the
+// book including CSS, fonts, and cover images; the spine lists the content
+// documents IN READING ORDER. Converting the manifest instead of the spine is
+// the classic epub-reader bug — it produces the right words in the wrong order,
+// with the copyright page in the middle.
+//
+// why an XHTML walker here rather than the vendored Readability+Turndown that
+// fetch_url uses: those need a DOM, which pins the conversion to the offscreen
+// document. EPUB content is spec-required XHTML, so the pure XML reader handles
+// it — and keeping it pure means the whole doc pipeline stays testable and
+// context-agnostic.
+
+import { parseXml, elements, textOf, find, findAll } from '../xml.js';
+import { readZipIndex, readZipText } from '../zip.js';
+import { makeDocument, heading, paragraph, table, inline, finalizeDocument } from '../model.js';
+import { DocParseError } from '../errors.js';
+
+/** Spine items past this are not read — a reference work can carry thousands. */
+const MAX_SPINE_ITEMS = 300;
+
+const BLOCK_SKIP = new Set(['script', 'style', 'head', 'nav', 'svg', 'audio', 'video', 'iframe']);
+const HEADINGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
+
+/** Resolve an OPF-relative href against the package document's directory. */
+export const resolveHref = (/** @type {string} */ base, /** @type {string} */ href) => {
+  const clean = href.split('#')[0];
+  if (!clean) return '';
+  if (clean.startsWith('/')) return clean.slice(1);
+  const dir = base.includes('/') ? base.slice(0, base.lastIndexOf('/') + 1) : '';
+  const parts = `${dir}${clean}`.split('/');
+  /** @type {string[]} */
+  const out = [];
+  for (const part of parts) {
+    if (part === '.' || part === '') continue;
+    if (part === '..') { out.pop(); continue; }
+    out.push(part);
+  }
+  return out.join('/');
+};
+
+/** Inline runs of an XHTML element, carrying emphasis and links. */
+const runsOf = (/** @type {import('../xml.js').XmlNode} */ node, /** @type {{bold?:boolean,italic?:boolean,code?:boolean,href?:string}} */ style = {}) => {
+  /** @type {import('../model.js').Inline[]} */
+  const out = [];
+  for (const child of node.children) {
+    if (typeof child === 'string') {
+      // XHTML collapses whitespace; keeping the raw newlines would break
+      // paragraphs into ragged lines.
+      out.push(inline(child.replace(/\s+/g, ' '), style));
+      continue;
+    }
+    const tag = child.local.toLowerCase();
+    if (BLOCK_SKIP.has(tag)) continue;
+    if (tag === 'br') { out.push(inline(' ', style)); continue; }
+    if (tag === 'img') {
+      const alt = child.attrs.alt?.trim();
+      if (alt) out.push(inline(`[image: ${alt}]`, style));
+      continue;
+    }
+    const next = { ...style };
+    if (tag === 'strong' || tag === 'b') next.bold = true;
+    if (tag === 'em' || tag === 'i') next.italic = true;
+    if (tag === 'code' || tag === 'tt' || tag === 'kbd') next.code = true;
+    if (tag === 'a' && child.attrs.href && !child.attrs.href.startsWith('#')) next.href = child.attrs.href;
+    out.push(...runsOf(child, next));
+  }
+  return out;
+};
+
+/**
+ * Flatten a `<ul>`/`<ol>` into ONE list block, nested items carrying a deeper
+ * level. Markdown expresses nesting as indentation inside a single list, so
+ * this matches the output format exactly.
+ *
+ * why it is worth its own function: the obvious version — take runsOf(li), then
+ * recurse for sublists — emits every nested item TWICE, because runsOf walks
+ * the whole subtree and a nested <ul> lives *inside* its parent <li>. So the
+ * item's own text must be read from its non-list children only.
+ *
+ * @param {import('../xml.js').XmlNode} listNode
+ * @param {import('../model.js').ListBlock} list
+ * @param {number} level
+ */
+const collectListItems = (listNode, list, level) => {
+  for (const li of elements(listNode, 'li')) {
+    const nested = /** @type {import('../xml.js').XmlNode[]} */ (
+      li.children.filter((c) => typeof c !== 'string' && (c.local === 'ul' || c.local === 'ol')));
+    const own = { ...li, children: li.children.filter((c) => !nested.includes(/** @type {any} */ (c))) };
+    const inlines = runsOf(own);
+    if (inlines.some((r) => r.text.trim())) list.items.push({ level, inlines });
+    // Depth is capped: a hostile or generated document can nest arbitrarily,
+    // and past a few levels the indentation stops meaning anything anyway.
+    if (level < 6) for (const sub of nested) collectListItems(sub, list, level + 1);
+  }
+};
+
+/**
+ * Walk an XHTML subtree into blocks.
+ * @param {import('../xml.js').XmlNode} node
+ * @param {import('../model.js').Block[]} out
+ * @param {number} listLevel
+ */
+export const walkHtml = (node, out, listLevel = 0) => {
+  for (const child of node.children) {
+    if (typeof child === 'string') continue;
+    const tag = child.local.toLowerCase();
+    if (BLOCK_SKIP.has(tag)) continue;
+
+    if (HEADINGS.has(tag)) { out.push(heading(Number(tag[1]), runsOf(child))); continue; }
+    if (tag === 'p') { out.push(paragraph(runsOf(child))); continue; }
+    if (tag === 'blockquote') { out.push({ type: 'quote', inlines: runsOf(child) }); continue; }
+    if (tag === 'pre') { out.push({ type: 'code', text: textOf(child).replace(/\s+$/, '') }); continue; }
+    if (tag === 'hr') { out.push({ type: 'divider' }); continue; }
+    if (tag === 'ul' || tag === 'ol') {
+      /** @type {import('../model.js').ListBlock} */
+      const list = { type: 'list', ordered: tag === 'ol', items: [] };
+      out.push(list);
+      collectListItems(child, list, listLevel);
+      continue;
+    }
+    if (tag === 'table') {
+      const rows = findAll(child, 'tr').map((tr) => (
+        [...findAll(tr, 'td'), ...findAll(tr, 'th')].map((cell) => textOf(cell).replace(/\s+/g, ' ').trim())
+      ));
+      const useful = rows.filter((r) => r.length);
+      if (useful.length) out.push(table(useful, { header: true }));
+      continue;
+    }
+    // Any other element (div, section, article, body…) is a container.
+    walkHtml(child, out, listLevel);
+  }
+};
+
+/**
+ * @param {Uint8Array} bytes
+ * @returns {Promise<import('../model.js').Document>}
+ */
+export const parseEpub = async (bytes) => {
+  const index = readZipIndex(bytes);
+  const containerXml = await readZipText(bytes, index, 'META-INF/container.xml');
+  if (!containerXml) throw new DocParseError('META-INF/container.xml is missing — not an EPUB', { format: 'epub' });
+
+  const rootfile = findAll(parseXml(containerXml), 'rootfile')[0];
+  const opfPath = rootfile?.attrs['full-path'];
+  if (!opfPath) throw new DocParseError('the EPUB container names no package document', { format: 'epub' });
+
+  const opfXml = await readZipText(bytes, index, opfPath);
+  if (!opfXml) throw new DocParseError(`the EPUB package document (${opfPath}) is missing`, { format: 'epub' });
+  const opf = parseXml(opfXml);
+
+  const doc = makeDocument({ format: 'epub' });
+  const metadata = find(opf, 'metadata');
+  if (metadata) {
+    const title = find(metadata, 'title');
+    if (title) doc.title = textOf(title).trim() || null;
+    const creator = find(metadata, 'creator');
+    if (creator) doc.meta.author = textOf(creator).trim();
+    const language = find(metadata, 'language');
+    if (language) doc.meta.language = textOf(language).trim();
+  }
+
+  // manifest id → href, then the spine's idrefs in reading order.
+  /** @type {Map<string,{href:string,type:string}>} */
+  const manifest = new Map();
+  const manifestNode = find(opf, 'manifest');
+  for (const item of manifestNode ? elements(manifestNode, 'item') : []) {
+    if (item.attrs.id && item.attrs.href) {
+      manifest.set(item.attrs.id, { href: item.attrs.href, type: item.attrs['media-type'] ?? '' });
+    }
+  }
+  const spineNode = find(opf, 'spine');
+  const spine = (spineNode ? elements(spineNode, 'itemref') : [])
+    .map((ref) => manifest.get(ref.attrs.idref ?? ''))
+    .filter(/** @returns {item is {href:string,type:string}} */ (item) => item !== undefined)
+    // Only content documents: the spine can also reference an SVG cover.
+    .filter((item) => /xhtml|html/i.test(item.type || item.href));
+
+  if (!spine.length) {
+    doc.notes.push('The EPUB spine lists no readable content documents.');
+    return finalizeDocument(doc);
+  }
+
+  const read = spine.slice(0, MAX_SPINE_ITEMS);
+  for (const item of read) {
+    const path = resolveHref(opfPath, item.href);
+    const xhtml = path ? await readZipText(bytes, index, path).catch(() => null) : null;
+    if (!xhtml) continue;
+    try {
+      const root = parseXml(xhtml);
+      walkHtml(find(root, 'body') ?? root, doc.blocks);
+    } catch {
+      doc.notes.push(`A chapter (${item.href}) could not be parsed and was skipped.`);
+    }
+  }
+  if (spine.length > read.length) {
+    doc.notes.push(`Only the first ${read.length} of ${spine.length} sections were read.`);
+  }
+  doc.meta.sections = String(spine.length);
+  return finalizeDocument(doc);
+};

--- a/extension/peerd-runtime/doc/parse/odf.js
+++ b/extension/peerd-runtime/doc/parse/odf.js
@@ -1,0 +1,206 @@
+// @ts-check
+// OpenDocument (.odt / .ods / .odp) → Markdown.
+//
+// One walker for all three, because ODF really is one format with three body
+// elements: `office:text`, `office:spreadsheet`, `office:presentation`. That is
+// the opposite of OOXML, where the three formats share only a ZIP container.
+//
+// The trap that makes or breaks an ODS reader is REPEAT COUNTS. ODF compresses
+// runs of identical cells and rows with `table:number-columns-repeated` — and
+// LibreOffice pads every sheet to its full grid, so a 3-column sheet ends with
+// a cell carrying `number-columns-repeated="16381"`. Expanding that naively
+// allocates a 16384-column row per row; ignoring it shifts every column after
+// a repeat. Both are wrong, so we expand with a cap and trim the padding after.
+
+import { parseXml, elements, textOf, find } from '../xml.js';
+import { readZipIndex, readZipText } from '../zip.js';
+import { makeDocument, heading, paragraph, table, inline, finalizeDocument } from '../model.js';
+import { DocParseError } from '../errors.js';
+
+const MAX_TABLE_ROWS = 500;
+const MAX_COLUMNS = 64;
+
+/** Inline runs of a text:p / text:h, following text:span and text:a. */
+const runsOf = (/** @type {import('../xml.js').XmlNode} */ node, /** @type {{bold?:boolean, italic?:boolean, href?:string}} */ style = {}) => {
+  /** @type {import('../model.js').Inline[]} */
+  const out = [];
+  for (const child of node.children) {
+    if (typeof child === 'string') { out.push(inline(child, style)); continue; }
+    if (child.local === 'a') {
+      out.push(...runsOf(child, { ...style, href: child.attrs.href }));
+      continue;
+    }
+    if (child.local === 's') {
+      // An explicit space run: `<text:s text:c="4"/>` is four spaces.
+      out.push(inline(' '.repeat(Number.parseInt(child.attrs.c ?? '1', 10) || 1), style));
+      continue;
+    }
+    if (child.local === 'tab') { out.push(inline(' ', style)); continue; }
+    if (child.local === 'line-break') { out.push(inline('\n', style)); continue; }
+    // span carries the styling, but the style NAME points into styles.xml,
+    // which we do not resolve — ODF has no direct bold attribute. So spans
+    // contribute text, not emphasis. (Losing bold is cheap; losing the text
+    // inside every span would not be.)
+    out.push(...runsOf(child, style));
+  }
+  return out;
+};
+
+/** Expand a repeated cell/row count, capped so a padded sheet cannot blow up. */
+const repeatOf = (/** @type {string|undefined} */ raw, /** @type {number} */ cap) => {
+  const n = Number.parseInt(raw ?? '1', 10);
+  if (!Number.isFinite(n) || n < 1) return 1;
+  return Math.min(n, cap);
+};
+
+/** One table:table → rows of cell text. */
+const rowsOfTable = (/** @type {import('../xml.js').XmlNode} */ node) => {
+  /** @type {string[][]} */
+  const rows = [];
+  let total = 0;
+  for (const rowNode of elements(node, 'table-row')) {
+    const rowRepeat = repeatOf(rowNode.attrs['number-rows-repeated'], MAX_TABLE_ROWS);
+    /** @type {string[]} */
+    const cells = [];
+    for (const cell of rowNode.children) {
+      if (typeof cell === 'string') continue;
+      if (cell.local !== 'table-cell' && cell.local !== 'covered-table-cell') continue;
+      const text = elements(cell, 'p').map((p) => textOf(p).trim()).filter(Boolean).join(' ');
+      const repeat = repeatOf(cell.attrs['number-columns-repeated'], MAX_COLUMNS);
+      for (let i = 0; i < repeat && cells.length < MAX_COLUMNS; i += 1) cells.push(text);
+    }
+    // An all-empty repeated row is LibreOffice's grid padding, not data.
+    const empty = cells.every((c) => !c.trim());
+    for (let i = 0; i < rowRepeat; i += 1) {
+      total += 1;
+      if (empty && rows.length === 0) break;               // leading padding
+      if (rows.length < MAX_TABLE_ROWS) rows.push(cells.slice());
+      if (empty) break;                                    // never repeat a blank row
+    }
+  }
+  while (rows.length && rows[rows.length - 1].every((c) => !c.trim())) rows.pop();
+  // Trim the trailing all-empty columns the padding left behind.
+  const width = rows.reduce((n, r) => Math.max(n, r.length), 0);
+  let last = -1;
+  for (let col = 0; col < width; col += 1) {
+    if (rows.some((r) => (r[col] ?? '').trim())) last = col;
+  }
+  const trimmed = rows.map((r) => Array.from({ length: last + 1 }, (_, i) => r[i] ?? ''));
+  return { rows: trimmed, truncated: Math.max(0, total - trimmed.length) };
+};
+
+/**
+ * A `text:list` and everything nested under it, as ONE list block.
+ * @param {import('../xml.js').XmlNode} listNode
+ * @param {number} level
+ * @returns {import('../model.js').ListBlock}
+ */
+const collectList = (listNode, level) => {
+  /** @type {import('../model.js').ListBlock} */
+  const list = { type: 'list', ordered: false, items: [] };
+  /** @param {import('../xml.js').XmlNode} node @param {number} depth */
+  const walk = (node, depth) => {
+    for (const item of elements(node, 'list-item')) {
+      for (const p of elements(item, 'p')) list.items.push({ level: depth, inlines: runsOf(p) });
+      // Capped like the EPUB walker: past a few levels the indentation carries
+      // no more meaning, and the depth is attacker-controlled.
+      if (depth < 6) for (const sub of elements(item, 'list')) walk(sub, depth + 1);
+    }
+  };
+  walk(listNode, level);
+  return list;
+};
+
+/** @param {import('../xml.js').XmlNode} node @param {import('../model.js').Block[]} out @param {number} listLevel */
+const walkText = (node, out, listLevel = 0) => {
+  for (const child of node.children) {
+    if (typeof child === 'string') continue;
+    switch (child.local) {
+      case 'h': {
+        const level = Number.parseInt(child.attrs['outline-level'] ?? '1', 10) || 1;
+        out.push(heading(level, runsOf(child)));
+        break;
+      }
+      case 'p':
+        out.push(paragraph(runsOf(child)));
+        break;
+      case 'list':
+        // ODF nests a sublist INSIDE the parent's list-item, so depth is the
+        // recursion depth — there is no per-item level attribute. Everything
+        // lands in ONE list block: recursing into `out` instead would append
+        // the sublist as a sibling block while the parent list is still
+        // collecting items, so a sublist would render BEFORE the parent items
+        // that follow it.
+        out.push(collectList(child, listLevel));
+        break;
+      case 'table': {
+        const { rows, truncated } = rowsOfTable(child);
+        if (rows.length) out.push(table(rows, { header: true, truncatedRows: truncated || undefined }));
+        break;
+      }
+      case 'section': case 'frame': case 'text-box': case 'a':
+        walkText(child, out, listLevel);
+        break;
+      default:
+        break;
+    }
+  }
+};
+
+/**
+ * @param {Uint8Array} bytes
+ * @param {'odt'|'ods'|'odp'} format
+ * @returns {Promise<import('../model.js').Document>}
+ */
+export const parseOdf = async (bytes, format) => {
+  const index = readZipIndex(bytes);
+  const xml = await readZipText(bytes, index, 'content.xml');
+  if (!xml) throw new DocParseError('content.xml is missing — not an OpenDocument file', { format });
+
+  const doc = makeDocument({ format });
+  // meta.xml is a separate part in ODF (unlike OOXML's docProps).
+  const metaXml = await readZipText(bytes, index, 'meta.xml').catch(() => null);
+  if (metaXml) {
+    try {
+      const meta = parseXml(metaXml);
+      doc.title = find(meta, 'title') ? textOf(/** @type {any} */ (find(meta, 'title'))).trim() || null : null;
+      const creator = find(meta, 'creator');
+      if (creator) doc.meta.author = textOf(creator).trim();
+    } catch { /* metadata is a nicety */ }
+  }
+
+  const root = parseXml(xml);
+  const body = find(root, 'body');
+  if (!body) throw new DocParseError('the OpenDocument file has no body', { format });
+
+  if (format === 'ods') {
+    const sheet = find(body, 'spreadsheet') ?? body;
+    for (const tbl of elements(sheet, 'table')) {
+      const name = tbl.attrs.name ?? 'Sheet';
+      const { rows, truncated } = rowsOfTable(tbl);
+      doc.blocks.push(heading(2, name));
+      if (!rows.length) {
+        doc.blocks.push(paragraph([inline('_(empty sheet)_')]));
+        continue;
+      }
+      doc.blocks.push(table(rows, { header: true, truncatedRows: truncated || undefined }));
+    }
+  } else if (format === 'odp') {
+    const presentation = find(body, 'presentation') ?? body;
+    let number = 0;
+    for (const page of elements(presentation, 'page')) {
+      number += 1;
+      /** @type {import('../model.js').Block[]} */
+      const slide = [];
+      walkText(page, slide);
+      doc.blocks.push(heading(2, page.attrs.name ? `Slide ${number}: ${page.attrs.name}` : `Slide ${number}`));
+      doc.blocks.push(...slide);
+    }
+    doc.meta.slides = String(number);
+  } else {
+    walkText(find(body, 'text') ?? body, doc.blocks);
+  }
+
+  if (!doc.blocks.length) doc.notes.push('The document contained no readable text.');
+  return finalizeDocument(doc);
+};

--- a/extension/peerd-runtime/doc/parse/ooxml.js
+++ b/extension/peerd-runtime/doc/parse/ooxml.js
@@ -1,0 +1,96 @@
+// @ts-check
+// Pieces shared by the three OOXML walkers (docx / xlsx / pptx).
+//
+// The one genuinely shared mechanism is RELATIONSHIPS. OOXML never puts a
+// hyperlink's URL in the body markup — the body carries an opaque `r:id` and
+// the target lives in a sibling `_rels/<part>.rels` file. Resolving it is what
+// makes links survive conversion instead of becoming bare text.
+
+import { parseXml, findAll } from '../xml.js';
+import { readZipText } from '../zip.js';
+
+/**
+ * The `_rels` path for a part: `word/document.xml` → `word/_rels/document.xml.rels`.
+ * @param {string} partPath
+ */
+export const relsPathFor = (partPath) => {
+  const slash = partPath.lastIndexOf('/');
+  const dir = slash === -1 ? '' : partPath.slice(0, slash + 1);
+  const file = partPath.slice(slash + 1);
+  return `${dir}_rels/${file}.rels`;
+};
+
+/**
+ * Load a part's relationships as id → target.
+ *
+ * @param {Uint8Array} bytes
+ * @param {Map<string, import('../zip.js').ZipEntry>} index
+ * @param {string} partPath
+ * @returns {Promise<Map<string,string>>}
+ */
+export const loadRelationships = async (bytes, index, partPath) => {
+  /** @type {Map<string,string>} */
+  const rels = new Map();
+  const xml = await readZipText(bytes, index, relsPathFor(partPath)).catch(() => null);
+  if (!xml) return rels;
+  try {
+    for (const rel of findAll(parseXml(xml), 'Relationship')) {
+      const id = rel.attrs.Id ?? rel.attrs.id;
+      const target = rel.attrs.Target ?? rel.attrs.target;
+      if (id && target) rels.set(id, target);
+    }
+  } catch { /* a malformed rels part costs links, not the document */ }
+  return rels;
+};
+
+/**
+ * Document properties from `docProps/core.xml` (title/author/subject), which
+ * all three OOXML formats share. Absent in files written by non-Microsoft
+ * tools, so every field is optional.
+ *
+ * @param {Uint8Array} bytes
+ * @param {Map<string, import('../zip.js').ZipEntry>} index
+ * @returns {Promise<{ title: string|null, meta: Record<string,string> }>}
+ */
+export const loadCoreProperties = async (bytes, index) => {
+  /** @type {Record<string,string>} */
+  const meta = {};
+  let title = null;
+  const xml = await readZipText(bytes, index, 'docProps/core.xml').catch(() => null);
+  if (!xml) return { title, meta };
+  try {
+    const root = parseXml(xml);
+    /** @param {string} local */
+    const value = (local) => {
+      const node = findAll(root, local)[0];
+      if (!node) return '';
+      return node.children.filter((c) => typeof c === 'string').join('').trim();
+    };
+    title = value('title') || null;
+    for (const [key, local] of /** @type {Array<[string,string]>} */ ([
+      ['author', 'creator'], ['subject', 'subject'], ['modified', 'modified'],
+    ])) {
+      const v = value(local);
+      if (v) meta[key] = v;
+    }
+  } catch { /* metadata is a nicety */ }
+  return { title, meta };
+};
+
+/**
+ * Is this style id a heading, and at what level? Matches the built-in
+ * `Heading1`…`Heading9` and `Title`/`Subtitle` ids that every Word-family
+ * writer emits, plus the localized-with-a-digit variants (`Ttulo2`) by falling
+ * back to the trailing number.
+ *
+ * @param {string} [styleId]
+ * @returns {number}   1-6, or 0 for "not a heading"
+ */
+export const headingLevelForStyle = (styleId) => {
+  if (!styleId) return 0;
+  const id = styleId.toLowerCase();
+  if (id === 'title') return 1;
+  if (id === 'subtitle') return 2;
+  const m = /^(?:heading|hd|berschrift|titre|ttulo|kop|rubrik)[\s_-]?(\d)$/.exec(id) ?? /heading(\d)/.exec(id);
+  return m ? Math.min(6, Number.parseInt(m[1], 10)) : 0;
+};

--- a/extension/peerd-runtime/doc/parse/pptx.js
+++ b/extension/peerd-runtime/doc/parse/pptx.js
@@ -1,0 +1,146 @@
+// @ts-check
+// .pptx → Markdown (one section per slide).
+//
+// Slide XML is a drawing tree: shapes (`p:sp`) positioned on a canvas, each
+// holding a text body of paragraphs (`a:p`) of runs (`a:r`/`a:t`). There is no
+// reading order in the markup — order is GEOMETRY, which we do not reconstruct;
+// document order is the writer's shape order and is right often enough.
+//
+// The two things worth doing beyond dumping text:
+//   * TITLE detection. A shape whose placeholder type is `title`/`ctrTitle` is
+//     the slide's heading, which turns a flat text dump into an outline.
+//   * SPEAKER NOTES, from the sibling notesSlideN.xml. Notes routinely carry
+//     the actual argument while the slide carries three words, so dropping them
+//     loses most of the document's content.
+
+import { parseXml, findAll, elements, textOf, find } from '../xml.js';
+import { readZipIndex, readZipText } from '../zip.js';
+import { makeDocument, heading, paragraph, table, inline, finalizeDocument } from '../model.js';
+import { loadRelationships, loadCoreProperties } from './ooxml.js';
+import { DocParseError } from '../errors.js';
+
+/** Slide part paths in presentation order. */
+const slidePathsOf = (/** @type {Map<string,string>} */ rels, /** @type {import('../xml.js').XmlNode} */ presentation) => {
+  /** @type {string[]} */
+  const paths = [];
+  // p:sldIdLst is the authoritative ORDER; the rels map alone is unordered.
+  const list = find(presentation, 'sldIdLst');
+  for (const slideId of list ? elements(list, 'sldId') : []) {
+    const target = slideId.attrs.id ? rels.get(slideId.attrs.id) : undefined;
+    if (target) paths.push(target.startsWith('/') ? target.slice(1) : `ppt/${target.replace(/^\.\.\//, '').replace(/^\.\//, '')}`);
+  }
+  return paths;
+};
+
+/** The runs of one `a:p`, carrying bold/italic from `a:rPr`. */
+const runsOfParagraph = (/** @type {import('../xml.js').XmlNode} */ node) => {
+  /** @type {import('../model.js').Inline[]} */
+  const out = [];
+  for (const child of node.children) {
+    if (typeof child === 'string') continue;
+    if (child.local === 'br') { out.push(inline(' ')); continue; }
+    if (child.local !== 'r' && child.local !== 'fld') continue;
+    const props = find(child, 'rPr');
+    const on = (/** @type {string} */ attr) => props?.attrs[attr] === '1' || props?.attrs[attr] === 'true';
+    const text = elements(child, 't').map(textOf).join('');
+    if (text) out.push(inline(text, { bold: on('b') || undefined, italic: on('i') || undefined }));
+  }
+  return out;
+};
+
+/** Is this shape the slide's title placeholder? */
+const isTitleShape = (/** @type {import('../xml.js').XmlNode} */ shape) => {
+  const ph = find(shape, 'ph');
+  const type = ph?.attrs.type ?? '';
+  return type === 'title' || type === 'ctrTitle';
+};
+
+/**
+ * @param {string} xml
+ * @param {number} number
+ * @returns {import('../model.js').Block[]}
+ */
+export const parseSlide = (xml, number) => {
+  const root = parseXml(xml);
+  /** @type {import('../model.js').Block[]} */
+  const blocks = [];
+  /** @type {import('../model.js').Block[]} */
+  const body = [];
+  let title = '';
+
+  for (const shape of findAll(root, 'sp')) {
+    const paragraphs = findAll(shape, 'p').map(runsOfParagraph).filter((runs) => runs.some((r) => r.text.trim()));
+    if (!paragraphs.length) continue;
+    if (!title && isTitleShape(shape)) {
+      title = paragraphs.map((runs) => runs.map((r) => r.text).join('')).join(' ').trim();
+      continue;
+    }
+    for (const runs of paragraphs) body.push(paragraph(runs));
+  }
+
+  // Tables live in graphicFrames, not shapes, so they are walked separately.
+  for (const tbl of findAll(root, 'tbl')) {
+    const rows = elements(tbl, 'tr').map((tr) => elements(tr, 'tc').map((tc) => textOf(tc).trim()));
+    if (rows.length) body.push(table(rows, { header: true }));
+  }
+
+  blocks.push(heading(2, title ? `Slide ${number}: ${title}` : `Slide ${number}`));
+  blocks.push(...body);
+  return blocks;
+};
+
+/**
+ * @param {Uint8Array} bytes
+ * @returns {Promise<import('../model.js').Document>}
+ */
+export const parsePptx = async (bytes) => {
+  const index = readZipIndex(bytes);
+  const presentationXml = await readZipText(bytes, index, 'ppt/presentation.xml');
+  if (!presentationXml) throw new DocParseError('ppt/presentation.xml is missing — not a PowerPoint file', { format: 'pptx' });
+
+  const [rels, core] = await Promise.all([
+    loadRelationships(bytes, index, 'ppt/presentation.xml'),
+    loadCoreProperties(bytes, index),
+  ]);
+
+  const doc = makeDocument({ format: 'pptx', title: core.title, meta: core.meta });
+  const paths = slidePathsOf(rels, parseXml(presentationXml));
+
+  let number = 0;
+  for (const path of paths) {
+    number += 1;
+    const xml = await readZipText(bytes, index, path).catch(() => null);
+    if (!xml) { doc.notes.push(`Slide ${number} could not be read.`); continue; }
+    try {
+      doc.blocks.push(...parseSlide(xml, number));
+    } catch {
+      doc.notes.push(`Slide ${number} is malformed and was skipped.`);
+      continue;
+    }
+    // Speaker notes: reached through the SLIDE's own rels, not the deck's.
+    const slideRels = await loadRelationships(bytes, index, path);
+    const notesTarget = [...slideRels.values()].find((t) => t.includes('notesSlide'));
+    if (!notesTarget) continue;
+    const notesPath = notesTarget.startsWith('/')
+      ? notesTarget.slice(1)
+      : `ppt/slides/${notesTarget}`.replace(/\/[^/]+\/\.\.\//g, '/');
+    const notesXml = await readZipText(bytes, index, notesPath).catch(() => null);
+    if (!notesXml) continue;
+    try {
+      const text = findAll(parseXml(notesXml), 'p')
+        .map((p) => runsOfParagraph(p).map((r) => r.text).join('').trim())
+        .filter(Boolean)
+        // The notes placeholder repeats the slide number as its own shape;
+        // a bare integer line is that artifact, not content.
+        .filter((line) => !/^\d+$/.test(line));
+      if (text.length) {
+        doc.blocks.push(heading(3, 'Speaker notes'));
+        for (const line of text) doc.blocks.push(paragraph(line));
+      }
+    } catch { /* notes are a bonus */ }
+  }
+
+  if (!paths.length) doc.notes.push('The presentation contains no slides.');
+  doc.meta.slides = String(paths.length);
+  return finalizeDocument(doc);
+};

--- a/extension/peerd-runtime/doc/parse/rtf.js
+++ b/extension/peerd-runtime/doc/parse/rtf.js
@@ -1,0 +1,156 @@
+// @ts-check
+// RTF → Markdown.
+//
+// RTF is a control-word stream, not a tree, so this is a tokenizer with a
+// group stack rather than a document walker. The parts that matter for text
+// extraction and the traps in each:
+//
+//   \b \i          — character formatting, and it is GROUP-SCOPED: `{\b x} y`
+//                    leaves y unbolded. Hence the state stack.
+//   \par \line     — paragraph and line breaks.
+//   \u<N>?         — a Unicode codepoint followed by a fallback character that
+//                    must be SKIPPED, or every non-ASCII character arrives with
+//                    a `?` glued to it.
+//   \'hh           — a byte in the current codepage.
+//   \*\<dest>      — an ignorable destination (fonts, colors, stylesheets,
+//                    embedded objects). Skipping these is what separates
+//                    readable output from a wall of table definitions.
+//   \fonttbl etc.  — non-ignorable destinations that are still not prose.
+
+import { makeDocument, paragraph, heading, inline, finalizeDocument } from '../model.js';
+
+// Destinations whose contents are never body text. \pict is here because an
+// embedded image is megabytes of hex that would otherwise be emitted verbatim.
+const SKIP_DESTINATIONS = new Set([
+  'fonttbl', 'colortbl', 'stylesheet', 'listtable', 'listoverridetable',
+  'info', 'pict', 'object', 'themedata', 'colorschememapping', 'datastore',
+  'latentstyles', 'rsidtbl', 'generator', 'xmlnstbl', 'filetbl', 'revtbl',
+  'upr', 'header', 'footer', 'footnote', 'annotation',
+]);
+
+/**
+ * @param {string} source
+ * @param {{ name?: string }} [opts]
+ * @returns {import('../model.js').Document}
+ */
+export const parseRtf = (source, opts = {}) => {
+  const doc = makeDocument({ format: 'rtf', title: opts.name ?? null });
+  /** @type {Array<{ bold: boolean, italic: boolean, skip: boolean, outline: number }>} */
+  const stack = [{ bold: false, italic: false, skip: false, outline: 0 }];
+  /** @type {import('../model.js').Inline[]} */
+  let runs = [];
+  let buffer = '';
+  let state = stack[0];
+  // \uN emits a fallback the reader must swallow; \uc sets how many.
+  let skipFallback = 0;
+  let unicodeSkip = 1;
+
+  const flushRun = () => {
+    if (buffer) {
+      runs.push(inline(buffer, { bold: state.bold || undefined, italic: state.italic || undefined }));
+      buffer = '';
+    }
+  };
+  const endParagraph = () => {
+    flushRun();
+    if (runs.length) {
+      // \outlinelevelN is Word's heading marker in RTF; 0 is Heading 1.
+      doc.blocks.push(state.outline > 0 ? heading(state.outline, runs) : paragraph(runs));
+    }
+    runs = [];
+  };
+  const emit = (/** @type {string} */ text) => {
+    if (state.skip) return;
+    if (skipFallback > 0) { skipFallback -= 1; return; }
+    buffer += text;
+  };
+
+  for (let i = 0; i < source.length; i += 1) {
+    const ch = source[i];
+
+    if (ch === '{') {
+      flushRun();
+      state = { ...state };
+      stack.push(state);
+      continue;
+    }
+    if (ch === '}') {
+      flushRun();
+      stack.pop();
+      state = stack[stack.length - 1] ?? stack[0];
+      continue;
+    }
+    if (ch !== '\\') {
+      if (ch === '\r' || ch === '\n') continue;    // raw newlines are not text in RTF
+      emit(ch);
+      continue;
+    }
+
+    // --- a control sequence ---
+    const next = source[i + 1];
+    if (next === undefined) break;
+    // Escaped literals.
+    if (next === '\\' || next === '{' || next === '}') { emit(next); i += 1; continue; }
+    // \'hh — a raw byte. Decoded as latin-1: without reading \ansicpg and
+    // carrying a full codepage table, latin-1 is right for Western text and
+    // wrong-but-harmless elsewhere (\u is what modern writers emit anyway).
+    if (next === "'") {
+      const hex = source.slice(i + 2, i + 4);
+      const code = Number.parseInt(hex, 16);
+      if (Number.isFinite(code)) emit(String.fromCharCode(code));
+      i += 3;
+      continue;
+    }
+    // \* — the ignorable-destination marker: skip this whole group.
+    if (next === '*') { state.skip = true; i += 1; continue; }
+    // A control SYMBOL (non-alphabetic), e.g. `\~` (non-breaking space).
+    if (!/[a-zA-Z]/.test(next)) {
+      if (next === '~') emit(' ');
+      if (next === '-' || next === '_') emit('');
+      i += 1;
+      continue;
+    }
+
+    // A control WORD: letters, an optional signed numeric parameter, and an
+    // optional single trailing space that is part of the delimiter, not text.
+    const match = /^([a-zA-Z]+)(-?\d+)? ?/.exec(source.slice(i + 1));
+    if (!match) { i += 1; continue; }
+    const word = match[1];
+    const param = match[2] === undefined ? null : Number.parseInt(match[2], 10);
+    i += match[0].length;
+
+    if (SKIP_DESTINATIONS.has(word)) { state.skip = true; continue; }
+    if (state.skip) continue;
+
+    switch (word) {
+      case 'par': case 'sect': endParagraph(); break;
+      case 'line': flushRun(); buffer = '\n'; break;
+      case 'tab': emit('\t'); break;
+      case 'b': flushRun(); state.bold = param !== 0; break;
+      case 'i': flushRun(); state.italic = param !== 0; break;
+      case 'plain': flushRun(); state.bold = false; state.italic = false; break;
+      case 'outlinelevel': state.outline = (param ?? 0) + 1; break;
+      case 'pard': state.outline = 0; break;
+      case 'uc': unicodeSkip = param ?? 1; break;
+      case 'u': {
+        if (param === null) break;
+        // RTF writes codepoints above 32767 as a negative 16-bit value.
+        const code = param < 0 ? param + 65536 : param;
+        emit(String.fromCodePoint(code));
+        skipFallback = unicodeSkip;
+        break;
+      }
+      case 'emdash': emit('—'); break;
+      case 'endash': emit('–'); break;
+      case 'lquote': emit('‘'); break;
+      case 'rquote': emit('’'); break;
+      case 'ldblquote': emit('“'); break;
+      case 'rdblquote': emit('”'); break;
+      case 'bullet': emit('•'); break;
+      default: break;                              // every other control word is formatting we drop
+    }
+  }
+  endParagraph();
+  if (!doc.blocks.length) doc.notes.push('No readable text was found in this RTF file.');
+  return finalizeDocument(doc);
+};

--- a/extension/peerd-runtime/doc/parse/xlsx.js
+++ b/extension/peerd-runtime/doc/parse/xlsx.js
@@ -185,7 +185,11 @@ export const parseXlsx = async (bytes) => {
     // the human-readable form lives in a number FORMAT we do not read. Silently
     // rendering 45000 as a date would be a guess presented as a fact; saying so
     // lets the reader convert it deliberately.
-    doc.notes.push('Dates are stored as serial numbers in .xlsx and appear here as numbers (day count from 1899-12-30).');
+    // Hedged deliberately: whether a given 5-digit number IS a date lives in a
+    // number FORMAT we do not read, so this says what MAY be true rather than
+    // asserting it. Rendering 45000 as a date would be a guess dressed as a fact.
+    doc.notes.push('Some cells hold 5-digit numbers. If any are dates, note that .xlsx stores dates '
+      + 'as serial day counts from 1899-12-30 — the display format is not read here.');
   }
   return finalizeDocument(doc);
 };

--- a/extension/peerd-runtime/doc/parse/xlsx.js
+++ b/extension/peerd-runtime/doc/parse/xlsx.js
@@ -1,0 +1,191 @@
+// @ts-check
+// .xlsx → Markdown (one table per sheet).
+//
+// The parts:
+//   xl/workbook.xml            — sheet names, in tab order
+//   xl/_rels/workbook.xml.rels — sheet name → worksheet part path
+//   xl/sharedStrings.xml       — the string pool
+//   xl/worksheets/sheetN.xml   — the cells
+//
+// Three things a naive reader gets wrong, all of which silently corrupt the
+// grid rather than failing:
+//
+//   * Cells are SPARSE. An empty cell is simply absent, so reading cells in
+//     document order shifts every value left. The cell's `r` ("C7") is the
+//     authority for its column, not its position among its siblings.
+//   * Strings are POOLED. `t="s"` means the value is an INDEX into
+//     sharedStrings, so an unresolved pool renders a spreadsheet of integers.
+//   * Formula cells carry both the formula and its last cached result. The
+//     cached value is what the user sees, so that is what we read.
+
+import { parseXml, findAll, elements, textOf, find } from '../xml.js';
+import { readZipIndex, readZipText } from '../zip.js';
+import { makeDocument, heading, table, finalizeDocument } from '../model.js';
+import { loadRelationships, loadCoreProperties } from './ooxml.js';
+import { DocParseError } from '../errors.js';
+
+const MAX_ROWS_PER_SHEET = 500;
+const MAX_COLUMNS = 64;
+
+/**
+ * Column index from a cell reference: A→0, Z→25, AA→26. Base-26 with no zero
+ * digit, so it is not quite positional arithmetic.
+ * @param {string} ref
+ */
+export const columnIndex = (ref) => {
+  let n = 0;
+  for (const ch of ref) {
+    const code = ch.charCodeAt(0);
+    if (code < 65 || code > 90) break;             // hit the row digits
+    n = n * 26 + (code - 64);
+  }
+  return n - 1;
+};
+
+/**
+ * The shared string pool. Each `si` may be a single `t`, or a set of styled
+ * runs (`r`) that concatenate into one string.
+ * @param {string|null} xml
+ * @returns {string[]}
+ */
+export const parseSharedStrings = (xml) => {
+  if (!xml) return [];
+  try {
+    return findAll(parseXml(xml), 'si').map((si) => {
+      const runs = elements(si, 'r');
+      if (runs.length) return runs.map((r) => elements(r, 't').map(textOf).join('')).join('');
+      return elements(si, 't').map(textOf).join('');
+    });
+  } catch { return []; }
+};
+
+/**
+ * One worksheet's cells as a dense grid.
+ *
+ * @param {string} xml
+ * @param {string[]} strings
+ * @returns {{ rows: string[][], totalRows: number, truncatedColumns: boolean }}
+ */
+export const parseSheet = (xml, strings) => {
+  const root = parseXml(xml);
+  const sheetData = find(root, 'sheetData');
+  /** @type {string[][]} */
+  const rows = [];
+  let totalRows = 0;
+  let truncatedColumns = false;
+  if (!sheetData) return { rows, totalRows, truncatedColumns };
+
+  for (const row of elements(sheetData, 'row')) {
+    totalRows += 1;
+    if (rows.length >= MAX_ROWS_PER_SHEET) continue;   // keep counting for the honest "N more rows"
+    /** @type {string[]} */
+    const cells = [];
+    for (const cell of elements(row, 'c')) {
+      const at = cell.attrs.r ? columnIndex(cell.attrs.r) : cells.length;
+      if (at >= MAX_COLUMNS) { truncatedColumns = true; continue; }
+      const type = cell.attrs.t;
+      let value = '';
+      if (type === 'inlineStr') {
+        value = elements(find(cell, 'is') ?? cell, 't').map(textOf).join('') || textOf(find(cell, 'is') ?? cell);
+      } else {
+        const v = find(cell, 'v');
+        const raw = v ? textOf(v) : '';
+        if (type === 's') {
+          const idx = Number.parseInt(raw, 10);
+          value = Number.isInteger(idx) ? (strings[idx] ?? '') : '';
+        } else if (type === 'b') {
+          value = raw === '1' ? 'TRUE' : 'FALSE';
+        } else if (type === 'e') {
+          value = raw;                                  // an error literal: #REF!, #DIV/0!
+        } else {
+          // Numeric (or a date, which Excel stores as a number plus a display
+          // format we do not read — see the note the parser attaches).
+          value = raw;
+        }
+      }
+      // Pad the gap left by absent cells so the column position is preserved.
+      while (cells.length < at) cells.push('');
+      cells[at] = value;
+    }
+    rows.push(cells);
+  }
+  return { rows, totalRows, truncatedColumns };
+};
+
+/** Trim wholly-empty trailing rows and columns — sheets are padded with them. */
+const trimGrid = (/** @type {string[][]} */ rows) => {
+  const out = rows.slice();
+  while (out.length && out[out.length - 1].every((c) => !c.trim())) out.pop();
+  const width = out.reduce((n, r) => Math.max(n, r.length), 0);
+  let last = -1;
+  for (let col = 0; col < width; col += 1) {
+    if (out.some((r) => (r[col] ?? '').trim())) last = col;
+  }
+  return out.map((r) => Array.from({ length: last + 1 }, (_, i) => r[i] ?? ''));
+};
+
+/**
+ * @param {Uint8Array} bytes
+ * @returns {Promise<import('../model.js').Document>}
+ */
+export const parseXlsx = async (bytes) => {
+  const index = readZipIndex(bytes);
+  const workbookXml = await readZipText(bytes, index, 'xl/workbook.xml');
+  if (!workbookXml) throw new DocParseError('xl/workbook.xml is missing — not an Excel workbook', { format: 'xlsx' });
+
+  const [rels, strings, core] = await Promise.all([
+    loadRelationships(bytes, index, 'xl/workbook.xml'),
+    readZipText(bytes, index, 'xl/sharedStrings.xml').catch(() => null).then(parseSharedStrings),
+    loadCoreProperties(bytes, index),
+  ]);
+
+  const doc = makeDocument({ format: 'xlsx', title: core.title, meta: core.meta });
+  const sheets = findAll(parseXml(workbookXml), 'sheet');
+  let anyDates = false;
+
+  for (const sheet of sheets) {
+    const name = sheet.attrs.name ?? 'Sheet';
+    // A hidden sheet is hidden from the USER, so reading it would report data
+    // the document does not present. Skipped, and counted in the notes.
+    if (sheet.attrs.state === 'hidden' || sheet.attrs.state === 'veryHidden') {
+      doc.notes.push(`Sheet "${name}" is hidden and was not read.`);
+      continue;
+    }
+    const relId = sheet.attrs.id;
+    const target = relId ? rels.get(relId) : undefined;
+    // Rel targets are relative to the part's directory (xl/), and some writers
+    // emit them absolute (/xl/worksheets/...).
+    const path = target
+      ? (target.startsWith('/') ? target.slice(1) : `xl/${target.replace(/^\.\//, '')}`)
+      : '';
+    const sheetXml = path ? await readZipText(bytes, index, path).catch(() => null) : null;
+    if (!sheetXml) {
+      doc.notes.push(`Sheet "${name}" could not be read.`);
+      continue;
+    }
+    let parsed;
+    try { parsed = parseSheet(sheetXml, strings); }
+    catch { doc.notes.push(`Sheet "${name}" is malformed and was skipped.`); continue; }
+
+    const rows = trimGrid(parsed.rows);
+    doc.blocks.push(heading(2, name));
+    if (!rows.length) {
+      doc.blocks.push({ type: 'paragraph', inlines: [{ text: '_(empty sheet)_' }] });
+      continue;
+    }
+    if (rows.some((r) => r.some((c) => /^\d{5}(\.\d+)?$/.test(c)))) anyDates = true;
+    const dropped = parsed.totalRows - rows.length;
+    doc.blocks.push(table(rows, { header: true, truncatedRows: dropped > 0 ? dropped : undefined }));
+    if (parsed.truncatedColumns) doc.notes.push(`Sheet "${name}" has more than ${MAX_COLUMNS} columns; the rest were omitted.`);
+  }
+
+  if (!sheets.length) doc.notes.push('The workbook contains no sheets.');
+  if (anyDates) {
+    // why say this rather than guess: Excel stores a date as a day count and
+    // the human-readable form lives in a number FORMAT we do not read. Silently
+    // rendering 45000 as a date would be a guess presented as a fact; saying so
+    // lets the reader convert it deliberately.
+    doc.notes.push('Dates are stored as serial numbers in .xlsx and appear here as numbers (day count from 1899-12-30).');
+  }
+  return finalizeDocument(doc);
+};

--- a/extension/peerd-runtime/doc/sniff.js
+++ b/extension/peerd-runtime/doc/sniff.js
@@ -1,0 +1,251 @@
+// @ts-check
+// Format detection — CONTENT first, name second.
+//
+// why content-first (the anydoc posture): the three signals disagree constantly
+// in the wild. A .docx served as application/octet-stream, a "report.pdf" link
+// that 200s to an HTML login page, a CSV export with no extension at all — the
+// bytes are the only one of the three that cannot lie. So the magic number
+// decides, and the filename/content-type are consulted only where the bytes are
+// genuinely ambiguous (every OOXML/ODF/EPUB file is a ZIP, and text formats have
+// no magic number at all).
+//
+// Pure: bytes in, a format tag out. No IO, no globals — bun-testable.
+
+/**
+ * @typedef {'docx'|'xlsx'|'pptx'|'odt'|'ods'|'odp'|'epub'|'rtf'|'csv'|'tsv'|'pdf'
+ *           |'ole2'|'xlsb'|'html'|'text'|'zip'|'unknown'} DocFormat
+ */
+
+/** Formats this reader converts to Markdown itself. */
+export const CONVERTIBLE = /** @type {const} */ ([
+  'docx', 'xlsx', 'pptx', 'odt', 'ods', 'odp', 'epub', 'rtf', 'csv', 'tsv',
+]);
+
+/**
+ * Recognized-but-not-convertible-here: the pre-2007 OLE2 compound binaries and
+ * the binary workbook. Real parsers for these are a CFB reader plus per-app
+ * record decoders — thousands of lines for formats that are ~all legacy. The
+ * WebVM (a real Linux) is the honest escape hatch, so we name the format
+ * precisely and hand the agent that route rather than pretending.
+ */
+export const LEGACY = /** @type {const} */ (['ole2', 'xlsb']);
+
+const ascii = (/** @type {Uint8Array} */ b, /** @type {number} */ off, /** @type {number} */ len) => {
+  let s = '';
+  for (let i = 0; i < len && off + i < b.length; i += 1) s += String.fromCharCode(b[off + i]);
+  return s;
+};
+
+/** @param {Uint8Array} bytes @param {number[]} sig @param {number} [off] */
+const startsWith = (bytes, sig, off = 0) => sig.every((byte, i) => bytes[off + i] === byte);
+
+// Extension → format, for the ambiguous cases only. Kept beside the sniffer
+// because it is the SECOND opinion, never the first.
+const BY_EXTENSION = /** @type {Record<string, DocFormat>} */ ({
+  docx: 'docx', docm: 'docx', dotx: 'docx',
+  xlsx: 'xlsx', xlsm: 'xlsx', xltx: 'xlsx',
+  pptx: 'pptx', pptm: 'pptx', potx: 'pptx', ppsx: 'pptx',
+  odt: 'odt', ott: 'odt',
+  ods: 'ods', ots: 'ods',
+  odp: 'odp', otp: 'odp',
+  epub: 'epub', rtf: 'rtf', csv: 'csv', tsv: 'tsv', tab: 'tsv',
+  pdf: 'pdf', xlsb: 'xlsb',
+  doc: 'ole2', xls: 'ole2', ppt: 'ole2',
+});
+
+const BY_MIME = /** @type {Array<[RegExp, DocFormat]>} */ ([
+  [/wordprocessingml\.document|msword.*openxml/i, 'docx'],
+  [/spreadsheetml\.sheet/i, 'xlsx'],
+  [/presentationml\.presentation/i, 'pptx'],
+  [/opendocument\.text/i, 'odt'],
+  [/opendocument\.spreadsheet/i, 'ods'],
+  [/opendocument\.presentation/i, 'odp'],
+  [/epub\+zip/i, 'epub'],
+  [/application\/rtf|text\/rtf/i, 'rtf'],
+  [/text\/csv/i, 'csv'],
+  [/text\/tab-separated/i, 'tsv'],
+  [/application\/pdf/i, 'pdf'],
+  [/ms-excel\.sheet\.binary/i, 'xlsb'],
+  [/application\/msword|ms-excel|ms-powerpoint/i, 'ole2'],
+]);
+
+/**
+ * The extension of a URL's path, lowercased, or ''. Query strings and
+ * fragments are stripped first — `?download=1` is not an extension.
+ * @param {string} [nameOrUrl]
+ */
+export const extensionOf = (nameOrUrl) => {
+  if (typeof nameOrUrl !== 'string' || !nameOrUrl) return '';
+  const path = nameOrUrl.split(/[?#]/, 1)[0];
+  const base = path.slice(path.lastIndexOf('/') + 1);
+  const dot = base.lastIndexOf('.');
+  return dot > 0 ? base.slice(dot + 1).toLowerCase() : '';
+};
+
+/**
+ * Which OOXML/ODF/EPUB flavor is this ZIP? Every one of them is a ZIP, so the
+ * container magic gets us only as far as "a zip"; the flavor lives in a member
+ * name. Cheap and allocation-free: we scan the raw bytes for the marker names
+ * rather than inflating the archive, because at this point we have not even
+ * decided the file is a document.
+ *
+ * ODF and EPUB both declare themselves properly — an uncompressed `mimetype`
+ * member stored FIRST, by spec, so its value sits in plain sight near byte 38.
+ * OOXML does not, so we look for the part paths its central directory must
+ * contain.
+ *
+ * @param {Uint8Array} bytes
+ * @returns {DocFormat}
+ */
+export const sniffZipFlavor = (bytes) => {
+  // Everything below searches the buffer as latin-1 rather than seeking to
+  // byte offsets. why: member names and the ODF/EPUB media type are ASCII and
+  // appear verbatim (local headers and the central directory are never
+  // compressed), whereas OFFSETS shift the moment the caller hands us a head
+  // that has been through a lossy decode — which is exactly what fetch_url has.
+  const flat = ascii(bytes, 0, bytes.length);
+  // ODF and EPUB declare themselves in a `mimetype` member the spec requires be
+  // STORED, so the media type sits in the archive as plain text.
+  if (flat.includes('mimetype')) {
+    if (flat.includes('application/epub+zip')) return 'epub';
+    if (flat.includes('application/vnd.oasis.opendocument.text')) return 'odt';
+    if (flat.includes('application/vnd.oasis.opendocument.spreadsheet')) return 'ods';
+    if (flat.includes('application/vnd.oasis.opendocument.presentation')) return 'odp';
+  }
+  // OOXML has no mimetype member, so identify by the part paths it must carry.
+  if (flat.includes('word/document.xml')) return 'docx';
+  if (flat.includes('xl/workbook.xml')) return 'xlsx';
+  if (flat.includes('ppt/presentation.xml')) return 'pptx';
+  // An EPUB whose mimetype member was (wrongly) deflated still has this.
+  if (flat.includes('META-INF/container.xml')) return 'epub';
+  return 'zip';
+};
+
+/**
+ * Does this text look like delimiter-separated values? Only asked of bytes
+ * that are already known to be plain text with no magic number, and only to
+ * separate "a table" from "prose in a .txt". Conservative on purpose: a false
+ * positive renders someone's log file as a mangled Markdown table.
+ *
+ * @param {string} text
+ * @returns {'csv'|'tsv'|null}
+ */
+export const sniffDelimited = (text) => {
+  const lines = text.split(/\r?\n/).filter((l) => l.trim()).slice(0, 20);
+  if (lines.length < 2) return null;
+  for (const [delimiter, format] of /** @type {Array<[string, 'csv'|'tsv']>} */ ([['\t', 'tsv'], [',', 'csv']])) {
+    const counts = lines.map((l) => l.split(delimiter).length - 1);
+    // Every line must carry the delimiter, and the column count must be stable
+    // — that consistency is what distinguishes a table from prose containing
+    // commas. (Quoted fields can hold a delimiter, so allow a ±1 wobble.)
+    if (counts.some((c) => c < 1)) continue;
+    const first = counts[0];
+    if (counts.every((c) => Math.abs(c - first) <= 1)) return format;
+  }
+  return null;
+};
+
+/**
+ * Identify a document from its bytes, with the filename/URL and content-type
+ * as tiebreakers. Returns the format plus HOW it was decided, because the tool
+ * surfaces that: "I read this as .xlsx because the bytes said so" is a very
+ * different claim from "because the URL ended in .xlsx".
+ *
+ * @param {Uint8Array} bytes
+ * @param {{ name?: string, contentType?: string }} [hints]
+ * @returns {{ format: DocFormat, via: 'magic'|'zip-member'|'extension'|'content-type'|'heuristic'|'none' }}
+ */
+export const sniffDocFormat = (bytes, hints = {}) => {
+  const ext = extensionOf(hints.name);
+  const ct = (hints.contentType ?? '').toLowerCase();
+
+  if (bytes && bytes.length >= 4) {
+    // Unambiguous magic numbers first.
+    if (startsWith(bytes, [0x25, 0x50, 0x44, 0x46])) return { format: 'pdf', via: 'magic' };        // %PDF
+    if (startsWith(bytes, [0x7b, 0x5c, 0x72, 0x74])) return { format: 'rtf', via: 'magic' };        // {\rt(f)
+    // OLE2 / CFB compound file: .doc, .xls, .ppt — and, confusingly, some
+    // encrypted OOXML. Either way we cannot open it here.
+    if (startsWith(bytes, [0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1])) {
+      // The extension is the only hint about WHICH legacy app wrote it; it
+      // does not change the outcome, only the message.
+      return { format: 'ole2', via: 'magic' };
+    }
+    // ZIP: PK\x03\x04 (normal) or PK\x05\x06 (empty archive).
+    if (startsWith(bytes, [0x50, 0x4b]) && (bytes[2] === 3 || bytes[2] === 5 || bytes[2] === 7)) {
+      const flavor = sniffZipFlavor(bytes);
+      if (flavor !== 'zip') return { format: flavor, via: 'zip-member' };
+      // A plain ZIP whose members we could not identify — .xlsb is a ZIP too
+      // (binary parts inside), so let the name break the tie.
+      if (ext === 'xlsb') return { format: 'xlsb', via: 'extension' };
+      const named = BY_EXTENSION[ext];
+      if (named && named !== 'ole2') return { format: named, via: 'extension' };
+      return { format: 'zip', via: 'magic' };
+    }
+  }
+
+  // No magic number: text-ish formats. Decode a leading slice to look at.
+  const head = new TextDecoder('utf-8', { fatal: false }).decode((bytes ?? new Uint8Array()).slice(0, 8192));
+  if (/^\s*(<!doctype html|<html[\s>])/i.test(head)) return { format: 'html', via: 'magic' };
+
+  for (const [re, format] of BY_MIME) {
+    if (re.test(ct)) return { format, via: 'content-type' };
+  }
+  const named = BY_EXTENSION[ext];
+  if (named) return { format: named, via: 'extension' };
+
+  const delimited = sniffDelimited(head);
+  if (delimited) return { format: delimited, via: 'heuristic' };
+
+  if (bytes?.length) {
+    // A NUL byte in the first 8k is the classic "this is binary" tell.
+    if (bytes.slice(0, 8192).includes(0)) return { format: 'unknown', via: 'none' };
+    return { format: 'text', via: 'heuristic' };
+  }
+  return { format: 'unknown', via: 'none' };
+};
+
+/**
+ * Does this HTTP response look like a document FILE rather than a web page?
+ *
+ * why this exists separately from sniffDocFormat: fetch_url never holds bytes
+ * — its primitive decodes every response with `Response.text()` — so by the
+ * time it could ask, a .docx is already a string of mojibake. This works on
+ * what fetch_url actually has: the content-type, the URL, and the decoded
+ * head. That is enough, because the ZIP/PDF/RTF signatures are ASCII and
+ * survive a UTF-8 decode intact.
+ *
+ * Returns the format plus the tool that WILL read it, so the caller can hand
+ * the agent a route instead of 16k characters of garbage.
+ *
+ * @param {{ contentType?: string, url?: string, bodyHead?: string }} input
+ * @returns {{ format: DocFormat, tool: 'read_doc'|'read_pdf' } | null}
+ */
+export const sniffResponseAsDocument = ({ contentType = '', url = '', bodyHead = '' }) => {
+  // Signatures first — they beat a wrong content-type, which is the common case
+  // (S3 and most CDNs serve application/octet-stream for everything).
+  if (bodyHead.startsWith('%PDF')) return { format: 'pdf', tool: 'read_pdf' };
+  if (bodyHead.startsWith('{\\rt')) return { format: 'rtf', tool: 'read_doc' };
+  if (bodyHead.startsWith('PK')) {
+    // A ZIP. Only claim it when we can say WHICH document it is — a plain
+    // .zip download is not something read_doc can open either.
+    const flavor = sniffZipFlavor(new TextEncoder().encode(bodyHead.slice(0, 4096)));
+    if (flavor !== 'zip') return { format: flavor, tool: 'read_doc' };
+    const named = BY_EXTENSION[extensionOf(url)];
+    return named && isConvertible(named) ? { format: named, tool: 'read_doc' } : null;
+  }
+  // No signature in the head: fall back to the declared type, then the name.
+  // CSV/TSV are deliberately NOT included — they decode to perfectly readable
+  // text, so fetch_url's own output is fine and a redirect would be noise.
+  for (const [re, format] of BY_MIME) {
+    if (!re.test(contentType.toLowerCase())) continue;
+    if (format === 'pdf') return { format, tool: 'read_pdf' };
+    if (isConvertible(format) && format !== 'csv' && format !== 'tsv') return { format, tool: 'read_doc' };
+  }
+  return null;
+};
+
+/** @param {DocFormat} format */
+export const isConvertible = (format) => /** @type {readonly string[]} */ (CONVERTIBLE).includes(format);
+
+/** @param {DocFormat} format */
+export const isLegacyBinary = (format) => /** @type {readonly string[]} */ (LEGACY).includes(format);

--- a/extension/peerd-runtime/doc/xml.js
+++ b/extension/peerd-runtime/doc/xml.js
@@ -1,0 +1,184 @@
+// @ts-check
+// A small, pure XML reader for OOXML / ODF / EPUB parts.
+//
+// why not DOMParser: the conversion core must stay PURE so it is bun-testable
+// and runnable in ANY context (SW, worker, offscreen) — DOMParser exists in
+// only some of those and in none of Bun. This is ~120 lines against the
+// machine-generated XML that office writers emit, not a general XML processor:
+// no DTDs, no entity declarations, no namespace resolution.
+//
+// NAMESPACES are handled by ignoring prefixes and matching LOCAL names. Office
+// writers are inconsistent about prefixes (`w:p` vs `ns0:p` after a round-trip
+// through a converter), and no office part meaningfully reuses a local name
+// across two namespaces in a way that would confuse a text extraction. Matching
+// locally is both simpler and more robust than resolving xmlns declarations.
+
+import { DocParseError } from './errors.js';
+
+/** @typedef {{ name: string, local: string, attrs: Record<string,string>, children: Array<XmlNode|string> }} XmlNode */
+
+const ENTITIES = /** @type {Record<string,string>} */ ({
+  amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ',
+});
+
+/** Expand the XML entity set plus numeric character references. */
+export const decodeEntities = (/** @type {string} */ text) => (
+  text.includes('&')
+    ? text.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]*);/g, (whole, body) => {
+      if (body[0] === '#') {
+        const code = body[1] === 'x' || body[1] === 'X'
+          ? Number.parseInt(body.slice(2), 16)
+          : Number.parseInt(body.slice(1), 10);
+        // Reject out-of-range / lone-surrogate references rather than
+        // emitting a replacement char that would corrupt the text.
+        return Number.isFinite(code) && code > 0 && code <= 0x10ffff && !(code >= 0xd800 && code <= 0xdfff)
+          ? String.fromCodePoint(code) : whole;
+      }
+      return ENTITIES[body] ?? whole;
+    })
+    : text
+);
+
+/** Local name of a possibly-prefixed tag: `w:tbl` → `tbl`. */
+export const localName = (/** @type {string} */ name) => {
+  const colon = name.indexOf(':');
+  return colon === -1 ? name : name.slice(colon + 1);
+};
+
+const ATTR_RE = /([^\s=/>]+)\s*=\s*("([^"]*)"|'([^']*)')/g;
+
+/** @param {string} source @returns {Record<string,string>} */
+const parseAttrs = (source) => {
+  /** @type {Record<string,string>} */
+  const attrs = {};
+  if (!source || !source.includes('=')) return attrs;
+  ATTR_RE.lastIndex = 0;
+  let m;
+  while ((m = ATTR_RE.exec(source)) !== null) {
+    attrs[localName(m[1])] = decodeEntities(m[3] ?? m[4] ?? '');
+  }
+  return attrs;
+};
+
+/**
+ * Parse an XML document into a tree. Whitespace-only text nodes are kept —
+ * `<w:t xml:space="preserve"> </w:t>` is a real space between two words, and
+ * dropping it runs sentences together.
+ *
+ * @param {string} text
+ * @returns {XmlNode}
+ */
+export const parseXml = (text) => {
+  if (typeof text !== 'string' || !text.trim()) throw new DocParseError('empty XML part');
+  /** @type {XmlNode} */
+  const root = { name: '#document', local: '#document', attrs: {}, children: [] };
+  /** @type {XmlNode[]} */
+  const stack = [root];
+  let i = 0;
+
+  while (i < text.length) {
+    const lt = text.indexOf('<', i);
+    if (lt === -1) {
+      const tail = text.slice(i);
+      if (tail) stack[stack.length - 1].children.push(decodeEntities(tail));
+      break;
+    }
+    if (lt > i) stack[stack.length - 1].children.push(decodeEntities(text.slice(i, lt)));
+
+    // CDATA is verbatim text — no entity expansion inside it.
+    if (text.startsWith('<![CDATA[', lt)) {
+      const end = text.indexOf(']]>', lt);
+      const stop = end === -1 ? text.length : end;
+      stack[stack.length - 1].children.push(text.slice(lt + 9, stop));
+      i = end === -1 ? text.length : end + 3;
+      continue;
+    }
+    // Comments, declarations, doctypes, processing instructions — skipped.
+    if (text.startsWith('<!--', lt)) {
+      const end = text.indexOf('-->', lt);
+      i = end === -1 ? text.length : end + 3;
+      continue;
+    }
+    if (text.startsWith('<?', lt) || text.startsWith('<!', lt)) {
+      const end = text.indexOf('>', lt);
+      i = end === -1 ? text.length : end + 1;
+      continue;
+    }
+
+    const gt = text.indexOf('>', lt);
+    if (gt === -1) break;                       // truncated tag — stop cleanly
+    const inner = text.slice(lt + 1, gt);
+
+    if (inner[0] === '/') {
+      const name = inner.slice(1).trim();
+      // Pop to the matching open tag. Office XML is well-formed, but a
+      // truncated part can leave a stray close; popping only when a match
+      // exists keeps one bad tag from collapsing the whole tree.
+      const depth = stack.findLastIndex((n) => n.name === name);
+      if (depth > 0) stack.length = depth;
+      i = gt + 1;
+      continue;
+    }
+
+    const selfClosing = inner.endsWith('/');
+    const body = selfClosing ? inner.slice(0, -1) : inner;
+    const space = body.search(/[\s]/);
+    const name = (space === -1 ? body : body.slice(0, space)).trim();
+    if (!name) { i = gt + 1; continue; }
+    /** @type {XmlNode} */
+    const node = {
+      name,
+      local: localName(name),
+      attrs: space === -1 ? {} : parseAttrs(body.slice(space)),
+      children: [],
+    };
+    stack[stack.length - 1].children.push(node);
+    if (!selfClosing) stack.push(node);
+    i = gt + 1;
+  }
+  return root;
+};
+
+/** Direct element children with the given local name. */
+export const elements = (/** @type {XmlNode} */ node, /** @type {string} */ local) => (
+  /** @type {XmlNode[]} */ (node.children.filter((c) => typeof c === 'object' && c.local === local))
+);
+
+/**
+ * The first descendant (depth-first) with the given local name, or null.
+ * @param {XmlNode} node @param {string} local @returns {XmlNode | null}
+ */
+export const find = (node, local) => {
+  for (const child of node.children) {
+    if (typeof child === 'string') continue;
+    if (child.local === local) return child;
+    const deeper = find(child, local);
+    if (deeper) return deeper;
+  }
+  return null;
+};
+
+/**
+ * Every descendant with the given local name, depth-first. Does NOT descend
+ * into a match (callers walk matched subtrees themselves), which is what makes
+ * nested-table extraction terminate sensibly.
+ * @param {XmlNode} node @param {string} local @returns {XmlNode[]}
+ */
+export const findAll = (node, local) => {
+  /** @type {XmlNode[]} */
+  const out = [];
+  for (const child of node.children) {
+    if (typeof child === 'string') continue;
+    if (child.local === local) out.push(child);
+    else out.push(...findAll(child, local));
+  }
+  return out;
+};
+
+/** Concatenated text of a subtree. */
+export const textOf = (/** @type {XmlNode|string} */ node) => {
+  if (typeof node === 'string') return node;
+  let out = '';
+  for (const child of node.children) out += textOf(child);
+  return out;
+};

--- a/extension/peerd-runtime/doc/zip.js
+++ b/extension/peerd-runtime/doc/zip.js
@@ -1,0 +1,209 @@
+// @ts-check
+// A minimal ZIP reader — the container every modern office format is built on.
+//
+// why hand-rolled and not vendored: the only thing hard about ZIP is DEFLATE,
+// and the platform ships that as `DecompressionStream('deflate-raw')`. What is
+// left is parsing a well-specified directory structure — ~150 lines with no
+// dependency, no build step, and no third-party bytes to audit. Vendoring a
+// zip library to avoid this would trade an auditable 150 lines for tens of
+// thousands.
+//
+// Read from the CENTRAL DIRECTORY, never by scanning local headers: a local
+// header may carry zeroed sizes with the real values in a trailing data
+// descriptor (streamed archives do this routinely), so local-header scanning
+// silently truncates entries. The central directory is authoritative.
+//
+// Pure apart from DecompressionStream (a platform primitive available in the
+// SW, workers, the offscreen doc, and Bun) — so this is bun-testable.
+
+import { ZipError } from './errors.js';
+
+const SIG_EOCD = 0x06054b50;         // End Of Central Directory
+const SIG_EOCD64_LOCATOR = 0x07064b50;
+const SIG_EOCD64 = 0x06064b50;
+const SIG_CENTRAL = 0x02014b50;
+const SIG_LOCAL = 0x04034b50;
+
+// Ceiling on a SINGLE inflated member. Generous against real documents — the
+// body part of a 500-page Word file is a few MB of XML — and the backstop
+// against a decompression bomb (see readZipEntry).
+export const MAX_ENTRY_BYTES = 128 * 1024 * 1024;
+
+/** @typedef {{ name: string, compression: number, compressedSize: number, size: number, offset: number }} ZipEntry */
+
+/**
+ * Find the End Of Central Directory record. It sits at the very end of the
+ * file unless a ZIP comment follows it, so scan backwards over the maximum
+ * comment length (64k) rather than assuming the last 22 bytes.
+ * @param {DataView} view
+ */
+const findEocd = (view) => {
+  const min = Math.max(0, view.byteLength - 0xffff - 22);
+  for (let i = view.byteLength - 22; i >= min; i -= 1) {
+    if (view.getUint32(i, true) === SIG_EOCD) return i;
+  }
+  throw new ZipError('not a ZIP archive (no end-of-central-directory record)');
+};
+
+/**
+ * Locate the central directory, transparently handling ZIP64. The classic
+ * EOCD stores 32-bit offsets; an archive over 4GB (or with >65535 members)
+ * writes 0xffffffff there and puts the real values in a ZIP64 record. We are
+ * unlikely to meet one in a .docx, but a wrong answer here reads as a corrupt
+ * archive rather than as "too big", so it is worth the dozen lines.
+ * @param {DataView} view
+ * @param {number} eocd
+ */
+const centralDirectoryAt = (view, eocd) => {
+  let count = view.getUint16(eocd + 10, true);
+  let offset = view.getUint32(eocd + 16, true);
+  if (offset !== 0xffffffff && count !== 0xffff) return { count, offset };
+
+  // ZIP64: a locator sits immediately before the EOCD and points at the
+  // ZIP64 EOCD, which holds the widened values.
+  const locator = eocd - 20;
+  if (locator < 0 || view.getUint32(locator, true) !== SIG_EOCD64_LOCATOR) {
+    throw new ZipError('ZIP64 archive with no ZIP64 locator');
+  }
+  const z64 = Number(view.getBigUint64(locator + 8, true));
+  if (view.getUint32(z64, true) !== SIG_EOCD64) throw new ZipError('malformed ZIP64 end-of-central-directory');
+  count = Number(view.getBigUint64(z64 + 32, true));
+  offset = Number(view.getBigUint64(z64 + 48, true));
+  return { count, offset };
+};
+
+/**
+ * Read a ZIP's central directory into an entry index. Nothing is decompressed
+ * here — that is per-entry and lazy, because a .docx carries dozens of parts
+ * (fonts, images, theme XML) of which a text conversion reads two or three.
+ *
+ * @param {Uint8Array} bytes
+ * @returns {Map<string, ZipEntry>}
+ */
+export const readZipIndex = (bytes) => {
+  if (!bytes || bytes.length < 22) throw new ZipError('file too small to be a ZIP archive');
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const { count, offset } = centralDirectoryAt(view, findEocd(view));
+
+  /** @type {Map<string, ZipEntry>} */
+  const entries = new Map();
+  const decoder = new TextDecoder('utf-8', { fatal: false });
+  let p = offset;
+  for (let i = 0; i < count; i += 1) {
+    if (p + 46 > bytes.length || view.getUint32(p, true) !== SIG_CENTRAL) {
+      // A truncated or lied-about directory: keep what we already indexed
+      // rather than failing the whole read. A .docx missing its last font
+      // part still converts perfectly.
+      break;
+    }
+    const flags = view.getUint16(p + 8, true);
+    const compression = view.getUint16(p + 10, true);
+    const compressedSize = view.getUint32(p + 20, true);
+    const size = view.getUint32(p + 24, true);
+    const nameLen = view.getUint16(p + 28, true);
+    const extraLen = view.getUint16(p + 30, true);
+    const commentLen = view.getUint16(p + 32, true);
+    const localOffset = view.getUint32(p + 42, true);
+    const name = decoder.decode(bytes.subarray(p + 46, p + 46 + nameLen));
+    // Bit 0 = encrypted. Refuse loudly: a password-protected document is a
+    // "you need the password" answer, not a parse failure.
+    if (flags & 0x1) throw new ZipError(`encrypted archive member: ${name}`);
+    entries.set(name, { name, compression, compressedSize, size, offset: localOffset });
+    p += 46 + nameLen + extraLen + commentLen;
+  }
+  if (!entries.size) throw new ZipError('ZIP archive contains no readable entries');
+  return entries;
+};
+
+/**
+ * Decompress one member. Only STORE (0) and DEFLATE (8) are supported —
+ * together they cover every OOXML/ODF/EPUB writer in practice; the exotic
+ * methods (bzip2, LZMA, zstd) are refused by name so the failure is legible.
+ *
+ * @param {Uint8Array} bytes   the whole archive
+ * @param {ZipEntry} entry
+ * @returns {Promise<Uint8Array>}
+ */
+export const readZipEntry = async (bytes, entry) => {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  if (entry.offset + 30 > bytes.length || view.getUint32(entry.offset, true) !== SIG_LOCAL) {
+    throw new ZipError(`bad local header for ${entry.name}`);
+  }
+  // The local header's own name/extra lengths are the authority for where the
+  // data starts — they legitimately differ from the central directory's.
+  const nameLen = view.getUint16(entry.offset + 26, true);
+  const extraLen = view.getUint16(entry.offset + 28, true);
+  const start = entry.offset + 30 + nameLen + extraLen;
+  const raw = bytes.subarray(start, start + entry.compressedSize);
+
+  if (entry.compression === 0) return raw;
+  if (entry.compression !== 8) {
+    throw new ZipError(`unsupported compression method ${entry.compression} for ${entry.name}`);
+  }
+  // DECOMPRESSION BOMB guard, and it is not theoretical: DEFLATE reaches ~1000:1
+  // on repetitive input, so a 1MB member inside an innocuous-looking .docx can
+  // inflate to a gigabyte and take the offscreen document (and the extension's
+  // renderer process) with it. The header's declared size is checked FIRST —
+  // free, and it catches the honest case — but a bomb can lie there, so the
+  // stream is also read incrementally and aborted the moment it exceeds the cap.
+  // why not trust the fetch-side MAX_BYTES: that bounds the COMPRESSED input,
+  // which is exactly what a bomb keeps small.
+  if (entry.size > MAX_ENTRY_BYTES) {
+    throw new ZipError(`archive member ${entry.name} declares ${entry.size} bytes (limit ${MAX_ENTRY_BYTES})`);
+  }
+  // 'deflate-raw' — a ZIP member is a bare DEFLATE stream with no zlib header.
+  // why the cast: TS types BlobPart's view as ArrayBuffer-backed, while a
+  // Uint8Array is ArrayBufferLike-backed (it could, in principle, be over a
+  // SharedArrayBuffer). Ours never is — it came from a fetch or a File.
+  const stream = new Blob([/** @type {BlobPart} */ (/** @type {unknown} */ (raw))])
+    .stream().pipeThrough(new DecompressionStream('deflate-raw'));
+
+  const reader = stream.getReader();
+  /** @type {Uint8Array[]} */
+  const chunks = [];
+  let total = 0;
+  try {
+    for (;;) {
+      // why a manual read loop rather than `new Response(stream).arrayBuffer()`:
+      // that buffers the WHOLE output before we could measure it, which is the
+      // bomb. Reading chunk by chunk lets us stop at the cap. (A counting loop
+      // is the sanctioned shape here — early exit, per eslint.config.js.)
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.length;
+      if (total > MAX_ENTRY_BYTES) {
+        throw new ZipError(`archive member ${entry.name} inflates past the ${MAX_ENTRY_BYTES}-byte limit`);
+      }
+      chunks.push(value);
+    }
+  } catch (e) {
+    if (e instanceof ZipError) throw e;
+    throw new ZipError(`could not inflate ${entry.name}: ${(/** @type {{ message?: string }} */ (e))?.message ?? e}`);
+  } finally {
+    // Release the lock so the underlying stream can be collected even when we
+    // bailed out mid-inflate.
+    try { reader.releaseLock(); } catch { /* already released */ }
+  }
+
+  const out = new Uint8Array(total);
+  let at = 0;
+  for (const chunk of chunks) { out.set(chunk, at); at += chunk.length; }
+  return out;
+};
+
+/**
+ * Read a member as UTF-8 text by name. Returns null when the member is absent
+ * — callers routinely probe for optional parts (styles, numbering, metadata)
+ * and "not there" is normal, not exceptional.
+ *
+ * @param {Uint8Array} bytes
+ * @param {Map<string, ZipEntry>} index
+ * @param {string} name
+ * @returns {Promise<string | null>}
+ */
+export const readZipText = async (bytes, index, name) => {
+  const entry = index.get(name);
+  if (!entry) return null;
+  const out = await readZipEntry(bytes, entry);
+  return new TextDecoder('utf-8', { fatal: false }).decode(out);
+};

--- a/extension/peerd-runtime/index.js
+++ b/extension/peerd-runtime/index.js
@@ -374,6 +374,14 @@ export {
   PdfFetchError, PdfParseError, OcrUnavailableError,
 } from './pdf/index.js';
 
+// --- doc (read_doc tool: office/publishing formats -> Markdown) ---------
+export {
+  convertToDocument, formatDocBody, toMarkdown, sniffDocFormat,
+  isConvertible, isLegacyBinary, CONVERTIBLE,
+  DocFetchError, DocParseError, UnsupportedDocFormatError,
+  LegacyDocFormatError, ZipError,
+} from './doc/index.js';
+
 // --- dom navigation (a11y tree + element refs; diffable snapshots) ------
 export {
   serializeAxTree,

--- a/extension/peerd-runtime/loop/system-prompt.js
+++ b/extension/peerd-runtime/loop/system-prompt.js
@@ -372,6 +372,8 @@ choose per task:
   • the DOM tools (snapshot / read_page / read_state / query_dom to observe,
     watch_changes to await a change; click / type / navigate / page_keys to act; read_pdf
     for PDFs) — to drive a rendered page that needs the user's login or client-side JS.
+  • read_doc — reads a DOCUMENT FILE as Markdown: Word/Excel/PowerPoint, OpenDocument,
+    RTF, EPUB, CSV. Takes a url, needs no tab.
 
 DECIDE — cheapest path that works. Public data → fetch_url, no tab. Needs login or a
 JS-rendered DOM → render: navigate opens your tab, drive it; then you may fetch_url that
@@ -403,7 +405,10 @@ tab); re-navigate for a fresh one. Work the loop: snapshot → act by ref (click
 → observe the diff before the next step; the DOM is your source of truth, re-snapshot when
 it changes. On "stale_ref"/"debugger_unavailable", re-snapshot or read_page + a CSS
 {selector}. <select>: type the option's visible label. For a PDF (.pdf, or an empty
-snapshot on a document), read_pdf.
+snapshot on a document), read_pdf. For an OFFICE/EBOOK file (.docx .xlsx .pptx .odt .ods
+.odp .rtf .epub .csv) read_doc — the browser DOWNLOADS those instead of rendering them, so
+navigating to one leaves you on a blank tab and fetch_url returns binary. Don't guess a
+document's contents from its filename or its link text: read it.
 
 STATEFUL — you persist across messages: keep a compact PROGRESS note (what you did, what
 you learned, where you are), never raw page text or fetch bodies. Each message brings a

--- a/extension/peerd-runtime/tools/defs/fetch-url.js
+++ b/extension/peerd-runtime/tools/defs/fetch-url.js
@@ -22,6 +22,8 @@ import { wrapUntrusted } from '../prompt-wrap.js';
 import { disarmMarkup, disarmText } from '../../dom/cdr.js';
 import { windowText, pagingFooter, excerptRelevant, excerptFooter } from '../web/spill.js';
 import { needsWebWriteConfirm } from '/peerd-engine/index.js';
+// The pure "is this response a document file?" test — see peerd-runtime/doc.
+import { sniffResponseAsDocument } from '../../doc/sniff.js';
 
 const MAX_BODY_CHARS = 16_000;   // hard cap to avoid context-blast on huge payloads
 
@@ -71,7 +73,9 @@ export const fetchUrlTool = {
     "carries its session, so hit that SAME origin's endpoints here instead of",
     're-scraping. Rides the denylist + SSRF + audit egress chain; does NOT follow',
     'redirects. Returns status, final URL, body + parsed JSON (capped 16k). HTML',
-    'is extracted to clean markdown by default (raw:true for the full HTML).',
+    'is extracted to clean markdown by default (raw:true for the full HTML). A DOCUMENT',
+    'FILE (.docx/.xlsx/.pptx/.odt/.rtf/.epub, or a PDF) is not readable here — those',
+    'come back as binary; read_doc and read_pdf open them.',
   ].join(' '),
   schema: {
     type: 'object',
@@ -135,6 +139,26 @@ export const fetchUrlTool = {
         ctx,
       );
       const ct = res.headers['content-type'] ?? '';
+      // A DOCUMENT FILE, not a page. fetch_url's primitive decodes every
+      // response with Response.text(), so a .docx/.xlsx/.pptx/PDF arrives as
+      // mojibake — and the paths below would then disarm it, window it, spill
+      // 16k of it to the cache, and hand the model a screenful of garbage it
+      // will nonetheless try to answer from. Hand over the reader that CAN
+      // open it instead. The bytes are re-fetched there (offscreen, under the
+      // same denylist + SSRF gates), which costs one request and is worth it:
+      // the alternative is a confident answer drawn from noise.
+      const asDocument = sniffResponseAsDocument({
+        contentType: ct, url: res.finalUrl || args.url, bodyHead: res.body.slice(0, 4096),
+      });
+      if (asDocument) {
+        return {
+          ok: false,
+          error: 'binary_document',
+          content: `${res.finalUrl || args.url} is a ${asDocument.format.toUpperCase()} document, not a web page — `
+            + `fetch_url can only read text, so its bytes would come back unreadable. `
+            + `Call ${asDocument.tool}({ url: "${res.finalUrl || args.url}" }) to read it.`,
+        };
+      }
       // HTML → clean markdown (the default; raw:true opts out). Boilerplate is
       // most of a page's bytes, and the JSON envelope below escapes every
       // quote in it — raw HTML routinely burns the whole 16k budget on nav and

--- a/extension/peerd-runtime/tools/defs/index.js
+++ b/extension/peerd-runtime/tools/defs/index.js
@@ -22,6 +22,7 @@ import { loginTool }                 from './login.js';
 import { typeTool }                  from './type.js';
 import { navigateTool }              from './navigate.js';
 import { readPdfTool }               from './read-pdf.js';
+import { readDocTool }               from './read-doc.js';
 import { fetchUrlTool }              from './fetch-url.js';
 import { readWebCacheTool }          from './read-web-cache.js';
 import { readRunCacheTool }          from './read-run-cache.js';
@@ -92,6 +93,7 @@ export {
   typeTool,
   navigateTool,
   readPdfTool,
+  readDocTool,
   // sessions
   actorListTool,
   openTabTool,
@@ -188,6 +190,10 @@ export const BUILTIN_TOOLS = Object.freeze([
   // main in exposure.js, allowed for kind:'web'). Holds no secret, fills no password.
   loginTool,
   readPdfTool,
+  // read_doc — the OFFICE-format sibling of read_pdf (Word/Excel/PowerPoint/
+  // OpenDocument/RTF/EPUB/CSV). Registered + hidden from main (actor-only, like
+  // every other reader of untrusted document content); allowed for kind:'web'.
+  readDocTool,
   // the web actor's SESSIONLESS secure fetch (its non-render web mechanism).
   // Registered + hidden from main (actor-only, like the DOM tools); allowed
   // for kind:'web' in ACTOR_TYPE_TOOLS.web and keyless by construction.

--- a/extension/peerd-runtime/tools/defs/read-doc.js
+++ b/extension/peerd-runtime/tools/defs/read-doc.js
@@ -73,7 +73,15 @@ export const readDocTool = {
     const docClient = /** @type {{ extract: (source: { url: string }, opts: { format?: string }) => Promise<{ doc: any, bytes: number, sniffedVia: string }> } | undefined} */ (
       /** @type {any} */ (ctx).docOffscreenClient);
     if (!docClient || typeof docClient.extract !== 'function') {
-      return { ok: false, error: 'doc_reader_unavailable' };
+      // Firefox has no offscreen-document API, so the converter has nowhere to
+      // run (read_pdf is unavailable there for the same reason). Say so — an
+      // opaque code reads as "this document is broken" and invites a retry.
+      return {
+        ok: false,
+        error: 'doc_reader_unavailable',
+        content: 'Document conversion is not available in this browser build. '
+          + 'If the document has an HTML version, read that instead.',
+      };
     }
 
     if (typeof args?.url !== 'string' || !args.url) return { ok: false, error: 'url_required' };

--- a/extension/peerd-runtime/tools/defs/read-doc.js
+++ b/extension/peerd-runtime/tools/defs/read-doc.js
@@ -1,0 +1,165 @@
+// @ts-check
+// read_doc — read a Word / Excel / PowerPoint / OpenDocument / RTF / EPUB /
+// CSV file as Markdown.
+//
+// An ACTOR-ONLY tool (hidden from the main agent in exposure.js, in the web
+// actor's toolset): its output is UNTRUSTED document content and must land in
+// the web actor's context, never the main loop — the same boundary read_page
+// and read_pdf sit on.
+//
+// The gap it closes: an office document is not a web page and not a PDF. The
+// browser does not render one — clicking the link downloads it — so snapshot
+// and read_page see nothing, and fetch_url (which decodes every response as
+// text) returns a screenful of mojibake that costs real context and says
+// nothing. Before this tool the honest answer to "read this .xlsx" was "I
+// can't"; the model instead tended to guess from the URL. read_doc converts the
+// bytes to Markdown in the offscreen document and returns the text.
+//
+// why one tool for eight formats rather than read_docx/read_xlsx/…: the agent
+// usually does NOT know which one it has. Links lie, content-types lie, and a
+// tool the agent must pick correctly BEFORE it can look is a tool it will pick
+// wrong. read_doc sniffs the bytes and reports what it found.
+
+import { wrapUntrusted } from '../prompt-wrap.js';
+import { originOfUrl, isDenylistedTab } from './dom-helpers.js';
+import { formatDocBody, formatDocHead, toMarkdown, DEFAULT_MAX_CHARS, CONVERTIBLE } from '../../doc/index.js';
+import { windowText, pagingFooter, excerptRelevant, excerptFooter } from '../web/spill.js';
+// Deep import of the PURE SSRF matcher (the read_pdf pattern): the egress
+// barrel pulls in vault/storage, and read_doc re-fetches the bytes offscreen,
+// so it must apply the SAME private-network refusal as open-web egress — the
+// denylist alone does not cover loopback / LAN / 169.254 metadata targets.
+import { isPrivateOrLocalHost } from '../../../peerd-egress/fetch/private-network.js';
+
+/** @type {import('/shared/tool-types.js').Tool} */
+export const readDocTool = {
+  name: 'read_doc',
+  primitive: 'web',
+  description: [
+    'Read a DOCUMENT FILE as Markdown: Word (.docx), Excel (.xlsx), PowerPoint (.pptx),',
+    'OpenDocument (.odt/.ods/.odp), RTF, EPUB, and CSV/TSV. Use it whenever a link points',
+    'at one of those — the browser downloads such files instead of rendering them, so',
+    'navigate/snapshot show you nothing and fetch_url returns unreadable binary.',
+    'Structure is preserved: headings, lists, tables, and links come back as Markdown;',
+    'spreadsheets come back as one table per sheet, decks as one section per slide with',
+    'speaker notes. You do NOT need to know the format in advance — it is detected from',
+    'the bytes, and reported back. For a PDF use read_pdf; for an HTML page use fetch_url',
+    'or open a tab. Long documents are stored whole and paged: pass a query to get the',
+    'matching passages, and follow the [paging] footer to read any other part.',
+  ].join(' '),
+  schema: {
+    type: 'object',
+    required: ['url'],
+    properties: {
+      url: { type: 'string', description: 'Absolute http(s) URL of the document file.' },
+      maxChars: { type: 'integer', description: `Cap on the returned Markdown (default ${DEFAULT_MAX_CHARS}). Raise it to read a long document whole.` },
+      query: { type: 'string', description: 'What you are looking for in this document (a few keywords). When it is too long to show whole, the most relevant passages are surfaced (BM25) instead of a blind head+tail window — so an answer in an appendix is not missed. Omit to get the head+tail window.' },
+      format: {
+        type: 'string',
+        enum: [...CONVERTIBLE],
+        description: 'Force a format instead of detecting one. Only needed when detection got it wrong — normally omit.',
+      },
+    },
+  },
+  sideEffect: 'read',
+  origins: (args) => {
+    const o = originOfUrl(args?.url);
+    return o ? [o] : [];
+  },
+
+  execute: async (args, ctx) => {
+    // why: docOffscreenClient is injected into the tool context by the SW
+    // (background/offscreen-doc-client.js) but isn't part of the shared
+    // ToolContext typedef; narrow it locally to the surface this tool uses.
+    const docClient = /** @type {{ extract: (source: { url: string }, opts: { format?: string }) => Promise<{ doc: any, bytes: number, sniffedVia: string }> } | undefined} */ (
+      /** @type {any} */ (ctx).docOffscreenClient);
+    if (!docClient || typeof docClient.extract !== 'function') {
+      return { ok: false, error: 'doc_reader_unavailable' };
+    }
+
+    if (typeof args?.url !== 'string' || !args.url) return { ok: false, error: 'url_required' };
+    let parsed;
+    try { parsed = new URL(args.url); }
+    catch { return { ok: false, error: `invalid_url: ${args.url}` }; }
+    if (!/^https?:$/.test(parsed.protocol)) return { ok: false, error: `unsupported_scheme: ${parsed.protocol}` };
+
+    // The same two gates read_pdf applies to its url override: the denylist,
+    // and the SSRF refusal (read_doc issues a NEW fetch offscreen, so a
+    // private/LAN/metadata host must be refused exactly like open-web egress).
+    if (isDenylistedTab(args.url, ctx.denylist)) return { ok: false, error: 'denylisted_target' };
+    if (isPrivateOrLocalHost(parsed.hostname)) return { ok: false, error: 'private_or_local_target_blocked' };
+
+    let result;
+    try {
+      result = await docClient.extract({ url: args.url }, { format: args.format });
+    } catch (e) {
+      const err = /** @type {{ code?: string, message?: string }} */ (e);
+      // The failures ARE the API here: each names the tool that will work
+      // instead, so a wrong first guess costs one turn rather than a dead end.
+      // The message already carries the specifics (from peerd-runtime/doc's
+      // typed errors); the code is what the agent can branch on.
+      return { ok: false, error: err?.code ?? 'doc_read_failed', content: err?.message ?? String(e) };
+    }
+    if (!result?.doc) return { ok: false, error: 'doc_read_failed', content: 'empty conversion result' };
+
+    const maxChars = Number.isFinite(args?.maxChars) && args.maxChars > 0
+      ? Math.floor(args.maxChars) : DEFAULT_MAX_CHARS;
+
+    // SPILL-AND-PAGE, exactly as fetch_url does it. A document is the case
+    // where a silent truncation hurts most — the answer is as likely to be in
+    // an appendix as in the intro, and unlike a web page there is no second
+    // way to reach the tail. So the FULL markdown is stored locally and the
+    // model gets a window plus the read_web_cache call that pages the rest;
+    // with a query it gets the passages that MATCH instead of a blind
+    // head+tail. Same idiom, same pager, same footer the actor already knows.
+    const markdown = toMarkdown(result.doc);
+    const head = formatDocHead({ doc: result.doc, source: args.url });
+    const webCache = /** @type {{ key?: () => string, put?: (r: object) => Promise<void> } | undefined} */ (
+      /** @type {any} */ (ctx).webCache);
+
+    if (!webCache?.key || !webCache?.put) {
+      // No spill capability → the plain capped render (which announces its cut).
+      return {
+        ok: true,
+        content: wrapUntrusted({
+          origin: originOfUrl(args.url),
+          tool: 'read_doc',
+          body: formatDocBody({ doc: result.doc, maxChars, source: args.url }),
+        }),
+      };
+    }
+
+    const query = typeof args.query === 'string' ? args.query.trim() : '';
+    const ex = query ? excerptRelevant(markdown, query, maxChars) : null;
+    const win = windowText(markdown, maxChars);
+    const text = ex ? ex.excerpt : win.window;
+    const truncated = ex ? ex.excerpted : win.windowed;
+
+    /** @type {string | null} */
+    let footer = null;
+    if (truncated) {
+      const cacheKey = webCache.key();
+      try {
+        // ownerSessionId stamps the OWNER — the spill store is one SW-level map
+        // keyed by an opaque handle, so without it any actor holding a key could
+        // page back a document a different actor fetched.
+        await webCache.put({
+          key: cacheKey, url: args.url, format: 'markdown', text: markdown,
+          ownerSessionId: ctx.session?.sessionId ?? null,
+        });
+        footer = ex
+          ? excerptFooter({ key: cacheKey, total: ex.total, passagesShown: ex.passagesShown, passagesTotal: ex.passagesTotal, query })
+          : pagingFooter({ key: cacheKey, total: win.total, headChars: win.headChars, tailChars: win.tailChars });
+      } catch { /* spill failed — the window still ships, with its elision markers */ }
+    }
+
+    // The footer is TOOL-AUTHORED (caller-computed values only, never document
+    // bytes) and rides OUTSIDE the fence — document content must never be able
+    // to forge or suppress it.
+    const fenced = wrapUntrusted({
+      origin: originOfUrl(args.url),
+      tool: 'read_doc',
+      body: `${head}\n\n${text}`,
+    });
+    return { ok: true, content: footer ? `${fenced}\n${footer}` : fenced };
+  },
+};

--- a/extension/peerd-runtime/tools/exposure.js
+++ b/extension/peerd-runtime/tools/exposure.js
@@ -33,8 +33,10 @@ export const MAIN_AGENT_HIDDEN_TOOLS = Object.freeze(new Set([
   'read_page', 'snapshot', 'read_state', 'watch_changes', 'query_dom',
   'page_eval', 'page_exec', 'page_keys', 'navigate', 'type', 'click',
   // read_pdf returns untrusted PDF text — same boundary as read_page; the
-  // web actor reaches it directly.
-  'read_pdf',
+  // web actor reaches it directly. read_doc is its office-format sibling
+  // (Word/Excel/PowerPoint/OpenDocument/RTF/EPUB/CSV) and returns the same
+  // thing — untrusted document text — so it sits on the same tier.
+  'read_pdf', 'read_doc',
   // view returns an UNTRUSTED page screenshot as a model-visible image — same
   // boundary as read_page (raw page content), so it stays actor-only; the web
   // actor sees the pixels and reports back. (capture is NOT here: its image is
@@ -234,7 +236,11 @@ const ACTOR_TYPE_TOOLS = Object.freeze({
   // per-origin API clients; site_capture records traffic to derive them (tab only —
   // an API actor has no tab, so the WEB_API_TOOLS set below drops site_capture).
   web: Object.freeze(new Set([
-    ...WEB_ACTOR_DOM_TOOLS, 'fetch_url', 'read_web_cache',
+    // read_doc rides beside fetch_url rather than in WEB_ACTOR_DOM_TOOLS for the
+    // same reason fetch_url does: it takes a URL and owns no tab, so it is not
+    // part of the DOM set. (read_pdf IS in that set — it reads the PDF sitting
+    // in the actor's own tab, which is where the browser puts one.)
+    ...WEB_ACTOR_DOM_TOOLS, 'fetch_url', 'read_doc', 'read_web_cache',
     'site_client_run', 'site_client_read', 'site_client_write', 'site_capture',
     // login (Tier 0) — the web actor drives a page's sign-in affordance; keyless
     // by construction (it holds no secret and fills no password).

--- a/extension/peerd-runtime/tools/manifests.js
+++ b/extension/peerd-runtime/tools/manifests.js
@@ -55,7 +55,7 @@ export const TOOL_MANIFEST_PRESETS = Object.freeze({
       // page DOM toolset (inherited by the web actor, which DOES the page work —
       // see invariant above)
       'snapshot', 'read_page', 'read_state', 'watch_changes',
-      'click', 'type', 'navigate', 'query_dom', 'page_keys', 'read_pdf', 'view',
+      'click', 'type', 'navigate', 'query_dom', 'page_keys', 'read_pdf', 'read_doc', 'view',
       // memory
       'remember', 'read_memory',
       // sovereignty / sessions introspection (one kind-discriminated tool)
@@ -72,7 +72,7 @@ export const TOOL_MANIFEST_PRESETS = Object.freeze({
       // it can observe but not click/type — the manifest constrains the actor too).
       'actor_list', 'open_tab', 'navigate', 'message_actor',
       // read-only DOM subset (observe, never mutate) — inherited by the web actor.
-      'snapshot', 'read_page', 'read_state', 'query_dom', 'read_pdf', 'view',
+      'snapshot', 'read_page', 'read_state', 'query_dom', 'read_pdf', 'read_doc', 'view',
       // web reads: fetch_url (the web actor's sessionless fetch) + its pager.
       // read_web_cache pages a spilled fetch_url / read_page body — it must be
       // present wherever a spill producer is, or the trusted paging footer names

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -119,7 +119,9 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // branch's DPoP work plus the new in-browser dpop-key-idb.test.js, merged with
 // main's two new checked files (settings-row.js, behavior-rows.test.js), put
 // the merged count at 579 (computed on the merged tree, not summed).
-const COVERED_FLOOR = 579;
+// peerd-runtime/doc + its offscreen/SW/tool wiring (the read_doc document
+// reader) all landed // @ts-check-clean, so the floor moves up to lock them in.
+const COVERED_FLOOR = 599;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/packaging/security-baseline.json
+++ b/packaging/security-baseline.json
@@ -468,6 +468,7 @@
     "engine-tabs/app-tab/app-tab.js": 1,
     "engine-tabs/notebook-tab/notebook-tab.js": 1,
     "engine-tabs/vm-tab/vm-tab.js": 1,
+    "offscreen/doc-extract.js": 1,
     "offscreen/dweb-base.js": 1,
     "offscreen/offscreen.js": 5,
     "offscreen/web-extract.js": 1,

--- a/tests/peerd-runtime/doc/convert.test.ts
+++ b/tests/peerd-runtime/doc/convert.test.ts
@@ -1,0 +1,166 @@
+// End-to-end conversion tests: real archives in, Markdown out.
+//
+// These are written against the OUTPUT, not the intermediate model, because
+// the output is the contract — it is what a model reads and answers from. A
+// test that asserts on block shapes passes happily while the serializer emits
+// `**Hel****lo**`.
+
+import { describe, test, expect } from 'bun:test';
+import { convertToDocument } from '../../../extension/peerd-runtime/doc/convert.js';
+import { toMarkdown } from '../../../extension/peerd-runtime/doc/markdown.js';
+import { formatDocBody } from '../../../extension/peerd-runtime/doc/format.js';
+import { makeDocx, makeXlsx, makePptx, makeOdt, makeOds, makeEpub, makeZip } from './fixtures.ts';
+
+const md = async (bytes: Uint8Array, hints = {}) => toMarkdown(await convertToDocument(bytes, hints));
+
+describe('.docx', () => {
+  test('headings, merged bold runs, links, lists and tables all survive', async () => {
+    const out = await md(await makeDocx());
+    expect(out).toContain('# Findings');
+    // The two adjacent bold runs must merge — `**Revenue ****rose**` renders wrong.
+    expect(out).toContain('**Revenue rose**');
+    expect(out).toContain('[the spec](https://example.com/spec)');
+    expect(out).toContain('Not bold.');
+    expect(out).not.toContain('**Not bold.**');
+    expect(out).toContain('1. First step');
+    expect(out).toContain('- A bullet');
+    // numId="0" is "explicitly not a list" — it must not gain a bullet.
+    expect(out).toMatch(/^Plain again$/m);
+    // A pipe inside a cell must be escaped or it splits the column.
+    expect(out).toContain('| EMEA \\| North | 12 |');
+    expect(out).toContain('| --- | --- |');
+  });
+
+  test('core properties become the title and metadata', async () => {
+    const doc = await convertToDocument(await makeDocx());
+    expect(doc.title).toBe('Quarterly Report');
+    expect(doc.meta.author).toBe('A. Writer');
+  });
+});
+
+describe('.xlsx', () => {
+  test('pooled strings resolve and a sparse row keeps its columns', async () => {
+    const out = await md(await makeXlsx());
+    expect(out).toContain('## Sales');
+    expect(out).toContain('| Region | Q1 | Q2 |');
+    // B2 is absent in the source; 91 belongs in the THIRD column, not the second.
+    expect(out).toContain('| EMEA |  | 91 |');
+    // Concatenated styled runs in one shared string.
+    expect(out).toContain('EMEA');
+    // A formula cell reports its cached VALUE, and a boolean renders as TRUE.
+    expect(out).toContain('| APAC | 3 | TRUE |');
+  });
+
+  test('a hidden sheet is not read, and says so', async () => {
+    const doc = await convertToDocument(await makeXlsx());
+    expect(toMarkdown(doc)).not.toContain('SECRET');
+    expect(doc.notes.join(' ')).toContain('hidden');
+  });
+});
+
+describe('.pptx', () => {
+  test('slides follow the sldIdLst order, not the relationship order', async () => {
+    const out = await md(await makePptx());
+    const first = out.indexOf('First Deck Slide');
+    const second = out.indexOf('Second Deck Slide');
+    expect(first).toBeGreaterThan(-1);
+    expect(second).toBeGreaterThan(-1);
+    expect(first).toBeLessThan(second);
+  });
+
+  test('titles head their slide and speaker notes are kept', async () => {
+    const out = await md(await makePptx());
+    expect(out).toContain('## Slide 1: First Deck Slide');
+    expect(out).toContain('### Speaker notes');
+    expect(out).toContain('Remember to mention margin.');
+    // The notes placeholder's bare slide number is an artifact, not content.
+    expect(out).not.toMatch(/^1$/m);
+  });
+});
+
+describe('OpenDocument', () => {
+  test('.odt keeps headings, links, lists and tables', async () => {
+    const doc = await convertToDocument(await makeOdt());
+    const out = toMarkdown(doc);
+    expect(doc.title).toBe('Field Notes');
+    expect(out).toContain('# Observations');
+    expect(out).toContain('[a link](https://example.org/x)');
+    expect(out).toContain('- Alpha');
+    expect(out).toContain('| Key | Value |');
+  });
+
+  test('.ods grid padding is trimmed, not expanded', async () => {
+    const out = await md(await makeOds());
+    expect(out).toContain('## Data');
+    expect(out).toContain('| Name | Count |');
+    expect(out).toContain('| widgets | 7 |');
+    // 16381 repeated empty columns and a million repeated empty rows must not
+    // reach the output — the whole sheet is four cells.
+    expect(out.length).toBeLessThan(400);
+    expect(out).not.toContain('|  |  |  |  |');
+  });
+});
+
+describe('.epub', () => {
+  test('chapters come out in SPINE order with structure intact', async () => {
+    const doc = await convertToDocument(await makeEpub());
+    const out = toMarkdown(doc);
+    expect(doc.title).toBe('A Short Book');
+    expect(doc.meta.author).toBe('E. Author');
+    // ch1 is listed SECOND in the manifest but FIRST in the spine.
+    expect(out.indexOf('Chapter One')).toBeLessThan(out.indexOf('Chapter Two'));
+    expect(out).toContain('It was a **dark** and stormy night.');
+    expect(out).toContain('- one');
+    expect(out).toContain('> A quoted line.');
+    // The stylesheet is in the manifest but not the spine.
+    expect(out).not.toContain('margin: 0');
+  });
+});
+
+describe('the refusals are specific', () => {
+  test('a legacy OLE2 binary names the format and the way out', async () => {
+    const ole2 = new Uint8Array(600);
+    ole2.set([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]);
+    const err = await convertToDocument(ole2, { name: 'old.doc' }).catch((e) => e);
+    expect(err.name).toBe('LegacyDocFormatError');
+    expect(err.message).toContain('Word 97-2003');
+    expect(err.message).toContain('libreoffice');
+  });
+
+  test('an unknown binary is refused rather than rendered as mojibake', async () => {
+    const junk = new Uint8Array([0x00, 0x01, 0x02, 0x03, 0xff, 0xfe, 0x00, 0x42]);
+    const err = await convertToDocument(junk).catch((e) => e);
+    expect(err.name).toBe('UnsupportedDocFormatError');
+  });
+
+  test('an encrypted archive says so instead of failing as corrupt', async () => {
+    const zip = await makeZip([{ name: 'word/document.xml', content: '<w/>' }]);
+    // Flip the central directory's general-purpose bit 0 (encrypted). It sits
+    // at offset 8 of the central header, which follows the local data.
+    const marker = zip.lastIndexOf(0x02);
+    const at = zip.findIndex((_, i) => i < zip.length - 4
+      && zip[i] === 0x50 && zip[i + 1] === 0x4b && zip[i + 2] === 0x01 && zip[i + 3] === 0x02);
+    expect(at).toBeGreaterThan(-1);
+    expect(marker).toBeGreaterThan(-1);
+    zip[at + 8] |= 0x01;
+    const err = await convertToDocument(zip, { name: 'locked.docx' }).catch((e) => e);
+    expect(err.name).toBe('ZipError');
+    expect(err.message).toContain('encrypted');
+  });
+});
+
+describe('formatDocBody', () => {
+  test('truncation is announced with the real numbers', async () => {
+    const doc = await convertToDocument(await makeDocx());
+    const body = formatDocBody({ doc, maxChars: 80, source: 'https://example.com/r.docx' });
+    expect(body).toContain('[source: https://example.com/r.docx]');
+    expect(body).toContain('truncated: showing');
+    expect(body).toContain('format: docx');
+  });
+
+  test('an empty conversion says so rather than returning nothing', async () => {
+    const doc = await convertToDocument(new TextEncoder().encode('a,b\n'), { name: 'x.csv' });
+    doc.blocks = [];
+    expect(formatDocBody({ doc })).toContain('converted to no text');
+  });
+});

--- a/tests/peerd-runtime/doc/fixtures.ts
+++ b/tests/peerd-runtime/doc/fixtures.ts
@@ -1,0 +1,315 @@
+// Build real office files in memory, so the doc tests exercise the WHOLE path
+// — ZIP central directory, DEFLATE, XML, the walkers — rather than handing the
+// parsers pre-chewed structures. A parser that only ever sees a hand-built tree
+// is not tested against the thing it actually meets.
+//
+// The writer emits both STORE and DEFLATE members, because those are the two
+// methods the reader supports and office writers mix them freely (ODF/EPUB
+// require the mimetype member to be stored, everything else is deflated).
+
+const encoder = new TextEncoder();
+
+// CRC-32, needed because a ZIP reader is entitled to reject a bad checksum and
+// a fixture that only works against our own reader would prove nothing.
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n += 1) {
+    let c = n;
+    for (let k = 0; k < 8; k += 1) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+const crc32 = (bytes: Uint8Array): number => {
+  let c = 0xffffffff;
+  for (const byte of bytes) c = CRC_TABLE[(c ^ byte) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+};
+
+const deflateRaw = async (bytes: Uint8Array): Promise<Uint8Array> => {
+  const stream = new Blob([bytes as unknown as BlobPart]).stream().pipeThrough(new CompressionStream('deflate-raw'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+};
+
+export type ZipMember = { name: string; content: string | Uint8Array; store?: boolean };
+
+/** Write a ZIP archive: local headers, then the central directory, then EOCD. */
+export const makeZip = async (members: ZipMember[]): Promise<Uint8Array> => {
+  const chunks: Uint8Array[] = [];
+  const central: Uint8Array[] = [];
+  let offset = 0;
+
+  for (const member of members) {
+    const raw = typeof member.content === 'string' ? encoder.encode(member.content) : member.content;
+    const stored = member.store === true;
+    const body = stored ? raw : await deflateRaw(raw);
+    const name = encoder.encode(member.name);
+    const crc = crc32(raw);
+
+    const local = new Uint8Array(30 + name.length);
+    const lv = new DataView(local.buffer);
+    lv.setUint32(0, 0x04034b50, true);
+    lv.setUint16(4, 20, true);
+    lv.setUint16(6, 0, true);
+    lv.setUint16(8, stored ? 0 : 8, true);
+    lv.setUint32(14, crc, true);
+    lv.setUint32(18, body.length, true);
+    lv.setUint32(22, raw.length, true);
+    lv.setUint16(26, name.length, true);
+    local.set(name, 30);
+    chunks.push(local, body);
+
+    const dir = new Uint8Array(46 + name.length);
+    const dv = new DataView(dir.buffer);
+    dv.setUint32(0, 0x02014b50, true);
+    dv.setUint16(4, 20, true);
+    dv.setUint16(6, 20, true);
+    dv.setUint16(10, stored ? 0 : 8, true);
+    dv.setUint32(16, crc, true);
+    dv.setUint32(20, body.length, true);
+    dv.setUint32(24, raw.length, true);
+    dv.setUint16(28, name.length, true);
+    dv.setUint32(42, offset, true);
+    dir.set(name, 46);
+    central.push(dir);
+
+    offset += local.length + body.length;
+  }
+
+  const centralSize = central.reduce((n, c) => n + c.length, 0);
+  const eocd = new Uint8Array(22);
+  const ev = new DataView(eocd.buffer);
+  ev.setUint32(0, 0x06054b50, true);
+  ev.setUint16(8, members.length, true);
+  ev.setUint16(10, members.length, true);
+  ev.setUint32(12, centralSize, true);
+  ev.setUint32(16, offset, true);
+
+  const all = [...chunks, ...central, eocd];
+  const total = all.reduce((n, c) => n + c.length, 0);
+  const out = new Uint8Array(total);
+  let p = 0;
+  for (const chunk of all) { out.set(chunk, p); p += chunk.length; }
+  return out;
+};
+
+const CONTENT_TYPES = '<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>';
+
+/** A .docx with headings, styled runs, a hyperlink, a numbered list and a table. */
+export const makeDocx = async (): Promise<Uint8Array> => makeZip([
+  { name: '[Content_Types].xml', content: CONTENT_TYPES },
+  {
+    name: 'docProps/core.xml',
+    content: '<?xml version="1.0"?><cp:coreProperties xmlns:cp="x" xmlns:dc="y">'
+      + '<dc:title>Quarterly Report</dc:title><dc:creator>A. Writer</dc:creator></cp:coreProperties>',
+  },
+  {
+    name: 'word/_rels/document.xml.rels',
+    content: '<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+      + '<Relationship Id="rId4" Target="https://example.com/spec"/></Relationships>',
+  },
+  {
+    name: 'word/numbering.xml',
+    content: '<?xml version="1.0"?><w:numbering xmlns:w="w">'
+      + '<w:abstractNum w:abstractNumId="0"><w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/></w:lvl></w:abstractNum>'
+      + '<w:abstractNum w:abstractNumId="1"><w:lvl w:ilvl="0"><w:numFmt w:val="bullet"/></w:lvl></w:abstractNum>'
+      + '<w:num w:numId="7"><w:abstractNumId w:val="0"/></w:num>'
+      + '<w:num w:numId="8"><w:abstractNumId w:val="1"/></w:num>'
+      + '</w:numbering>',
+  },
+  {
+    name: 'word/document.xml',
+    content: '<?xml version="1.0"?><w:document xmlns:w="w" xmlns:r="r"><w:body>'
+      + '<w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>Findings</w:t></w:r></w:p>'
+      // Two runs of the same styling: they must merge into one **bold** span.
+      + '<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>Revenue </w:t></w:r>'
+      + '<w:r><w:rPr><w:b/></w:rPr><w:t>rose</w:t></w:r>'
+      + '<w:r><w:t xml:space="preserve"> by 4%. See </w:t></w:r>'
+      + '<w:hyperlink r:id="rId4"><w:r><w:t>the spec</w:t></w:r></w:hyperlink>'
+      + '<w:r><w:t>.</w:t></w:r></w:p>'
+      // b val="0" is bold OFF — a common trap.
+      + '<w:p><w:r><w:rPr><w:b w:val="0"/></w:rPr><w:t>Not bold.</w:t></w:r></w:p>'
+      + '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="7"/></w:numPr></w:pPr><w:r><w:t>First step</w:t></w:r></w:p>'
+      + '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="7"/></w:numPr></w:pPr><w:r><w:t>Second step</w:t></w:r></w:p>'
+      + '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="8"/></w:numPr></w:pPr><w:r><w:t>A bullet</w:t></w:r></w:p>'
+      // numId 0 means "explicitly not a list" — must NOT become a bullet.
+      + '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="0"/></w:numPr></w:pPr><w:r><w:t>Plain again</w:t></w:r></w:p>'
+      + '<w:tbl>'
+      + '<w:tr><w:tc><w:p><w:r><w:t>Region</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>Total</w:t></w:r></w:p></w:tc></w:tr>'
+      + '<w:tr><w:tc><w:p><w:r><w:t>EMEA | North</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>12</w:t></w:r></w:p></w:tc></w:tr>'
+      + '</w:tbl>'
+      + '<w:sectPr/></w:body></w:document>',
+  },
+]);
+
+/** A .xlsx with a shared-string pool, a sparse row, a formula and a hidden sheet. */
+export const makeXlsx = async (): Promise<Uint8Array> => makeZip([
+  { name: '[Content_Types].xml', content: CONTENT_TYPES },
+  {
+    name: 'xl/_rels/workbook.xml.rels',
+    content: '<?xml version="1.0"?><Relationships xmlns="r">'
+      + '<Relationship Id="rId1" Target="worksheets/sheet1.xml"/>'
+      + '<Relationship Id="rId2" Target="worksheets/sheet2.xml"/></Relationships>',
+  },
+  {
+    name: 'xl/workbook.xml',
+    content: '<?xml version="1.0"?><workbook xmlns="w" xmlns:r="r"><sheets>'
+      + '<sheet name="Sales" sheetId="1" r:id="rId1"/>'
+      + '<sheet name="Scratch" sheetId="2" state="hidden" r:id="rId2"/>'
+      + '</sheets></workbook>',
+  },
+  {
+    name: 'xl/sharedStrings.xml',
+    content: '<?xml version="1.0"?><sst xmlns="s">'
+      + '<si><t>Region</t></si><si><t>Q1</t></si><si><t>Q2</t></si>'
+      + '<si><r><t>EM</t></r><r><t>EA</t></r></si>'
+      + '</sst>',
+  },
+  {
+    name: 'xl/worksheets/sheet1.xml',
+    content: '<?xml version="1.0"?><worksheet xmlns="w"><sheetData>'
+      + '<row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c><c r="C1" t="s"><v>2</v></c></row>'
+      // B2 is ABSENT — the sparse-cell trap. C2 must stay in column 3.
+      + '<row r="2"><c r="A2" t="s"><v>3</v></c><c r="C2"><v>91</v></c></row>'
+      + '<row r="3"><c r="A3" t="inlineStr"><is><t>APAC</t></is></c>'
+      + '<c r="B3"><f>SUM(1,2)</f><v>3</v></c><c r="C3" t="b"><v>1</v></c></row>'
+      + '</sheetData></worksheet>',
+  },
+  {
+    name: 'xl/worksheets/sheet2.xml',
+    content: '<?xml version="1.0"?><worksheet xmlns="w"><sheetData>'
+      + '<row r="1"><c r="A1" t="inlineStr"><is><t>SECRET</t></is></c></row></sheetData></worksheet>',
+  },
+]);
+
+/** A .pptx with two ordered slides, a title placeholder and speaker notes. */
+export const makePptx = async (): Promise<Uint8Array> => makeZip([
+  { name: '[Content_Types].xml', content: CONTENT_TYPES },
+  {
+    name: 'ppt/_rels/presentation.xml.rels',
+    content: '<?xml version="1.0"?><Relationships xmlns="r">'
+      + '<Relationship Id="rId2" Target="slides/slide1.xml"/>'
+      + '<Relationship Id="rId3" Target="slides/slide2.xml"/></Relationships>',
+  },
+  {
+    name: 'ppt/presentation.xml',
+    // Deliberately listed out of rels order: the sldIdLst is the authority.
+    content: '<?xml version="1.0"?><p:presentation xmlns:p="p" xmlns:r="r"><p:sldIdLst>'
+      + '<p:sldId id="rId3"/><p:sldId id="rId2"/>'
+      + '</p:sldIdLst></p:presentation>',
+  },
+  {
+    name: 'ppt/slides/slide1.xml',
+    content: '<?xml version="1.0"?><p:sld xmlns:p="p" xmlns:a="a"><p:cSld><p:spTree>'
+      + '<p:sp><p:nvSpPr><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>'
+      + '<p:txBody><a:p><a:r><a:t>Second Deck Slide</a:t></a:r></a:p></p:txBody></p:sp>'
+      + '<p:sp><p:txBody><a:p><a:r><a:t>Body text here</a:t></a:r></a:p></p:txBody></p:sp>'
+      + '</p:spTree></p:cSld></p:sld>',
+  },
+  {
+    name: 'ppt/slides/_rels/slide1.xml.rels',
+    content: '<?xml version="1.0"?><Relationships xmlns="r">'
+      + '<Relationship Id="rId1" Target="../notesSlides/notesSlide1.xml"/></Relationships>',
+  },
+  {
+    name: 'ppt/notesSlides/notesSlide1.xml',
+    content: '<?xml version="1.0"?><p:notes xmlns:p="p" xmlns:a="a"><p:cSld><p:spTree>'
+      + '<p:sp><p:txBody><a:p><a:r><a:t>1</a:t></a:r></a:p>'
+      + '<a:p><a:r><a:t>Remember to mention margin.</a:t></a:r></a:p></p:txBody></p:sp>'
+      + '</p:spTree></p:cSld></p:notes>',
+  },
+  {
+    name: 'ppt/slides/slide2.xml',
+    content: '<?xml version="1.0"?><p:sld xmlns:p="p" xmlns:a="a"><p:cSld><p:spTree>'
+      + '<p:sp><p:nvSpPr><p:nvPr><p:ph type="ctrTitle"/></p:nvPr></p:nvSpPr>'
+      + '<p:txBody><a:p><a:r><a:t>First Deck Slide</a:t></a:r></a:p></p:txBody></p:sp>'
+      + '</p:spTree></p:cSld></p:sld>',
+  },
+]);
+
+/** An .odt — mimetype STORED first, as the spec requires. */
+export const makeOdt = async (): Promise<Uint8Array> => makeZip([
+  { name: 'mimetype', content: 'application/vnd.oasis.opendocument.text', store: true },
+  {
+    name: 'meta.xml',
+    content: '<?xml version="1.0"?><office:document-meta xmlns:office="o" xmlns:dc="dc">'
+      + '<office:meta><dc:title>Field Notes</dc:title><dc:creator>O. Writer</dc:creator></office:meta>'
+      + '</office:document-meta>',
+  },
+  {
+    name: 'content.xml',
+    content: '<?xml version="1.0"?><office:document-content xmlns:office="o" xmlns:text="t" xmlns:table="tb" xmlns:xlink="x">'
+      + '<office:body><office:text>'
+      + '<text:h text:outline-level="1">Observations</text:h>'
+      + '<text:p>Plain paragraph with <text:a xlink:href="https://example.org/x">a link</text:a>.</text:p>'
+      + '<text:list><text:list-item><text:p>Alpha</text:p></text:list-item>'
+      + '<text:list-item><text:p>Beta</text:p></text:list-item></text:list>'
+      + '<table:table table:name="T1">'
+      + '<table:table-row><table:table-cell><text:p>Key</text:p></table:table-cell>'
+      + '<table:table-cell><text:p>Value</text:p></table:table-cell></table:table-row>'
+      + '<table:table-row><table:table-cell><text:p>depth</text:p></table:table-cell>'
+      + '<table:table-cell><text:p>12m</text:p></table:table-cell></table:table-row>'
+      + '</table:table>'
+      + '</office:text></office:body></office:document-content>',
+  },
+]);
+
+/** An .ods exercising the repeated-cell padding LibreOffice emits. */
+export const makeOds = async (): Promise<Uint8Array> => makeZip([
+  { name: 'mimetype', content: 'application/vnd.oasis.opendocument.spreadsheet', store: true },
+  {
+    name: 'content.xml',
+    content: '<?xml version="1.0"?><office:document-content xmlns:office="o" xmlns:text="t" xmlns:table="tb">'
+      + '<office:body><office:spreadsheet>'
+      + '<table:table table:name="Data">'
+      + '<table:table-row><table:table-cell><text:p>Name</text:p></table:table-cell>'
+      + '<table:table-cell><text:p>Count</text:p></table:table-cell>'
+      + '<table:table-cell table:number-columns-repeated="16381"/></table:table-row>'
+      + '<table:table-row><table:table-cell><text:p>widgets</text:p></table:table-cell>'
+      + '<table:table-cell><text:p>7</text:p></table:table-cell>'
+      + '<table:table-cell table:number-columns-repeated="16381"/></table:table-row>'
+      + '<table:table-row table:number-rows-repeated="1048574"><table:table-cell table:number-columns-repeated="16384"/></table:table-row>'
+      + '</table:table>'
+      + '</office:spreadsheet></office:body></office:document-content>',
+  },
+]);
+
+/** An .epub whose spine order differs from its manifest order. */
+export const makeEpub = async (): Promise<Uint8Array> => makeZip([
+  { name: 'mimetype', content: 'application/epub+zip', store: true },
+  {
+    name: 'META-INF/container.xml',
+    content: '<?xml version="1.0"?><container xmlns="c"><rootfiles>'
+      + '<rootfile full-path="OEBPS/book.opf" media-type="application/oebps-package+xml"/>'
+      + '</rootfiles></container>',
+  },
+  {
+    name: 'OEBPS/book.opf',
+    content: '<?xml version="1.0"?><package xmlns="p" xmlns:dc="dc">'
+      + '<metadata><dc:title>A Short Book</dc:title><dc:creator>E. Author</dc:creator>'
+      + '<dc:language>en</dc:language></metadata>'
+      + '<manifest>'
+      + '<item id="css" href="style.css" media-type="text/css"/>'
+      + '<item id="two" href="text/ch2.xhtml" media-type="application/xhtml+xml"/>'
+      + '<item id="one" href="text/ch1.xhtml" media-type="application/xhtml+xml"/>'
+      + '</manifest>'
+      + '<spine><itemref idref="one"/><itemref idref="two"/></spine>'
+      + '</package>',
+  },
+  { name: 'OEBPS/style.css', content: 'body { margin: 0 }' },
+  {
+    name: 'OEBPS/text/ch1.xhtml',
+    content: '<?xml version="1.0"?><html xmlns="h"><body>'
+      + '<h1>Chapter One</h1><p>It was a <strong>dark</strong> and stormy night.</p>'
+      + '<ul><li>one</li><li>two</li></ul>'
+      + '</body></html>',
+  },
+  {
+    name: 'OEBPS/text/ch2.xhtml',
+    content: '<?xml version="1.0"?><html xmlns="h"><body>'
+      + '<h1>Chapter Two</h1><p>The morning came.</p>'
+      + '<blockquote>A quoted line.</blockquote>'
+      + '</body></html>',
+  },
+]);

--- a/tests/peerd-runtime/doc/hardening.test.ts
+++ b/tests/peerd-runtime/doc/hardening.test.ts
@@ -9,7 +9,7 @@
 import { describe, test, expect } from 'bun:test';
 import { readZipIndex, readZipEntry, MAX_ENTRY_BYTES } from '../../../extension/peerd-runtime/doc/zip.js';
 import { convertToDocument } from '../../../extension/peerd-runtime/doc/convert.js';
-import { toMarkdown } from '../../../extension/peerd-runtime/doc/markdown.js';
+import { toMarkdown, renderTable } from '../../../extension/peerd-runtime/doc/markdown.js';
 import { parseXml } from '../../../extension/peerd-runtime/doc/xml.js';
 import { makeZip } from './fixtures.ts';
 
@@ -126,5 +126,24 @@ describe('nested lists are not duplicated or reordered', () => {
     // The trap: recursing into the block list would emit the sublist BEFORE
     // "Two", which is pushed to the parent list afterwards.
     expect(out.indexOf('One a')).toBeLessThan(out.indexOf('Two'));
+  });
+});
+
+describe('table-cell escaping is complete', () => {
+  test('a backslash before a pipe cannot break out of its cell', () => {
+    // The CodeQL finding: escaping `|` alone turns `a\|b` into `a\\|b`, where
+    // the doubled backslash is an escaped backslash and the pipe is left bare —
+    // so the cell splits and every column after it shifts by one.
+    const out = renderTable([['h1', 'h2'], ['a\\|b', 'x']], true);
+    const body = out.split('\n')[2];
+    // Three separators = two cells. Four would mean the cell split.
+    expect(body.split(/(?<!\\)\|/).filter(Boolean)).toHaveLength(2);
+    expect(body).toContain('a\\\\\\|b');
+  });
+
+  test('a lone backslash at the end of a cell does not escape the delimiter', () => {
+    const body = renderTable([['h1', 'h2'], ['ends\\', 'next']], true).split('\n')[2];
+    expect(body.split(/(?<!\\)\|/).filter(Boolean)).toHaveLength(2);
+    expect(body).toContain('next');
   });
 });

--- a/tests/peerd-runtime/doc/hardening.test.ts
+++ b/tests/peerd-runtime/doc/hardening.test.ts
@@ -1,0 +1,130 @@
+// The adversarial cases: a hostile archive, and the two nesting bugs that
+// produce plausible-looking-but-wrong output rather than an error.
+//
+// why these deserve their own file: each is a case where the naive
+// implementation SUCCEEDS and returns something. A bomb "works" right up until
+// it takes the renderer with it, and a duplicated nested list reads perfectly
+// well while telling the model the document says things twice.
+
+import { describe, test, expect } from 'bun:test';
+import { readZipIndex, readZipEntry, MAX_ENTRY_BYTES } from '../../../extension/peerd-runtime/doc/zip.js';
+import { convertToDocument } from '../../../extension/peerd-runtime/doc/convert.js';
+import { toMarkdown } from '../../../extension/peerd-runtime/doc/markdown.js';
+import { parseXml } from '../../../extension/peerd-runtime/doc/xml.js';
+import { makeZip } from './fixtures.ts';
+
+describe('decompression bombs', () => {
+  test('a member that inflates past the cap is refused, not inflated', async () => {
+    // 8 MB of zeros deflates to ~8 KB — a ~1000:1 ratio, the real shape of the
+    // attack. The cap is far above this, so we assert on the mechanism by
+    // checking the DECLARED size guard with a lying header below; here we
+    // prove the honest large member still round-trips.
+    const big = new Uint8Array(8 * 1024 * 1024);
+    const zip = await makeZip([{ name: 'big.bin', content: big }]);
+    const index = readZipIndex(zip);
+    const entry = index.get('big.bin')!;
+    // The compressed form is a tiny fraction of the original — this is the
+    // ratio that makes a bomb possible in the first place.
+    expect(entry.compressedSize).toBeLessThan(big.length / 100);
+    const out = await readZipEntry(zip, entry);
+    expect(out.length).toBe(big.length);
+  });
+
+  test('a header declaring more than the cap is refused before inflating', async () => {
+    const zip = await makeZip([{ name: 'word/document.xml', content: '<w:document/>' }]);
+    const index = readZipIndex(zip);
+    const entry = index.get('word/document.xml')!;
+    // Simulate the declared-size lie a bomb uses to look small on the wire.
+    const bomb = { ...entry, size: MAX_ENTRY_BYTES + 1 };
+    await expect(readZipEntry(zip, bomb)).rejects.toThrow(/limit|declares/);
+  });
+});
+
+describe('hostile XML', () => {
+  test('a DOCTYPE with entity declarations is skipped, not resolved (no XXE)', () => {
+    // The classic billion-laughs / file-read payload. The reader must treat the
+    // doctype as noise and never expand `&xxe;` — an undefined entity is left
+    // as literal text rather than resolved against anything.
+    const xml = '<?xml version="1.0"?>'
+      + '<!DOCTYPE r [<!ENTITY xxe SYSTEM "file:///etc/passwd"><!ENTITY lol "haha">]>'
+      + '<r><a>&xxe;</a><b>&lol;</b></r>';
+    const root = parseXml(xml);
+    const text = JSON.stringify(root);
+    expect(text).not.toContain('/etc/passwd');
+    expect(text).not.toContain('haha');
+    // Undefined entities survive verbatim — visible, not silently emptied.
+    expect(text).toContain('&xxe;');
+  });
+
+  test('an unclosed tag truncates cleanly instead of collapsing the tree', () => {
+    const root = parseXml('<a><b>first</b><c>second');
+    expect(JSON.stringify(root)).toContain('first');
+    expect(JSON.stringify(root)).toContain('second');
+  });
+});
+
+describe('nested lists are not duplicated or reordered', () => {
+  // A chapter that nests a list inside a list item, with a sibling item AFTER
+  // the nested list — the ordering trap.
+  const epubWithNesting = async () => makeZip([
+      { name: 'mimetype', content: 'application/epub+zip', store: true },
+      {
+        name: 'META-INF/container.xml',
+        content: '<?xml version="1.0"?><container xmlns="c"><rootfiles>'
+          + '<rootfile full-path="b.opf" media-type="application/oebps-package+xml"/></rootfiles></container>',
+      },
+      {
+        name: 'b.opf',
+        content: '<?xml version="1.0"?><package xmlns="p" xmlns:dc="dc">'
+          + '<metadata><dc:title>Nested</dc:title></metadata>'
+          + '<manifest><item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/></manifest>'
+          + '<spine><itemref idref="c1"/></spine></package>',
+      },
+      {
+        name: 'c1.xhtml',
+        content: '<?xml version="1.0"?><html xmlns="h"><body><ul>'
+          + '<li>Alpha<ul><li>Alpha one</li><li>Alpha two</li></ul></li>'
+          + '<li>Beta</li>'
+          + '</ul></body></html>',
+      },
+  ]);
+
+  test('EPUB: each nested item appears exactly once, indented, in order', async () => {
+    const out = toMarkdown(await convertToDocument(await epubWithNesting()));
+    // Exactly once — the naive walker emits nested items twice (once folded
+    // into the parent's own text, once from the recursion).
+    expect(out.match(/Alpha one/g)).toHaveLength(1);
+    // The parent keeps only its OWN text, not its children's.
+    expect(out).toContain('- Alpha\n');
+    expect(out).not.toContain('- AlphaAlpha one');
+    // Nesting shows as indentation…
+    expect(out).toContain('  - Alpha one');
+    expect(out).toContain('  - Alpha two');
+    // …and the sibling that FOLLOWS the nested list stays after it.
+    expect(out.indexOf('- Beta')).toBeGreaterThan(out.indexOf('Alpha two'));
+    // One list block, not three.
+    expect(out.split('\n').filter((l) => l.trim().startsWith('- '))).toHaveLength(4);
+  });
+
+  test('ODF: a sublist stays inside its parent list, in document order', async () => {
+    const ods = await makeZip([
+      { name: 'mimetype', content: 'application/vnd.oasis.opendocument.text', store: true },
+      {
+        name: 'content.xml',
+        content: '<?xml version="1.0"?><office:document-content xmlns:office="o" xmlns:text="t">'
+          + '<office:body><office:text><text:list>'
+          + '<text:list-item><text:p>One</text:p>'
+          + '<text:list><text:list-item><text:p>One a</text:p></text:list-item></text:list>'
+          + '</text:list-item>'
+          + '<text:list-item><text:p>Two</text:p></text:list-item>'
+          + '</text:list></office:text></office:body></office:document-content>',
+      },
+    ]);
+    const out = toMarkdown(await convertToDocument(ods));
+    expect(out.match(/One a/g)).toHaveLength(1);
+    expect(out).toContain('  - One a');
+    // The trap: recursing into the block list would emit the sublist BEFORE
+    // "Two", which is pushed to the parent list afterwards.
+    expect(out.indexOf('One a')).toBeLessThan(out.indexOf('Two'));
+  });
+});

--- a/tests/peerd-runtime/doc/sniff.test.ts
+++ b/tests/peerd-runtime/doc/sniff.test.ts
@@ -1,0 +1,126 @@
+// Format detection, and the two text formats that need no container.
+//
+// Sniffing is where a document reader is most often wrong in the field: the
+// filename lies, the server sends application/octet-stream, and the link that
+// ends in .pdf serves an HTML login page. So each of those is a test.
+
+import { describe, test, expect } from 'bun:test';
+import { sniffDocFormat, sniffDelimited, extensionOf } from '../../../extension/peerd-runtime/doc/sniff.js';
+import { parseCsv, parseDelimited } from '../../../extension/peerd-runtime/doc/parse/csv.js';
+import { parseRtf } from '../../../extension/peerd-runtime/doc/parse/rtf.js';
+import { toMarkdown } from '../../../extension/peerd-runtime/doc/markdown.js';
+import { makeDocx, makeXlsx, makeOdt, makeEpub } from './fixtures.ts';
+
+const bytes = (s: string) => new TextEncoder().encode(s);
+
+describe('sniffDocFormat — content beats the name', () => {
+  test('OOXML flavors are read out of the ZIP members, not the extension', async () => {
+    // Served as octet-stream under a WRONG extension: the bytes must still win.
+    expect(sniffDocFormat(await makeDocx(), { name: 'report.txt', contentType: 'application/octet-stream' }))
+      .toEqual({ format: 'docx', via: 'zip-member' });
+    expect(sniffDocFormat(await makeXlsx(), { name: 'x' }).format).toBe('xlsx');
+  });
+
+  test('ODF and EPUB are read from the stored mimetype member', async () => {
+    expect(sniffDocFormat(await makeOdt(), {})).toEqual({ format: 'odt', via: 'zip-member' });
+    expect(sniffDocFormat(await makeEpub(), {})).toEqual({ format: 'epub', via: 'zip-member' });
+  });
+
+  test('a .pdf link that actually serves HTML is identified as HTML', () => {
+    const html = bytes('<!DOCTYPE html><html><body>Sign in to continue</body></html>');
+    expect(sniffDocFormat(html, { name: 'report.pdf', contentType: 'application/pdf' }).format).toBe('html');
+  });
+
+  test('magic numbers win for PDF, RTF and legacy OLE2', () => {
+    expect(sniffDocFormat(bytes('%PDF-1.7\n...'), {}).format).toBe('pdf');
+    expect(sniffDocFormat(bytes('{\\rtf1\\ansi'), { name: 'a.docx' }).format).toBe('rtf');
+    const ole = new Uint8Array(16);
+    ole.set([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]);
+    expect(sniffDocFormat(ole, {}).format).toBe('ole2');
+  });
+
+  test('formats with no signature fall back to content-type, then name', () => {
+    expect(sniffDocFormat(bytes('a;b;c'), { contentType: 'text/csv; charset=utf-8' }))
+      .toEqual({ format: 'csv', via: 'content-type' });
+    expect(sniffDocFormat(bytes('anything at all'), { name: '/files/notes.tsv?dl=1' }))
+      .toEqual({ format: 'tsv', via: 'extension' });
+  });
+
+  test('binary with no known signature is unknown, never "text"', () => {
+    const junk = new Uint8Array([0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00]);
+    expect(sniffDocFormat(junk, {}).format).toBe('unknown');
+  });
+});
+
+describe('extensionOf', () => {
+  test('query strings and fragments are not part of the extension', () => {
+    expect(extensionOf('https://x.test/a/b/report.DOCX?token=1#p2')).toBe('docx');
+    expect(extensionOf('https://x.test/download')).toBe('');
+    expect(extensionOf('https://x.test/a.b/c')).toBe('');
+  });
+});
+
+describe('sniffDelimited — conservative on purpose', () => {
+  test('a consistent grid is delimited; prose containing commas is not', () => {
+    expect(sniffDelimited('a,b,c\n1,2,3\n4,5,6')).toBe('csv');
+    expect(sniffDelimited('a\tb\n1\t2')).toBe('tsv');
+    expect(sniffDelimited('Hello, world.\nThis is prose with no structure at all.')).toBe(null);
+    expect(sniffDelimited('single line, nothing else')).toBe(null);
+  });
+});
+
+describe('CSV', () => {
+  test('quoted fields carry delimiters, newlines and doubled quotes', () => {
+    const rows = parseDelimited('name,note\n"Smith, J.","He said ""hi""\nthen left"\n', ',');
+    expect(rows).toEqual([
+      ['name', 'note'],
+      ['Smith, J.', 'He said "hi"\nthen left'],
+    ]);
+  });
+
+  test('a BOM does not contaminate the first column name', () => {
+    const doc = parseCsv('﻿id,value\n1,x');
+    expect(toMarkdown(doc)).toContain('| id | value |');
+  });
+
+  test('an embedded newline is flattened inside the cell, not across rows', () => {
+    const out = toMarkdown(parseCsv('a,b\n"one\ntwo",3'));
+    const rows = out.split('\n').filter((l) => l.startsWith('|'));
+    expect(rows).toHaveLength(3);                    // header, rule, one body row
+    expect(out).toContain('| one two | 3 |');
+  });
+
+  test('rows past the cap are counted, not silently dropped', () => {
+    const many = ['a,b', ...Array.from({ length: 600 }, (_, i) => `${i},x`)].join('\n');
+    const out = toMarkdown(parseCsv(many));
+    expect(out).toContain('more rows not shown');
+  });
+});
+
+describe('RTF', () => {
+  test('group-scoped bold does not leak past its closing brace', () => {
+    const out = toMarkdown(parseRtf('{\\rtf1\\ansi {\\b bold} plain\\par}'));
+    expect(out).toContain('**bold**');
+    expect(out).toContain('plain');
+    expect(out).not.toContain('**bold plain**');
+  });
+
+  test('\\u escapes decode and their fallback character is swallowed', () => {
+    const out = toMarkdown(parseRtf('{\\rtf1 caf\\u233 ? and \\u8212 - done\\par}'));
+    expect(out).toContain('café');
+    expect(out).toContain('—');
+    expect(out).not.toContain('?');
+  });
+
+  test('ignorable destinations and font tables never reach the text', () => {
+    const rtf = '{\\rtf1{\\fonttbl{\\f0 Times New Roman;}}{\\*\\generator Word;}Real text.\\par}';
+    const out = toMarkdown(parseRtf(rtf));
+    expect(out).toBe('Real text.');
+  });
+
+  test('outline levels become headings', () => {
+    const out = toMarkdown(parseRtf('{\\rtf1\\pard\\outlinelevel0 Title Here\\par\\pard Body.\\par}'));
+    expect(out).toContain('# Title Here');
+    expect(out).toContain('Body.');
+  });
+});

--- a/tests/peerd-runtime/exposure.test.ts
+++ b/tests/peerd-runtime/exposure.test.ts
@@ -281,9 +281,14 @@ describe('DESIGN-17 web actor — the fourth kind (DOM toolset + tab pin)', () =
     // call_api stays OUT — the web actor's open-web read is fetch_url (sessionless),
     // not the credential-capable call_api.
     expect(isAllowedForActorType('call_api', 'web')).toBe(false);
-    // == DOM toolset + fetch_url + read_web_cache + the 4 DESIGN-19 site-client
-    // tools (run/read/write/capture) + login (Tier 0) (drift: bump if the set grows).
-    expect(actorAllowedTools('web').size).toBe(WEB_ACTOR_DOM_TOOLS.length + 7);
+    // == DOM toolset + fetch_url + read_doc + read_web_cache + the 4 DESIGN-19
+    // site-client tools (run/read/write/capture) + login (Tier 0)
+    // (drift: bump if the set grows).
+    expect(actorAllowedTools('web').size).toBe(WEB_ACTOR_DOM_TOOLS.length + 8);
+    // read_doc reads an office/ebook FILE by url (no tab) — same tier as
+    // fetch_url, and refused for every other actor kind.
+    expect(isAllowedForActorType('read_doc', 'web')).toBe(true);
+    expect(isAllowedForActorType('read_doc', 'app')).toBe(false);
     // DESIGN-19: the site-client family is in the web actor's toolset.
     for (const n of ['site_client_run', 'site_client_read', 'site_client_write', 'site_capture']) {
       expect(isAllowedForActorType(n, 'web')).toBe(true);


### PR DESCRIPTION
## What & why

An office document is not a web page and not a PDF, and peerd could read neither kind. The browser **downloads** a `.docx` instead of rendering it, so `snapshot`/`read_page` came back empty; `fetch_url` decodes every response with `Response.text()` (`tools/web/primitives.js:60`), so the same link returned 16k characters of mojibake — which then got disarmed, windowed, and spilled to the cache as if it were content. The honest answer was "I can't read this"; what the model actually did was guess from the filename.

This adds **`peerd-runtime/doc`**, the office-format sibling of `peerd-runtime/pdf`, modeled on [Firecrawl's anydoc](https://github.com/firecrawl/anydoc):

```
bytes → sniff → per-format parser → unified Document → GFM Markdown
```

The shared model in the middle is what makes a table from a `.docx` and a sheet from a `.xlsx` come out identical, and puts every escaping and truncation decision in one file instead of seven.

**Nothing is vendored.** anydoc itself is a Rust crate with no browser/WASM target, so this implements its *shape*, not its bytes. DEFLATE is the platform's (`DecompressionStream('deflate-raw')`); the ZIP reader (central-directory based, ZIP64-aware) and XML reader are ~300 lines we own and can audit, against tens of thousands of dependency. The core is **pure** — only `TextDecoder` and `DecompressionStream` — so it runs in any context and is exercised from Bun.

Formats: `.docx` `.xlsx` `.pptx` `.odt` `.ods` `.odp` `.rtf` `.epub` `.csv` `.tsv`. Legacy OLE2 (`.doc`/`.xls`/`.ppt`) and `.xlsb` are recognized and refused **by name**, naming the WebVM conversion route — a real escape hatch beats a pretend parser.

### Surfaces

- **`read_doc`** — actor-only (untrusted document text, the `read_pdf`/`read_page` boundary), url-based, no tab. Rides beside `fetch_url` in the web actor's set rather than in `WEB_ACTOR_DOM_TOOLS`: it owns no tab, so it is not a DOM tool. Spills-and-pages through the **same** `webCache` + `read_web_cache` idiom `fetch_url` uses, and takes the same `query` for BM25 passages — an answer in an appendix is not missed.
- **`fetch_url`** — now detects a document response and hands over the reader that can open it, instead of returning bytes as text.
- **The failures are the API.** A PDF, an HTML login wall behind a document link, a legacy `.doc`, and an encrypted archive each name what to do next rather than dead-ending.

One tool for eight formats, not eight tools: the agent usually does not know which one it has, and a tool it must pick correctly *before* it can look is one it will pick wrong. Detection is content-first — a magic number cannot lie the way a filename or a CDN's `application/octet-stream` does.

Closes #

## Checklist

- [x] `bun run preflight` passes (tests, typecheck, lint, in-browser, dweb-boundary, no manifest drift) — see below
- [x] Only original or permissively-licensed code — **no GPL / AGPL / copyleft** (no new dependencies at all)
- [x] Tests added or updated — 36 new Bun tests across 3 files, against real in-memory archives
- [x] No hand-edited generated files
- [x] Called out below if this touches a **danger zone**

## Notes for reviewers

### Danger zone: egress + a new offscreen message route

Conversion runs in the **offscreen document** (the `read_pdf` precedent) — not because it needs a DOM (the core is pure and would run anywhere), but so the multi-megabyte untrusted buffer never sits in the service worker, which is also the context holding the vault DK.

- `read_doc` applies the **same two gates** `read_pdf` applies to its url override: the denylist, and `isPrivateOrLocalHost` (deep import of the pure SSRF matcher). It issues a new fetch, so it must refuse loopback/LAN/link-local/metadata exactly like open-web egress.
- The offscreen fetch is `redirect:'manual'` — a 3xx becomes an `opaqueredirect` we reject rather than follow, so a public host cannot pivot the request onto an origin no gate saw (INV-7).
- The new `doc/extract` listener is `isTrustedSender`-gated like every sibling handler. `packaging/security-baseline.json` is re-blessed for exactly that one line.
- `eslint.config.js` adds `offscreen/doc-extract.js` to the same bare-`fetch` exemption `offscreen/pdf-extract.js` already has, with the rationale inline.
- The conversion is entirely declarative — no eval, no scripting engine, no DOM insertion.

### Adversarial pass — four real findings, all fixed with tests

1. **Decompression bomb** (the security one). `readZipEntry` inflated with no output cap; DEFLATE reaches ~1000:1, so a 1MB member in an innocuous `.docx` could inflate to a gigabyte and take the renderer down. Now refused on declared size **and** read incrementally so a lying header can't get past the cap. The fetch-side byte cap bounds the *compressed* input, which is exactly what a bomb keeps small.
2. **Nested lists emitted twice.** The obvious walker takes `runsOf(li)` then recurses for sublists — but a nested `<ul>` lives *inside* its parent `<li>`, so every nested item appeared once folded into the parent's text and once from the recursion. Fails silently: the output reads fine and just tells the model the document says things twice.
3. **ODF sublists reordered.** Recursing into the block list appended the sublist while the parent list was still collecting items, so a sublist rendered *before* the siblings that follow it. Both 2 and 3 now flatten into one list block with correct levels.
4. **`read_doc` truncated where `fetch_url` pages.** A document is where a silent cut hurts most and there's no second way to reach the tail. Now spills and pages like `fetch_url`.

Plus the format-specific traps, each with a test: `.ods` grid padding (`number-columns-repeated="16381"`) trimmed rather than expanded; sparse `.xlsx` cells keep their column (`C2` stays in column 3 when `B2` is absent); pooled shared strings resolved; hidden sheets skipped **and said so**; `.pptx` slides in `sldIdLst` order rather than relationship order, with speaker notes; Word's `numId="0"` ("explicitly not a list") not turned into a bullet; adjacent same-styled runs merged so bold doesn't serialize as `**Hel****lo**`; EPUB read in **spine** order, not manifest order. Excel date serials are reported *as serials* with a note — the display format lives in a part we don't read, and a guess presented as a fact is worse than the number.

### Verification

| Gate | Result |
|---|---|
| `bun test ./tests` | 4079 pass, 0 fail |
| in-browser (CDP headless) | 713 pass, 0 fail |
| `test:e2e` | 21 states, 128/128 checks |
| `check:pages` | 9 pages boot, both channels |
| lint / typecheck | clean |
| `check:` tscheck, imports, boundary, hygiene, invariants, docpaths, vendor | all OK |

`check:web` and `feeds:check` fail in this sandbox for environmental reasons only (no `web-dist/` build, no `gh` CLI) — untouched by this change.

`COVERED_FLOOR` bumped 579 → 599: every new file landed `// @ts-check`-clean.

### Deliberately not in scope

User **attachments** are still refused for these formats (`loop/attachments.js` `classifyAttachment` → `'unsupported'`). That's the *user* path rather than the actor path this PR is about, and routing an attached `.docx` through the same converter is a clean follow-up now that the pipeline exists.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QuTKbXkL7ZhH2fTPzFnXJa)_