### PR TITLE
fix(security): close the three mechanical findings from the #255 arc review (#267, #276, #278)

### DIFF
--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -728,12 +728,16 @@ evaluating peerd should know. Each cites where it lives in the code.
   hosts, asked at origin level), origins with a stored credential, and two signals
   LEARNED from ordinary use — a password field seen on a page, and a write the user
   approved. It fails open, so an unlisted credentialed site is treated as ordinary until
-  a signal fires. In practice the password-field signal fires on the first page walk of
-  any sign-in surface, so the exposure is narrower than "until you configure something";
-  but the FIRST landing on a site whose login the actor never sees is unprotected by
-  construction, and nothing un-learns, so an origin stays classified until the profile
-  is reset. Detecting credentials directly would need the `cookies` permission, which is
-  not requested for the same reason `webNavigation` is not.
+  a signal fires. The password-field signal fires on a SNAPSHOT specifically — not on
+  any page walk — so which tool the actor reaches for decides whether peerd learns at
+  all: an actor that perceives with `read_page` or `query_dom` never teaches the
+  classifier, and that choice belongs to whoever is driving it (#267). The FIRST landing
+  on a site whose login the actor never sees is unprotected by construction. An origin
+  can now be un-learned: Settings → Learned sites lists what was inferred and removes it
+  (#262), and a signal the probe cannot attribute to the page the caller resolved is
+  dropped rather than credited to the wrong origin (#278). Detecting credentials
+  directly would need the `cookies` permission, which is not requested for the same
+  reason `webNavigation` is not.
 - R16. The identity-provider list is the one place a bound actor may leave its origin,
   and it is deliberately short — a host qualifies only if signing in is essentially all
   it does. github.com, gitlab.com and facebook.com are excluded despite speaking OAuth,

--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -728,14 +728,14 @@ evaluating peerd should know. Each cites where it lives in the code.
   hosts, asked at origin level), origins with a stored credential, and two signals
   LEARNED from ordinary use — a password field seen on a page, and a write the user
   approved. It fails open, so an unlisted credentialed site is treated as ordinary until
-  a signal fires. The password-field signal fires on a SNAPSHOT specifically — not on
-  any page walk — so which tool the actor reaches for decides whether peerd learns at
-  all: an actor that perceives with `read_page` or `query_dom` never teaches the
-  classifier, and that choice belongs to whoever is driving it (#267). The FIRST landing
-  on a site whose login the actor never sees is unprotected by construction. An origin
-  can now be un-learned: Settings → Learned sites lists what was inferred and removes it
-  (#262), and a signal the probe cannot attribute to the page the caller resolved is
-  dropped rather than credited to the wrong origin (#278). Detecting credentials
+  a signal fires. The signal is observed at the DOM chokepoint every DOM tool passes
+  through, so which tool an actor reaches for no longer decides whether peerd learns
+  (#267 — it used to fire only on `snapshot`, and tool choice belongs to whoever is
+  driving the actor). The FIRST landing on a site whose login the actor never sees is
+  unprotected by construction. An origin can now be un-learned: Settings → Learned
+  sites lists what was inferred and removes it (#262), and the signal is credited to
+  the origin the probe REPORTS rather than to the caller's tab record, so a page that
+  navigates mid-call cannot spend it on someone else (#278). Detecting credentials
   directly would need the `cookies` permission, which is not requested for the same
   reason `webNavigation` is not.
 - R16. The identity-provider list is the one place a bound actor may leave its origin,

--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -755,6 +755,68 @@ evaluating peerd should know. Each cites where it lives in the code.
   trust, so a hijacked page gets one attempt at persuading it to open a helper somewhere
   the user never asked about. (`peerd-runtime/actor/origin-lock-report.js`.)
 
+- R18. The identity-provider registry is invisible to the sensitivity classifier
+  (#265). peerd keeps exactly one curated list of origins whose whole purpose is
+  authentication, and it is consumed only to OPEN a bound actor's excursion
+  (`actor/origin-lock.js`, `actor/landing-rule.js`) — never as a sensitivity signal.
+  The classifier's seeds are the UGC registry, a stored credential, and what was
+  learned. So the big IdP hosts classify as ORDINARY until something happens to see a
+  password field on one, which is backwards: they are the set on which a session cookie
+  is worth the most. The fix is plausibly one seed, but whether an IdP should be
+  "sensitive" or a THIRD state — enterable on an excursion, never roamable — is a
+  design call, and adding the seed naively would make the excursion mechanism refuse
+  the landings it exists to permit.
+- R19. Learning is unauthenticated, page-controlled input (#268). A hostile page that
+  renders one password field classifies ITSELF as credentialed, and the landing rule
+  then hands off to a successor bound to the attacker's own origin. R17 already records
+  that the attacker names the successor; what this adds is the CAPABILITY difference —
+  the successor is bound, so it may open an auth excursion onto a real IdP host, which
+  the roaming actor it replaced could not. Two things bound it today: a signal is
+  credited to the origin the probe reports rather than to the caller's tab record
+  (#278), so a page can only mark the document it controls; and Settings → Learned
+  sites shows what was inferred and removes it (#262). Moving the probe to the DOM
+  chokepoint (#267) deliberately widened the trigger from one tool to all of them,
+  which widens this too — the trade is stated in that commit: unfixed #267 let a
+  hijacked actor KEEP authority on a real credentialed site, while this direction costs
+  availability and fills the learned cap faster.
+- R20. Type-the-scrape-into-a-form exfil is invisible to the tripwire (#269). The
+  scanner inspects tool ARGUMENTS for URL-shaped payloads. Typing a scraped blob into a
+  form field and clicking submit moves the same bytes with no URL in any argument: the
+  blob is seen in the `text` slot and discarded because it does not parse as a URL, and
+  the request that actually carries it — the form submission — is a `click`, whose args
+  are a ref or a selector. The module header already puts page-driven beacons out of
+  scope; this path is tool-driven, so it is inside the stated scope and is a gap rather
+  than an exclusion (`tools/egress-heuristics.js`).
+- R21. `fetch_url` headers and body are structurally invisible to the same scanner
+  (#270). The tripwire was widened to cover the web actor's own fetch, but it reads
+  only the URL-shaped fields; header values and any request body are never examined,
+  and the candidate collector only walks top-level strings, so an object argument could
+  not be read even if it were listed. `fetch_url` strips the credential-bearing headers
+  and passes the rest through verbatim. The scanner is already a pure function over
+  strings, so the cheapest close is to run it over those values too — it is listed here
+  because it is not done, not because it is hard.
+- R22. The auth excursion is scoped to TIME, not to the sign-in it was opened for
+  (#273). Inside a live excursion the only refusals are the deadline, a sensitive
+  landing that is not the opener, and budget exhaustion — and budget is spent on an
+  ORIGIN CHANGE, so one hop onto an attacker origin buys read/click/type across every
+  path of it for the rest of the window. The opener is recorded but only used to exempt
+  itself; the return-to is never enforced. Whether an excursion should be bounded by
+  the flow that opened it rather than by a clock is the open question
+  (`actor/landing-rule.js`).
+- R23. The password probe is top-frame and light-DOM only (#277). A site whose sign-in
+  lives in an iframe — an embedded IdP or payment widget, or a plain `<iframe
+  src=/login>` — or inside a shadow root is invisible to the learned signal
+  permanently, however often peerd walks it. This is the one residual that pulls
+  AGAINST another: widening the probe widens both directions at once, and #257 exists
+  because false positives on this signal have their own cost. It wants a deliberate
+  call, not a wider selector (`dom/walk-injected.js`).
+- R24. Chunked exfil defeats the minimum-blob threshold (#279). The tripwire is a pure
+  per-call function over one call's slots, and the dispatcher hands it no history, so a
+  payload split below the threshold passes as many times as an attacker cares to
+  repeat it and reassembles server-side. Cross-call aggregation is the only real
+  answer; the module header already lists fragmentation as accepted, and this records
+  it as a decision rather than an oversight (`tools/egress-heuristics.js`).
+
 Candidates for future red-team scenarios, from the partially-defended surfaces above:
 R2 memory poisoning and R3 skill-body smuggling. (R4 chain tampering, R5 grant
 scoping, and R6 import gating gained direct bun coverage when they were narrowed:

--- a/extension/peerd-runtime/dom/capture.js
+++ b/extension/peerd-runtime/dom/capture.js
@@ -45,10 +45,15 @@ import { domWalkInjected, hasPasswordFieldInjected } from './walk-injected.js';
  * origin is one the user has an identity on. `null` means unknown — a probe that
  * could not run — and must never be read as `false`.
  *
+ * `probeOrigin` says WHERE that signal was observed. The caller's tab record is
+ * resolved before this runs, so the two can disagree if the page navigates in
+ * between; a caller that cannot attribute the signal must drop it rather than
+ * credit it to the wrong origin (issue 278). `null` = unknown, same posture.
+ *
  * @returns {Promise<
  *   { ok: true, source: 'cdp'|'dom-walk', text: string, refs: object[],
  *     truncated: boolean, capped: boolean, nodeCount: number, refCount: number,
- *     hasPasswordField: boolean | null }
+ *     hasPasswordField: boolean | null, probeOrigin?: string | null }
  *   | { ok: false, source: 'cdp'|'dom-walk'|'none', error: string }>}
  */
 export const captureSnapshot = async (tab, ctx, { budget = 8000 } = {}) => {
@@ -71,14 +76,17 @@ export const captureSnapshot = async (tab, ctx, { budget = 8000 } = {}) => {
     // failure means UNKNOWN, never false: the classifier must not read "we could
     // not look" as "there is nothing here".
     let hasPasswordField = /** @type {boolean | null} */ (null);
+    // Where the probe ran, which is NOT necessarily where the caller thinks the
+    // tab is — the caller's tab record predates this injection. Null = unknown.
+    let probeOrigin = /** @type {string | null} */ (null);
     if (typeof scripting?.executeScript === 'function') {
       try {
         const probe = await scripting.executeScript({ target: { tabId: tab.id }, func: hasPasswordFieldInjected });
         const v = probe?.[0]?.result;
-        if (typeof v === 'boolean') hasPasswordField = v;
-      } catch { hasPasswordField = null; }
+        if (typeof v?.has === 'boolean') { hasPasswordField = v.has; probeOrigin = typeof v.origin === 'string' ? v.origin : null; }
+      } catch { hasPasswordField = null; probeOrigin = null; }
     }
-    return { ok: true, source: 'cdp', capped: false, hasPasswordField, ...serializeAxTree(nodes, { budget }) };
+    return { ok: true, source: 'cdp', capped: false, hasPasswordField, probeOrigin, ...serializeAxTree(nodes, { budget }) };
   }
 
   if (typeof scripting?.executeScript !== 'function') {
@@ -112,8 +120,9 @@ export const captureSnapshot = async (tab, ctx, { budget = 8000 } = {}) => {
     ok: true,
     source: 'dom-walk',
     capped: !!walk.capped,
-    // The walk reports it inline — free, since it is already in the page.
+    // The walk reports both inline — free, since it is already in the page.
     hasPasswordField: typeof walk.hasPasswordField === 'boolean' ? walk.hasPasswordField : null,
+    probeOrigin: typeof walk.probeOrigin === 'string' ? walk.probeOrigin : null,
     ...serializeAxTree(walk.nodes, { budget }),
   };
 };
@@ -129,3 +138,26 @@ export const describeSource = (source) => (
     ? 'pseudo-a11y snapshot (DOM-walk fallback — no CDP here; top frame only)'
     : 'a11y snapshot'
 );
+
+/**
+ * Can a password-field signal observed by the probe be credited to `origin`?
+ *
+ * The tab record is resolved BEFORE the capture and the probe runs after, in
+ * whatever document is committed by then. A page that navigates cross-origin
+ * inside that window would otherwise have its password field recorded against
+ * the origin we started on — which lets a hostile page mark arbitrary third
+ * parties as "the user has an account here" (roaming helpers are then refused
+ * there), and, repeated, fills the learned-origin cap so nothing further is
+ * ever learned (issue 278).
+ *
+ * `null` from the probe is UNKNOWN, not a mismatch: an opaque document cannot
+ * report its origin, and treating that as a mismatch would silently stop
+ * learning on pages where the signal is still the caller's own. That is the
+ * same posture as reading `hasPasswordField === true` strictly.
+ *
+ * @param {string | null | undefined} probeOrigin  where the probe says it ran
+ * @param {string | null | undefined} origin       where the caller thinks it ran
+ * @returns {boolean}
+ */
+export const signalIsAttributable = (probeOrigin, origin) =>
+  probeOrigin == null || probeOrigin === origin;

--- a/extension/peerd-runtime/dom/index.js
+++ b/extension/peerd-runtime/dom/index.js
@@ -17,7 +17,7 @@ export { summarizeMutations } from './action-result.js';
 // Firefox-parity fallback: captureSnapshot picks CDP when the pool is
 // wired, else the chrome.scripting DOM-walk pseudo-snapshot
 // (walk-injected.js) — same serializer, same ref contract.
-export { captureSnapshot, describeSource } from './capture.js';
+export { captureSnapshot, describeSource, signalIsAttributable } from './capture.js';
 export { domWalkInjected } from './walk-injected.js';
 
 // The in-page activity indicator injected into the tab the web actor drives.

--- a/extension/peerd-runtime/dom/walk-injected.js
+++ b/extension/peerd-runtime/dom/walk-injected.js
@@ -310,9 +310,14 @@ export function domWalkInjected() {
     pushChildren(el, parentNodeId);
   }
 
+  // probeOrigin: where this walk ACTUALLY ran. See hasPasswordFieldInjected —
+  // the caller's tab record is a snapshot taken before injection, so the
+  // password-field signal is only attributable if these agree.
+  var probeOrigin = null;
+  try { probeOrigin = location.origin; } catch (e) { probeOrigin = null; }
   return {
     ok: true, nodes: nodes, refElementCount: els.size, capped: capped,
-    hasPasswordField: hasPasswordField,
+    hasPasswordField: hasPasswordField, probeOrigin: probeOrigin,
   };
 }
 
@@ -333,19 +338,31 @@ export function domWalkInjected() {
  * body closes over nothing, so the two copies must each stand alone. Keep them
  * in step; the walk copy carries the full rationale.
  *
- * @returns {boolean}
+ * @returns {{ has: boolean, origin: string | null }} the signal, and WHERE it was
+ *   observed — the caller must drop it if that disagrees with the tab it resolved.
  */
 export function hasPasswordFieldInjected() {
   'use strict';
+  // Reports WHERE it ran, not just what it saw. The caller resolves the tab
+  // first and reads `tab.url` from that frozen record, but this body runs later,
+  // in whatever document is committed by then — so a page that navigates in
+  // between could have its password field attributed to the origin the caller
+  // still thinks is loaded. Returning location.origin lets the caller drop a
+  // signal it cannot attribute. (`origin: null` on a throw, so an opaque or
+  // unreadable document is UNKNOWN rather than silently matching.)
+  var origin = null;
+  try { origin = location.origin; } catch (e) { origin = null; }
   try {
     var fields = document.querySelectorAll('input[type="password"]');
     for (var i = 0; i < fields.length; i++) {
       var autocomplete = fields[i].getAttribute('autocomplete');
       // A registration field is evidence the user has NO account here.
-      if (String(autocomplete == null ? '' : autocomplete).toLowerCase() !== 'new-password') return true;
+      if (String(autocomplete == null ? '' : autocomplete).toLowerCase() !== 'new-password') {
+        return { has: true, origin: origin };
+      }
     }
-    return false;
+    return { has: false, origin: origin };
   } catch (e) {
-    return false;
+    return { has: false, origin: origin };
   }
 }

--- a/extension/peerd-runtime/dom/walk-injected.js
+++ b/extension/peerd-runtime/dom/walk-injected.js
@@ -338,8 +338,9 @@ export function domWalkInjected() {
  * body closes over nothing, so the two copies must each stand alone. Keep them
  * in step; the walk copy carries the full rationale.
  *
- * @returns {{ has: boolean, origin: string | null }} the signal, and WHERE it was
- *   observed — the caller must drop it if that disagrees with the tab it resolved.
+ * @returns {{ has: boolean, origin: string | null, href: string | null }} the signal,
+ *   and WHERE it was observed — the caller must drop it if that disagrees with the
+ *   tab it resolved.
  */
 export function hasPasswordFieldInjected() {
   'use strict';
@@ -350,19 +351,28 @@ export function hasPasswordFieldInjected() {
   // still thinks is loaded. Returning location.origin lets the caller drop a
   // signal it cannot attribute. (`origin: null` on a throw, so an opaque or
   // unreadable document is UNKNOWN rather than silently matching.)
+  //
+  // `location` is [Unforgeable] and this body runs in the ISOLATED world, so a
+  // hostile page can neither shadow it nor reach in and rewrite the answer: the
+  // document cannot lie about which document it is. That is what makes this
+  // usable as a live re-check of the caller's frozen tab record and not merely
+  // as a hint. href as well as origin, because the landing judge is asked about
+  // a URL and a path-scoped rule must not be handed a bare origin.
   var origin = null;
+  var href = null;
   try { origin = location.origin; } catch (e) { origin = null; }
+  try { href = location.href; } catch (e) { href = null; }
   try {
     var fields = document.querySelectorAll('input[type="password"]');
     for (var i = 0; i < fields.length; i++) {
       var autocomplete = fields[i].getAttribute('autocomplete');
       // A registration field is evidence the user has NO account here.
       if (String(autocomplete == null ? '' : autocomplete).toLowerCase() !== 'new-password') {
-        return { has: true, origin: origin };
+        return { has: true, origin: origin, href: href };
       }
     }
-    return { has: false, origin: origin };
+    return { has: false, origin: origin, href: href };
   } catch (e) {
-    return { has: false, origin: origin };
+    return { has: false, origin: origin, href: href };
   }
 }

--- a/extension/peerd-runtime/tools/defs/dom-helpers.js
+++ b/extension/peerd-runtime/tools/defs/dom-helpers.js
@@ -162,18 +162,32 @@ export const resolveTargetTab = async (args, ctx) => {
   // issue 267: while we are in there, observe the password field — so every DOM
   // tool teaches the classifier, not just `snapshot`.
   const live = await probeLiveDocument(tab, ctx);
-  if (live?.origin && live.origin !== originOfUrl(tab.url)) {
+  // Only a WEB origin is actionable: the denylist matches hostnames and the
+  // landing rule reasons about http(s) origins, so handing either an opaque
+  // `null`, a data: or a blob: document would be asking a question neither can
+  // answer. Those fall through untouched — fail open, as everywhere else here.
+  const liveOrigin = live?.origin && /^https?:\/\//.test(live.origin) ? live.origin : null;
+  if (liveOrigin && liveOrigin !== originOfUrl(tab.url)) {
+    const liveUrl = live?.href ?? liveOrigin;
     // It moved. Judge where it IS, on the same two rules, and refuse on either.
-    if (isDenylistedTab(live.href ?? live.origin, ctx.denylist)) return null;
+    if (isDenylistedTab(liveUrl, ctx.denylist)) return null;
     if (ctx.judgeLanding) {
-      const verdict = await ctx.judgeLanding(live.href ?? live.origin);
+      const verdict = await ctx.judgeLanding(liveUrl);
       if (verdict && verdict.action !== 'continue') return null;
     }
+    // It moved somewhere allowed — so hand the caller where it IS. A copy, not a
+    // mutation: `tab` is the tabs API's record and navigate.js relies on the pin
+    // objects it shares staying its own. why it matters beyond tidiness: login.js
+    // derives the origin it https-gates, NAMES IN THE CONFIRM, and audits from
+    // this url. A stale one there is the confused deputy in its purest form — the
+    // user approves a sign-in on the origin the tab record remembers while the
+    // ceremony runs in the document that replaced it.
+    if (live?.href) tab = { ...tab, url: live.href };
   }
-  if (live?.hasPasswordField === true && live.origin) {
+  if (live?.hasPasswordField === true && liveOrigin) {
     // Attributed to the origin that REPORTED it, never to the tab record — the
     // #278 rule, held by construction here rather than by comparison.
-    try { ctx.noteLearnedOrigin?.(live.origin, 'password-field'); } catch { /* best-effort */ }
+    try { ctx.noteLearnedOrigin?.(liveOrigin, 'password-field'); } catch { /* best-effort */ }
   }
   // The loop just targeted THIS tab by id (navigate/click/type/read/… on a tab
   // the agent opened) — update the "current agent tab" card so it tracks where

--- a/extension/peerd-runtime/tools/defs/dom-helpers.js
+++ b/extension/peerd-runtime/tools/defs/dom-helpers.js
@@ -13,6 +13,10 @@
 // break this module's unit tests. composer/resolvers.js imports it the
 // same way for the same reason.
 import { findDenylistMatch } from '../../../peerd-egress/denylist/denylist.js';
+// The one live look at the target document (issues 267 + 276). Deep import for
+// the same reason as above — dom/index.js is fine, but this file is unit-tested
+// without a browser and the barrel is wider than the one function needed.
+import { hasPasswordFieldInjected } from '../../dom/walk-injected.js';
 //
 //   2. Functions that get INJECTED into the page via
 //      chrome.scripting.executeScript. Those functions:
@@ -22,6 +26,63 @@ import { findDenylistMatch } from '../../../peerd-egress/denylist/denylist.js';
 //          (closed-over imports don't get serialized)
 //      So every injected fn is self-contained. We keep them here for
 //      organization but each is independently executable.
+
+/**
+ * How long the live probe gets before the chokepoint gives up on it.
+ *
+ * why a timeout at all: the probe is the only thing on this path that depends
+ * on the RENDERER answering. A tool that drives the page through CDP (page_exec,
+ * page_keys) never needed the renderer's cooperation, and a wedged main thread
+ * must not turn into a hung tool call. Short enough to be invisible next to the
+ * injections the DOM tools already do, long enough that an ordinary busy page
+ * still answers.
+ */
+const LIVE_PROBE_TIMEOUT_MS = 400;
+
+/**
+ * Ask the document that is ACTUALLY committed in the target tab where it is and
+ * whether it is showing a password field. Best-effort by construction: null
+ * means "could not look", never "nothing there".
+ *
+ * why here and not in each tool: this is the only place that knows the tool is
+ * about to touch a specific tab, and it is the only place every DOM tool passes
+ * through. Before this, the password-field signal was observed in exactly ONE
+ * tool (`snapshot`) — so an actor that perceived with `read_page` instead never
+ * taught the classifier anything, and staying unlearned was a matter of which
+ * tool it chose to call (issue 267). Tool choice belongs to whoever is driving
+ * the actor, which is precisely the party the classifier exists to constrain.
+ *
+ * @param {{ id?: number }} tab
+ * @param {{ scripting?: any }} ctx
+ * @returns {Promise<{ origin: string | null, href: string | null, hasPasswordField: boolean | null } | null>}
+ */
+const probeLiveDocument = async (tab, ctx) => {
+  if (typeof tab?.id !== 'number' || typeof ctx?.scripting?.executeScript !== 'function') return null;
+  /** @type {any} */
+  let timer = null;
+  try {
+    const probe = ctx.scripting.executeScript({ target: { tabId: tab.id }, func: hasPasswordFieldInjected });
+    const raced = await Promise.race([
+      probe,
+      new Promise((resolve) => { timer = setTimeout(() => resolve(null), LIVE_PROBE_TIMEOUT_MS); }),
+    ]);
+    const v = raced?.[0]?.result;
+    if (!v) return null;
+    return {
+      origin: typeof v.origin === 'string' ? v.origin : null,
+      href: typeof v.href === 'string' ? v.href : null,
+      hasPasswordField: typeof v.has === 'boolean' ? v.has : null,
+    };
+  } catch {
+    // Pages the browser refuses to inject into (chrome:, the extension stores,
+    // a tab mid-navigation) land here. FAIL OPEN: the caller keeps the verdict
+    // it already reached on tab.url. Refusing instead would break every
+    // CDP-driven tool on exactly the pages CDP exists for.
+    return null;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+};
 
 /**
  * Get the tab the tool should operate on. Returns the chrome.tabs Tab
@@ -39,7 +100,7 @@ import { findDenylistMatch } from '../../../peerd-egress/denylist/denylist.js';
  * yields null, which every caller already surfaces as a refusal.
  *
  * @param {{ tabId?: number }} args
- * @param {{ tabs: any, denylist?: readonly string[], activeTab?: { id: number, url: string, origin: string }, actorType?: string, noteTab?: (tabId: number, url?: string, opts?: { opened?: boolean }) => void, judgeLanding?: (url: string) => Promise<{ action: string } | null> }} ctx
+ * @param {{ tabs: any, denylist?: readonly string[], activeTab?: { id: number, url: string, origin: string }, actorType?: string, noteTab?: (tabId: number, url?: string, opts?: { opened?: boolean }) => void, judgeLanding?: (url: string) => Promise<{ action: string } | null>, scripting?: any, noteLearnedOrigin?: (origin: string, reason: string) => void }} ctx
  *
  * `judgeLanding` (issue 251) is the origin lock, injected by the SW so this
  * file stays free of actor state and the policy stays pure and unit-tested
@@ -85,6 +146,34 @@ export const resolveTargetTab = async (args, ctx) => {
   if (ctx.judgeLanding) {
     const verdict = await ctx.judgeLanding(tab.url);
     if (verdict && verdict.action !== 'continue') return null;
+  }
+  // ONE live look at the document that is actually there — the answer to two
+  // findings, and the reason it is worth a round trip.
+  //
+  // issue 276: everything above judged `tab.url`, which is what the BROWSER
+  // recorded, read out of a record frozen before this function was called. The
+  // document committed right now can be a different origin, and the tool's own
+  // injection lands in that one. Re-checking the origin the document reports
+  // about ITSELF narrows the window from "however stale the tab record is" to
+  // "one message round trip". It does not close it: the tool injects after we
+  // return, and only pinning the judged documentId at injection time would make
+  // that airtight. Stated plainly so the next reader does not over-trust it.
+  //
+  // issue 267: while we are in there, observe the password field — so every DOM
+  // tool teaches the classifier, not just `snapshot`.
+  const live = await probeLiveDocument(tab, ctx);
+  if (live?.origin && live.origin !== originOfUrl(tab.url)) {
+    // It moved. Judge where it IS, on the same two rules, and refuse on either.
+    if (isDenylistedTab(live.href ?? live.origin, ctx.denylist)) return null;
+    if (ctx.judgeLanding) {
+      const verdict = await ctx.judgeLanding(live.href ?? live.origin);
+      if (verdict && verdict.action !== 'continue') return null;
+    }
+  }
+  if (live?.hasPasswordField === true && live.origin) {
+    // Attributed to the origin that REPORTED it, never to the tab record — the
+    // #278 rule, held by construction here rather than by comparison.
+    try { ctx.noteLearnedOrigin?.(live.origin, 'password-field'); } catch { /* best-effort */ }
   }
   // The loop just targeted THIS tab by id (navigate/click/type/read/… on a tab
   // the agent opened) — update the "current agent tab" card so it tracks where

--- a/extension/peerd-runtime/tools/defs/snapshot.js
+++ b/extension/peerd-runtime/tools/defs/snapshot.js
@@ -19,7 +19,7 @@
 
 import { wrapUntrusted } from '../prompt-wrap.js';
 import { resolveTargetTab, originOfUrl } from './dom-helpers.js';
-import { captureSnapshot, describeSource, diffSnapshots } from '../../dom/index.js';
+import { captureSnapshot, signalIsAttributable, describeSource, diffSnapshots } from '../../dom/index.js';
 
 /** @typedef {import('../../dom/snapshot-diff.js').SnapRef} SnapRef */
 /**
@@ -89,7 +89,17 @@ export const snapshotTool = {
     // which origins peerd treats as the user's. Strictly `=== true`, because
     // `null` from the capture means the probe could not run — unknown, not
     // absent. Best-effort: a learning failure must never fail a snapshot.
-    if (cap.hasPasswordField === true) {
+    //
+    // ATTRIBUTION. `origin` above comes from the tab record resolved BEFORE the
+    // capture; the probe runs after, in whatever document is committed by then.
+    // A page that navigates cross-origin inside that window would otherwise have
+    // its password field recorded against the origin we started on — letting a
+    // hostile page mark arbitrary third parties as "the user has an account
+    // here" (and, repeated, fill the 500-entry cap so nothing further is ever
+    // learned). So the probe reports where it ran, and a signal we cannot
+    // attribute is DROPPED: unknown, not absent, which is the same posture as
+    // the `=== true` check itself.
+    if (cap.hasPasswordField === true && signalIsAttributable(cap.probeOrigin, origin)) {
       try { /** @type {any} */ (ctx).noteLearnedOrigin?.(origin, 'password-field'); }
       catch { /* best-effort */ }
     }

--- a/extension/tests/unit/peerd-runtime/dom-walk.test.js
+++ b/extension/tests/unit/peerd-runtime/dom-walk.test.js
@@ -288,21 +288,21 @@ describe('dom walk — the password-field signal', () => {
   it('no password field anywhere: both entry points say false', async () => {
     await withInputs('<input type="text" name="q">', () => {
       expect(domWalkInjected().hasPasswordField).toBe(false);
-      expect(hasPasswordFieldInjected()).toBe(false);
+      expect(hasPasswordFieldInjected().has).toBe(false);
     });
   });
 
   it('a bare password field marks the origin', async () => {
     await withInputs('<input type="password" name="pass">', () => {
       expect(domWalkInjected().hasPasswordField).toBe(true);
-      expect(hasPasswordFieldInjected()).toBe(true);
+      expect(hasPasswordFieldInjected().has).toBe(true);
     });
   });
 
   it('autocomplete="current-password" marks the origin — that IS a sign-in box', async () => {
     await withInputs('<input type="password" autocomplete="current-password">', () => {
       expect(domWalkInjected().hasPasswordField).toBe(true);
-      expect(hasPasswordFieldInjected()).toBe(true);
+      expect(hasPasswordFieldInjected().has).toBe(true);
     });
   });
 
@@ -313,7 +313,7 @@ describe('dom walk — the password-field signal', () => {
     // reads the document rather than the walk.
     await withInputs('<div style="display:none"><input type="password" autocomplete="current-password"></div>', () => {
       expect(domWalkInjected().hasPasswordField).toBe(true);
-      expect(hasPasswordFieldInjected()).toBe(true);
+      expect(hasPasswordFieldInjected().has).toBe(true);
     });
   });
 
@@ -327,7 +327,7 @@ describe('dom walk — the password-field signal', () => {
       + '</form>',
       () => {
         expect(domWalkInjected().hasPasswordField).toBe(false);
-        expect(hasPasswordFieldInjected()).toBe(false);
+        expect(hasPasswordFieldInjected().has).toBe(false);
       },
     );
   });
@@ -350,7 +350,7 @@ describe('dom walk — the password-field signal', () => {
       + '<input type="password" autocomplete="current-password">',
       () => {
         expect(domWalkInjected().hasPasswordField).toBe(true);
-        expect(hasPasswordFieldInjected()).toBe(true);
+        expect(hasPasswordFieldInjected().has).toBe(true);
       },
     );
   });
@@ -358,7 +358,30 @@ describe('dom walk — the password-field signal', () => {
   it('the token is matched case-insensitively', async () => {
     await withInputs('<input type="password" autocomplete="NEW-PASSWORD">', () => {
       expect(domWalkInjected().hasPasswordField).toBe(false);
-      expect(hasPasswordFieldInjected()).toBe(false);
+      expect(hasPasswordFieldInjected().has).toBe(false);
     });
+  });
+});
+
+// ── attribution (issue 278) ─────────────────────────────────────────────────
+// The caller resolves the tab BEFORE injecting, so `tab.url` is a snapshot; the
+// probe runs later, in whatever document is committed by then. Without the probe
+// saying where it ran, a page that navigates inside that window gets its password
+// field credited to the origin the caller started on — which lets a hostile page
+// mark arbitrary third parties as "the user has an account here", and, repeated,
+// fill the 500-entry cap so nothing further is ever learned.
+describe('peerd-runtime.dom-walk · the probe reports where it ran', () => {
+  it('hasPasswordFieldInjected returns the observing origin alongside the boolean', () => {
+    const r = hasPasswordFieldInjected();
+    expect(typeof r).toBe('object');
+    expect(typeof r.has).toBe('boolean');
+    // In the test page this is the extension origin; what matters is that it is
+    // the DOCUMENT's own origin, not anything the caller passed in.
+    expect(r.origin).toBe(location.origin);
+  });
+
+  it('the full walk reports it too — the dom-walk path races identically', () => {
+    const walk = domWalkInjected();
+    expect(walk.probeOrigin).toBe(location.origin);
   });
 });

--- a/tests/peerd-runtime/dom/signal-attribution.test.ts
+++ b/tests/peerd-runtime/dom/signal-attribution.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from 'bun:test';
+import { signalIsAttributable } from '../../../extension/peerd-runtime/dom/capture.js';
+
+// The tab record is resolved BEFORE the capture; the password-field probe runs
+// after, in whatever document is committed by then. Crediting the signal to the
+// origin we started on is a primitive: a hostile page can mark arbitrary third
+// parties as "the user has an account here" — roaming helpers are then refused
+// there — and repeating it fills the learned-origin cap so nothing further is
+// ever learned (issue 278).
+
+describe('signalIsAttributable', () => {
+  test('same origin → attributable', () => {
+    expect(signalIsAttributable('https://bank.test', 'https://bank.test')).toBe(true);
+  });
+
+  test('the page moved under the probe → NOT attributable', () => {
+    // The attack shape: start on the attacker, land on the bank mid-capture.
+    expect(signalIsAttributable('https://bank.test', 'https://attacker.test')).toBe(false);
+    // …and the reverse, which is the one that marks a third party.
+    expect(signalIsAttributable('https://attacker.test', 'https://bank.test')).toBe(false);
+  });
+
+  test('a probe that cannot report its origin is UNKNOWN, not a mismatch', () => {
+    // An opaque document cannot read location.origin. Treating that as a
+    // mismatch would silently stop learning on pages where the signal is still
+    // the caller's own — the same posture as reading hasPasswordField strictly.
+    expect(signalIsAttributable(null, 'https://bank.test')).toBe(true);
+    expect(signalIsAttributable(undefined, 'https://bank.test')).toBe(true);
+  });
+
+  test('port and scheme are part of the identity — no accidental folding here', () => {
+    // Cookie-scope folding is a separate, deliberate decision (issue 264). This
+    // rule must not quietly pre-empt it.
+    expect(signalIsAttributable('https://bank.test:8443', 'https://bank.test')).toBe(false);
+    expect(signalIsAttributable('http://bank.test', 'https://bank.test')).toBe(false);
+  });
+});

--- a/tests/peerd-runtime/dom/walk-ref-actions.test.ts
+++ b/tests/peerd-runtime/dom/walk-ref-actions.test.ts
@@ -10,6 +10,7 @@ import { snapshotTool } from '../../../extension/peerd-runtime/tools/defs/snapsh
 import { clickTool, clickInjected } from '../../../extension/peerd-runtime/tools/defs/click.js';
 import { typeTool, typeInjected } from '../../../extension/peerd-runtime/tools/defs/type.js';
 import { createRefRegistry } from '../../../extension/peerd-runtime/dom/ref-registry.js';
+import { hasPasswordFieldInjected } from '../../../extension/peerd-runtime/dom/walk-injected.js';
 
 const WALK_RESULT = {
   ok: true,
@@ -29,7 +30,14 @@ const makeCtx = (scriptImpl: (req: any) => any) => {
       query: async () => [{ id: 7, url: 'https://example.com/' }],
     },
     scripting: {
-      executeScript: async (req: any) => { injections.push(req); return scriptImpl(req); },
+      // The chokepoint's live probe (issues 267/276) injects on every DOM tool
+      // call. It is not part of the dispatch under test here, and counting it
+      // would make these assertions about injection ORDER a proxy for an
+      // unrelated feature — so it is recorded out.
+      executeScript: async (req: any) => {
+        if (req?.func !== hasPasswordFieldInjected) injections.push(req);
+        return scriptImpl(req);
+      },
     },
     domRefs: createRefRegistry(),
     // No debuggerPool — the advanced-automation-off / Firefox shape.

--- a/tests/peerd-runtime/tools/live-document-probe.test.ts
+++ b/tests/peerd-runtime/tools/live-document-probe.test.ts
@@ -85,9 +85,12 @@ describe('issue 276 — the live origin is re-judged when the document moved', (
     const judged: string[] = [];
     const ctx: any = baseCtx({
       scripting: scriptingSaying({ has: false, origin: 'https://evil.test', href: 'https://evil.test/x' }),
+      // Exact match, not a prefix: a `startsWith` on a URL is the classic
+      // incomplete-sanitization shape (evil.test.attacker.example passes it), and
+      // a security test should not model the rule it pins with a broken one.
       judgeLanding: async (url: string) => {
         judged.push(url);
-        return url.startsWith('https://evil.test') ? { action: 'end' } : { action: 'continue' };
+        return url === 'https://evil.test/x' ? { action: 'end' } : { action: 'continue' };
       },
     });
     expect(await resolveTargetTab({}, ctx)).toBeNull();
@@ -106,6 +109,33 @@ describe('issue 276 — the live origin is re-judged when the document moved', (
     });
     await resolveTargetTab({}, ctx);
     expect(judged[1]).toBe('https://x.test/u/settings');
+  });
+
+  test('a document that moved somewhere ALLOWED hands the caller where it is', async () => {
+    // login.js derives the origin it https-gates, names in the confirm, and audits
+    // from this url. Stale here is a confused deputy: the user approves a sign-in
+    // on one origin while the ceremony runs in the document that replaced it.
+    const ctx: any = baseCtx({
+      scripting: scriptingSaying({ has: false, origin: 'https://moved.test', href: 'https://moved.test/next' }),
+    });
+    const tab = await resolveTargetTab({}, ctx);
+    expect(tab?.url).toBe('https://moved.test/next');
+    // A COPY — the tabs API record it came from is left alone.
+    expect((await ctx.tabs.get(1)).url).toBe('https://example.com/');
+  });
+
+  test('a non-web live document (opaque, data:, blob:) is left entirely alone', async () => {
+    // The denylist matches hostnames and the landing rule reasons about http(s):
+    // asking either about "null" is asking a question it cannot answer.
+    const judged: string[] = [];
+    const ctx: any = baseCtx({
+      scripting: scriptingSaying({ has: true, origin: 'null', href: 'about:blank' }),
+      judgeLanding: async (url: string) => { judged.push(url); return { action: 'continue' }; },
+      noteLearnedOrigin: () => { throw new Error('must not learn an opaque origin'); },
+    });
+    const tab = await resolveTargetTab({}, ctx);
+    expect(tab?.url).toBe('https://example.com/');
+    expect(judged).toEqual(['https://example.com/']);
   });
 
   test('a document still on the judged origin is NOT re-judged (no second ask)', async () => {

--- a/tests/peerd-runtime/tools/live-document-probe.test.ts
+++ b/tests/peerd-runtime/tools/live-document-probe.test.ts
@@ -1,0 +1,180 @@
+// The chokepoint's one live look at the target document — issues 267 and 276.
+//
+// 267: before this, `snapshot` was the ONLY tool that observed the password
+// field, so an actor that perceived with `read_page` stayed unlearned forever.
+// Which tool gets called is the attacker's choice, so the classifier's growth
+// must not depend on it.
+//
+// 276: everything above the probe judges `tab.url` — a record frozen before the
+// call. These pin that a document reporting a DIFFERENT origin is re-judged on
+// both rules (denylist and landing), and that a probe which cannot run leaves
+// the earlier verdict untouched rather than refusing.
+
+import { describe, test, expect } from 'bun:test';
+import { resolveTargetTab } from '../../../extension/peerd-runtime/tools/defs/dom-helpers.js';
+
+const tabsApi = (byId: Record<number, any>) => ({
+  get: async (id: number) => { if (!byId[id]) throw new Error('no tab'); return byId[id]; },
+  query: async () => Object.values(byId),
+});
+
+/** A scripting stub whose injected probe answers with a fixed document. */
+const scriptingSaying = (result: unknown, opts: { calls?: number[] } = {}) => ({
+  executeScript: async (o: any) => { opts.calls?.push(o?.target?.tabId); return [{ result }]; },
+});
+
+const baseCtx = (over: Record<string, unknown> = {}) => ({
+  activeTab: { id: 1, url: 'https://example.com/', origin: 'https://example.com' },
+  tabs: tabsApi({ 1: { id: 1, url: 'https://example.com/' } }),
+  ...over,
+});
+
+describe('issue 267 — every DOM tool teaches the classifier, not just snapshot', () => {
+  test('a password field seen at the chokepoint is learned', async () => {
+    const learned: Array<[string, string]> = [];
+    const ctx: any = baseCtx({
+      scripting: scriptingSaying({ has: true, origin: 'https://example.com', href: 'https://example.com/login' }),
+      noteLearnedOrigin: (o: string, r: string) => learned.push([o, r]),
+    });
+    expect((await resolveTargetTab({}, ctx))?.id).toBe(1);
+    expect(learned).toEqual([['https://example.com', 'password-field']]);
+  });
+
+  test('no password field teaches nothing', async () => {
+    const learned: string[] = [];
+    const ctx: any = baseCtx({
+      scripting: scriptingSaying({ has: false, origin: 'https://example.com', href: 'https://example.com/' }),
+      noteLearnedOrigin: (o: string) => learned.push(o),
+    });
+    await resolveTargetTab({}, ctx);
+    expect(learned).toEqual([]);
+  });
+
+  test('the signal is credited to the origin that REPORTED it, not to the tab record', async () => {
+    // The #278 rule, held here by construction: we never pass tab.url's origin.
+    const learned: string[] = [];
+    const ctx: any = baseCtx({
+      scripting: scriptingSaying({ has: true, origin: 'https://elsewhere.test', href: 'https://elsewhere.test/login' }),
+      noteLearnedOrigin: (o: string) => learned.push(o),
+    });
+    await resolveTargetTab({}, ctx);
+    expect(learned).toEqual(['https://elsewhere.test']);
+  });
+
+  test('an unreadable origin (opaque document) is not learned as anything', async () => {
+    const learned: string[] = [];
+    const ctx: any = baseCtx({
+      scripting: scriptingSaying({ has: true, origin: null, href: null }),
+      noteLearnedOrigin: (o: string) => learned.push(o),
+    });
+    await resolveTargetTab({}, ctx);
+    expect(learned).toEqual([]);
+  });
+});
+
+describe('issue 276 — the live origin is re-judged when the document moved', () => {
+  test('a document that navigated onto the denylist is refused', async () => {
+    const ctx: any = baseCtx({
+      denylist: ['chase.com', '*.chase.com'],
+      scripting: scriptingSaying({ has: false, origin: 'https://chase.com', href: 'https://chase.com/transfer' }),
+    });
+    expect(await resolveTargetTab({}, ctx)).toBeNull();
+  });
+
+  test('a document that navigated somewhere the landing rule stops is refused', async () => {
+    const judged: string[] = [];
+    const ctx: any = baseCtx({
+      scripting: scriptingSaying({ has: false, origin: 'https://evil.test', href: 'https://evil.test/x' }),
+      judgeLanding: async (url: string) => {
+        judged.push(url);
+        return url.startsWith('https://evil.test') ? { action: 'end' } : { action: 'continue' };
+      },
+    });
+    expect(await resolveTargetTab({}, ctx)).toBeNull();
+    // Judged tab.url first (passed), then the live href (refused) — the second
+    // ask is the whole point: the first one was about a document that is gone.
+    expect(judged).toEqual(['https://example.com/', 'https://evil.test/x']);
+  });
+
+  test('the live judge is asked about the full href, not a bare origin', async () => {
+    // A path-scoped rule handed "https://x.test" would silently see "/" and let
+    // through what it exists to stop.
+    const judged: string[] = [];
+    const ctx: any = baseCtx({
+      scripting: scriptingSaying({ has: false, origin: 'https://x.test', href: 'https://x.test/u/settings' }),
+      judgeLanding: async (url: string) => { judged.push(url); return { action: 'continue' }; },
+    });
+    await resolveTargetTab({}, ctx);
+    expect(judged[1]).toBe('https://x.test/u/settings');
+  });
+
+  test('a document still on the judged origin is NOT re-judged (no second ask)', async () => {
+    const judged: string[] = [];
+    const ctx: any = baseCtx({
+      scripting: scriptingSaying({ has: false, origin: 'https://example.com', href: 'https://example.com/deep/path' }),
+      judgeLanding: async (url: string) => { judged.push(url); return { action: 'continue' }; },
+    });
+    expect((await resolveTargetTab({}, ctx))?.id).toBe(1);
+    expect(judged).toEqual(['https://example.com/']);
+  });
+});
+
+describe('the probe fails OPEN — it can only ever add a refusal, never remove one', () => {
+  test('a context with no scripting API resolves exactly as before', async () => {
+    const ctx: any = baseCtx();
+    expect((await resolveTargetTab({}, ctx))?.id).toBe(1);
+  });
+
+  test('an injection the browser refuses (chrome:// and friends) does not refuse the tool', async () => {
+    const ctx: any = baseCtx({
+      scripting: { executeScript: async () => { throw new Error('Cannot access a chrome:// URL'); } },
+    });
+    expect((await resolveTargetTab({}, ctx))?.id).toBe(1);
+  });
+
+  test('a probe that answers with nothing usable is treated as "could not look"', async () => {
+    const learned: string[] = [];
+    const ctx: any = baseCtx({
+      scripting: { executeScript: async () => [] },
+      noteLearnedOrigin: (o: string) => learned.push(o),
+    });
+    expect((await resolveTargetTab({}, ctx))?.id).toBe(1);
+    expect(learned).toEqual([]);
+  });
+
+  test('a denylisted tab is still refused BEFORE the probe ever runs', async () => {
+    // The probe must not become a way to touch a denylisted renderer at all.
+    const calls: number[] = [];
+    const ctx: any = {
+      denylist: ['chase.com'],
+      activeTab: { id: 9, url: 'https://chase.com/', origin: 'https://chase.com' },
+      tabs: tabsApi({ 9: { id: 9, url: 'https://chase.com/' } }),
+      scripting: scriptingSaying({ has: true, origin: 'https://chase.com', href: 'https://chase.com/' }, { calls }),
+    };
+    expect(await resolveTargetTab({}, ctx)).toBeNull();
+    expect(calls).toEqual([]);
+  });
+
+  test('a landing verdict of "end" refuses before the probe runs', async () => {
+    const calls: number[] = [];
+    const ctx: any = baseCtx({
+      judgeLanding: async () => ({ action: 'end' }),
+      scripting: scriptingSaying({ has: true, origin: 'https://example.com', href: 'https://example.com/' }, { calls }),
+    });
+    expect(await resolveTargetTab({}, ctx)).toBeNull();
+    expect(calls).toEqual([]);
+  });
+});
+
+describe('the probe cannot hang a tool call', () => {
+  test('a renderer that never answers resolves the tab anyway (timeout, fail open)', async () => {
+    const ctx: any = baseCtx({
+      scripting: { executeScript: () => new Promise(() => { /* wedged main thread */ }) },
+    });
+    const started = performance.now();
+    expect((await resolveTargetTab({}, ctx))?.id).toBe(1);
+    // The timeout is the point; the exact value lives in the source. Just pin
+    // that it returned on the timer rather than waiting on the renderer.
+    expect(performance.now() - started).toBeLessThan(5_000);
+  });
+});

--- a/tests/peerd-runtime/tools/login-tool.test.ts
+++ b/tests/peerd-runtime/tools/login-tool.test.ts
@@ -39,8 +39,14 @@ const makeCtx = (over: Over = {}) => {
     denylist: [],
     scripting: {
       executeScript: async (opts: any) => {
-        calls.execute.push(opts);
         const fn = opts?.func?.name;
+        // The DOM chokepoint's live probe (issues 267/276) injects once per tool
+        // call, BEFORE login's own https/inbound refusals — deliberately, since
+        // those are judged against the live resolved tab. It reads nothing back
+        // into the turn and drives nothing, so it is not "page-driving" in the
+        // sense the counts below pin.
+        if (fn === 'hasPasswordFieldInjected') return [{ result: { has: false, origin, href: `${origin}/login` } }];
+        calls.execute.push(opts);
         if (fn === 'loginTargetReader') {
           return [{ result: over.readerResult ?? { ok: true, descriptor: over.descriptor ?? { tag: 'button', name: 'x' } } }];
         }


### PR DESCRIPTION
**Why.** Ariel is cutting 1.0. Triage of the adversarial review's open findings left three that need no design decision - the rest are trades or design calls, and are now written down instead.

**What.**
- **#278** — the password-field probe ran after the tab record was frozen, so a page that navigated mid-call had its field credited to the origin we started on. A hostile page could mark arbitrary third-party origins as credentialed and fill the learned cap, after which nothing is ever learned again. Probes now report where they ran; an unattributable signal is dropped.
- **#267** — only `snapshot` observed the signal, so an actor that perceived with `read_page` never taught the classifier. The observation moves to the DOM chokepoint: every DOM tool teaches.
- **#276** — the chokepoint judged `tab.url` and the tool injected later, into whatever was committed by then. The same probe re-checks the origin the document reports about itself, re-runs both rules on a mismatch, and hands the caller the live url (login.js https-gates, confirms and audits from it). This **narrows** the window to one round trip; it does not close it (pinning the judged documentId at injection would).
- **R15 corrected** (it claimed the signal fired "on the first page walk of any sign-in surface" - it did not), and **R18-R24** added for the seven findings that stay open: #265, #268, #269, #270, #273, #277, #279.

Known interaction, recorded on #268 and in R19: widening the trigger to all DOM tools also widens an attacker's ability to plant the signal. Deliberate - #267 unfixed lets a hijacked actor keep session authority on a real credentialed site; amplified #268 costs availability.

**How verified.** 4101 bun / 0 fail (13 new tests across two files, the #278 guard revert-proven), 715 in-browser / 0 fail, typecheck + lint + boundary + imports + tscheck + hygiene + invariants + docpaths green. The probe fails open on every path it can (no scripting API, a refused injection, an unusable answer, a non-web origin) and is timeout-bounded, so it can only ever add a refusal, never remove one.