### PR TITLE
feat(attachments): accept Word/Excel/PowerPoint/ODF/RTF/EPUB files

### DIFF
--- a/extension/background/routes/sessions.js
+++ b/extension/background/routes/sessions.js
@@ -16,7 +16,8 @@
 export const makeSessionRoutes = (deps) => {
   const {
     vault, auditLog, sessions, sessionCache, turnSlots, manifestLabel,
-    buildToolContext, applyComposer, commandSources, prepareUserAttachments,
+    buildToolContext, applyComposer, commandSources, prepareUserAttachmentsWithDocs,
+    convertDocAttachment,
     runAgentTurn, runInit, handleSystemCommand, handleToolsCommand,
     postChatNote, spawnActor, requestReview, appClient,
     browser, originOfTabUrl, matchesDenylist, denylistStore,
@@ -175,7 +176,14 @@ export const makeSessionRoutes = (deps) => {
       let turnAttachments = null;
       if (Array.isArray(attachments) && attachments.length > 0) {
         try {
-          const prepared = prepareUserAttachments({ text: userText, attachments });
+          // Office/e-book attachments are CONVERTED to Markdown on the way
+          // through (the offscreen doc reader — the same converter read_doc
+          // uses), so by the time the pure inlining step runs they are
+          // ordinary text. Validate-then-convert-then-inline is sequenced
+          // inside prepareUserAttachmentsWithDocs.
+          const prepared = await prepareUserAttachmentsWithDocs({
+            text: userText, attachments, convert: convertDocAttachment,
+          });
           userText = prepared.text;
           turnAttachments = prepared.attachments;
         } catch (e) {

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -131,8 +131,12 @@ import {
   detectInterruptedTurn,
   RESUME_NUDGE,
   // file attachments — agent/send validates + shapes through the pure
-  // core (fail closed) before the turn starts.
-  prepareUserAttachments,
+  // core (fail closed) before the turn starts. Office/e-book files get one
+  // extra, IMPURE step first (convertDocAttachments) — the converter is
+  // injected, so the pure core never imports a parser.
+  prepareUserAttachmentsWithDocs,
+  formatDocBody,
+  DOC_TEXT_MAX_CHARS,
   makeSpawnActor,
   makeRequestReview,
   createRefRegistry,
@@ -2571,6 +2575,23 @@ const docOffscreenClient = offscreenAvailable ? makeOffscreenDocClient({
   ensureOffscreen,
   sendMessage: (m) => browser.runtime.sendMessage(m),
 }) : null;
+
+// Convert an ATTACHED office/e-book file to Markdown. Same offscreen reader as
+// read_doc, handed the bytes directly — so an attached .docx and a linked one
+// go through exactly one implementation. Returns the formatted body (header,
+// conversion notes, truncation announcement) that gets inlined into the turn.
+// null where offscreen is unavailable (Firefox): convertDocAttachments turns a
+// missing converter into a clear refusal.
+const convertDocAttachment = offscreenAvailable
+  ? async (/** @type {{ name: string, mediaType: string, data?: string }} */ att) => {
+    if (!att?.data) throw new Error('the file was empty');
+    if (!docOffscreenClient) throw new Error('document conversion is not available in this browser build');
+    const { doc } = await docOffscreenClient.extract(
+      { bytesB64: att.data, name: att.name, contentType: att.mediaType }, {},
+    );
+    return formatDocBody({ doc, maxChars: DOC_TEXT_MAX_CHARS, source: att.name });
+  }
+  : null;
 
 // The HTML -> markdown extraction client (fetch_url's clean-content path).
 // Readability/Turndown need a DOM Document only the offscreen doc can build
@@ -5368,7 +5389,12 @@ browser.runtime.onMessage.addListener(/** @type {any} */ (makeDispatcher({
   ...makeContactsRoutes({ vault, auditLog, contacts, appRegistry, mergeContacts }),
   ...makeSessionRoutes({
     vault, auditLog, sessions, sessionCache, turnSlots, manifestLabel, buildToolContext,
-    applyComposer, commandSources, prepareUserAttachments, runAgentTurn, runInit,
+    applyComposer, commandSources, prepareUserAttachmentsWithDocs, runAgentTurn, runInit,
+    // Attached-document conversion: the SAME offscreen reader read_doc uses,
+    // fed inline bytes instead of a URL (doc-extract has always accepted a
+    // bytesB64 source). null on Firefox — the prepare step then refuses with
+    // a legible message rather than attaching an empty file.
+    convertDocAttachment,
     handleSystemCommand, handleToolsCommand, postChatNote, spawnActor, requestReview, appClient,
     browser, originOfTabUrl, matchesDenylist, denylistStore,
     // goal mode (the mode-row Goal toggle): start an autonomous run, and halt

--- a/extension/peerd-provider/types.js
+++ b/extension/peerd-provider/types.js
@@ -28,7 +28,10 @@
  * @typedef {Object} Attachment
  * @property {string} name                       original filename (chip label)
  * @property {string} mediaType                  e.g. 'image/png', 'application/pdf', 'text/plain'
- * @property {'image'|'pdf'|'text'} kind         classified by peerd-runtime/loop/attachments.js
+ * @property {'image'|'pdf'|'text'|'doc'} kind   classified by peerd-runtime/loop/attachments.js.
+ *                                               'text' and 'doc' never become content blocks —
+ *                                               their payload is inlined into the message text
+ *                                               upstream, so only the metadata reaches here
  * @property {number} size                       decoded byte size
  * @property {string} [data]                     base64 payload — present ONLY on the turn the
  *                                               attachment is sent (send-once-then-strip)

--- a/extension/peerd-runtime/index.js
+++ b/extension/peerd-runtime/index.js
@@ -61,7 +61,9 @@ export { renderSystemPrompt, _setTemplateForTests } from './loop/system-prompt.j
 // same caps/classifier for instant pre-send feedback; the loop strips.
 export {
   classifyAttachment, validateAttachment, validateAttachments,
-  prepareUserAttachments, stripAttachment, stripAttachments,
+  prepareUserAttachments, prepareUserAttachmentsWithDocs, convertDocAttachments,
+  stripAttachment, stripAttachments,
+  AttachmentConversionError, DOC_MEDIA_TYPES, DOC_EXTENSIONS, DOC_TEXT_MAX_CHARS,
   attachmentBytes, formatBytes,
   ATTACHMENT_CAPS, MAX_ATTACHMENTS_PER_MESSAGE, IMAGE_MEDIA_TYPES, PDF_MEDIA_TYPE,
   UnsupportedAttachmentError, AttachmentTooLargeError, TooManyAttachmentsError,

--- a/extension/peerd-runtime/loop/attachments.js
+++ b/extension/peerd-runtime/loop/attachments.js
@@ -10,6 +10,10 @@
 //                               text as <peerd_file name="…"> (the
 //                               composer @file precedent), so the
 //                               payload persists with the transcript.
+//   office / e-book           → CONVERTED to Markdown (peerd-runtime/doc)
+//                               and inlined on the text transport. The
+//                               model has no native block for a .docx, so
+//                               the choice is convert or refuse.
 //
 // Everything else is refused — fail closed, never silently dropped.
 //
@@ -37,6 +41,39 @@ export const IMAGE_MEDIA_TYPES = Object.freeze([
 
 export const PDF_MEDIA_TYPE = 'application/pdf';
 
+// Office / e-book documents. These have no model-native transport — Anthropic
+// takes images and PDFs, nothing else — so they are CONVERTED to Markdown
+// (peerd-runtime/doc) and inlined as text, exactly like a .txt.
+//
+// The extension list carries the LEGACY binaries (.doc/.xls/.ppt/.xlsb) on
+// purpose even though nothing can convert them: classifying them here means
+// the user gets the converter's specific "this is a Word 97-2003 file, here is
+// what to do instead" rather than a flat "unsupported type". A precise refusal
+// is worth more than an early one.
+//
+// peerd-runtime/doc/sniff.js is the authority on what actually converts; this
+// table only decides what to ATTEMPT. Drift fails safe — a wrong guess becomes
+// a clear conversion error, never a crash.
+export const DOC_MEDIA_TYPES = Object.freeze([
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'application/vnd.oasis.opendocument.text',
+  'application/vnd.oasis.opendocument.spreadsheet',
+  'application/vnd.oasis.opendocument.presentation',
+  'application/epub+zip',
+  'application/rtf',
+  'application/msword',
+  'application/vnd.ms-excel',
+  'application/vnd.ms-powerpoint',
+]);
+
+export const DOC_EXTENSIONS = Object.freeze([
+  'docx', 'docm', 'dotx', 'xlsx', 'xlsm', 'xltx', 'pptx', 'pptm', 'potx', 'ppsx',
+  'odt', 'ott', 'ods', 'ots', 'odp', 'otp', 'epub', 'rtf',
+  'doc', 'xls', 'ppt', 'xlsb',
+]);
+
 export const MAX_ATTACHMENTS_PER_MESSAGE = 5;
 
 // Caps keyed by kind, in BYTES of the decoded file.
@@ -44,7 +81,23 @@ export const ATTACHMENT_CAPS = Object.freeze({
   image: 5 * 1024 * 1024,   // Anthropic image block limit
   pdf: 10 * 1024 * 1024,    // Anthropic document block limit
   text: 64 * 1024,          // inlined into the prompt — keep it cheap
+  // A document's SOURCE may be large while its text is small — most of a .docx
+  // is usually embedded media the conversion discards — so the real limit is
+  // DOC_TEXT_MAX_CHARS on the OUTPUT, which is what costs context.
+  //
+  // The input cap is nonetheless the PDF one rather than something generous,
+  // because of the transport: an attachment is base64 (≈1.37×) and crosses two
+  // message hops — panel → service worker, then service worker → offscreen for
+  // the conversion. 10MB is already a ~14MB string copied twice, and real
+  // office files sit far below it.
+  doc: 10 * 1024 * 1024,
 });
+
+// Cap on the Markdown a converted document contributes to the prompt. It rides
+// EVERY later turn (inlined text persists with the transcript, unlike image and
+// PDF bytes which are stripped after one turn), so this is a recurring cost and
+// is capped tighter than it would be for a one-shot read.
+export const DOC_TEXT_MAX_CHARS = 40_000;
 
 /** A single attachment was a type peerd can't ship to the model. */
 export class UnsupportedAttachmentError extends TypedError {
@@ -54,7 +107,8 @@ export class UnsupportedAttachmentError extends TypedError {
    */
   constructor(name, mediaType) {
     super(`Unsupported attachment type: "${name}" (${mediaType || 'unknown type'}). `
-      + 'Supported: PNG/JPEG/GIF/WebP images, PDF, and plain-text files.');
+      + 'Supported: PNG/JPEG/GIF/WebP images, PDF, Word/Excel/PowerPoint/OpenDocument, '
+      + 'RTF, EPUB, and plain-text files.');
     this.attachmentName = name;
     this.mediaType = mediaType;
   }
@@ -78,6 +132,19 @@ export class AttachmentTooLargeError extends TypedError {
   }
 }
 
+/** A document attachment could not be converted to text. */
+export class AttachmentConversionError extends TypedError {
+  /**
+   * @param {string} name
+   * @param {string} reason
+   */
+  constructor(name, reason) {
+    super(`Could not read "${name}": ${reason}`);
+    this.attachmentName = name;
+    this.reason = reason;
+  }
+}
+
 /** The message carries more attachments than the per-message cap. */
 export class TooManyAttachmentsError extends TypedError {
   /** @param {number} count */
@@ -89,19 +156,35 @@ export class TooManyAttachmentsError extends TypedError {
 }
 
 /**
- * Classify a candidate file by media type.
+ * Classify a candidate file by media type, falling back to its extension.
+ *
+ * why the extension fallback, for documents only: the browser's File.type is
+ * routinely EMPTY for office files (it depends on an OS media-type registry
+ * that often has no entry for .docx), so media-type-only classification
+ * refuses the common case. Images and PDFs don't need it — those types are
+ * universally registered — and a blanket extension fallback would let a
+ * mislabeled file through as something it isn't.
+ *
+ * Order matters: text/* is checked BEFORE the extension fallback, so a
+ * text/csv file stays 'text' and is inlined verbatim rather than being
+ * re-rendered as a Markdown table.
  *
  * Pure. Never throws — 'unsupported' is a value, so callers (the panel's
  * add-file path, the SW's validator) decide how loudly to fail.
  *
  * @param {{ name?: string, mediaType?: string, size?: number }} att
- * @returns {'image' | 'pdf' | 'text' | 'unsupported'}
+ * @returns {'image' | 'pdf' | 'text' | 'doc' | 'unsupported'}
  */
 export const classifyAttachment = (att) => {
   const mt = String(att?.mediaType ?? '').toLowerCase().split(';')[0].trim();
   if (IMAGE_MEDIA_TYPES.includes(mt)) return 'image';
   if (mt === PDF_MEDIA_TYPE) return 'pdf';
+  if (DOC_MEDIA_TYPES.includes(mt)) return 'doc';
   if (mt.startsWith('text/')) return 'text';
+  const name = String(att?.name ?? '');
+  const dot = name.lastIndexOf('.');
+  const ext = dot > 0 ? name.slice(dot + 1).toLowerCase() : '';
+  if (ext && DOC_EXTENSIONS.includes(ext)) return 'doc';
   return 'unsupported';
 };
 
@@ -134,8 +217,8 @@ export const attachmentBytes = (att) => {
  * Throws UnsupportedAttachmentError / AttachmentTooLargeError. Returns
  * the normalized internal shape (kind resolved, size measured).
  *
- * @param {{ name?: string, mediaType?: string, size?: number, data?: string }} att
- * @returns {{ name: string, mediaType: string, kind: 'image'|'pdf'|'text', size: number, data?: string }}
+ * @param {{ name?: string, mediaType?: string, size?: number, data?: string, text?: string }} att
+ * @returns {{ name: string, mediaType: string, kind: 'image'|'pdf'|'text'|'doc', size: number, data?: string, text?: string }}
  */
 export const validateAttachment = (att) => {
   const name = String(att?.name ?? '') || 'file';
@@ -152,6 +235,12 @@ export const validateAttachment = (att) => {
     kind,
     size,
     ...(typeof att?.data === 'string' && att.data.length > 0 ? { data: att.data } : {}),
+    // Carried through so validation stays IDEMPOTENT: prepareUserAttachments
+    // re-validates, and by then a converted document holds its Markdown here
+    // instead of base64. Rebuilding the record field-by-field without this
+    // silently drops the converted text and inlines an empty file.
+    ...(typeof (/** @type {{ text?: string }} */ (att).text) === 'string'
+      ? { text: /** @type {{ text?: string }} */ (att).text } : {}),
   };
 };
 
@@ -170,18 +259,64 @@ export const validateAttachments = (list) => {
 };
 
 /**
+ * Convert the 'doc' attachments in a validated batch into inlinable text.
+ *
+ * The ONE impure step in this file, and the IO is injected rather than
+ * imported (the house rule) — the caller passes a converter, which in the
+ * service worker is the offscreen document client. That keeps the parsers out
+ * of this module entirely: the side panel imports classifyAttachment from
+ * here, and must not drag seven format walkers along with it.
+ *
+ * Each converted record trades its base64 `data` for a `text` field. Nothing
+ * downstream sees document bytes: the Markdown is what gets inlined, persisted
+ * and re-sent, and the original file is dropped after this step.
+ *
+ * FAIL CLOSED, per attachment, with the converter's own message — "this is a
+ * Word 97-2003 binary, ask for a .docx or convert it in a WebVM" is the whole
+ * value of attempting a legacy file, and a generic error would throw it away.
+ *
+ * @param {Object} args
+ * @param {Array<{ name: string, mediaType: string, kind: string, size: number, data?: string }>} args.attachments
+ * @param {(att: { name: string, mediaType: string, data?: string }) => Promise<string>} args.convert
+ * @returns {Promise<Array<{ name: string, mediaType: string, kind: string, size: number, data?: string, text?: string }>>}
+ */
+export const convertDocAttachments = async ({ attachments, convert }) => {
+  const list = Array.isArray(attachments) ? attachments : [];
+  if (!list.some((att) => att.kind === 'doc')) return list;
+  if (typeof convert !== 'function') {
+    throw new AttachmentConversionError(
+      list.find((att) => att.kind === 'doc')?.name ?? 'file',
+      'document conversion is not available in this browser build',
+    );
+  }
+  const out = [];
+  for (const att of list) {
+    if (att.kind !== 'doc') { out.push(att); continue; }
+    let text;
+    try {
+      text = await convert({ name: att.name, mediaType: att.mediaType, data: att.data });
+    } catch (e) {
+      throw new AttachmentConversionError(att.name, /** @type {{ message?: string }} */ (e)?.message ?? String(e));
+    }
+    const { data: _drop, ...meta } = att;
+    out.push({ ...meta, text: String(text ?? '') });
+  }
+  return out;
+};
+
+/**
  * Metadata-only shape for persistence and every later re-send. The
  * payload is gone; name/type/kind/size stay so the UI can render the
  * chip and the model can see what WAS attached.
  *
- * @param {{ name: string, mediaType: string, kind: 'image'|'pdf'|'text', size: number, data?: string }} att
- * @returns {{ name: string, mediaType: string, kind: 'image'|'pdf'|'text', size: number, stripped: true }}
+ * @param {{ name: string, mediaType: string, kind: 'image'|'pdf'|'text'|'doc', size: number, data?: string }} att
+ * @returns {{ name: string, mediaType: string, kind: 'image'|'pdf'|'text'|'doc', size: number, stripped: true }}
  */
 export const stripAttachment = ({ name, mediaType, kind, size }) =>
   ({ name, mediaType, kind, size, stripped: true });
 
 /**
- * @param {ReadonlyArray<{ name: string, mediaType: string, kind: 'image'|'pdf'|'text', size: number, data?: string }>} list
+ * @param {ReadonlyArray<{ name: string, mediaType: string, kind: 'image'|'pdf'|'text'|'doc', size: number, data?: string }>} list
  * @returns {Array<ReturnType<typeof stripAttachment>>}
  */
 export const stripAttachments = (list) => (Array.isArray(list) ? list.map(stripAttachment) : []);
@@ -228,19 +363,58 @@ export const prepareUserAttachments = ({ text, attachments }) => {
   let outText = typeof text === 'string' ? text : '';
   const outAttachments = [];
   for (const att of validated) {
-    if (att.kind === 'text') {
+    if (att.kind === 'text' || att.kind === 'doc') {
       // why decode here (pure) and not at render time: the inlined text
       // must persist with the message — to-anthropic never sees the
       // base64, so there's no live/stripped split to manage for text.
-      const body = att.data ? decodeBase64Text(att.data) : '';
+      //
+      // A 'doc' arrives already converted (convertDocAttachments ran before
+      // this, upstream) and carries `text` instead of `data`. It rides the
+      // SAME transport because a converted document IS text — which also
+      // means it persists with the transcript, so the model can still see
+      // the spreadsheet three turns later. The chip keeps kind:'doc', so
+      // the UI still says "report.docx" rather than calling it a text file.
+      const body = att.kind === 'doc'
+        ? String(att.text ?? '')
+        : (att.data ? decodeBase64Text(att.data) : '');
       outText += `\n\n<peerd_file name="${escAttr(att.name)}">\n${body}\n</peerd_file>`;
-      const { data: _drop, ...meta } = att;
+      const { data: _drop, text: _dropText, ...meta } = att;
       outAttachments.push(meta);
     } else {
       outAttachments.push(att);
     }
   }
   return { text: outText, attachments: outAttachments };
+};
+
+/**
+ * The send path's ONE attachment entry point: validate, convert documents,
+ * then inline. Async only because conversion is.
+ *
+ * why this wrapper exists rather than three calls at the call site: the ORDER
+ * is a correctness property, not a convenience. Validation must run BEFORE
+ * conversion (otherwise a 200MB file is parsed and only then rejected for
+ * being over cap), and conversion must run before inlining (the pure step has
+ * no way to produce text from a .docx). Encoding that here means the service
+ * worker route cannot get it wrong, and the sequence is testable on its own.
+ *
+ * @param {{
+ *   text: string,
+ *   attachments: ReadonlyArray<{ name?: string, mediaType?: string, size?: number, data?: string }>,
+ *   convert?: (att: { name: string, mediaType: string, data?: string }) => Promise<string>,
+ * }} args
+ * @returns {Promise<{
+ *   text: string,
+ *   attachments: Array<{ name: string, mediaType: string, kind: string, size: number, data?: string }>,
+ * }>}
+ */
+export const prepareUserAttachmentsWithDocs = async ({ text, attachments, convert }) => {
+  const validated = validateAttachments(/** @type {any} */ (attachments));
+  const converted = await convertDocAttachments({
+    attachments: validated,
+    convert: /** @type {any} */ (convert),
+  });
+  return prepareUserAttachments({ text, attachments: /** @type {any} */ (converted) });
 };
 
 /**

--- a/extension/sidepanel/components/input-bar.js
+++ b/extension/sidepanel/components/input-bar.js
@@ -34,7 +34,7 @@
 import m from '/vendor/mithril/mithril.js';
 import {
   MicButton, activeTrigger,
-  classifyAttachment, ATTACHMENT_CAPS, MAX_ATTACHMENTS_PER_MESSAGE,
+  classifyAttachment, ATTACHMENT_CAPS, MAX_ATTACHMENTS_PER_MESSAGE, DOC_MEDIA_TYPES,
   IMAGE_MEDIA_TYPES, formatBytes,
 } from '/peerd-runtime/index.js';
 import { CommandPalette, visibleCandidates, PALETTE_OPTION_ID } from './command-palette.js';
@@ -96,7 +96,20 @@ const PAPERCLIP_ICON = () => m('svg', {
 }));
 
 // What the picker offers = exactly what classifyAttachment admits.
-const ATTACH_ACCEPT = [...IMAGE_MEDIA_TYPES, 'application/pdf', 'text/*'].join(',');
+//
+// The office/e-book types are listed by EXTENSION as well as media type, and
+// that is load-bearing rather than belt-and-braces: the OS media-type registry
+// often has no entry for .docx, so a media-type-only `accept` greys the file
+// out in the picker even though peerd can read it. classifyAttachment applies
+// the same extension fallback, so the two stay in step.
+const DOC_ACCEPT_EXTENSIONS = [
+  '.docx', '.xlsx', '.pptx', '.odt', '.ods', '.odp', '.rtf', '.epub',
+  '.doc', '.xls', '.ppt',
+];
+const ATTACH_ACCEPT = [
+  ...IMAGE_MEDIA_TYPES, 'application/pdf', 'text/*',
+  ...DOC_MEDIA_TYPES, ...DOC_ACCEPT_EXTENSIONS,
+].join(',');
 
 // File → base64 payload (no data: prefix). FileReader keeps the panel
 // off raw ArrayBuffer/btoa chunking for multi-MB files.
@@ -312,7 +325,8 @@ export const InputBar = {
         }
         const kind = classifyAttachment({ name: f.name, mediaType: f.type, size: f.size });
         if (kind === 'unsupported') {
-          ui.attachError = `"${f.name}": unsupported type — images (PNG/JPEG/GIF/WebP), PDF, or text files.`;
+          ui.attachError = `"${f.name}": unsupported type — images (PNG/JPEG/GIF/WebP), PDF, `
+            + 'Word/Excel/PowerPoint/OpenDocument, RTF, EPUB, or text files.';
           continue;
         }
         if (f.size > ATTACHMENT_CAPS[kind]) {

--- a/tests/background/routes-sessions.test.ts
+++ b/tests/background/routes-sessions.test.ts
@@ -25,7 +25,7 @@ const baseDeps = (over: any = {}) => {
       buildToolContext: async () => ({}),
       applyComposer: async ({ text }: any) => ({ text: `${text}!`, refs: [], command: null }),
       commandSources: { list: async () => [{ name: 'c', description: 'd' }] },
-      prepareUserAttachments: ({ text }: any) => ({ text, attachments: [] }),
+      prepareUserAttachmentsWithDocs: async ({ text }: any) => ({ text, attachments: [] }),
       runAgentTurn: async (a: any) => { calls.turns.push(a); },
       runInit: async () => { calls.runInit += 1; },
       startGoalRun: async (req: any) => { calls.goal.push(req); },
@@ -94,7 +94,7 @@ describe('agent/send slash-command routing', () => {
     expect(calls.turns[0].userText).toBe('hello!');
   });
   test('invalid attachment batch fails closed', async () => {
-    const { deps } = baseDeps({ prepareUserAttachments: () => { throw new Error('bad file'); } });
+    const { deps } = baseDeps({ prepareUserAttachmentsWithDocs: async () => { throw new Error('bad file'); } });
     expect(await makeSessionRoutes(deps)['agent/send']({ text: 'hi', attachments: [{}] })).toEqual({ ok: false, error: 'bad file' });
   });
 });

--- a/tests/peerd-runtime/doc/attachment-integration.test.ts
+++ b/tests/peerd-runtime/doc/attachment-integration.test.ts
@@ -1,0 +1,88 @@
+// The attach path end to end: a real .docx in, inlined Markdown out.
+//
+// The unit tests either side of this seam use a stub converter, which proves
+// the sequencing but not that the two halves actually fit. This wires the REAL
+// converter (the same functions the offscreen host calls) to the REAL
+// attachment pipeline, so a change to either side that breaks the join fails
+// here rather than in a browser.
+
+import { describe, test, expect } from 'bun:test';
+import { convertToDocument } from '../../../extension/peerd-runtime/doc/convert.js';
+import { formatDocBody } from '../../../extension/peerd-runtime/doc/format.js';
+import {
+  prepareUserAttachmentsWithDocs,
+  DOC_TEXT_MAX_CHARS,
+} from '../../../extension/peerd-runtime/loop/attachments.js';
+import { makeDocx, makeXlsx } from './fixtures.ts';
+
+const toBase64 = (bytes: Uint8Array): string => {
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+};
+
+// Exactly what background/service-worker.js's convertDocAttachment does, minus
+// the offscreen hop (which only moves bytes).
+const realConvert = async (att: { name: string; mediaType: string; data?: string }) => {
+  const bin = atob(att.data ?? '');
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i += 1) bytes[i] = bin.charCodeAt(i);
+  const doc = await convertToDocument(bytes, { name: att.name, contentType: att.mediaType });
+  return formatDocBody({ doc, maxChars: DOC_TEXT_MAX_CHARS, source: att.name });
+};
+
+const attach = async (name: string, bytes: Uint8Array, mediaType = '') => prepareUserAttachmentsWithDocs({
+  text: 'what does this say?',
+  attachments: [{ name, mediaType, size: bytes.length, data: toBase64(bytes) }],
+  convert: realConvert,
+});
+
+describe('attaching a real office file', () => {
+  test('a .docx arrives as inlined Markdown with its structure intact', async () => {
+    const out = await attach('quarterly.docx', await makeDocx());
+    // Wrapped like any other inlined file, under its real name.
+    expect(out.text).toContain('<peerd_file name="quarterly.docx">');
+    expect(out.text).toContain('</peerd_file>');
+    // The user's own words still lead the message.
+    expect(out.text.startsWith('what does this say?')).toBe(true);
+    // Structure survived the whole trip: ZIP → XML → model → Markdown.
+    expect(out.text).toContain('# Findings');
+    expect(out.text).toContain('**Revenue rose**');
+    expect(out.text).toContain('| Region | Total |');
+    // Provenance rides along, so the model knows what it is reading.
+    expect(out.text).toContain('format: docx');
+    expect(out.text).toContain('title: Quarterly Report');
+    // The record is metadata-only — the bytes do not persist.
+    expect(out.attachments[0]).toEqual({
+      name: 'quarterly.docx',
+      mediaType: '',
+      kind: 'doc',
+      size: expect.any(Number),
+    });
+  });
+
+  test('a .xlsx arrives as one table per sheet, hidden sheets withheld', async () => {
+    const out = await attach('sales.xlsx', await makeXlsx());
+    expect(out.text).toContain('## Sales');
+    expect(out.text).toContain('| Region | Q1 | Q2 |');
+    // The hidden sheet's contents must not reach the model…
+    expect(out.text).not.toContain('SECRET');
+    // …and the omission is stated rather than silent.
+    expect(out.text).toContain('hidden and was not read');
+  });
+
+  test('an unreadable file fails the SEND rather than attaching noise', async () => {
+    // A .docx that is not a ZIP at all — the case that used to reach the model
+    // as mojibake. The send must fail with something the user can act on.
+    const junk = new TextEncoder().encode('this is not a docx at all, just text');
+    const err = await attach('broken.docx', junk).catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain('broken.docx');
+  });
+
+  test('the inlined text is capped, and the cap is announced', async () => {
+    const out = await attach('quarterly.docx', await makeDocx());
+    const body = out.text.split('<peerd_file name="quarterly.docx">')[1];
+    expect(body.length).toBeLessThan(DOC_TEXT_MAX_CHARS + 2000);
+  });
+});

--- a/tests/peerd-runtime/loop/attachments.test.ts
+++ b/tests/peerd-runtime/loop/attachments.test.ts
@@ -8,6 +8,7 @@ import {
   validateAttachment,
   validateAttachments,
   prepareUserAttachments,
+  prepareUserAttachmentsWithDocs,
   stripAttachment,
   stripAttachments,
   attachmentBytes,
@@ -17,6 +18,7 @@ import {
   UnsupportedAttachmentError,
   AttachmentTooLargeError,
   TooManyAttachmentsError,
+  AttachmentConversionError,
 } from '../../../extension/peerd-runtime/loop/attachments.js';
 
 const b64 = (s: string) => btoa(s);
@@ -197,5 +199,134 @@ describe('helpers', () => {
     expect(formatBytes(512)).toBe('512 B');
     expect(formatBytes(2048)).toBe('2.0 KB');
     expect(formatBytes(5 * 1024 * 1024)).toBe('5.0 MB');
+  });
+});
+
+// --- office / e-book attachments (the 'doc' kind) -------------------------
+//
+// These have no model-native transport, so they are converted to Markdown and
+// ride the text transport. The interesting cases are all about the SEAM: the
+// conversion is injected, so the pure core must sequence it correctly and fail
+// closed with the converter's own message.
+
+describe('classifyAttachment — documents', () => {
+  test('office media types classify as doc', () => {
+    for (const mediaType of [
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'application/vnd.oasis.opendocument.text',
+      'application/epub+zip',
+    ]) {
+      expect(classifyAttachment({ name: 'f', mediaType })).toBe('doc');
+    }
+  });
+
+  test('an EMPTY media type falls back to the extension — the common real case', () => {
+    // Chrome reports File.type '' for .docx on machines whose OS has no
+    // registry entry. Without the fallback the picker refuses a file peerd
+    // reads perfectly.
+    expect(classifyAttachment({ name: 'report.docx', mediaType: '' })).toBe('doc');
+    expect(classifyAttachment({ name: 'BUDGET.XLSX', mediaType: '' })).toBe('doc');
+    expect(classifyAttachment({ name: 'book.epub' })).toBe('doc');
+  });
+
+  test('legacy binaries classify as doc so the refusal can be specific', () => {
+    // Nothing converts these, but reaching the converter is what produces
+    // "this is a Word 97-2003 file, here is what to do" instead of a generic
+    // unsupported-type error.
+    expect(classifyAttachment({ name: 'old.doc', mediaType: '' })).toBe('doc');
+    expect(classifyAttachment({ name: 'old.xls', mediaType: 'application/vnd.ms-excel' })).toBe('doc');
+  });
+
+  test('the extension fallback does NOT rescue arbitrary unknown files', () => {
+    expect(classifyAttachment({ name: 'archive.zip', mediaType: '' })).toBe('unsupported');
+    expect(classifyAttachment({ name: 'app.exe', mediaType: '' })).toBe('unsupported');
+  });
+
+  test('text/* still wins over the extension fallback', () => {
+    // A .csv stays text and is inlined verbatim rather than re-rendered.
+    expect(classifyAttachment({ name: 'data.csv', mediaType: 'text/csv' })).toBe('text');
+  });
+});
+
+describe('prepareUserAttachmentsWithDocs', () => {
+  const docx = { name: 'q3.docx', mediaType: '', size: 2048, data: b64('PK-not-really') };
+
+  test('a converted document is inlined as text and its payload dropped', async () => {
+    const convert = async () => '# Q3\n\nRevenue rose.';
+    const out = await prepareUserAttachmentsWithDocs({ text: 'summarize this', attachments: [docx], convert });
+    expect(out.text).toContain('<peerd_file name="q3.docx">');
+    expect(out.text).toContain('Revenue rose.');
+    // The chip keeps its identity — the UI should not call a .docx a text file.
+    expect(out.attachments[0].kind).toBe('doc');
+    // Neither the source bytes nor the converted text ride the attachment
+    // record: the text lives in the message, which is what persists.
+    expect(out.attachments[0]).not.toHaveProperty('data');
+    expect(out.attachments[0]).not.toHaveProperty('text');
+  });
+
+  test('the converter sees the file and its declared type', async () => {
+    const seen: any[] = [];
+    await prepareUserAttachmentsWithDocs({
+      text: '', attachments: [docx], convert: async (a: any) => { seen.push(a); return 'x'; },
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0].name).toBe('q3.docx');
+    expect(seen[0].data).toBe(docx.data);
+  });
+
+  test('validation runs BEFORE conversion — an over-cap file is never parsed', async () => {
+    let converted = false;
+    const huge = { name: 'big.docx', mediaType: '', size: ATTACHMENT_CAPS.doc + 1 };
+    await expect(prepareUserAttachmentsWithDocs({
+      text: '', attachments: [huge], convert: async () => { converted = true; return ''; },
+    })).rejects.toThrow(AttachmentTooLargeError);
+    expect(converted).toBe(false);
+  });
+
+  test('a conversion failure fails the send with the converter\'s own message', async () => {
+    // The whole point of routing legacy binaries here: the specific advice
+    // survives to the user instead of collapsing into "unsupported".
+    const convert = async () => { throw new Error('Word 97-2003 (.doc) is a binary format this reader cannot open.'); };
+    const err = await prepareUserAttachmentsWithDocs({
+      text: '', attachments: [{ name: 'old.doc', mediaType: '', size: 10, data: b64('x') }], convert,
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(AttachmentConversionError);
+    expect(err.message).toContain('old.doc');
+    expect(err.message).toContain('Word 97-2003');
+  });
+
+  test('no converter (Firefox — no offscreen document) refuses legibly', async () => {
+    const err = await prepareUserAttachmentsWithDocs({
+      text: '', attachments: [docx], convert: undefined,
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(AttachmentConversionError);
+    expect(err.message).toContain('not available in this browser build');
+  });
+
+  test('a batch with no documents never touches the converter', async () => {
+    let called = false;
+    const out = await prepareUserAttachmentsWithDocs({
+      text: 'hi',
+      attachments: [{ name: 'a.txt', mediaType: 'text/plain', size: 5, data: b64('hello') }],
+      convert: async () => { called = true; return ''; },
+    });
+    expect(called).toBe(false);
+    expect(out.text).toContain('hello');
+  });
+
+  test('images and documents mix in one message', async () => {
+    const out = await prepareUserAttachmentsWithDocs({
+      text: 'compare',
+      attachments: [
+        { name: 'chart.png', mediaType: 'image/png', size: 100, data: b64('img') },
+        docx,
+      ],
+      convert: async () => 'converted body',
+    });
+    // The image keeps its bytes for this turn; the document became text.
+    expect(out.attachments[0].kind).toBe('image');
+    expect(out.attachments[0].data).toBeTruthy();
+    expect(out.text).toContain('converted body');
   });
 });


### PR DESCRIPTION
## What & why

Follow-up to #311, which was explicitly scoped to the *actor* path. The reader landed for the agent; the **user still couldn't attach the same files**. Dropping a `.docx` into the composer hit `classifyAttachment`'s `'unsupported'` and was refused at the picker — arguably the more visible half of the gap, since a user attaching a spreadsheet is a more common act than an actor meeting one on the open web.

An office file has no model-native transport (Anthropic takes images and PDFs, nothing else), so the choice is convert or refuse. It now converts, through the **same offscreen reader `read_doc` uses**, handed bytes inline instead of a URL — `doc-extract.js` has always accepted a `bytesB64` source, so an attached `.docx` and a linked one go through exactly one implementation.

The converted Markdown rides the **existing text transport**, inlined as `<peerd_file name="…">`. That means it *persists with the transcript* — the model can still read the spreadsheet three turns later, unlike image/PDF bytes which are stripped after one turn. The chip keeps `kind:'doc'`, so the UI still says "report.docx" rather than calling it a text file.

Closes #

## Checklist

- [x] `bun run preflight` passes (tests, typecheck, lint, in-browser, dweb-boundary, no manifest drift) — table below
- [x] Only original or permissively-licensed code — **no GPL / AGPL / copyleft** (no new dependencies)
- [x] Tests added or updated — 12 new (seam + end-to-end)
- [x] No hand-edited generated files
- [x] Called out below if this touches a **danger zone**

## Notes for reviewers

### Three decisions worth checking

**Extension fallback, for documents only.** Chrome reports `File.type === ''` for `.docx` on any machine whose OS media-type registry lacks an entry, so media-type-only classification refuses the common case. Images and PDFs get no fallback — those types are universally registered, and a blanket fallback would let a mislabeled file through as something it isn't. The picker's `accept` list carries the extensions for the same reason: without them the file is greyed out in the dialog before classification ever runs.

**`text/*` is checked before the fallback**, so a `.csv` stays `'text'` and is inlined verbatim rather than re-rendered as a Markdown table — no behaviour change for files that already worked.

**Legacy binaries (`.doc`/`.xls`/`.ppt`/`.xlsb`) classify as `'doc'` on purpose**, even though nothing converts them. Reaching the converter is what produces *"this is a Word 97-2003 file, ask for a .docx or convert it in a WebVM"* instead of a flat "unsupported type". A precise refusal beats an early one.

### Structure

The conversion is the one impure step and its IO is **injected, not imported** — the side panel imports `classifyAttachment` from this module and must not drag seven format parsers along with it.

`prepareUserAttachmentsWithDocs` sequences validate → convert → inline in one place, because the **order is a correctness property**: validating first is what stops a 200MB file being parsed and only then rejected for being over cap. The SW route calls it once and cannot get the order wrong. This replaced an earlier version where the route made three separate calls and validation ran twice.

### Danger zone: transport sizing

No egress surface — bytes come from the user's disk, and `fetchDocBytes` returns early for a `bytesB64` source, so none of the SSRF machinery is even reachable on this path.

The sizing is the thing to check. I initially set the doc cap to 20MB reasoning that a document's source is mostly discardable embedded media; on review that ignores the **transport**. An attachment is base64 (≈1.37×) and crosses two message hops — panel → SW, then SW → offscreen — so 20MB meant a ~27MB string copied twice. Lowered to the PDF cap of 10MB (~14MB, still twice), which real office files sit far below. The cap that actually matters is `DOC_TEXT_MAX_CHARS` (40k) on the **output**, because inlined text is a *recurring* per-turn cost, not a one-turn one.

### Tests

The seam with a stub converter (sequencing, validation-before-conversion, fail-closed carrying the converter's own message, no-converter on Firefox, mixed image+doc batches), plus an end-to-end pass wiring the **real** converter to the **real** attachment pipeline — so a change to either half that breaks the join fails in Bun rather than in a browser. That one also pins the property worth pinning: a hidden sheet's contents do not reach the model, and the omission is stated rather than silent.

### Verification

| Gate | Result |
|---|---|
| `bun test ./tests` | 4097 pass, 0 fail |
| in-browser (CDP headless) | 713 pass, 0 fail |
| `test:e2e` | 21 states, 128/128 checks |
| `check:pages` | 9 pages boot, both channels |
| lint / typecheck | clean |
| `check:` tscheck, imports, boundary, hygiene, invariants, docpaths, vendor | all OK |

### Known rough edge

On Firefox there is no offscreen document, so conversion fails at **send** time rather than at pick time — the picker still offers the file. The error is explicit ("not available in this browser build"), and making the picker channel-aware is more machinery than the case warrants. Flagging rather than hiding it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QuTKbXkL7ZhH2fTPzFnXJa)_