### PR TITLE
feat(lifecycle): the interruption/recovery contract — core + live wiring

### DIFF
--- a/extension/background/app-tab-tracker.js
+++ b/extension/background/app-tab-tracker.js
@@ -15,14 +15,18 @@ import { APP_TAB_PATH } from '/peerd-engine/index.js';
 
 const READY_TIMEOUT_MS = 15_000;
 
-/** @param {{ announce?: import('./tab-tracker.js').TabTrackerConfig['announce'] }} [deps] */
-export const createAppTabTracker = ({ announce } = {}) => {
+/** @param {{ announce?: import('./tab-tracker.js').TabTrackerConfig['announce'],
+ *   onAdopt?: import('./tab-tracker.js').TabTrackerConfig['onAdopt'],
+ *   onDrop?: import('./tab-tracker.js').TabTrackerConfig['onDrop'] }} [deps] */
+export const createAppTabTracker = ({ announce, onAdopt, onDrop } = {}) => {
   const tracker = createTabTracker({
     tabPath: APP_TAB_PATH,
     readyTimeoutMs: READY_TIMEOUT_MS,
     closedError: () => new Error('app tab closed before ready'),
     notReadyMessage: (id) => `app ${id} did not become ready`,
     announce,
+    onAdopt,
+    onDrop,
     kindLabel: 'an App',
   });
 

--- a/extension/background/notebook-tab-tracker.js
+++ b/extension/background/notebook-tab-tracker.js
@@ -14,14 +14,18 @@ import { NOTEBOOK_TAB_PATH } from '/peerd-engine/index.js';
 
 const READY_TIMEOUT_MS = 15_000;       // Notebooks boot fast; tighter than VMs
 
-/** @param {{ announce?: import('./tab-tracker.js').TabTrackerConfig['announce'] }} [deps] */
-export const createJsTabTracker = ({ announce } = {}) => {
+/** @param {{ announce?: import('./tab-tracker.js').TabTrackerConfig['announce'],
+ *   onAdopt?: import('./tab-tracker.js').TabTrackerConfig['onAdopt'],
+ *   onDrop?: import('./tab-tracker.js').TabTrackerConfig['onDrop'] }} [deps] */
+export const createJsTabTracker = ({ announce, onAdopt, onDrop } = {}) => {
   const tracker = createTabTracker({
     tabPath: NOTEBOOK_TAB_PATH,
     readyTimeoutMs: READY_TIMEOUT_MS,
     closedError: () => new Error('Notebook tab closed before ready'),
     notReadyMessage: (id) => `Notebook ${id} did not become ready in ${READY_TIMEOUT_MS}ms`,
     announce,
+    onAdopt,
+    onDrop,
     kindLabel: 'a Notebook',
   });
 

--- a/extension/background/routes/session-mutations.js
+++ b/extension/background/routes/session-mutations.js
@@ -17,6 +17,7 @@ export const makeSessionMutationRoutes = (deps) => {
     vault, auditLog, pushState, sessions, sessionCache, sessionState, autoMemory,
     resolvePermission, normalizeMode, normalizeConfirmActions, SessionNotFoundError,
     maybeAutoResume, haltGoalRun, turnSlots, actorMessaging, nukeSessionWorkspace,
+    purgeLifecycleSession,
   } = deps;
 
   return {
@@ -139,6 +140,12 @@ export const makeSessionMutationRoutes = (deps) => {
         // Fire-and-forget + guarded: workspace bytes are agent scratch,
         // best-effort cleanup must never fail the archive.
         Promise.resolve(nukeSessionWorkspace?.(sessionId)).catch(() => {});
+        // Lifecycle §2.5: the user's archive dominates recovery — purge the
+        // session's pending recovery notices (a put-away chat's operations
+        // must not resurrect as notes elsewhere) and settle its nonterminal
+        // operations cancelled so no future boot reconciles them back.
+        // Fire-and-forget: best-effort cleanup never fails the archive.
+        Promise.resolve(purgeLifecycleSession?.(sessionId)).catch(() => {});
         return { ok: true };
       } catch (e) {
         if (e instanceof SessionNotFoundError) return { ok: false, error: 'session-not-found' };

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -442,7 +442,11 @@ const lifecycleBoot = makeLifecycleBoot({
 });
 /** @type {ReturnType<typeof makeDispatchTracker> | null} */
 let lifecycleTracker = null;
-const lifecycleReady = lifecycleBoot.init()
+// Fire-and-forget by design: nothing awaits the boot — a dispatch that
+// races it simply runs untracked (the pre-lifecycle behavior), and the
+// chain's own catch keeps a failed boot from surfacing as an unhandled
+// rejection.
+lifecycleBoot.init()
   .then(async ({ generation }) => {
     lifecycleTracker = makeDispatchTracker({
       operationLog: lifecycleBoot.operationLog,

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -361,6 +361,8 @@ import {
   // DESIGN-19: the shared non-GET web-write predicate (site-fetch/call gates a
   // non-GET through the same web:write confirm as fetch_url / call_api).
   needsWebWriteConfirm,
+  // §11.5: the dormant App-bodies store's write gate (self-hosted DB).
+  setAppBodyWriteGate,
 } from '/peerd-engine/index.js';
 import { createDebuggerPool } from './debugger-pool.js';
 import { normalizeSettingsPatch } from './settings-patch.js';
@@ -406,6 +408,11 @@ const kv = storeWriteGuard.wrapKv(rawKv);
 const idb = storeWriteGuard.wrapIdb(rawIdb);
 const idbKV = (/** @type {string} */ store) =>
   storeWriteGuard.wrapIdbKvAdapter(store, rawIdbKV(store));
+// The two SELF-HOSTED databases (own IDB, unreachable through the wrapped
+// adapters) get the same verdict via injected gates: skills below at its
+// construction, App bodies here (dormant store, gate installed anyway so a
+// future consumer can never ship ungated).
+setAppBodyWriteGate(() => storeWriteGuard.assertWritable('app-manifests'));
 
 // ---------------------------------------------------------------------------
 // 1. Layer 1 instances
@@ -970,7 +977,11 @@ loadUserHooks({ kv })
 // the ToolContext (ctx.skills) in buildToolContext so the tool can read a
 // body on invocation. Descriptions are injected into the system prompt
 // per turn (skillsBlock below) — bodies never are.
-const skillStore = createSkillStore();
+// §11.5: skills live in their own database — the write guard's verdict is
+// injected here since the wrapped adapters can't reach it.
+const skillStore = createSkillStore({
+  canWrite: () => storeWriteGuard.assertWritable('skills'),
+});
 const skillRegistry = createSkillRegistry({ store: skillStore, audit: auditLog.append });
 registerTool(loadSkillTool);
 

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -73,12 +73,15 @@ import {
   createAuditLog,
   // confirmation protocol (SW ↔ side panel round-trip)
   makeConfirmCoordinator,
-  // storage namespaces
-  kv,
-  idb,
-  idbKV,
+  // storage namespaces — imported RAW; the write guard below wraps them
+  // once, and every store in this file is constructed on the wrapped pair.
+  kv as rawKv,
+  idb as rawIdb,
+  idbKV as rawIdbKV,
   sessionCache,
 } from '/peerd-egress/index.js';
+
+
 
 import { base64ToBytes, bytesToBase64 } from '/shared/util.js';
 import { applyFetchExtract } from '/shared/fetch-extract.js';
@@ -168,6 +171,9 @@ import {
   // per-tool retry classifier, and the per-store schema stamps.
   makeLifecycleBoot,
   makeDispatchTracker,
+  makeFailClosedTracker,
+  makeWriteGuard,
+  makeEngineLiveness,
   retryClassForTool,
   checkStores,
   stampStores,
@@ -386,6 +392,21 @@ import { makeLocalModelRoutes } from './routes/local-model.js';
 import { makeDwebRoutes } from './routes/dweb.js';
 import { makeToolboxRoutes } from './routes/toolbox.js';
 
+// ---- §11.5 universal write guard -------------------------------------------
+// EVERY store this file constructs gets its storage through these wrapped
+// adapters, so a read-only verdict from the §11.1 schema check (a NEWER
+// stamp than this build supports) is enforced at the one chokepoint all
+// writes share — no per-store wiring, no store left out. The blocked set
+// starts empty (zero overhead until a store is actually blocked) and is
+// filled inside the lifecycle boot chain below. Two self-hosted databases
+// (peerd-skills, peerd-app-bodies) sit outside the adapters — the registry
+// marks them and their enforcement is a per-module follow-up.
+const storeWriteGuard = makeWriteGuard();
+const kv = storeWriteGuard.wrapKv(rawKv);
+const idb = storeWriteGuard.wrapIdb(rawIdb);
+const idbKV = (/** @type {string} */ store) =>
+  storeWriteGuard.wrapIdbKvAdapter(store, rawIdbKV(store));
+
 // ---------------------------------------------------------------------------
 // 1. Layer 1 instances
 // ---------------------------------------------------------------------------
@@ -431,6 +452,10 @@ const auditLog = createAuditLog({ idb, maxEntries: CHANNEL_DEFAULTS.auditLogMaxE
 // just run untracked, as they did before this landed), fail-CLOSED on
 // replay (once armed, the tracker refuses automatic re-dispatch of an
 // unproven side effect).
+// §9: the durable engine-liveness ledger — the tab trackers write it on
+// adopt/drop; the registry-init sweep below reaps instances whose tabs did
+// not survive the interruption.
+const engineLiveness = makeEngineLiveness({ storage: kv });
 const lifecycleBoot = makeLifecycleBoot({
   storage: kv,
   appendAudit: (/** @type {any} */ entry) =>
@@ -452,13 +477,15 @@ const lifecycleBoot = makeLifecycleBoot({
   },
   nonce: () => crypto.randomUUID(),
 });
-/** @type {ReturnType<typeof makeDispatchTracker> | null} */
+/** @type {ReturnType<typeof makeDispatchTracker> | ReturnType<typeof makeFailClosedTracker> | null} */
 let lifecycleTracker = null;
-// Fire-and-forget by design: nothing awaits the boot — a dispatch that
-// races it simply runs untracked (the pre-lifecycle behavior), and the
-// chain's own catch keeps a failed boot from surfacing as an unhandled
-// rejection.
-lifecycleBoot.init()
+// buildToolContext awaits this before handing out a ctx, which closes the
+// boot window: a Class D/E dispatch can never race the tracker into
+// running untracked. The chain NEVER rejects — on boot failure it arms
+// the fail-closed tracker instead (D/E refused with the reason, A/B/C
+// untracked), so a broken storage layer degrades the side-effect surface
+// loudly rather than silently, and never bricks reads.
+const lifecycleArmed = lifecycleBoot.init()
   .then(async ({ generation }) => {
     lifecycleTracker = makeDispatchTracker({
       operationLog: lifecycleBoot.operationLog,
@@ -478,8 +505,15 @@ lifecycleBoot.init()
         write: (/** @type {any} */ map) => kv.set(VERSION_STAMP_KEY, map),
       });
     } else {
-      for (const s of storesCheck.stores.filter((/** @type {any} */ x) => x.mode === 'read-only')) {
-        console.error('[sw] store schema blocked:', s.store, s.reason);
+      const blocked = storesCheck.stores
+        .filter((/** @type {any} */ x) => x.mode === 'read-only');
+      // §11.5 ENFORCED: the guard flips these surfaces' physical locations
+      // to refuse-writes at the shared adapter chokepoint. Reads keep
+      // working; the thrown StoreReadOnlyError names the store and says no
+      // data was changed.
+      storeWriteGuard.block(blocked.map((/** @type {any} */ x) => x.store));
+      for (const s of blocked) {
+        console.error('[sw] store schema blocked (writes refused):', s.store, s.reason);
         auditLog.append({
           type: 'lifecycle.migration.failed',
           details: { store: s.store, reason: s.reason, diagnosticId: s.diagnosticId },
@@ -489,7 +523,11 @@ lifecycleBoot.init()
     return generation;
   })
   .catch((/** @type {unknown} */ e) => {
-    console.error('[sw] lifecycle boot failed; dispatches run untracked', e);
+    console.error('[sw] lifecycle boot failed; Class D/E dispatches fail closed', e);
+    lifecycleTracker = makeFailClosedTracker({
+      reason: 'lifecycle boot failed',
+      retryClassFor: retryClassForTool,
+    });
     return null;
   });
 
@@ -1408,6 +1446,11 @@ const buildToolContext = async (/** @type {any} */ { sessionId: overrideSessionI
   // rejects) — it cannot hang the turn. Every dispatch path (main turn, direct
   // dispatch, spawned actors) routes through here, so all are covered.
   await denylistReady;
+  // The lifecycle tracker must be ARMED before any ctx exists — otherwise a
+  // Class D/E dispatch could race the boot into running untracked. The
+  // promise settles once (subsequent awaits are free) and never rejects; a
+  // failed boot arms the fail-closed tracker instead.
+  await lifecycleArmed;
   // Same shape, one layer down: never dispatch a tool while the DNR backstop
   // trails the driven-tab set. Most binding paths kick the sync without awaiting
   // it (bind() is a sync callback), so an actor's FIRST tool call could
@@ -2308,7 +2351,11 @@ const trackerNote = (/** @type {any} */ registry, /** @type {string} */ kind) =>
     .then((r) => noteAgentTab(tabId, { kind, name: r?.name ?? null }))
     .catch(() => noteAgentTab(tabId, { kind }));
 };
-const vmTabTracker = createVmTabTracker({ announce: trackerNote(vmRegistry, 'WebVM') });
+const vmTabTracker = createVmTabTracker({
+  announce: trackerNote(vmRegistry, 'WebVM'),
+  onAdopt: (/** @type {string} */ id, /** @type {number} */ tabId) => engineLiveness.adopt('vm', id, tabId),
+  onDrop: (/** @type {string} */ id) => engineLiveness.drop('vm', id),
+});
 const vmClient = createVmClient({ registry: vmRegistry, tracker: vmTabTracker });
 
 // Notebook registry + tracker + client. Same lifecycle pattern as
@@ -2316,13 +2363,21 @@ const vmClient = createVmClient({ registry: vmRegistry, tracker: vmTabTracker })
 // via chrome.tabs.sendMessage to the Notebook's host page. (The IDB
 // store name 'notebooks' is the persistence key — see notebook-registry.)
 const jsRegistry = createNotebookRegistry({ storage: idbKV('notebooks'), onActorArchive: archiveOrphanedActor });
-const jsTabTracker = createJsTabTracker({ announce: trackerNote(jsRegistry, 'Notebook') });
+const jsTabTracker = createJsTabTracker({
+  announce: trackerNote(jsRegistry, 'Notebook'),
+  onAdopt: (/** @type {string} */ id, /** @type {number} */ tabId) => engineLiveness.adopt('notebook', id, tabId),
+  onDrop: (/** @type {string} */ id) => engineLiveness.drop('notebook', id),
+});
 const jsClient = createJsClient({ registry: jsRegistry, tracker: jsTabTracker });
 
 // App registry + tracker + client. Apps' files live in OPFS at
 // peerd-apps/<appId>/; the registry tracks metadata only.
 const appRegistry = createAppRegistry({ storage: idbKV('apps'), onActorArchive: archiveOrphanedActor });
-const appTabTracker = createAppTabTracker({ announce: trackerNote(appRegistry, 'App') });
+const appTabTracker = createAppTabTracker({
+  announce: trackerNote(appRegistry, 'App'),
+  onAdopt: (/** @type {string} */ id, /** @type {number} */ tabId) => engineLiveness.adopt('app', id, tabId),
+  onDrop: (/** @type {string} */ id) => engineLiveness.drop('app', id),
+});
 const appClient = createAppClient({ registry: appRegistry, tracker: appTabTracker });
 
 // Sessions that have ENGAGED the dweb — a dweb tool was called this turn-or-
@@ -5725,6 +5780,48 @@ ensureOffscreen().catch((e) => console.error('[sw] boot ensureOffscreen failed',
     await appTabTracker.bootstrap();
     console.log('[sw] instance registries initialized — live tabs:',
       { vm: vmTabTracker.listLive(), js: jsTabTracker.listLive(), app: appTabTracker.listLive() });
+    // §9 engine orphan reap — instances the liveness ledger says were
+    // HOSTED before this SW start whose tabs did not survive. The
+    // registry catalog (files, metadata) persists; the running process is
+    // gone. Reap → audit → the §14 resource-lost notice to the owner's
+    // chat + the agent's next turn.
+    try {
+      const surviving = [
+        ...vmTabTracker.listLive().map((/** @type {string} */ id) => `vm:${id}`),
+        ...jsTabTracker.listLive().map((/** @type {string} */ id) => `notebook:${id}`),
+        ...appTabTracker.listLive().map((/** @type {string} */ id) => `app:${id}`),
+      ];
+      const lost = await engineLiveness.sweep({ surviving });
+      const KIND_LABEL = { vm: 'Linux VM', notebook: 'Notebook', app: 'App' };
+      const REGISTRY_OF = { vm: vmRegistry, notebook: jsRegistry, app: appRegistry };
+      for (const entry of lost) {
+        auditLog.append({
+          type: 'lifecycle.engine.orphan-reaped',
+          details: { kind: entry.kind, id: entry.id },
+        }).catch(() => {});
+        const registry = /** @type {any} */ (REGISTRY_OF)[entry.kind];
+        const record = await Promise.resolve(registry?.get?.(entry.id)).catch(() => null);
+        const owner = record?.ownerSessionId;
+        if (!owner) continue; // no owner to tell; the audit entry stands
+        await lifecycleBoot.parkNotice(owner, {
+          recoveryRecord: {
+            operation: `${entry.kind}:${entry.id}`,
+            recoveryState: 'interrupted',
+            sideEffectStatus: 'none attempted',
+            resourceLost: true,
+          },
+          user: `The ${/** @type {any} */ (KIND_LABEL)[entry.kind] ?? entry.kind} `
+            + `"${record?.name ?? entry.id}" stopped with the browser session. `
+            + 'Your saved files remain, but live process state was lost.',
+        }).catch(() => {});
+      }
+      if (lost.length) {
+        console.log('[sw] engine orphans reaped:',
+          lost.map((/** @type {any} */ l) => `${l.kind}:${l.id}`));
+      }
+    } catch (e) {
+      console.warn('[sw] engine orphan sweep failed', e);
+    }
     // An SW restart re-adopts engine tabs that never stopped running, so the
     // network backstop's tab scope has to be rebuilt from what bootstrap found.
     denylistNetGuard.sync();

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -438,6 +438,18 @@ const lifecycleBoot = makeLifecycleBoot({
   // postChatNote is declared far below — the standard late-dep deferral.
   notify: (/** @type {string} */ _sessionId, /** @type {string} */ text) =>
     postChatNote(`Recovered from a browser interruption: ${text}`),
+  // Actor sessions may never take another turn, so their recovery notices
+  // walk parentSessionId up to the root chat (bounded — a corrupt chain
+  // stops at the depth cap and falls back to the child).
+  resolveNoticeSession: async (/** @type {string} */ sid) => {
+    let cursor = sid;
+    for (let hops = 0; hops < 8; hops += 1) {
+      const record = await sessions.get(cursor).catch(() => null);
+      if (!record?.parentSessionId) break;
+      cursor = record.parentSessionId;
+    }
+    return cursor;
+  },
   nonce: () => crypto.randomUUID(),
 });
 /** @type {ReturnType<typeof makeDispatchTracker> | null} */

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -163,6 +163,16 @@ import {
   makeToolsCommand,
   dispatchToolCall,
   BUILTIN_TOOLS,
+  // lifecycle — the recovery contract's shells: SW-generation boot +
+  // startup reconcile, the dispatch tracker every tool ctx carries, the
+  // per-tool retry classifier, and the per-store schema stamps.
+  makeLifecycleBoot,
+  makeDispatchTracker,
+  retryClassForTool,
+  checkStores,
+  stampStores,
+  VERSION_STAMP_KEY,
+  classifyFailure,
   // hooks (pre/post-tool-use lifecycle)
   registerHook,
   listHooks,
@@ -411,6 +421,61 @@ const vault = createVault({
 // maxEntries: capped retention — oldest entries pruned, amortized on
 // append — so a long-lived install's audit log doesn't grow unbounded.
 const auditLog = createAuditLog({ idb, maxEntries: CHANNEL_DEFAULTS.auditLogMaxEntries });
+
+// ---- Lifecycle boot (the recovery contract's imperative shell) -------------
+// Every SW start mints a new generation, settles the previous generation's
+// orphaned operation records (interrupted vs outcome_unknown by retry
+// class), stamps the per-store schema versions, and arms the dispatch
+// tracker that buildToolContext hands to every dispatch. Posture: fail-OPEN
+// on tracking (a broken boot must never brick the tool surface — dispatches
+// just run untracked, as they did before this landed), fail-CLOSED on
+// replay (once armed, the tracker refuses automatic re-dispatch of an
+// unproven side effect).
+const lifecycleBoot = makeLifecycleBoot({
+  storage: kv,
+  appendAudit: (/** @type {any} */ entry) =>
+    auditLog.append({ type: entry.event, details: entry }),
+  // postChatNote is declared far below — the standard late-dep deferral.
+  notify: (/** @type {string} */ _sessionId, /** @type {string} */ text) =>
+    postChatNote(`Recovered from a browser interruption: ${text}`),
+  nonce: () => crypto.randomUUID(),
+});
+/** @type {ReturnType<typeof makeDispatchTracker> | null} */
+let lifecycleTracker = null;
+const lifecycleReady = lifecycleBoot.init()
+  .then(async ({ generation }) => {
+    lifecycleTracker = makeDispatchTracker({
+      operationLog: lifecycleBoot.operationLog,
+      generationId: () => generation.id,
+      retryClassFor: retryClassForTool,
+      classifyFailure: /** @type {any} */ (classifyFailure),
+    });
+    // §11.1 — independent per-store schema stamps. A newer stamp than this
+    // build supports leaves that store read-only (refuse-newer); the check
+    // result is audited so a blocked profile is diagnosable, and stamping
+    // only proceeds when every store is writable.
+    const readStamps = async () => (await kv.get(VERSION_STAMP_KEY)) ?? undefined;
+    const storesCheck = await checkStores({ read: readStamps });
+    if (storesCheck.ok) {
+      await stampStores({
+        read: readStamps,
+        write: (/** @type {any} */ map) => kv.set(VERSION_STAMP_KEY, map),
+      });
+    } else {
+      for (const s of storesCheck.stores.filter((/** @type {any} */ x) => x.mode === 'read-only')) {
+        console.error('[sw] store schema blocked:', s.store, s.reason);
+        auditLog.append({
+          type: 'lifecycle.migration.failed',
+          details: { store: s.store, reason: s.reason, diagnosticId: s.diagnosticId },
+        }).catch(() => {});
+      }
+    }
+    return generation;
+  })
+  .catch((/** @type {unknown} */ e) => {
+    console.error('[sw] lifecycle boot failed; dispatches run untracked', e);
+    return null;
+  });
 
 // INV-15 — the proof-of-possession key seam. Backed by the `dpop_keys` IDB store
 // (one non-extractable keypair per owned https origin, minted lazily on the first
@@ -1431,6 +1496,12 @@ const buildToolContext = async (/** @type {any} */ { sessionId: overrideSessionI
     // the capability strip below makes its ctx keyless).
     exposure: exposure ?? null,
     synthetic: synthetic === true,
+    // The recovery contract's dispatch tracker (lifecycle/dispatch-tracking.js).
+    // Read at ctx-build time: before the async boot resolves this is null and
+    // the dispatch runs untracked (pre-lifecycle behavior); once armed, every
+    // path through this builder — main turn, actor relay, page-call — records
+    // side-effecting calls durably and refuses unproven replays.
+    lifecycle: lifecycleTracker,
     // DESIGN-17: the message_actor sender gate's untrusted-ORIGIN signal. A
     // synthetic turn (goal continuation / async wake / actor reply-wake) is
     // "inbound" — refused — UNLESS it is an explicit first-party continuation
@@ -3226,6 +3297,8 @@ const { runAgentTurn, maybeAutoResume } = makeTurnDriver({
   resolveFailoverChain, shouldFailover, callModel, runUserTurn, getSecret,
   safeFetch, REASONING_BUDGET_TOKENS, REASONING_EFFORT_LEVELS, DEFAULT_SETTINGS, trimEnricher,
   contextWindowFor, liveContextWindow, currentAppScope, checkpointMgr, detectInterruptedTurn,
+  // Lifecycle recovery notices → the next turn's <context> message (read-once).
+  drainRecoveryNotices: (/** @type {string} */ sid) => lifecycleBoot.drainNoticesFor(sid),
   recordModelCall: contextSnapshots.record,
   // prewalk: the turn-boundary reconcile (swap/restore) + the per-tool-call gate,
   // plus the engine-actor reconcile (VM/Notebook/App swap after their first turn).

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -5451,6 +5451,9 @@ const startGoalRun = async (/** @type {{ sessionId: string, goal: string }} */ r
 // run, so a vault-lock-PAUSED run (evicted from the runner's map but kept in the
 // kv mirror for resume) would survive a Stop and resurrect on the next unlock.
 const haltGoalRun = (/** @type {string} */ sid) => /** @type {any} */ (goalRunner)?.stop(sid);
+// §2.5: session archive/delete purges its lifecycle state — pending recovery
+// notices + nonterminal operations settle cancelled (boot.purgeSession).
+const purgeLifecycleSession = (/** @type {string} */ sid) => lifecycleBoot.purgeSession(sid);
 const resumeGoalRuns = () => /** @type {any} */ (goalRunner)?.resume();
 // Background scheduling: drive a full scheduler catch-up. The SINGLE entry point
 // for every wake (alarm, onStartup, cold boot, vault unlock) so the ordering is
@@ -5626,6 +5629,8 @@ browser.runtime.onMessage.addListener(/** @type {any} */ (makeDispatcher({
     turnSlots, actorMessaging,
     // Session teardown drops the durable script workspace subtree.
     nukeSessionWorkspace,
+    // …and the session's lifecycle state (§2.5 cancellation dominance).
+    purgeLifecycleSession,
   }),
   ...makeLocalModelRoutes({ ensureOffscreen, browser, localModelState }),
   ...makeDwebRoutes({

--- a/extension/background/tab-tracker.js
+++ b/extension/background/tab-tracker.js
@@ -48,6 +48,11 @@ import browser from '/vendor/browser-polyfill.js';
  *   Injected by the SW (announceAgentTab); null when no announcer is wired.
  * @property {string} [kindLabel]
  *   Human noun for the announce card ('a Linux VM', 'a Notebook', 'an App').
+ * @property {((id: string, tabId: number) => void) | null} [onAdopt]
+ *   Lifecycle liveness hook: fired on every id↔tab association (spawn,
+ *   tab-ready, bootstrap re-adoption). Best-effort — see the §9 ledger.
+ * @property {((id: string) => void) | null} [onDrop]
+ *   Lifecycle liveness hook: fired on a clean tab removal.
  */
 
 /**
@@ -66,6 +71,12 @@ export const createTabTracker = ({
   // human noun for the card ('a Linux VM', 'a Notebook', 'an App').
   announce = null,
   kindLabel = 'a tab',
+  // Lifecycle liveness hooks (§9): fired on every id↔tab association and
+  // clean drop, so the durable ledger knows which instances were HOSTED if
+  // an eviction hits. Optional + best-effort — tracker bookkeeping never
+  // depends on them.
+  onAdopt = /** @type {((id: string, tabId: number) => void) | null} */ (null),
+  onDrop = /** @type {((id: string) => void) | null} */ (null),
 }) => {
   const tabUrlPrefix = browser.runtime.getURL(tabPath);
 
@@ -111,6 +122,7 @@ export const createTabTracker = ({
       entry.tabId = tabId;
     }
     tabIdToId.set(tabId, id);
+    try { onAdopt?.(id, tabId); } catch { /* liveness is best-effort */ }
     return entry;
   };
 
@@ -195,6 +207,7 @@ export const createTabTracker = ({
       entry.rejectReady?.(closedError(id));
       byId.delete(id);
     }
+    try { onDrop?.(id); } catch { /* liveness is best-effort */ }
     return id;
   };
 

--- a/extension/background/vm-tab-tracker.js
+++ b/extension/background/vm-tab-tracker.js
@@ -21,14 +21,18 @@ const READY_TIMEOUT_MS = 30_000;
  * @param {import('webextension-polyfill').Tabs.Static} [deps.tabs]
  *   Injected tabs API; defaults to the real browser.tabs.
  * @param {import('./tab-tracker.js').TabTrackerConfig['announce']} [deps.announce]
+ * @param {import('./tab-tracker.js').TabTrackerConfig['onAdopt']} [deps.onAdopt]
+ * @param {import('./tab-tracker.js').TabTrackerConfig['onDrop']} [deps.onDrop]
  */
-export const createVmTabTracker = ({ tabs, announce } = {}) => {
+export const createVmTabTracker = ({ tabs, announce, onAdopt, onDrop } = {}) => {
   const tracker = createTabTracker({
     tabPath: VM_TAB_PATH,
     readyTimeoutMs: READY_TIMEOUT_MS,
     closedError: (vmId) => new VMTabClosedError(vmId),
     notReadyMessage: (vmId) => `vm tab ${vmId} did not become ready in ${READY_TIMEOUT_MS}ms`,
     announce,
+    onAdopt,
+    onDrop,
     kindLabel: 'a Linux VM',
     ...(tabs ? { tabs } : {}),
   });

--- a/extension/peerd-engine/app-store.js
+++ b/extension/peerd-engine/app-store.js
@@ -20,6 +20,18 @@ const DB_VERSION = 1;
  * @type {Promise<IDBDatabase> | null}
  */
 let openPromise = null;
+
+// §11.5 write gate: App bodies live in their OWN database (peerd-app-bodies),
+// outside the shared kv/idb write guard — the SW installs the same schema
+// verdict here (throws StoreReadOnlyError when the profile is newer than
+// this build supports). why a module-level setter: this store is a module
+// of free functions, not a factory; the gate mirrors the tool-registry
+// registration shape. Unset → always writable.
+/** @type {(() => void) | null} */
+let writeGate = null;
+/** @param {(() => void) | null} gate */
+export const setAppBodyWriteGate = (gate) => { writeGate = typeof gate === 'function' ? gate : null; };
+
 const openDb = () => {
   if (openPromise) return openPromise;
   openPromise = new Promise((resolve, reject) => {
@@ -80,6 +92,7 @@ export const getAppBody = async (id) => {
  * @param {string} html
  */
 export const putAppBody = async (id, html) => {
+  writeGate?.();
   return tx('readwrite', (store) => /** @type {Promise<void>} */ (new Promise(
     (resolve, reject) => {
       const r = store.put({ id, html, updatedAt: Date.now() });
@@ -90,6 +103,7 @@ export const putAppBody = async (id, html) => {
 
 /** @param {string} id */
 export const deleteAppBody = async (id) => {
+  writeGate?.();
   return tx('readwrite', (store) => /** @type {Promise<void>} */ (new Promise(
     (resolve, reject) => {
       const r = store.delete(id);

--- a/extension/peerd-engine/index.js
+++ b/extension/peerd-engine/index.js
@@ -153,4 +153,8 @@ export {
 // The IDB body store (./app-store.js) is reserved for the future
 // SNAPSHOT tier. Not re-exported here -- consumers should import
 // directly when they need it, to keep the public engine surface
-// focused on what's actually wired up today.
+// focused on what's actually wired up today. The ONE exception is its
+// §11.5 write gate: the SW must be able to install the newer-schema
+// refusal even while the store is dormant, so a future consumer can
+// never ship ungated.
+export { setAppBodyWriteGate } from './app-store.js';

--- a/extension/peerd-provider/format/to-anthropic.js
+++ b/extension/peerd-provider/format/to-anthropic.js
@@ -383,7 +383,14 @@ const repairOrphanToolUses = (msgs, causeByToolUseId = new Map()) => {
       type: 'tool_result',
       tool_use_id: id,
       content: causeByToolUseId.get(id)
-        ?? 'tool dispatch did not complete. Treat as failed and retry if needed.',
+        // why the recovery-note deferral: for a tracked side effect the
+        // dispatch may have LANDED before the interruption — the same
+        // request can carry an <interruption-recovery> block saying
+        // outcome_unknown/do-not-repeat, and this synthesized result must
+        // not contradict it with a flat "retry".
+        ?? 'tool dispatch did not complete before an interruption. If an '
+          + 'interruption-recovery note covers this call, follow it; '
+          + 'otherwise treat as failed and retry if needed.',
       is_error: true,
     }));
 

--- a/extension/peerd-provider/format/to-openai.js
+++ b/extension/peerd-provider/format/to-openai.js
@@ -271,7 +271,12 @@ const repairOrphanToolCalls = (msgs) => {
         out.push({
           role: 'tool',
           tool_call_id: tc.id,
-          content: 'tool dispatch did not complete. Treat as failed and retry if needed.',
+          // Mirrors to-anthropic.js: defer to an interruption-recovery
+          // note when one covers this call — a tracked side effect may
+          // have landed, and "retry" would contradict it.
+          content: 'tool dispatch did not complete before an interruption. If an '
+            + 'interruption-recovery note covers this call, follow it; '
+            + 'otherwise treat as failed and retry if needed.',
         });
       }
     }

--- a/extension/peerd-runtime/actor/page-call-handler.js
+++ b/extension/peerd-runtime/actor/page-call-handler.js
@@ -79,10 +79,17 @@ export const makePageCallHandler = ({ dispatchToolCall, buildActorContext }) => 
 
   // Pin the owned tab onto the tool args (security invariant above). The DOM
   // tools all accept tabId; ones that don't ignore the extra key.
+  //
+  // why the id must be UNIQUE per dispatch: the lifecycle tracker keys
+  // operations on (sessionId, call id), and the SW route doesn't thread the
+  // worker's rid through — a constant id made every page.* write after the
+  // first read as a replay of it and refuse. These are fresh interactive
+  // calls the worker awaits one at a time; there is no resume path that
+  // re-drives them, so a collision-free random id is the correct identity.
   const call = {
     name: toolCall.name,
     args: { ...toolCall.args, tabId: req.tabId },
-    id: `page-${req.rid ?? ''}`,
+    id: `page-${req.rid ?? ''}-${crypto.randomUUID()}`,
   };
 
   /** @type {ToolResult} */

--- a/extension/peerd-runtime/index.js
+++ b/extension/peerd-runtime/index.js
@@ -445,6 +445,30 @@ export {
   RECOVERY_CATEGORIES, categorizeRecovery, describeRecovery,
   securityDegradationReport, migrationBlockedReport,
 } from './lifecycle/recovery-report.js';
+// §16.1: every tool resolves to a retry class — explicit field, name
+// override table, then the sideEffect/primitive taxonomy, failing closed
+// to E. The inventory test asserts totality over the live tool set.
+export { retryClassForTool, RETRY_CLASS_OVERRIDES } from './lifecycle/tool-retry-class.js';
+// §9: engine-resource recovery decisions — tab revalidation, notebook
+// output labelling, VM reboot plans, App sandbox recreation.
+export {
+  revalidateDrivenTab, TAB_DISPOSITIONS,
+  notebookCellState, NOTEBOOK_CELL_STATES,
+  vmRecoveryPlan, appSandboxRebuild,
+} from './lifecycle/resource-recovery.js';
+// §11.1/§12: independent per-store schema versions + durability tiers.
+export {
+  DURABILITY_TIERS, STORE_REGISTRY, VERSION_STAMP_KEY,
+  storeEntry, portableStores, omittedDeviceBoundStores,
+  checkStores, stampStores,
+} from './lifecycle/store-registry.js';
+// The wiring shells: dispatch tracking (the dispatcher consumes it via
+// ctx.lifecycle) and the SW boot sequence (generation + reconcile +
+// notices).
+export { makeDispatchTracker } from './lifecycle/dispatch-tracking.js';
+export {
+  makeLifecycleBoot, GENERATION_KEY, PENDING_NOTICES_KEY,
+} from './lifecycle/boot.js';
 
 // --- errors -------------------------------------------------------------
 export {

--- a/extension/peerd-runtime/index.js
+++ b/extension/peerd-runtime/index.js
@@ -462,10 +462,22 @@ export {
   storeEntry, portableStores, omittedDeviceBoundStores,
   checkStores, stampStores,
 } from './lifecycle/store-registry.js';
+// §11.5 enforced: the SW wraps its kv/idb adapters through the guard once
+// and a read-only verdict refuses writes at the shared chokepoint.
+export { makeWriteGuard, StoreReadOnlyError } from './lifecycle/write-guard.js';
+// §9: the durable engine-liveness ledger the tab trackers feed and the
+// boot sweep reaps orphans from.
+export { makeEngineLiveness, ENGINE_LIVENESS_KEY } from './lifecycle/engine-liveness.js';
 // The wiring shells: dispatch tracking (the dispatcher consumes it via
 // ctx.lifecycle) and the SW boot sequence (generation + reconcile +
 // notices).
-export { makeDispatchTracker } from './lifecycle/dispatch-tracking.js';
+export { makeDispatchTracker, makeFailClosedTracker } from './lifecycle/dispatch-tracking.js';
+// Typed failure outcomes — throw sites stamp outcomeKind so recovery is a
+// table lookup, not a regex (adoption is incremental; see the module).
+export {
+  FAILURE_OUTCOMES, isFailureOutcomeKind, outcomeKindOf,
+  TransportLostError, ExecutionHostLostError, PreEffectFailureError,
+} from './lifecycle/failure-taxonomy.js';
 export {
   makeLifecycleBoot, GENERATION_KEY, PENDING_NOTICES_KEY,
 } from './lifecycle/boot.js';

--- a/extension/peerd-runtime/index.js
+++ b/extension/peerd-runtime/index.js
@@ -403,6 +403,47 @@ export {
   drainFetchTapInjected,
 } from './dom/index.js';
 
+// --- lifecycle (the interruption/recovery contract's functional core) ---
+// Canonical operation states + the retry-class recovery decision, SW/actor
+// generations (authority never survives restart by assumption), single-use
+// confirmation binding, the startup reconciler, versioned-store migration
+// guard, the durable operation log, and the paired user/agent recovery
+// reports. The vault session-mirror side of the contract already lives in
+// peerd-egress/vault; this is the operation/authority side.
+export {
+  OPERATION_STATES, TERMINAL_STATES, isTerminal, isOperationState,
+  canTransition, assertTransition, IllegalTransitionError,
+  provesCompletion, provesFailure, resolveUnknownOutcome,
+  UnknownOutcomeUnresolvedError,
+} from './lifecycle/operation-state.js';
+export {
+  RETRY_CLASSES, isRetryClass, normalizeRetryClass, decideRecovery,
+} from './lifecycle/retry-class.js';
+export {
+  mintGeneration, authorityValid, sweepStaleAuthority, acceptActorMessage,
+} from './lifecycle/generation.js';
+export {
+  bindConfirmation, confirmationSatisfies, consumeConfirmation,
+  normalizeConfirmationTarget, CONFIRMATION_TTL_MS,
+} from './lifecycle/confirmation.js';
+export {
+  reconcileAtStartup, buildTurnRecoveryRecord,
+} from './lifecycle/reconcile.js';
+export {
+  classifyStoreVersion, guardStore, runMigration, StoreVersionError,
+} from './lifecycle/store-version.js';
+export {
+  LIFECYCLE_EVENTS, lifecycleAuditEntry, sanitizeDetail,
+} from './lifecycle/audit-events.js';
+export {
+  createOperationLog, OperationNotFoundError,
+  OPERATION_LOG_KEY, OPERATION_LOG_MAX_TERMINAL,
+} from './lifecycle/operation-log.js';
+export {
+  RECOVERY_CATEGORIES, categorizeRecovery, describeRecovery,
+  securityDegradationReport, migrationBlockedReport,
+} from './lifecycle/recovery-report.js';
+
 // --- errors -------------------------------------------------------------
 export {
   SessionNotFoundError,

--- a/extension/peerd-runtime/index.js
+++ b/extension/peerd-runtime/index.js
@@ -439,7 +439,7 @@ export {
 export {
   createOperationLog,
   OperationNotFoundError, OperationExistsError, RetryRefusedError,
-  OPERATION_LOG_KEY, OPERATION_LOG_MAX_TERMINAL,
+  OPERATION_LOG_KEY, OPERATION_LOG_MAX_TERMINAL, OPERATION_LOG_MAX_UNKNOWN,
 } from './lifecycle/operation-log.js';
 export {
   RECOVERY_CATEGORIES, categorizeRecovery, describeRecovery,

--- a/extension/peerd-runtime/index.js
+++ b/extension/peerd-runtime/index.js
@@ -412,7 +412,8 @@ export {
 // peerd-egress/vault; this is the operation/authority side.
 export {
   OPERATION_STATES, TERMINAL_STATES, isTerminal, isOperationState,
-  canTransition, assertTransition, IllegalTransitionError,
+  canTransition, assertTransition, canRecoverySettle, IllegalTransitionError,
+  COMPLETION_EVIDENCE, FAILURE_EVIDENCE,
   provesCompletion, provesFailure, resolveUnknownOutcome,
   UnknownOutcomeUnresolvedError,
 } from './lifecycle/operation-state.js';
@@ -430,13 +431,14 @@ export {
   reconcileAtStartup, buildTurnRecoveryRecord,
 } from './lifecycle/reconcile.js';
 export {
-  classifyStoreVersion, guardStore, runMigration, StoreVersionError,
+  classifyStoreVersion, guardStore, runMigration,
 } from './lifecycle/store-version.js';
 export {
   LIFECYCLE_EVENTS, lifecycleAuditEntry, sanitizeDetail,
 } from './lifecycle/audit-events.js';
 export {
-  createOperationLog, OperationNotFoundError,
+  createOperationLog,
+  OperationNotFoundError, OperationExistsError, RetryRefusedError,
   OPERATION_LOG_KEY, OPERATION_LOG_MAX_TERMINAL,
 } from './lifecycle/operation-log.js';
 export {

--- a/extension/peerd-runtime/lifecycle/audit-events.js
+++ b/extension/peerd-runtime/lifecycle/audit-events.js
@@ -30,16 +30,24 @@ export const LIFECYCLE_EVENTS = Object.freeze({
 });
 
 // Keys that must never appear in a lifecycle audit entry's detail, at any
-// depth. Substring match on the lowercased key — 'authorization',
-// 'x-api-key', 'setCookie' and friends all trip it.
+// depth. Substring match on the lowercased key — 'auth' subsumes
+// 'authorization'; 'x-api-key', 'setCookie', 'bearerToken', 'dpopProof'
+// and friends all trip it.
 const FORBIDDEN_KEY_FRAGMENTS = Object.freeze([
   'secret', 'token', 'password', 'passphrase', 'credential', 'apikey',
-  'api_key', 'authorization', 'cookie', 'dpop', 'proof', 'header', 'body',
+  'api_key', 'auth', 'cookie', 'dpop', 'proof', 'header', 'body',
+  'bearer', 'jwt', 'signature', 'private',
   'pagecontent', 'page_content',
 ]);
 
+// Keys whose ASSIGNMENT is itself the attack: writing out['__proto__']
+// mutates the sanitized object's prototype instead of adding a property.
+// Dropped outright before the fragment check ever runs.
+const DANGEROUS_KEYS = Object.freeze(new Set(['__proto__', 'constructor', 'prototype']));
+
 /** @param {string} key */
 const keyForbidden = (key) => {
+  if (DANGEROUS_KEYS.has(key)) return true;
   const lower = key.toLowerCase();
   return FORBIDDEN_KEY_FRAGMENTS.some((fragment) => lower.includes(fragment));
 };
@@ -62,6 +70,13 @@ export const sanitizeDetail = (value, depth = 0) => {
     return value.length > MAX_STRING_CHARS ? `${value.slice(0, MAX_STRING_CHARS)}…` : value;
   }
   if (depth >= MAX_DETAIL_DEPTH) return '[depth-capped]';
+  // The two non-plain shapes audit detail legitimately carries: an Error
+  // (keep its name+message — the reason the entry exists) and a Date.
+  // Everything else exotic falls through to its type name below.
+  if (value instanceof Error) {
+    return { name: value.name, message: String(sanitizeDetail(value.message)) };
+  }
+  if (value instanceof Date) return value.toISOString();
   if (Array.isArray(value)) return value.slice(0, 64).map((v) => sanitizeDetail(v, depth + 1));
   if (typeof value === 'object') {
     /** @type {Record<string, unknown>} */ const out = {};

--- a/extension/peerd-runtime/lifecycle/audit-events.js
+++ b/extension/peerd-runtime/lifecycle/audit-events.js
@@ -15,6 +15,7 @@ export const LIFECYCLE_EVENTS = Object.freeze({
   OPERATION_COMPLETED: /** @type {const} */ ('lifecycle.operation.completed'),
   OPERATION_INTERRUPTED: /** @type {const} */ ('lifecycle.operation.interrupted'),
   OUTCOME_UNKNOWN: /** @type {const} */ ('lifecycle.operation.outcome_unknown'),
+  OUTCOME_UNKNOWN_OVERFLOW: /** @type {const} */ ('lifecycle.operation.unknown-overflow'),
   RETRY_ATTEMPTED: /** @type {const} */ ('lifecycle.retry.attempted'),
   RETRY_REFUSED: /** @type {const} */ ('lifecycle.retry.refused'),
   SW_GENERATION_CHANGED: /** @type {const} */ ('lifecycle.generation.sw-changed'),

--- a/extension/peerd-runtime/lifecycle/audit-events.js
+++ b/extension/peerd-runtime/lifecycle/audit-events.js
@@ -1,0 +1,102 @@
+// @ts-check
+// Lifecycle audit vocabulary + the sanitizer for lifecycle entries.
+//
+// The audit log records lifecycle events with enough correlation to
+// reconstruct session → actor → operation → attempt → result, and NOTHING
+// sensitive: no secrets, DPoP proofs, raw headers, cookies, request
+// bodies, or untrusted page content (contract §13). The sanitizer here is
+// the single chokepoint every lifecycle entry passes through before the
+// egress audit appender sees it.
+//
+// Pure shaping; the shell appends via peerd-egress's audit chain.
+
+export const LIFECYCLE_EVENTS = Object.freeze({
+  OPERATION_STARTED: /** @type {const} */ ('lifecycle.operation.started'),
+  OPERATION_COMPLETED: /** @type {const} */ ('lifecycle.operation.completed'),
+  OPERATION_INTERRUPTED: /** @type {const} */ ('lifecycle.operation.interrupted'),
+  OUTCOME_UNKNOWN: /** @type {const} */ ('lifecycle.operation.outcome_unknown'),
+  RETRY_ATTEMPTED: /** @type {const} */ ('lifecycle.retry.attempted'),
+  RETRY_REFUSED: /** @type {const} */ ('lifecycle.retry.refused'),
+  SW_GENERATION_CHANGED: /** @type {const} */ ('lifecycle.generation.sw-changed'),
+  ACTOR_GENERATION_CHANGED: /** @type {const} */ ('lifecycle.generation.actor-changed'),
+  STALE_GRANT_REFUSED: /** @type {const} */ ('lifecycle.grant.stale-refused'),
+  STALE_CONFIRMATION_REFUSED: /** @type {const} */ ('lifecycle.confirmation.stale-refused'),
+  VAULT_RESUME_ACCEPTED: /** @type {const} */ ('lifecycle.vault.resume-accepted'),
+  VAULT_RESUME_REFUSED: /** @type {const} */ ('lifecycle.vault.resume-refused'),
+  MIGRATION_STARTED: /** @type {const} */ ('lifecycle.migration.started'),
+  MIGRATION_COMPLETED: /** @type {const} */ ('lifecycle.migration.completed'),
+  MIGRATION_FAILED: /** @type {const} */ ('lifecycle.migration.failed'),
+  ORPHAN_REAPED: /** @type {const} */ ('lifecycle.engine.orphan-reaped'),
+});
+
+// Keys that must never appear in a lifecycle audit entry's detail, at any
+// depth. Substring match on the lowercased key — 'authorization',
+// 'x-api-key', 'setCookie' and friends all trip it.
+const FORBIDDEN_KEY_FRAGMENTS = Object.freeze([
+  'secret', 'token', 'password', 'passphrase', 'credential', 'apikey',
+  'api_key', 'authorization', 'cookie', 'dpop', 'proof', 'header', 'body',
+  'pagecontent', 'page_content',
+]);
+
+/** @param {string} key */
+const keyForbidden = (key) => {
+  const lower = key.toLowerCase();
+  return FORBIDDEN_KEY_FRAGMENTS.some((fragment) => lower.includes(fragment));
+};
+
+const MAX_DETAIL_DEPTH = 4;
+const MAX_STRING_CHARS = 512;
+
+/**
+ * Deep-scrub a detail object: forbidden keys dropped, strings truncated
+ * (audit is correlation, not content), depth bounded so an adversarial
+ * record can't smuggle bulk. Arrays and plain objects only; anything
+ * exotic serializes to its type name.
+ *
+ * @param {unknown} value @param {number} [depth]
+ * @returns {unknown}
+ */
+export const sanitizeDetail = (value, depth = 0) => {
+  if (value === null || typeof value === 'number' || typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    return value.length > MAX_STRING_CHARS ? `${value.slice(0, MAX_STRING_CHARS)}…` : value;
+  }
+  if (depth >= MAX_DETAIL_DEPTH) return '[depth-capped]';
+  if (Array.isArray(value)) return value.slice(0, 64).map((v) => sanitizeDetail(v, depth + 1));
+  if (typeof value === 'object') {
+    /** @type {Record<string, unknown>} */ const out = {};
+    for (const [key, v] of Object.entries(value)) {
+      if (keyForbidden(key)) continue;
+      out[key] = sanitizeDetail(v, depth + 1);
+    }
+    return out;
+  }
+  return `[${typeof value}]`;
+};
+
+/**
+ * Shape one lifecycle audit entry. Correlation fields are first-class so
+ * the chain session → actor → operation → attempt → result reconstructs
+ * from entries alone; everything else rides in sanitized `detail`.
+ *
+ * @param {{ event: string, sessionId?: string, actorId?: string,
+ *   operationId?: string, attempt?: number, result?: string,
+ *   generationId?: string, detail?: unknown }} input
+ */
+export const lifecycleAuditEntry = ({
+  event, sessionId, actorId, operationId, attempt, result, generationId, detail,
+}) => {
+  if (!Object.values(LIFECYCLE_EVENTS).includes(/** @type {any} */ (event))) {
+    throw new TypeError(`lifecycleAuditEntry: unknown lifecycle event ${String(event)}`);
+  }
+  return {
+    event,
+    ...(sessionId ? { sessionId } : {}),
+    ...(actorId ? { actorId } : {}),
+    ...(operationId ? { operationId } : {}),
+    ...(typeof attempt === 'number' ? { attempt } : {}),
+    ...(result ? { result } : {}),
+    ...(generationId ? { generationId } : {}),
+    ...(detail !== undefined ? { detail: sanitizeDetail(detail) } : {}),
+  };
+};

--- a/extension/peerd-runtime/lifecycle/boot.js
+++ b/extension/peerd-runtime/lifecycle/boot.js
@@ -1,0 +1,129 @@
+// @ts-check
+// Lifecycle boot — what every fresh service-worker generation does first.
+//
+// The imperative shell's one entry point into the recovery contract: mint
+// the new generation (persisting the seq so it stays monotonic), settle the
+// dead generation's orphaned operations through the reconciler, append the
+// plan's audit trail, and park each parent-session notification where BOTH
+// audiences will see it — the user via the injected notify callback, the
+// agent via drainNoticesFor(), which the turn driver folds into the next
+// turn's <context> block (same semantic distinction on both sides, §14).
+//
+// All IO injected (storage kv, audit appender, notifier, entropy, clock);
+// bun-tested with in-memory adapters, exercised against real
+// chrome.storage in the in-browser suite.
+
+import { mintGeneration } from './generation.js';
+import { reconcileAtStartup } from './reconcile.js';
+import { describeRecovery } from './recovery-report.js';
+import { OPERATION_STATES } from './operation-state.js';
+import { createOperationLog } from './operation-log.js';
+
+export const GENERATION_KEY = 'peerd.lifecycle.generation';
+export const PENDING_NOTICES_KEY = 'peerd.lifecycle.pendingNotices';
+
+// Notices kept per session before oldest are dropped — a bound, not a
+// history (the operation log holds the durable record).
+const MAX_NOTICES_PER_SESSION = 8;
+
+/**
+ * @param {Object} deps
+ * @param {{ get: (key: string) => Promise<any>,
+ *   set: (key: string, value: any) => Promise<void> }} deps.storage
+ * @param {(entry: Record<string, unknown>) => Promise<unknown>} [deps.appendAudit]
+ * @param {(sessionId: string, userText: string) => unknown} [deps.notify]
+ * @param {() => string} deps.nonce   injected entropy (crypto.randomUUID)
+ * @param {() => number} [deps.now]
+ */
+export const makeLifecycleBoot = ({ storage, appendAudit, notify, nonce, now = Date.now }) => {
+  if (!storage || typeof nonce !== 'function') {
+    throw new TypeError('makeLifecycleBoot: storage and nonce are required');
+  }
+
+  const operationLog = createOperationLog({ storage, now });
+
+  /**
+   * Run the §5.3 startup sequence. Idempotent per SW start; a repeated call
+   * mints a fresh generation and finds nothing left to settle.
+   */
+  const init = async () => {
+    const previous = await storage.get(GENERATION_KEY).catch(() => undefined);
+    const generation = mintGeneration(
+      previous && typeof previous === 'object' ? previous : null,
+      { nonce: nonce(), now: now() },
+    );
+    // Persist BEFORE reconciling: if we die mid-reconcile, the next boot
+    // must still see this seq (monotonicity is what stale-authority
+    // refusal keys on).
+    await storage.set(GENERATION_KEY, generation);
+
+    const records = await operationLog.listNonterminal();
+    const plan = reconcileAtStartup({ records, generation });
+
+    for (const transition of plan.transitions) {
+      // Per-record isolation: one malformed record must not stop the rest
+      // of the sweep from settling.
+      await operationLog.settle(transition.operationId, transition.verdict)
+        .catch(() => {});
+    }
+
+    if (appendAudit) {
+      for (const entry of plan.auditEvents) {
+        await Promise.resolve(appendAudit(entry)).catch(() => {});
+      }
+    }
+
+    // Park + deliver the notifications. The pending store is what the NEXT
+    // turn drains into the agent's context; notify() is the immediate
+    // user-facing surface (a chat note) — best-effort, the durable copy is
+    // the one that matters.
+    if (plan.notifications.length > 0) {
+      const pending = (await storage.get(PENDING_NOTICES_KEY).catch(() => null)) ?? {};
+      for (const notification of plan.notifications) {
+        const { sessionId, recoveryRecord } = notification;
+        const transition = plan.transitions.find(
+          (t) => t.operationId === recoveryRecord.operationId);
+        const verdict = transition?.verdict;
+        const user = verdict
+          && (verdict.state === OPERATION_STATES.INTERRUPTED
+            || verdict.state === OPERATION_STATES.OUTCOME_UNKNOWN)
+          ? describeRecovery(verdict, { toolName: recoveryRecord.operation }).user
+          : `${recoveryRecord.operation} was settled as ${recoveryRecord.recoveryState} after an interruption.`;
+        const list = Array.isArray(pending[sessionId]) ? pending[sessionId] : [];
+        list.push({ recoveryRecord, user, at: now() });
+        pending[sessionId] = list.slice(-MAX_NOTICES_PER_SESSION);
+        try { notify?.(sessionId, user); } catch { /* panel gone */ }
+      }
+      await storage.set(PENDING_NOTICES_KEY, pending).catch(() => {});
+    }
+
+    return { generation, plan };
+  };
+
+  /**
+   * Drain a session's pending recovery notices into a context block for the
+   * agent's next turn — read-and-clear, so a notice is delivered once. why
+   * text and not raw JSON alone: the agent needs the same sentence the user
+   * saw plus the structured record; both ride the block.
+   *
+   * @param {string} sessionId
+   * @returns {Promise<string>} '' when nothing is pending
+   */
+  const drainNoticesFor = async (sessionId) => {
+    if (!sessionId) return '';
+    const pending = (await storage.get(PENDING_NOTICES_KEY).catch(() => null)) ?? {};
+    const list = pending[sessionId];
+    if (!Array.isArray(list) || list.length === 0) return '';
+    delete pending[sessionId];
+    await storage.set(PENDING_NOTICES_KEY, pending).catch(() => {});
+    const lines = list.map((/** @type {{ user: string, recoveryRecord: unknown }} */ n) =>
+      `- ${n.user}\n  ${JSON.stringify(n.recoveryRecord)}`);
+    return '<interruption-recovery>\nA previous browser session ended while '
+      + 'work was in flight. Recovered operation states:\n'
+      + `${lines.join('\n')}\n`
+      + 'Do not repeat any operation marked outcome_unknown without verifying '
+      + 'the external state first.\n</interruption-recovery>';
+  };
+
+  return { operationLog, init, drainNoticesFor };
+};

--- a/extension/peerd-runtime/lifecycle/boot.js
+++ b/extension/peerd-runtime/lifecycle/boot.js
@@ -50,12 +50,37 @@ export const makeLifecycleBoot = ({
 
   const operationLog = createOperationLog({ storage, now });
 
+  // The notices mutation queue. why: park (init + engine reaps) and drain
+  // (every turn start) are read-modify-writes of ONE kv key from
+  // concurrent callers — exactly the post-restart moment when both fire.
+  // Unserialized, a stale drain write erases a just-parked notice forever
+  // (the agent never hears the do-not-repeat instruction), and a stale
+  // park write resurrects a just-delivered one (read-once broken). The
+  // queue holds only the RMW; slow work (session resolution's parent
+  // walk) stays outside the slot.
+  /** @type {Promise<unknown>} */
+  let noticesQueueTail = Promise.resolve();
+  /** @template T @param {() => Promise<T>} job @returns {Promise<T>} */
+  const enqueueNotices = (job) => {
+    const run = noticesQueueTail.then(job, job);
+    noticesQueueTail = run.then(() => undefined, () => undefined);
+    return run;
+  };
+
+  /** @returns {Promise<Record<string, unknown[]>>} fail-safe normalized */
+  const loadPending = async () => {
+    const raw = await storage.get(PENDING_NOTICES_KEY).catch(() => null);
+    return raw && typeof raw === 'object' && !Array.isArray(raw)
+      ? /** @type {Record<string, unknown[]>} */ (raw)
+      : {};
+  };
+
   /**
    * Park one notice for a session's next turn (+ the immediate user note).
-   * Routed through resolveNoticeSession; fail-safe normalization on a
-   * corrupted pending store (a torn write can leave a primitive here —
-   * treat it as empty and repair by overwrite). Used by init() for
-   * reconcile notifications and by the shell for engine-orphan reaps.
+   * Routed through resolveNoticeSession (outside the queue slot); fail-safe
+   * normalization on a corrupted pending store (a torn write can leave a
+   * primitive here — treat it as empty and repair by overwrite). Used by
+   * init() for reconcile notifications and by the shell for engine reaps.
    *
    * @param {string} operationSessionId
    * @param {{ recoveryRecord: Record<string, unknown>, user: string }} notice
@@ -64,14 +89,13 @@ export const makeLifecycleBoot = ({
     const sessionId = await Promise.resolve(
       resolveNoticeSession?.(operationSessionId) ?? operationSessionId,
     ).catch(() => operationSessionId) || operationSessionId;
-    const raw = await storage.get(PENDING_NOTICES_KEY).catch(() => null);
-    const pending = raw && typeof raw === 'object' && !Array.isArray(raw)
-      ? /** @type {Record<string, unknown[]>} */ (raw)
-      : {};
-    const list = Array.isArray(pending[sessionId]) ? pending[sessionId] : [];
-    list.push({ recoveryRecord, user, at: now() });
-    pending[sessionId] = list.slice(-MAX_NOTICES_PER_SESSION);
-    await storage.set(PENDING_NOTICES_KEY, pending).catch(() => {});
+    await enqueueNotices(async () => {
+      const pending = await loadPending();
+      const list = Array.isArray(pending[sessionId]) ? pending[sessionId] : [];
+      list.push({ recoveryRecord, user, at: now() });
+      pending[sessionId] = list.slice(-MAX_NOTICES_PER_SESSION);
+      await storage.set(PENDING_NOTICES_KEY, pending).catch(() => {});
+    });
     try { notify?.(sessionId, user); } catch { /* panel gone */ }
   };
 
@@ -137,13 +161,19 @@ export const makeLifecycleBoot = ({
    */
   const drainNoticesFor = async (sessionId) => {
     if (!sessionId) return '';
-    const pending = (await storage.get(PENDING_NOTICES_KEY).catch(() => null)) ?? {};
-    const list = pending[sessionId];
-    if (!Array.isArray(list) || list.length === 0) return '';
-    delete pending[sessionId];
-    await storage.set(PENDING_NOTICES_KEY, pending).catch(() => {});
-    const lines = list.map((/** @type {{ user: string, recoveryRecord: unknown }} */ n) =>
-      `- ${n.user}\n  ${JSON.stringify(n.recoveryRecord)}`);
+    // The read-and-clear rides the same queue as park — a stale drain
+    // write must never erase a notice parked between its read and write.
+    const list = await enqueueNotices(async () => {
+      const pending = await loadPending();
+      const entry = pending[sessionId];
+      if (!Array.isArray(entry) || entry.length === 0) return null;
+      delete pending[sessionId];
+      await storage.set(PENDING_NOTICES_KEY, pending).catch(() => {});
+      return entry;
+    }).catch(() => null);
+    if (!list) return '';
+    const lines = /** @type {Array<{ user: string, recoveryRecord: unknown }>} */ (list)
+      .map((n) => `- ${n.user}\n  ${JSON.stringify(n.recoveryRecord)}`);
     return '<interruption-recovery>\nA previous browser session ended while '
       + 'work was in flight. Recovered operation states:\n'
       + `${lines.join('\n')}\n`
@@ -151,5 +181,37 @@ export const makeLifecycleBoot = ({
       + 'the external state first.\n</interruption-recovery>';
   };
 
-  return { operationLog, init, drainNoticesFor, parkNotice };
+  /**
+   * §2.5 — explicit user cancellation dominates recovery: when a session is
+   * deleted/archived, its pending notices are purged (a deleted chat's
+   * operations must not resurrect as notes elsewhere) and its nonterminal
+   * operations settle `cancelled` (the user ended the work; nothing may
+   * auto-resume it at the next boot). Best-effort per record.
+   *
+   * @param {string} sessionId
+   */
+  const purgeSession = async (sessionId) => {
+    if (!sessionId) return;
+    await enqueueNotices(async () => {
+      const pending = await loadPending();
+      if (sessionId in pending) {
+        delete pending[sessionId];
+        await storage.set(PENDING_NOTICES_KEY, pending).catch(() => {});
+      }
+    }).catch(() => {});
+    const open = await operationLog.listNonterminal().catch(() => []);
+    for (const record of open.filter((r) => r.sessionId === sessionId)) {
+      await operationLog.settle(record.operationId, {
+        state: OPERATION_STATES.CANCELLED,
+        autoRetry: false,
+        retryRequires: [],
+        keepIdempotencyKey: false,
+        verificationRequired: false,
+        recreateResource: false,
+        reason: 'session deleted by the user; cancellation dominates recovery',
+      }).catch(() => {});
+    }
+  };
+
+  return { operationLog, init, drainNoticesFor, parkNotice, purgeSession };
 };

--- a/extension/peerd-runtime/lifecycle/boot.js
+++ b/extension/peerd-runtime/lifecycle/boot.js
@@ -18,6 +18,7 @@ import { reconcileAtStartup } from './reconcile.js';
 import { describeRecovery } from './recovery-report.js';
 import { OPERATION_STATES } from './operation-state.js';
 import { createOperationLog } from './operation-log.js';
+import { LIFECYCLE_EVENTS, lifecycleAuditEntry } from './audit-events.js';
 
 export const GENERATION_KEY = 'peerd.lifecycle.generation';
 export const PENDING_NOTICES_KEY = 'peerd.lifecycle.pendingNotices';
@@ -134,6 +135,36 @@ export const makeLifecycleBoot = ({
     // turn drains into the agent's context; notify() is the immediate
     // user-facing surface (a chat note) — best-effort, the durable copy is
     // the one that matters.
+    // Surface any unknown-compaction evidence from prior sessions: the
+    // discard of unresolved uncertainty is itself reported (§14), never
+    // silent. Audited + parked for each affected session's next turn.
+    const overflow = await operationLog.drainUnknownOverflow?.().catch(() => null);
+    if (overflow) {
+      if (appendAudit) {
+        await Promise.resolve(appendAudit(lifecycleAuditEntry({
+          event: LIFECYCLE_EVENTS.OUTCOME_UNKNOWN_OVERFLOW,
+          detail: {
+            droppedCount: overflow.droppedCount,
+            oldestDroppedAt: overflow.oldestDroppedAt,
+          },
+        }))).catch(() => {});
+      }
+      const affected = Array.isArray(overflow.sessionsAffected)
+        ? overflow.sessionsAffected : [];
+      for (const sid of affected.slice(0, 8)) {
+        await parkNotice(sid, {
+          recoveryRecord: {
+            operation: 'outcome_unknown_overflow',
+            droppedCount: overflow.droppedCount,
+            recoveryState: 'compacted',
+          },
+          user: `${overflow.droppedCount} unresolved operation record(s) with `
+            + 'uncertain outcomes were compacted to bound storage. Verify the '
+            + 'audit log or external state before repeating older actions.',
+        }).catch(() => {});
+      }
+    }
+
     for (const notification of plan.notifications) {
       const { recoveryRecord } = notification;
       const transition = plan.transitions.find(

--- a/extension/peerd-runtime/lifecycle/boot.js
+++ b/extension/peerd-runtime/lifecycle/boot.js
@@ -32,10 +32,18 @@ const MAX_NOTICES_PER_SESSION = 8;
  *   set: (key: string, value: any) => Promise<void> }} deps.storage
  * @param {(entry: Record<string, unknown>) => Promise<unknown>} [deps.appendAudit]
  * @param {(sessionId: string, userText: string) => unknown} [deps.notify]
+ * @param {(sessionId: string) => Promise<string>} [deps.resolveNoticeSession]
+ *   maps an operation's session to the session whose NEXT TURN should hear
+ *   the notice. why: most side effects dispatch inside ACTOR sessions,
+ *   which may never take another turn (ephemeral children) — the shell
+ *   passes a parent-chain walk so the notice lands on the root chat, where
+ *   the turn driver actually drains it. Default: identity.
  * @param {() => string} deps.nonce   injected entropy (crypto.randomUUID)
  * @param {() => number} [deps.now]
  */
-export const makeLifecycleBoot = ({ storage, appendAudit, notify, nonce, now = Date.now }) => {
+export const makeLifecycleBoot = ({
+  storage, appendAudit, notify, resolveNoticeSession, nonce, now = Date.now,
+}) => {
   if (!storage || typeof nonce !== 'function') {
     throw new TypeError('makeLifecycleBoot: storage and nonce are required');
   }
@@ -80,7 +88,13 @@ export const makeLifecycleBoot = ({ storage, appendAudit, notify, nonce, now = D
     if (plan.notifications.length > 0) {
       const pending = (await storage.get(PENDING_NOTICES_KEY).catch(() => null)) ?? {};
       for (const notification of plan.notifications) {
-        const { sessionId, recoveryRecord } = notification;
+        const { recoveryRecord } = notification;
+        // Route to the session that will actually take a next turn. A
+        // failed resolution falls back to the operation's own session —
+        // a possibly-undrained notice beats a lost one.
+        const sessionId = await Promise.resolve(
+          resolveNoticeSession?.(notification.sessionId) ?? notification.sessionId,
+        ).catch(() => notification.sessionId) || notification.sessionId;
         const transition = plan.transitions.find(
           (t) => t.operationId === recoveryRecord.operationId);
         const verdict = transition?.verdict;

--- a/extension/peerd-runtime/lifecycle/boot.js
+++ b/extension/peerd-runtime/lifecycle/boot.js
@@ -51,6 +51,31 @@ export const makeLifecycleBoot = ({
   const operationLog = createOperationLog({ storage, now });
 
   /**
+   * Park one notice for a session's next turn (+ the immediate user note).
+   * Routed through resolveNoticeSession; fail-safe normalization on a
+   * corrupted pending store (a torn write can leave a primitive here —
+   * treat it as empty and repair by overwrite). Used by init() for
+   * reconcile notifications and by the shell for engine-orphan reaps.
+   *
+   * @param {string} operationSessionId
+   * @param {{ recoveryRecord: Record<string, unknown>, user: string }} notice
+   */
+  const parkNotice = async (operationSessionId, { recoveryRecord, user }) => {
+    const sessionId = await Promise.resolve(
+      resolveNoticeSession?.(operationSessionId) ?? operationSessionId,
+    ).catch(() => operationSessionId) || operationSessionId;
+    const raw = await storage.get(PENDING_NOTICES_KEY).catch(() => null);
+    const pending = raw && typeof raw === 'object' && !Array.isArray(raw)
+      ? /** @type {Record<string, unknown[]>} */ (raw)
+      : {};
+    const list = Array.isArray(pending[sessionId]) ? pending[sessionId] : [];
+    list.push({ recoveryRecord, user, at: now() });
+    pending[sessionId] = list.slice(-MAX_NOTICES_PER_SESSION);
+    await storage.set(PENDING_NOTICES_KEY, pending).catch(() => {});
+    try { notify?.(sessionId, user); } catch { /* panel gone */ }
+  };
+
+  /**
    * Run the §5.3 startup sequence. Idempotent per SW start; a repeated call
    * mints a fresh generation and finds nothing left to settle.
    */
@@ -85,30 +110,17 @@ export const makeLifecycleBoot = ({
     // turn drains into the agent's context; notify() is the immediate
     // user-facing surface (a chat note) — best-effort, the durable copy is
     // the one that matters.
-    if (plan.notifications.length > 0) {
-      const pending = (await storage.get(PENDING_NOTICES_KEY).catch(() => null)) ?? {};
-      for (const notification of plan.notifications) {
-        const { recoveryRecord } = notification;
-        // Route to the session that will actually take a next turn. A
-        // failed resolution falls back to the operation's own session —
-        // a possibly-undrained notice beats a lost one.
-        const sessionId = await Promise.resolve(
-          resolveNoticeSession?.(notification.sessionId) ?? notification.sessionId,
-        ).catch(() => notification.sessionId) || notification.sessionId;
-        const transition = plan.transitions.find(
-          (t) => t.operationId === recoveryRecord.operationId);
-        const verdict = transition?.verdict;
-        const user = verdict
-          && (verdict.state === OPERATION_STATES.INTERRUPTED
-            || verdict.state === OPERATION_STATES.OUTCOME_UNKNOWN)
-          ? describeRecovery(verdict, { toolName: recoveryRecord.operation }).user
-          : `${recoveryRecord.operation} was settled as ${recoveryRecord.recoveryState} after an interruption.`;
-        const list = Array.isArray(pending[sessionId]) ? pending[sessionId] : [];
-        list.push({ recoveryRecord, user, at: now() });
-        pending[sessionId] = list.slice(-MAX_NOTICES_PER_SESSION);
-        try { notify?.(sessionId, user); } catch { /* panel gone */ }
-      }
-      await storage.set(PENDING_NOTICES_KEY, pending).catch(() => {});
+    for (const notification of plan.notifications) {
+      const { recoveryRecord } = notification;
+      const transition = plan.transitions.find(
+        (t) => t.operationId === recoveryRecord.operationId);
+      const verdict = transition?.verdict;
+      const user = verdict
+        && (verdict.state === OPERATION_STATES.INTERRUPTED
+          || verdict.state === OPERATION_STATES.OUTCOME_UNKNOWN)
+        ? describeRecovery(verdict, { toolName: recoveryRecord.operation }).user
+        : `${recoveryRecord.operation} was settled as ${recoveryRecord.recoveryState} after an interruption.`;
+      await parkNotice(notification.sessionId, { recoveryRecord, user });
     }
 
     return { generation, plan };
@@ -139,5 +151,5 @@ export const makeLifecycleBoot = ({
       + 'the external state first.\n</interruption-recovery>';
   };
 
-  return { operationLog, init, drainNoticesFor };
+  return { operationLog, init, drainNoticesFor, parkNotice };
 };

--- a/extension/peerd-runtime/lifecycle/confirmation.js
+++ b/extension/peerd-runtime/lifecycle/confirmation.js
@@ -61,11 +61,26 @@ export const bindConfirmation = ({ operationId, action, target, generationId, no
   if (!operationId || !action || !generationId) {
     throw new TypeError('bindConfirmation: operationId, action and generationId are required');
   }
-  const ttl = typeof ttlMs === 'number' && ttlMs > 0 ? ttlMs : CONFIRMATION_TTL_MS;
+  // A target that does not normalize to a non-empty string must REFUSE, not
+  // bind: a proof with target '' would match any other empty-normalizing
+  // request — a wildcard approval, the exact opposite of "bound to one
+  // normalized target". (A URL object passed where a string was meant is an
+  // ordinary call-site mistake; it must fail loudly here, not silently
+  // widen the approval.)
+  const normalizedTarget = normalizeConfirmationTarget(target);
+  if (!normalizedTarget) {
+    throw new TypeError('bindConfirmation: target must normalize to a non-empty string');
+  }
+  if (typeof now !== 'number' || !Number.isFinite(now)) {
+    throw new TypeError('bindConfirmation: now must be a finite epoch-ms number');
+  }
+  const ttl = typeof ttlMs === 'number' && Number.isFinite(ttlMs) && ttlMs > 0
+    ? ttlMs
+    : CONFIRMATION_TTL_MS;
   return {
     operationId,
     action,
-    target: normalizeConfirmationTarget(target),
+    target: normalizedTarget,
     generationId,
     grantedAt: now,
     expiresAt: now + ttl,
@@ -95,7 +110,14 @@ export const confirmationSatisfies = (proof, request) => {
   if (proof.action !== request.action) {
     return { valid: false, reason: 'confirmation bound to a different action' };
   }
-  if (proof.target !== normalizeConfirmationTarget(request.target)) {
+  // Empty targets refuse on BOTH sides: a legacy/crafted proof with target
+  // '' must never act as a wildcard, and a request whose target normalizes
+  // to '' has nothing to match against.
+  const requestTarget = normalizeConfirmationTarget(request.target);
+  if (typeof proof.target !== 'string' || !proof.target || !requestTarget) {
+    return { valid: false, reason: 'confirmation target missing or unnormalizable; re-confirm required' };
+  }
+  if (proof.target !== requestTarget) {
     return { valid: false, reason: 'confirmation bound to a different target' };
   }
   if (proof.generationId !== request.generationId) {
@@ -103,6 +125,13 @@ export const confirmationSatisfies = (proof, request) => {
       valid: false,
       reason: 'capability generation changed since approval; re-confirm required',
     };
+  }
+  // The window fails CLOSED on a malformed deadline: a proof whose
+  // expiresAt is missing or non-numeric (legacy schema, crafted storage)
+  // would otherwise pass every NaN comparison and become an eternal
+  // standing approval.
+  if (typeof proof.expiresAt !== 'number' || !Number.isFinite(proof.expiresAt)) {
+    return { valid: false, reason: 'confirmation window malformed; re-confirm required' };
   }
   if (request.now >= proof.expiresAt) {
     return { valid: false, reason: 'confirmation window expired' };

--- a/extension/peerd-runtime/lifecycle/confirmation.js
+++ b/extension/peerd-runtime/lifecycle/confirmation.js
@@ -1,0 +1,122 @@
+// @ts-check
+// Confirmation binding — one approval, one action, once.
+//
+// A user confirmation is a narrow, single-use proof: it authorizes exactly
+// one named action against one normalized target for one operation under
+// one capability generation, inside a bounded time window. Anything else —
+// a retry that recreated the operation, a SW restart that changed the
+// generation, a redirect that changed the target — must re-ask. The user
+// must never approve one operation and have that approval silently
+// consumed by another (contract §8.3).
+//
+// Pure: clock injected, no IO.
+
+// Default approval window. why 5 minutes: long enough for the user to read
+// a confirm card and act, short enough that a forgotten prompt can't be
+// harvested by a much later retry.
+export const CONFIRMATION_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Normalize a confirmation target so cosmetic URL differences don't defeat
+ * (or fake) a match: lowercase scheme+host, drop default ports and the
+ * fragment, keep path + query verbatim (they select the resource). A
+ * non-URL target (a vault key name, an actor handle) normalizes to its
+ * trimmed self.
+ *
+ * @param {unknown} target @returns {string}
+ */
+export const normalizeConfirmationTarget = (target) => {
+  const raw = typeof target === 'string' ? target.trim() : '';
+  if (!raw) return '';
+  try {
+    const url = new URL(raw);
+    // URL already lowercases scheme/host and strips default ports.
+    url.hash = '';
+    return url.href;
+  } catch {
+    return raw;
+  }
+};
+
+/**
+ * @typedef {Object} ConfirmationProof
+ * @property {string} operationId
+ * @property {string} action        the tool/action name approved
+ * @property {string} target        normalized (normalizeConfirmationTarget)
+ * @property {string} generationId  capability generation at approval time
+ * @property {number} grantedAt     epoch ms
+ * @property {number} expiresAt     epoch ms
+ * @property {boolean} consumed     single-use latch
+ */
+
+/**
+ * Bind a fresh confirmation proof. The shell records this the moment the
+ * user approves, BEFORE dispatch (§8.1).
+ *
+ * @param {{ operationId: string, action: string, target: unknown,
+ *   generationId: string, now: number, ttlMs?: number }} input
+ * @returns {ConfirmationProof}
+ */
+export const bindConfirmation = ({ operationId, action, target, generationId, now, ttlMs }) => {
+  if (!operationId || !action || !generationId) {
+    throw new TypeError('bindConfirmation: operationId, action and generationId are required');
+  }
+  const ttl = typeof ttlMs === 'number' && ttlMs > 0 ? ttlMs : CONFIRMATION_TTL_MS;
+  return {
+    operationId,
+    action,
+    target: normalizeConfirmationTarget(target),
+    generationId,
+    grantedAt: now,
+    expiresAt: now + ttl,
+    consumed: false,
+  };
+};
+
+/**
+ * Does this proof authorize this dispatch? Every binding must match and
+ * the window must be open and the proof unconsumed — one mismatch, one
+ * refusal, with the first failing binding named so the UI can say WHY the
+ * user is being asked again.
+ *
+ * @param {ConfirmationProof | null | undefined} proof
+ * @param {{ operationId: string, action: string, target: unknown,
+ *   generationId: string, now: number }} request
+ * @returns {{ valid: boolean, reason: string }}
+ */
+export const confirmationSatisfies = (proof, request) => {
+  if (!proof) return { valid: false, reason: 'no confirmation on record' };
+  if (proof.consumed) {
+    return { valid: false, reason: 'confirmation already consumed; one approval covers one dispatch' };
+  }
+  if (proof.operationId !== request.operationId) {
+    return { valid: false, reason: 'confirmation bound to a different operation' };
+  }
+  if (proof.action !== request.action) {
+    return { valid: false, reason: 'confirmation bound to a different action' };
+  }
+  if (proof.target !== normalizeConfirmationTarget(request.target)) {
+    return { valid: false, reason: 'confirmation bound to a different target' };
+  }
+  if (proof.generationId !== request.generationId) {
+    return {
+      valid: false,
+      reason: 'capability generation changed since approval; re-confirm required',
+    };
+  }
+  if (request.now >= proof.expiresAt) {
+    return { valid: false, reason: 'confirmation window expired' };
+  }
+  return { valid: true, reason: 'confirmation matches action, target, operation, generation and window' };
+};
+
+/**
+ * Consume a proof at dispatch. Returns a new consumed copy — the caller
+ * persists it BEFORE dispatching, so an eviction between persist and
+ * dispatch errs toward re-asking, never toward double-spending one
+ * approval.
+ *
+ * @param {ConfirmationProof} proof
+ * @returns {ConfirmationProof}
+ */
+export const consumeConfirmation = (proof) => ({ ...proof, consumed: true });

--- a/extension/peerd-runtime/lifecycle/dispatch-tracking.js
+++ b/extension/peerd-runtime/lifecycle/dispatch-tracking.js
@@ -1,0 +1,321 @@
+// @ts-check
+// Dispatch tracking — the lifecycle contract wired into the tool choke point.
+//
+// The dispatcher calls beginTracking() after every gate/confirm/hook has
+// passed and before execute(), and settleTracking() with the outcome. In
+// between, the durable operation record exists with dispatched:true — so a
+// service-worker eviction at ANY point leaves evidence the startup
+// reconciler can settle truthfully (interrupted vs outcome_unknown).
+//
+// This file also enforces contract guarantee 2 at the seam where it was
+// weakest: the auto-resume path re-drives a dead turn's pending tool calls
+// with their ORIGINAL tool_use ids. Without tracking, that silently
+// re-executes a non-idempotent action whose first dispatch may have landed.
+// beginTracking recognizes the operationId and REFUSES the re-execution
+// with the semantic outcome instead of running the effect twice.
+//
+// Failure semantics (§16.2 — no generic timeouts): a settled failure is
+// classified. A definitive error response is `failed`; an ambiguous
+// transport loss (timeout, dropped connection) settles by retry class —
+// interrupted for A/B/C, outcome_unknown for D/E — and the tool result's
+// error string carries that state, so the agent hears the distinction, not
+// "timeout".
+//
+// Functional core over the injected operation log; no chrome.*, bun-tested.
+
+import { OPERATION_STATES, canTransition } from './operation-state.js';
+import { RETRY_CLASSES, decideRecovery, normalizeRetryClass } from './retry-class.js';
+import { describeRecovery } from './recovery-report.js';
+import { OperationExistsError } from './operation-log.js';
+
+// Error shapes that mean "the wire died with the request possibly delivered"
+// — the ambiguous bucket. Kept alongside the classifier kind 'timeout'
+// because fetch-layer failures surface as bare TypeError messages that the
+// taxonomy files under 'environment'/'internal'.
+// HTTP 5xx is here on purpose: the server RECEIVED the request before
+// erroring, so for a non-idempotent action the effect may have landed
+// before the failure was minted. Only pre-effect refusals (4xx validation,
+// gate blocks) are definitive.
+const AMBIGUOUS_ERROR = /timed? ?out|timeout|failed to fetch|networkerror|network error|connection (reset|closed|lost|refused)|socket hang ?up|ERR_(NETWORK|CONNECTION|INTERNET|TIMED_OUT)|fetch failed|load failed|HTTP 5\d\d|\b50[0-4]\b.*(server|gateway)|internal server error|bad gateway|service unavailable|gateway time/i;
+
+/** @param {string | undefined} error @param {string} kind */
+const isAmbiguousLoss = (error, kind) =>
+  kind === 'timeout' || (typeof error === 'string' && AMBIGUOUS_ERROR.test(error));
+
+/**
+ * @typedef {Object} TrackingHandle
+ * @property {string} operationId
+ * @property {import('./retry-class.js').RetryClass} retryClass
+ * @property {string} toolName
+ */
+
+/**
+ * @typedef {{ refuse: { error: string, recovery: ReturnType<typeof describeRecovery>['agent'] } }
+ *   | { handle: TrackingHandle } | null} BeginOutcome
+ */
+
+/**
+ * @param {Object} deps
+ * @param {ReturnType<import('./operation-log.js').createOperationLog>} deps.operationLog
+ * @param {() => string} deps.generationId    current SW generation id
+ * @param {(tool: { name?: string, sideEffect?: string, primitive?: string,
+ *   retryClass?: unknown }) => import('./retry-class.js').RetryClass} deps.retryClassFor
+ * @param {(error: string) => string | { kind: string }} [deps.classifyFailure]
+ *   observability taxonomy (its native shape is { kind, label }); absent →
+ *   only the transport regex decides ambiguity
+ */
+export const makeDispatchTracker = ({ operationLog, generationId, retryClassFor, classifyFailure }) => {
+  if (!operationLog || typeof generationId !== 'function' || typeof retryClassFor !== 'function') {
+    throw new TypeError('makeDispatchTracker: operationLog, generationId and retryClassFor are required');
+  }
+
+  /** @param {string | undefined} error */
+  const failureKind = (error) => {
+    try {
+      const out = classifyFailure?.(error ?? '');
+      if (typeof out === 'string') return out;
+      return out?.kind ?? 'internal';
+    } catch { return 'internal'; }
+  };
+
+  /**
+   * Decide what an EXISTING record for this operationId means for a fresh
+   * dispatch attempt. This is the auto-replay guard.
+   *
+   * @param {import('./reconcile.js').OperationRecord} record
+   * @param {import('./retry-class.js').RetryClass} retryClass
+   * @returns {Promise<BeginOutcome>}
+   */
+  const resumeExisting = async (record, retryClass) => {
+    const settledUnknown = record.state === OPERATION_STATES.OUTCOME_UNKNOWN;
+    const inFlightUnproven = !record.state || !record.dispatched
+      ? false
+      : record.state !== OPERATION_STATES.COMPLETED
+        && record.state !== OPERATION_STATES.FAILED
+        && record.state !== OPERATION_STATES.CANCELLED;
+
+    if (record.state === OPERATION_STATES.COMPLETED) {
+      // The first dispatch provably landed; re-running it is exactly the
+      // duplicate the contract forbids. Refuse with the truth.
+      return {
+        refuse: {
+          error: `completed: ${record.toolName} already completed on a previous `
+            + 'dispatch of this same call — not re-executing. Use the recorded '
+            + 'result or issue a NEW operation.',
+          recovery: {
+            category: 'verify_before_retry', state: OPERATION_STATES.COMPLETED,
+            autoRetry: false, retryRequires: [], verificationRequired: false,
+            keepIdempotencyKey: false, reason: 'duplicate of a completed dispatch',
+          },
+        },
+      };
+    }
+
+    if ((settledUnknown || inFlightUnproven)
+        && (retryClass === RETRY_CLASSES.SIDE_EFFECT
+          || retryClass === RETRY_CLASSES.CONDITIONAL_ACTION)) {
+      // Class D/E whose earlier dispatch has no proven outcome: the
+      // re-dispatch is automatic (same tool_use id ⇒ nobody instructed it),
+      // so it must not run.
+      const verdict = decideRecovery({ retryClass, dispatched: true });
+      const report = describeRecovery(verdict, {
+        retryClass, operationId: record.operationId, toolName: record.toolName,
+      });
+      if (!settledUnknown && canTransition(record.state, OPERATION_STATES.OUTCOME_UNKNOWN)) {
+        await operationLog.transition(record.operationId, OPERATION_STATES.OUTCOME_UNKNOWN)
+          .catch(() => {});
+      } else if (!settledUnknown) {
+        await operationLog.settle(record.operationId, verdict).catch(() => {});
+      }
+      return {
+        refuse: {
+          error: `outcome_unknown: ${record.toolName} was already dispatched and `
+            + 'its result was lost. It may have completed — verify the external '
+            + 'state before repeating it. Not re-executing automatically.',
+          recovery: report.agent,
+        },
+      };
+    }
+
+    if (record.state === OPERATION_STATES.INTERRUPTED
+        && retryClass !== RETRY_CLASSES.SIDE_EFFECT) {
+      // A/B/C/D-undispatched interruption: the sanctioned retry — same
+      // operation, fresh attempt number.
+      const next = await operationLog.newAttempt(record.operationId);
+      await operationLog.transition(record.operationId, OPERATION_STATES.RUNNING);
+      return { handle: { operationId: next.operationId, retryClass, toolName: next.toolName } };
+    }
+
+    if (record.state === OPERATION_STATES.INTERRUPTED) {
+      // Interrupted Class E, re-driven with the same id: still automatic.
+      // Safe (nothing dispatched) but Class E repeats only on explicit
+      // instruction, which arrives as a NEW call id, never a replay.
+      const verdict = decideRecovery({ retryClass, dispatched: false });
+      const report = describeRecovery(verdict, {
+        retryClass, operationId: record.operationId, toolName: record.toolName,
+      });
+      return {
+        refuse: {
+          error: `interrupted: ${record.toolName} was interrupted before any `
+            + 'external change and is safe to retry — but not automatically. '
+            + 'Ask the user, or re-issue it as a new call.',
+          recovery: report.agent,
+        },
+      };
+    }
+
+    // A live nonterminal record that is NOT dispatched (created/queued/
+    // running pre-dispatch orphan of this same generation, or a failed/
+    // cancelled terminal): settle the orphan as interrupted where legal and
+    // let the fresh dispatch proceed under a new attempt via newAttempt
+    // when possible; otherwise refuse duplicates conservatively.
+    if (record.state === OPERATION_STATES.CREATED
+        || record.state === OPERATION_STATES.QUEUED
+        || record.state === OPERATION_STATES.RUNNING) {
+      const verdict = decideRecovery({ retryClass, dispatched: false });
+      await operationLog.settle(record.operationId, verdict).catch(() => {});
+      const fresh = await operationLog.get(record.operationId);
+      if (fresh?.state === OPERATION_STATES.INTERRUPTED
+          && retryClass !== RETRY_CLASSES.SIDE_EFFECT) {
+        const next = await operationLog.newAttempt(record.operationId);
+        await operationLog.transition(record.operationId, OPERATION_STATES.RUNNING);
+        return { handle: { operationId: next.operationId, retryClass, toolName: next.toolName } };
+      }
+    }
+    return {
+      refuse: {
+        error: `interrupted: a previous dispatch of this exact call is on record `
+          + `(state: ${record.state}); not re-executing automatically.`,
+        recovery: {
+          category: 'verify_before_retry', state: record.state,
+          autoRetry: false, retryRequires: ['user-instruction'],
+          verificationRequired: false, keepIdempotencyKey: false,
+          reason: 'duplicate dispatch of a recorded operation',
+        },
+      },
+    };
+  };
+
+  /**
+   * Record the operation and mark it dispatched. Returns null for Class A
+   * (pure reads are reconstructible and duplicate-invisible — tracking
+   * them would put a storage write on every read), a handle to settle
+   * later, or a refusal the dispatcher must return WITHOUT executing.
+   *
+   * @param {Object} input
+   * @param {string} input.callId       the tool_use id — the operation identity
+   * @param {{ name?: string, sideEffect?: string, primitive?: string, retryClass?: unknown }} input.tool
+   * @param {string} [input.sessionId]
+   * @param {string} [input.actorId]
+   * @param {string} [input.target]
+   * @returns {Promise<BeginOutcome>}
+   */
+  const beginTracking = async ({ callId, tool, sessionId, actorId, target }) => {
+    const retryClass = normalizeRetryClass(retryClassFor(tool));
+    if (retryClass === RETRY_CLASSES.PURE_READ) return null;
+    if (typeof callId !== 'string' || !callId) return null;
+
+    // The operation identity is SESSION-scoped. why: the replay guard must
+    // fire on the same call re-driven within its own session (auto-resume
+    // replaying pending tool_use ids), and must NOT fire when two unrelated
+    // sessions happen to see the same provider call id — that is a new
+    // operation, not a replay.
+    const operationId = sessionId ? `${sessionId}:${callId}` : callId;
+    try {
+      await operationLog.begin({
+        operationId,
+        sessionId: sessionId || 'unknown-session',
+        ...(actorId ? { actorId } : {}),
+        toolName: tool.name ?? 'unknown-tool',
+        retryClass,
+        generationId: generationId(),
+        ...(target ? { target } : {}),
+      });
+    } catch (error) {
+      if (error instanceof OperationExistsError) {
+        const record = await operationLog.get(operationId);
+        if (record) return resumeExisting(record, retryClass);
+      }
+      // Tracking must never make a healthy dispatch impossible: a broken
+      // storage layer degrades to untracked execution (and the audit trail
+      // shows the begin failure via the thrown error's absence), not a
+      // hard-down tool surface. The CONTRACT-critical direction — refusing
+      // replays — only needs begin() to fail on DUPLICATES, which it did not.
+      return null;
+    }
+    await operationLog.transition(operationId, OPERATION_STATES.RUNNING);
+    // Dispatched is stamped BEFORE execute(): once execute starts, an
+    // effect may leave peerd at any instant, and the record must already
+    // say so if the SW dies mid-flight.
+    await operationLog.markDispatched(operationId);
+    return { handle: { operationId, retryClass, toolName: tool.name ?? 'unknown-tool' } };
+  };
+
+  /**
+   * Settle a tracked dispatch from its outcome. Returns null (nothing to
+   * change) or a semantic rewrite the dispatcher applies to the result.
+   *
+   * @param {TrackingHandle} handle
+   * @param {{ ok: boolean, error?: string, aborted?: boolean, resultDigest?: string }} outcome
+   * @returns {Promise<{ error: string, recovery: ReturnType<typeof describeRecovery>['agent'] } | null>}
+   */
+  const settleTracking = async (handle, outcome) => {
+    const { operationId, retryClass } = handle;
+    try {
+      if (outcome.ok) {
+        await operationLog.transition(operationId, OPERATION_STATES.COMPLETED, {
+          evidence: { kind: 'success-response' },
+          ...(outcome.resultDigest ? { resultDigest: outcome.resultDigest } : {}),
+        });
+        return null;
+      }
+
+      const kind = failureKind(outcome.error);
+      const cancelRequested = outcome.aborted === true || kind === 'aborted';
+      const ambiguous = isAmbiguousLoss(outcome.error, kind);
+
+      if (!ambiguous && !cancelRequested) {
+        // A definitive error response — the target refused before the
+        // effect. Honest `failed`.
+        await operationLog.transition(operationId, OPERATION_STATES.FAILED, {
+          evidence: { kind: 'error-response-before-effect' },
+        });
+        return null;
+      }
+
+      const verdict = decideRecovery({ retryClass, dispatched: true, cancelRequested });
+      const record = await operationLog.get(operationId);
+      if (record && canTransition(record.state, verdict.state)) {
+        await operationLog.transition(operationId, verdict.state);
+      } else if (record) {
+        await operationLog.settle(operationId, verdict);
+      }
+      if (verdict.state === OPERATION_STATES.CANCELLED) {
+        // A clean cancel is settled, not a recovery case — describeRecovery
+        // deliberately refuses settled verdicts, and the abort surface
+        // already tells the user what happened.
+        return {
+          error: `cancelled: ${handle.toolName} was stopped before its effect `
+            + `landed (${outcome.error ?? 'aborted'})`,
+          recovery: {
+            category: 'safe_to_retry', state: verdict.state, autoRetry: false,
+            retryRequires: ['user-instruction'], verificationRequired: false,
+            keepIdempotencyKey: verdict.keepIdempotencyKey, reason: verdict.reason,
+          },
+        };
+      }
+      const report = describeRecovery(verdict, {
+        retryClass, operationId, toolName: handle.toolName,
+      });
+      return {
+        error: `${verdict.state}: ${report.user} (${handle.toolName}: ${outcome.error ?? 'connection lost'})`,
+        recovery: report.agent,
+      };
+    } catch {
+      // Settling must never mask the tool's own outcome.
+      return null;
+    }
+  };
+
+  return { beginTracking, settleTracking };
+};

--- a/extension/peerd-runtime/lifecycle/dispatch-tracking.js
+++ b/extension/peerd-runtime/lifecycle/dispatch-tracking.js
@@ -7,12 +7,14 @@
 // service-worker eviction at ANY point leaves evidence the startup
 // reconciler can settle truthfully (interrupted vs outcome_unknown).
 //
-// This file also enforces contract guarantee 2 at the seam where it was
-// weakest: the auto-resume path re-drives a dead turn's pending tool calls
-// with their ORIGINAL tool_use ids. Without tracking, that silently
-// re-executes a non-idempotent action whose first dispatch may have landed.
-// beginTracking recognizes the operationId and REFUSES the re-execution
-// with the semantic outcome instead of running the effect twice.
+// This file also enforces contract guarantee 2 as a structural backstop:
+// any dispatch that re-presents an operationId whose earlier dispatch has
+// no proven outcome is REFUSED with the semantic state instead of executed
+// twice. (The auto-resume path itself repairs orphaned tool_use blocks as
+// synthesized error results rather than re-dispatching — see the format
+// layer's orphan repair — so the guard's live coverage is the other replay
+// shapes: an OpenAI-compat model re-emitting an id it used before, a
+// duplicated wake delivery, or any future resume path that does re-drive.)
 //
 // Failure semantics (§16.2 — no generic timeouts): a settled failure is
 // classified. A definitive error response is `failed`; an ambiguous
@@ -38,9 +40,19 @@ import { OperationExistsError } from './operation-log.js';
 // gate blocks) are definitive.
 const AMBIGUOUS_ERROR = /timed? ?out|timeout|failed to fetch|networkerror|network error|connection (reset|closed|lost|refused)|socket hang ?up|ERR_(NETWORK|CONNECTION|INTERNET|TIMED_OUT)|fetch failed|load failed|HTTP 5\d\d|\b50[0-4]\b.*(server|gateway)|internal server error|bad gateway|service unavailable|gateway time/i;
 
+// Execution-HOST deaths: the channel to the code doing the work died — a
+// closed message port, a closed engine tab, a terminated worker, an
+// invalidated extension context. These are NOT the tool attesting failure
+// (a returned "element not found" is); they are the transport dying with
+// the effect possibly in flight, so for a non-idempotent action they are
+// ambiguous, never positive failure evidence.
+const HOST_DEATH_ERROR = /message port closed|receiving end does not exist|could not establish connection|tab (was |is )?closed|no tab with id|VM(NotReady|BootFailed|TabClosed)|worker (was )?(terminated|died|killed)|context invalidated|extension context|target (closed|crashed)|frame (was )?detached/i;
+
 /** @param {string | undefined} error @param {string} kind */
 const isAmbiguousLoss = (error, kind) =>
-  kind === 'timeout' || (typeof error === 'string' && AMBIGUOUS_ERROR.test(error));
+  kind === 'timeout'
+  || (typeof error === 'string'
+    && (AMBIGUOUS_ERROR.test(error) || HOST_DEATH_ERROR.test(error)));
 
 /**
  * @typedef {Object} TrackingHandle
@@ -140,9 +152,16 @@ export const makeDispatchTracker = ({ operationLog, generationId, retryClassFor,
     if (record.state === OPERATION_STATES.INTERRUPTED
         && retryClass !== RETRY_CLASSES.SIDE_EFFECT) {
       // A/B/C/D-undispatched interruption: the sanctioned retry — same
-      // operation, fresh attempt number.
-      const next = await operationLog.newAttempt(record.operationId);
+      // operation, fresh attempt number, re-stamped with the LIVE
+      // generation. markDispatched mirrors the fresh path: the retry's
+      // effect can leave peerd the instant it executes, and a record still
+      // claiming dispatched:false would reconcile a second interruption as
+      // "never attempted, safe to auto-retry" — the exact false claim the
+      // contract forbids.
+      const next = await operationLog.newAttempt(record.operationId,
+        { generationId: generationId() });
       await operationLog.transition(record.operationId, OPERATION_STATES.RUNNING);
+      await operationLog.markDispatched(record.operationId);
       return { handle: { operationId: next.operationId, retryClass, toolName: next.toolName } };
     }
 
@@ -177,8 +196,12 @@ export const makeDispatchTracker = ({ operationLog, generationId, retryClassFor,
       const fresh = await operationLog.get(record.operationId);
       if (fresh?.state === OPERATION_STATES.INTERRUPTED
           && retryClass !== RETRY_CLASSES.SIDE_EFFECT) {
-        const next = await operationLog.newAttempt(record.operationId);
+        // Same shape as the sanctioned-retry branch above: live generation
+        // stamp + dispatched marked before the effect can leave.
+        const next = await operationLog.newAttempt(record.operationId,
+          { generationId: generationId() });
         await operationLog.transition(record.operationId, OPERATION_STATES.RUNNING);
+        await operationLog.markDispatched(record.operationId);
         return { handle: { operationId: next.operationId, retryClass, toolName: next.toolName } };
       }
     }

--- a/extension/peerd-runtime/lifecycle/dispatch-tracking.js
+++ b/extension/peerd-runtime/lifecycle/dispatch-tracking.js
@@ -32,18 +32,70 @@ import { OperationExistsError } from './operation-log.js';
 import { FAILURE_OUTCOMES, isFailureOutcomeKind } from './failure-taxonomy.js';
 import { bindConfirmation, consumeConfirmation } from './confirmation.js';
 
-// FNV-1a over a stable serialization — the deterministic idempotency key
-// for Class C/D records (§8: same call + same args = same operation; a
-// retry must reuse this key, never mint a fresh one).
-/** @param {string} text */
-const fnv1a = (text) => {
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < text.length; i += 1) {
-    hash ^= text.charCodeAt(i);
-    hash = Math.imul(hash, 0x01000193) >>> 0;
+// --- Idempotency keys ------------------------------------------------------
+//
+// The deterministic key for Class C/D records (§8: same call + same args =
+// same operation; a retry must reuse this key, never mint a fresh one).
+//
+// why CANONICAL serialization and not JSON.stringify: property order is an
+// accident of how the args object was built — a model re-emitting the same
+// call with `{b,a}` instead of `{a,b}`, or a hook rewriting args through a
+// different code path, must produce the SAME key or the "reuse the original
+// key on retry" rule silently breaks. Keys are sorted at every depth;
+// ARRAY order is preserved because it is semantic.
+//
+// why SHA-256 and not a 32-bit hash: these keys are durable metadata today
+// and the intended carrier for external idempotency headers (RFC-style
+// Idempotency-Key) tomorrow. A 32-bit digest collides at ~77k distinct
+// argument sets by the birthday bound — fine for a local dedup hint, not
+// fine for something that may one day tell a payment API "this is the same
+// request". 256 bits makes the collision question moot before it is asked.
+
+// why a depth cap: args come from the model and could nest adversarially
+// deep; a bounded walk keeps a pathological payload from blowing the stack
+// on a path that must never fail a dispatch.
+const CANONICAL_MAX_DEPTH = 8;
+
+/**
+ * Order-independent, stable serialization of an arbitrary args value.
+ * Undefined/functions/symbols collapse to null (JSON.stringify's own
+ * behavior for them), so the output is always valid JSON text.
+ *
+ * @param {unknown} value @param {number} [depth]
+ * @returns {string}
+ */
+export const canonicalJson = (value, depth = 0) => {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value) ?? 'null';
   }
-  return hash.toString(16).padStart(8, '0');
+  if (depth >= CANONICAL_MAX_DEPTH) return '"[depth-capped]"';
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalJson(entry, depth + 1)).join(',')}]`;
+  }
+  const entries = Object.keys(value).sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(
+      /** @type {Record<string, unknown>} */ (value)[key], depth + 1)}`);
+  return `{${entries.join(',')}}`;
 };
+
+/**
+ * SHA-256 of a string, lowercase hex. WebCrypto is present in every context
+ * this runs in (service worker, offscreen worker, the bun test runner).
+ * @param {string} text @returns {Promise<string>}
+ */
+export const sha256Hex = async (text) => {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(text));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+};
+
+/**
+ * The durable idempotency key for one call: tool name + canonical args
+ * digest. Same tool + same args (in any property order) → same key.
+ *
+ * @param {string} toolName @param {unknown} args @returns {Promise<string>}
+ */
+export const idempotencyKeyFor = async (toolName, args) =>
+  `${toolName}:${await sha256Hex(canonicalJson(args ?? {}))}`;
 
 // Error shapes that mean "the wire died with the request possibly delivered"
 // — the ambiguous bucket. Kept alongside the classifier kind 'timeout'
@@ -80,6 +132,19 @@ const isAmbiguousLoss = (error, kind) =>
  * @typedef {{ refuse: { error: string, recovery: ReturnType<typeof describeRecovery>['agent'] } }
  *   | { handle: TrackingHandle } | null} BeginOutcome
  */
+
+/**
+ * The replay-identity store could not be read, so "has this already run?"
+ * is unanswered. Named so the total wrapper's refusal reason says which
+ * question went unanswered rather than leaking a raw storage message.
+ */
+class TombstoneUnreadableError extends Error {
+  /** @param {string} message */
+  constructor(message) {
+    super(`replay-identity lookup failed: ${message}`);
+    this.name = 'TombstoneUnreadableError';
+  }
+}
 
 /**
  * The fail-closed refusal for a Class D/E dispatch whose tracking cannot
@@ -330,7 +395,7 @@ export const makeDispatchTracker = ({ operationLog, generationId, retryClassFor,
    *   records derive their deterministic idempotency key from these
    * @returns {Promise<BeginOutcome>}
    */
-  const beginTracking = async ({ callId, tool, sessionId, actorId, target, confirmed, args }) => {
+  const beginTrackingInner = async ({ callId, tool, sessionId, actorId, target, confirmed, args }) => {
     const retryClass = normalizeRetryClass(retryClassFor(tool));
     if (retryClass === RETRY_CLASSES.PURE_READ) return null;
     if (typeof callId !== 'string' || !callId) return null;
@@ -344,11 +409,21 @@ export const makeDispatchTracker = ({ operationLog, generationId, retryClassFor,
     // Tombstone check (D/E only — the only classes that mint them): a call
     // id whose FULL record was pruned still carries compact replay
     // identity; re-presenting it is refused exactly as the record would
-    // have. Best-effort read — a failed lookup falls through to begin().
+    // have.
+    //
+    // why an unreadable tombstone store FAILS CLOSED rather than falling
+    // through to begin(): this branch only runs for non-idempotent classes,
+    // and the question it answers is "has this exact call already run?".
+    // A storage error means that question is UNANSWERED — proceeding would
+    // be assuming "no" with no evidence, which is the replay the guard
+    // exists to prevent.
     if (retryClass === RETRY_CLASSES.SIDE_EFFECT
         || retryClass === RETRY_CLASSES.CONDITIONAL_ACTION) {
-      const tombstone = await operationLog.getTombstone?.(operationId)
-        ?? undefined;
+      const tombstone = await Promise.resolve(operationLog.getTombstone?.(operationId))
+        .catch((error) => {
+          throw new TombstoneUnreadableError(
+            error instanceof Error ? error.message : String(error));
+        });
       if (tombstone) {
         return {
           refuse: {
@@ -375,14 +450,35 @@ export const makeDispatchTracker = ({ operationLog, generationId, retryClassFor,
     }
     // Class C/D: the deterministic idempotency key (same call + same args =
     // same operation; retries reuse it, never mint fresh — §4/§8).
+    // Best-effort: the key is durable METADATA, not a gate — the replay
+    // guard keys on operationId — so a digest failure degrades the record's
+    // richness, never the dispatch's safety.
     const idempotencyKey = (retryClass === RETRY_CLASSES.IDEMPOTENT_WRITE
       || retryClass === RETRY_CLASSES.CONDITIONAL_ACTION)
-      ? `${tool.name ?? 'tool'}:${fnv1a(JSON.stringify(args ?? {}))}`
+      ? await idempotencyKeyFor(tool.name ?? 'tool', args).catch(() => undefined)
       : undefined;
     // An approved confirmation becomes a single-use proof, consumed BEFORE
     // dispatch and persisted on the record: generation-bound (a restart
     // invalidates it), target-bound, expiring — the durable chain the
     // contract's §8.3 verification asks for.
+    //
+    // TRUST BOUNDARY — what this proof does and does not mean. It is the
+    // DISPATCHER'S OWN RECORD that it observed a valid approval for exactly
+    // this operation and consumed it before dispatching. It is NOT a
+    // cryptographic attestation from the UI: nothing here is signed, and
+    // the side panel does not hand back a token peerd verifies. The proof
+    // is minted service-worker-side from `confirmed`, which is the confirm
+    // coordinator's own return value.
+    //
+    // So it defends against the failures inside peerd's trust boundary —
+    // an approval being REPLAYED onto a second dispatch, SURVIVING a
+    // restart that should have invalidated it, drifting to a DIFFERENT
+    // target or operation, or outliving its window — and it gives audit a
+    // truthful record of what was approved. It does not, and cannot,
+    // defend against a compromised service worker: code that can call this
+    // function can also fabricate `confirmed: true`. Raising that bar
+    // needs a signed capability from the UI surface, which is a separate
+    // design (and would change this from evidence into attestation).
     const confirmationProof = confirmed === true
       ? consumeConfirmation(bindConfirmation({
         operationId,
@@ -546,6 +642,38 @@ export const makeDispatchTracker = ({ operationLog, generationId, retryClassFor,
       // Report building itself failed (should be unreachable) — fall back
       // to the tool's own outcome rather than masking it with a throw.
       return null;
+    }
+  };
+
+  /**
+   * beginTracking is a TOTAL function: it resolves to a refusal, a handle,
+   * or null — it never rejects. why this matters more than it looks: the
+   * dispatcher's call site is the last branch point before execute(), so a
+   * rejection there is indistinguishable from "tracking is optional" and
+   * would degrade a non-idempotent dispatch to untracked execution. Every
+   * expected failure is already handled inside (storage down, duplicate
+   * record, unreadable replay identity); this wrapper is the backstop for
+   * the UNexpected — a throwing injected classifier, a generationId() that
+   * blows up, a storage layer rejecting somewhere new after a refactor.
+   *
+   * The refusal it produces is class-correct: if even classification threw,
+   * the class defaults to E (refuse), never to "probably safe".
+   *
+   * @param {Parameters<typeof beginTrackingInner>[0]} input
+   * @returns {Promise<BeginOutcome>}
+   */
+  const beginTracking = async (input) => {
+    try {
+      return await beginTrackingInner(input);
+    } catch (error) {
+      /** @type {import('./retry-class.js').RetryClass} */
+      let retryClass = RETRY_CLASSES.SIDE_EFFECT;
+      try { retryClass = normalizeRetryClass(retryClassFor(input?.tool)); }
+      catch { /* classification itself threw — stay at E, the closed default */ }
+      return refuseUntracked(retryClass, input?.tool?.name,
+        error instanceof TombstoneUnreadableError
+          ? error.message
+          : `tracking failed unexpectedly (${error instanceof Error ? error.message : String(error)})`);
     }
   };
 

--- a/extension/peerd-runtime/lifecycle/dispatch-tracking.js
+++ b/extension/peerd-runtime/lifecycle/dispatch-tracking.js
@@ -29,6 +29,7 @@ import { OPERATION_STATES, canTransition } from './operation-state.js';
 import { RETRY_CLASSES, decideRecovery, normalizeRetryClass } from './retry-class.js';
 import { describeRecovery } from './recovery-report.js';
 import { OperationExistsError } from './operation-log.js';
+import { FAILURE_OUTCOMES } from './failure-taxonomy.js';
 
 // Error shapes that mean "the wire died with the request possibly delivered"
 // — the ambiguous bucket. Kept alongside the classifier kind 'timeout'
@@ -65,6 +66,61 @@ const isAmbiguousLoss = (error, kind) =>
  * @typedef {{ refuse: { error: string, recovery: ReturnType<typeof describeRecovery>['agent'] } }
  *   | { handle: TrackingHandle } | null} BeginOutcome
  */
+
+/**
+ * The fail-closed refusal for a Class D/E dispatch whose tracking cannot
+ * start; A/B/C degrade to untracked (null). Shared by the live tracker's
+ * storage-failure path and makeFailClosedTracker below.
+ *
+ * @param {import('./retry-class.js').RetryClass} retryClass
+ * @param {string | undefined} toolName
+ * @param {string} reason
+ * @returns {BeginOutcome}
+ */
+const refuseUntracked = (retryClass, toolName, reason) => {
+  if (retryClass !== RETRY_CLASSES.SIDE_EFFECT
+      && retryClass !== RETRY_CLASSES.CONDITIONAL_ACTION) {
+    return null;
+  }
+  return {
+    refuse: {
+      error: `failed: ${toolName ?? 'this action'} was NOT executed — lifecycle `
+        + `tracking is unavailable (${reason}) and a non-idempotent action must `
+        + 'not run untracked: an interruption could then never be reported or '
+        + 'guarded against. Retry once storage recovers, or run a read-only '
+        + 'alternative.',
+      recovery: {
+        category: 'security_degradation',
+        state: OPERATION_STATES.FAILED,
+        autoRetry: false,
+        retryRequires: ['lifecycle-storage'],
+        verificationRequired: false,
+        keepIdempotencyKey: false,
+        reason: `tracking unavailable: ${reason}`,
+      },
+    },
+  };
+};
+
+/**
+ * The tracker the shell arms when lifecycle BOOT itself failed: Class D/E
+ * dispatches are refused (fail closed — same rationale as a mid-flight
+ * storage failure), everything else runs untracked as it did before the
+ * lifecycle landed. settleTracking is a no-op (nothing was recorded).
+ *
+ * @param {Object} input
+ * @param {string} input.reason
+ * @param {(tool: { name?: string, sideEffect?: string, primitive?: string,
+ *   retryClass?: unknown }) => import('./retry-class.js').RetryClass} input.retryClassFor
+ */
+export const makeFailClosedTracker = ({ reason, retryClassFor }) => ({
+  /** @param {{ tool: { name?: string, sideEffect?: string, primitive?: string,
+   *   retryClass?: unknown } }} input
+   *  @returns {Promise<BeginOutcome>} */
+  beginTracking: async ({ tool }) =>
+    refuseUntracked(normalizeRetryClass(retryClassFor(tool)), tool?.name, reason),
+  settleTracking: async () => null,
+});
 
 /**
  * @param {Object} deps
@@ -254,23 +310,28 @@ export const makeDispatchTracker = ({ operationLog, generationId, retryClassFor,
         generationId: generationId(),
         ...(target ? { target } : {}),
       });
+      await operationLog.transition(operationId, OPERATION_STATES.RUNNING);
+      // Dispatched is stamped BEFORE execute(): once execute starts, an
+      // effect may leave peerd at any instant, and the record must already
+      // say so if the SW dies mid-flight.
+      await operationLog.markDispatched(operationId);
     } catch (error) {
       if (error instanceof OperationExistsError) {
         const record = await operationLog.get(operationId);
         if (record) return resumeExisting(record, retryClass);
       }
-      // Tracking must never make a healthy dispatch impossible: a broken
-      // storage layer degrades to untracked execution (and the audit trail
-      // shows the begin failure via the thrown error's absence), not a
-      // hard-down tool surface. The CONTRACT-critical direction — refusing
-      // replays — only needs begin() to fail on DUPLICATES, which it did not.
-      return null;
+      // Tracking storage is DOWN (or died mid-sequence). Two postures:
+      //   A/B/C — degrade to untracked execution: duplicates are invisible
+      //   or idempotent, so losing the record loses nothing the contract
+      //   protects, and a broken log must not brick the read/write surface.
+      //   D/E — REFUSE. An untracked non-idempotent effect is one whose
+      //   outcome could never be recovered: no record means a later
+      //   interruption silently violates guarantee 1 (uncertainty would be
+      //   unreportable) and guarantee 2 (nothing would stop the replay).
+      //   The action is NOT run; that is the §14 security-degradation case.
+      return refuseUntracked(retryClass, tool.name,
+        `operation log unavailable (${error instanceof Error ? error.message : String(error)})`);
     }
-    await operationLog.transition(operationId, OPERATION_STATES.RUNNING);
-    // Dispatched is stamped BEFORE execute(): once execute starts, an
-    // effect may leave peerd at any instant, and the record must already
-    // say so if the SW dies mid-flight.
-    await operationLog.markDispatched(operationId);
     return { handle: { operationId, retryClass, toolName: tool.name ?? 'unknown-tool' } };
   };
 
@@ -279,40 +340,58 @@ export const makeDispatchTracker = ({ operationLog, generationId, retryClassFor,
    * change) or a semantic rewrite the dispatcher applies to the result.
    *
    * @param {TrackingHandle} handle
-   * @param {{ ok: boolean, error?: string, aborted?: boolean, resultDigest?: string }} outcome
+   * @param {{ ok: boolean, error?: string, aborted?: boolean, resultDigest?: string,
+   *   outcomeKind?: import('./failure-taxonomy.js').FailureOutcomeKind }} outcome
    * @returns {Promise<{ error: string, recovery: ReturnType<typeof describeRecovery>['agent'] } | null>}
    */
   const settleTracking = async (handle, outcome) => {
     const { operationId, retryClass } = handle;
+    // Persistence failures are isolated per-branch below, NEVER allowed to
+    // swallow the semantic report: if the settle write dies, the durable
+    // record stays awaiting_remote and the next boot reconciles it to
+    // outcome_unknown (a truthful uncertainty) — but the AGENT must still
+    // hear the semantic state NOW, or it reads a raw timeout as a definite
+    // failure and re-issues the non-idempotent action under a fresh call
+    // id the replay guard cannot key on.
+    if (outcome.ok) {
+      // A lost success-settle only costs a false uncertainty at the next
+      // boot — never a false claim — so success stays reported as success.
+      await operationLog.transition(operationId, OPERATION_STATES.COMPLETED, {
+        evidence: { kind: 'success-response' },
+        ...(outcome.resultDigest ? { resultDigest: outcome.resultDigest } : {}),
+      }).catch(() => {});
+      return null;
+    }
+
+    const kind = failureKind(outcome.error);
+    const cancelRequested = outcome.aborted === true || kind === 'aborted';
+    // A TYPED outcome stamped at the throw site outranks every string
+    // heuristic (failure-taxonomy.js): pre-effect-failure is definitive,
+    // transport/host loss is ambiguous, full stop. Unstamped failures
+    // fall back to the regex + taxonomy guesswork below.
+    const ambiguous = outcome.outcomeKind
+      ? outcome.outcomeKind !== FAILURE_OUTCOMES.PRE_EFFECT_FAILURE
+      : isAmbiguousLoss(outcome.error, kind);
+
+    if (!ambiguous && !cancelRequested) {
+      // A definitive error response — the target refused before the
+      // effect. Honest `failed`.
+      await operationLog.transition(operationId, OPERATION_STATES.FAILED, {
+        evidence: { kind: 'error-response-before-effect' },
+      }).catch(() => {});
+      return null;
+    }
+
+    const verdict = decideRecovery({ retryClass, dispatched: true, cancelRequested });
     try {
-      if (outcome.ok) {
-        await operationLog.transition(operationId, OPERATION_STATES.COMPLETED, {
-          evidence: { kind: 'success-response' },
-          ...(outcome.resultDigest ? { resultDigest: outcome.resultDigest } : {}),
-        });
-        return null;
-      }
-
-      const kind = failureKind(outcome.error);
-      const cancelRequested = outcome.aborted === true || kind === 'aborted';
-      const ambiguous = isAmbiguousLoss(outcome.error, kind);
-
-      if (!ambiguous && !cancelRequested) {
-        // A definitive error response — the target refused before the
-        // effect. Honest `failed`.
-        await operationLog.transition(operationId, OPERATION_STATES.FAILED, {
-          evidence: { kind: 'error-response-before-effect' },
-        });
-        return null;
-      }
-
-      const verdict = decideRecovery({ retryClass, dispatched: true, cancelRequested });
       const record = await operationLog.get(operationId);
       if (record && canTransition(record.state, verdict.state)) {
         await operationLog.transition(operationId, verdict.state);
       } else if (record) {
         await operationLog.settle(operationId, verdict);
       }
+    } catch { /* durable copy deferred to the next boot's reconcile */ }
+    try {
       if (verdict.state === OPERATION_STATES.CANCELLED) {
         // A clean cancel is settled, not a recovery case — describeRecovery
         // deliberately refuses settled verdicts, and the abort surface
@@ -335,7 +414,8 @@ export const makeDispatchTracker = ({ operationLog, generationId, retryClassFor,
         recovery: report.agent,
       };
     } catch {
-      // Settling must never mask the tool's own outcome.
+      // Report building itself failed (should be unreachable) — fall back
+      // to the tool's own outcome rather than masking it with a throw.
       return null;
     }
   };

--- a/extension/peerd-runtime/lifecycle/dispatch-tracking.js
+++ b/extension/peerd-runtime/lifecycle/dispatch-tracking.js
@@ -30,6 +30,20 @@ import { RETRY_CLASSES, decideRecovery, normalizeRetryClass } from './retry-clas
 import { describeRecovery } from './recovery-report.js';
 import { OperationExistsError } from './operation-log.js';
 import { FAILURE_OUTCOMES, isFailureOutcomeKind } from './failure-taxonomy.js';
+import { bindConfirmation, consumeConfirmation } from './confirmation.js';
+
+// FNV-1a over a stable serialization — the deterministic idempotency key
+// for Class C/D records (§8: same call + same args = same operation; a
+// retry must reuse this key, never mint a fresh one).
+/** @param {string} text */
+const fnv1a = (text) => {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, '0');
+};
 
 // Error shapes that mean "the wire died with the request possibly delivered"
 // — the ambiguous bucket. Kept alongside the classifier kind 'timeout'
@@ -131,8 +145,9 @@ export const makeFailClosedTracker = ({ reason, retryClassFor }) => ({
  * @param {(error: string) => string | { kind: string }} [deps.classifyFailure]
  *   observability taxonomy (its native shape is { kind, label }); absent →
  *   only the transport regex decides ambiguity
+ * @param {() => number} [deps.now]  injectable clock (confirmation proofs)
  */
-export const makeDispatchTracker = ({ operationLog, generationId, retryClassFor, classifyFailure }) => {
+export const makeDispatchTracker = ({ operationLog, generationId, retryClassFor, classifyFailure, now = Date.now }) => {
   if (!operationLog || typeof generationId !== 'function' || typeof retryClassFor !== 'function') {
     throw new TypeError('makeDispatchTracker: operationLog, generationId and retryClassFor are required');
   }
@@ -306,9 +321,16 @@ export const makeDispatchTracker = ({ operationLog, generationId, retryClassFor,
    * @param {string} [input.sessionId]
    * @param {string} [input.actorId]
    * @param {string} [input.target]
+   * @param {boolean} [input.confirmed]  the user approved a confirm
+   *   round-trip for exactly this dispatch — a single-use, generation-bound
+   *   proof is minted, CONSUMED, and persisted on the record (§8.3: the
+   *   durable forensic chain shows what was approved, under which
+   *   generation, and that the approval covers exactly one dispatch)
+   * @param {Record<string, unknown>} [input.args]  post-hook args; C/D
+   *   records derive their deterministic idempotency key from these
    * @returns {Promise<BeginOutcome>}
    */
-  const beginTracking = async ({ callId, tool, sessionId, actorId, target }) => {
+  const beginTracking = async ({ callId, tool, sessionId, actorId, target, confirmed, args }) => {
     const retryClass = normalizeRetryClass(retryClassFor(tool));
     if (retryClass === RETRY_CLASSES.PURE_READ) return null;
     if (typeof callId !== 'string' || !callId) return null;
@@ -319,6 +341,57 @@ export const makeDispatchTracker = ({ operationLog, generationId, retryClassFor,
     // sessions happen to see the same provider call id — that is a new
     // operation, not a replay.
     const operationId = sessionId ? `${sessionId}:${callId}` : callId;
+    // Tombstone check (D/E only — the only classes that mint them): a call
+    // id whose FULL record was pruned still carries compact replay
+    // identity; re-presenting it is refused exactly as the record would
+    // have. Best-effort read — a failed lookup falls through to begin().
+    if (retryClass === RETRY_CLASSES.SIDE_EFFECT
+        || retryClass === RETRY_CLASSES.CONDITIONAL_ACTION) {
+      const tombstone = await operationLog.getTombstone?.(operationId)
+        ?? undefined;
+      if (tombstone) {
+        return {
+          refuse: {
+            error: tombstone.terminalState === OPERATION_STATES.COMPLETED
+              ? `completed: ${tool.name ?? 'this action'} already completed on a `
+                + 'previous dispatch of this same call (compacted record) — not '
+                + 're-executing. Issue a NEW operation if a repeat is intended.'
+              : `outcome_unknown: a previous dispatch of this same call ended `
+                + `${tombstone.terminalState} and its full record was compacted. `
+                + 'Verify the external state before repeating it. Not re-executing '
+                + 'automatically.',
+            recovery: {
+              category: 'verify_before_retry',
+              state: /** @type {import('./operation-state.js').OperationState} */ (
+                tombstone.terminalState),
+              autoRetry: false, retryRequires: ['user-instruction'],
+              verificationRequired: tombstone.terminalState !== OPERATION_STATES.COMPLETED,
+              keepIdempotencyKey: false,
+              reason: 'replay of a compacted (tombstoned) operation',
+            },
+          },
+        };
+      }
+    }
+    // Class C/D: the deterministic idempotency key (same call + same args =
+    // same operation; retries reuse it, never mint fresh — §4/§8).
+    const idempotencyKey = (retryClass === RETRY_CLASSES.IDEMPOTENT_WRITE
+      || retryClass === RETRY_CLASSES.CONDITIONAL_ACTION)
+      ? `${tool.name ?? 'tool'}:${fnv1a(JSON.stringify(args ?? {}))}`
+      : undefined;
+    // An approved confirmation becomes a single-use proof, consumed BEFORE
+    // dispatch and persisted on the record: generation-bound (a restart
+    // invalidates it), target-bound, expiring — the durable chain the
+    // contract's §8.3 verification asks for.
+    const confirmationProof = confirmed === true
+      ? consumeConfirmation(bindConfirmation({
+        operationId,
+        action: tool.name ?? 'unknown-tool',
+        target: target || `tool:${tool.name ?? 'unknown-tool'}`,
+        generationId: generationId(),
+        now: now(),
+      }))
+      : undefined;
     try {
       await operationLog.begin({
         operationId,
@@ -328,6 +401,11 @@ export const makeDispatchTracker = ({ operationLog, generationId, retryClassFor,
         retryClass,
         generationId: generationId(),
         ...(target ? { target } : {}),
+        ...(idempotencyKey ? { idempotencyKey } : {}),
+        ...(confirmationProof ? {
+          confirmationRef: `${operationId}:confirm`,
+          confirmationProof,
+        } : {}),
       });
       await operationLog.transition(operationId, OPERATION_STATES.RUNNING);
       // Dispatched is stamped BEFORE execute(): once execute starts, an
@@ -408,9 +486,18 @@ export const makeDispatchTracker = ({ operationLog, generationId, retryClassFor,
     const typedKind = isFailureOutcomeKind(outcome.outcomeKind)
       ? outcome.outcomeKind
       : undefined;
+    // The burden of proof is INVERTED by class. For a DISPATCHED Class D/E
+    // action, `failed` is a positive claim — "the effect did not occur" —
+    // and only an explicit typed pre-effect-failure carries that proof. An
+    // unrecognized error string proves nothing about whether the effect
+    // landed, so the default is uncertainty; the string heuristics may only
+    // WIDEN ambiguity, never establish definitive non-execution. A/B/C keep
+    // the heuristic split: a wrong `failed` there is retryable and harmless.
+    const conservative = retryClass === RETRY_CLASSES.SIDE_EFFECT
+      || retryClass === RETRY_CLASSES.CONDITIONAL_ACTION;
     const ambiguous = typedKind
       ? typedKind !== FAILURE_OUTCOMES.PRE_EFFECT_FAILURE
-      : isAmbiguousLoss(outcome.error, kind);
+      : (conservative || isAmbiguousLoss(outcome.error, kind));
 
     if (!ambiguous && !cancelRequested) {
       // A definitive error response — the target refused before the

--- a/extension/peerd-runtime/lifecycle/dispatch-tracking.js
+++ b/extension/peerd-runtime/lifecycle/dispatch-tracking.js
@@ -29,7 +29,7 @@ import { OPERATION_STATES, canTransition } from './operation-state.js';
 import { RETRY_CLASSES, decideRecovery, normalizeRetryClass } from './retry-class.js';
 import { describeRecovery } from './recovery-report.js';
 import { OperationExistsError } from './operation-log.js';
-import { FAILURE_OUTCOMES } from './failure-taxonomy.js';
+import { FAILURE_OUTCOMES, isFailureOutcomeKind } from './failure-taxonomy.js';
 
 // Error shapes that mean "the wire died with the request possibly delivered"
 // — the ambiguous bucket. Kept alongside the classifier kind 'timeout'
@@ -185,28 +185,47 @@ export const makeDispatchTracker = ({ operationLog, generationId, retryClassFor,
       // Class D/E whose earlier dispatch has no proven outcome: the
       // re-dispatch is automatic (same tool_use id ⇒ nobody instructed it),
       // so it must not run.
+      //
+      // why the force-settle is GENERATION-GATED: "in flight, unproven" only
+      // means "outcome lost" when the driving generation is DEAD. A
+      // current-generation record in awaiting_remote is still being driven
+      // by a live handle in THIS SW — its execute() may resolve seconds
+      // from now with real evidence, and pre-settling it to outcome_unknown
+      // would discard that evidence (the duplicate is refused either way;
+      // the mutation is the bug, not the refusal).
+      const driverIsDead = record.generationId !== generationId();
       const verdict = decideRecovery({ retryClass, dispatched: true });
       const report = describeRecovery(verdict, {
         retryClass, operationId: record.operationId, toolName: record.toolName,
       });
-      if (!settledUnknown && canTransition(record.state, OPERATION_STATES.OUTCOME_UNKNOWN)) {
-        await operationLog.transition(record.operationId, OPERATION_STATES.OUTCOME_UNKNOWN)
-          .catch(() => {});
-      } else if (!settledUnknown) {
-        await operationLog.settle(record.operationId, verdict).catch(() => {});
+      if (!settledUnknown && driverIsDead) {
+        if (canTransition(record.state, OPERATION_STATES.OUTCOME_UNKNOWN)) {
+          await operationLog.transition(record.operationId, OPERATION_STATES.OUTCOME_UNKNOWN)
+            .catch(() => {});
+        } else {
+          await operationLog.settle(record.operationId, verdict).catch(() => {});
+        }
       }
       return {
         refuse: {
           error: `outcome_unknown: ${record.toolName} was already dispatched and `
-            + 'its result was lost. It may have completed — verify the external '
-            + 'state before repeating it. Not re-executing automatically.',
+            + `its result is ${driverIsDead ? 'lost' : 'still pending'}. It may `
+            + 'have completed — verify the external state before repeating it. '
+            + 'Not re-executing automatically.',
           recovery: report.agent,
         },
       };
     }
 
     if (record.state === OPERATION_STATES.INTERRUPTED
-        && retryClass !== RETRY_CLASSES.SIDE_EFFECT) {
+        && retryClass !== RETRY_CLASSES.SIDE_EFFECT
+        // The RECORD's class binds too: a call id whose recorded operation
+        // was Class E re-presented under a softer classification is a
+        // class-confusion replay, not a sanctioned retry — newAttempt would
+        // refuse it anyway (RetryRefusedError), and that rejection must
+        // surface as a REFUSAL, not bubble into the dispatcher's fail-open
+        // catch and run untracked.
+        && normalizeRetryClass(record.retryClass) !== RETRY_CLASSES.SIDE_EFFECT) {
       // A/B/C/D-undispatched interruption: the sanctioned retry — same
       // operation, fresh attempt number, re-stamped with the LIVE
       // generation. markDispatched mirrors the fresh path: the retry's
@@ -317,8 +336,17 @@ export const makeDispatchTracker = ({ operationLog, generationId, retryClassFor,
       await operationLog.markDispatched(operationId);
     } catch (error) {
       if (error instanceof OperationExistsError) {
-        const record = await operationLog.get(operationId);
-        if (record) return resumeExisting(record, retryClass);
+        // resumeExisting must never REJECT into the dispatcher's fail-open
+        // catch — that would convert a refusal-worthy replay into an
+        // UNTRACKED execution. Any error inside the resume decision takes
+        // the same fail-closed posture as a storage failure.
+        try {
+          const record = await operationLog.get(operationId);
+          if (record) return await resumeExisting(record, retryClass);
+        } catch (resumeError) {
+          return refuseUntracked(retryClass, tool.name,
+            `replay resolution failed (${resumeError instanceof Error ? resumeError.message : String(resumeError)})`);
+        }
       }
       // Tracking storage is DOWN (or died mid-sequence). Two postures:
       //   A/B/C — degrade to untracked execution: duplicates are invisible
@@ -356,10 +384,16 @@ export const makeDispatchTracker = ({ operationLog, generationId, retryClassFor,
     if (outcome.ok) {
       // A lost success-settle only costs a false uncertainty at the next
       // boot — never a false claim — so success stays reported as success.
+      // If the record was force-parked outcome_unknown while this dispatch
+      // was executing (a refused duplicate of a dead generation's record),
+      // the LATE positive evidence is exactly what resolveUnknown exists
+      // for — record it rather than discard it.
       await operationLog.transition(operationId, OPERATION_STATES.COMPLETED, {
         evidence: { kind: 'success-response' },
         ...(outcome.resultDigest ? { resultDigest: outcome.resultDigest } : {}),
-      }).catch(() => {});
+      }).catch(() =>
+        operationLog.resolveUnknown(operationId, { kind: 'success-response' })
+          .catch(() => {}));
       return null;
     }
 
@@ -369,16 +403,24 @@ export const makeDispatchTracker = ({ operationLog, generationId, retryClassFor,
     // heuristic (failure-taxonomy.js): pre-effect-failure is definitive,
     // transport/host loss is ambiguous, full stop. Unstamped failures
     // fall back to the regex + taxonomy guesswork below.
-    const ambiguous = outcome.outcomeKind
-      ? outcome.outcomeKind !== FAILURE_OUTCOMES.PRE_EFFECT_FAILURE
+    // VALIDATED first — outcomeKind can cross relay boundaries carrying
+    // garbage; an unknown value falls back to the heuristics, never trusted.
+    const typedKind = isFailureOutcomeKind(outcome.outcomeKind)
+      ? outcome.outcomeKind
+      : undefined;
+    const ambiguous = typedKind
+      ? typedKind !== FAILURE_OUTCOMES.PRE_EFFECT_FAILURE
       : isAmbiguousLoss(outcome.error, kind);
 
     if (!ambiguous && !cancelRequested) {
       // A definitive error response — the target refused before the
-      // effect. Honest `failed`.
+      // effect. Honest `failed`. Same late-evidence recovery as the
+      // success path for a record parked outcome_unknown mid-execute.
       await operationLog.transition(operationId, OPERATION_STATES.FAILED, {
         evidence: { kind: 'error-response-before-effect' },
-      }).catch(() => {});
+      }).catch(() =>
+        operationLog.resolveUnknown(operationId, { kind: 'error-response-before-effect' })
+          .catch(() => {}));
       return null;
     }
 

--- a/extension/peerd-runtime/lifecycle/engine-liveness.js
+++ b/extension/peerd-runtime/lifecycle/engine-liveness.js
@@ -1,0 +1,99 @@
+// @ts-check
+// Engine liveness ledger — which engine instances were HOSTED when the
+// lights went out (§9's missing durable fact).
+//
+// The engine registries are durable CATALOGS (which instances exist); the
+// tab trackers know which are LIVE — but only in SW memory, which is
+// exactly what an eviction destroys. Without a durable copy, a fresh boot
+// cannot tell "dormant instance" (normal, most of the catalog) from
+// "instance whose running process was just lost" (the §9/§14
+// resource-lost case that must be reaped, audited, and reported).
+//
+// This ledger is that copy: the tab trackers write it on adopt/drop, and
+// boot sweeps it against the tabs that actually survived — entries with no
+// surviving tab are the orphans (process state lost, files persist).
+// Session-tier data about session-tier resources: a stale ledger is
+// self-healing (the sweep rewrites it to the survivor set every boot).
+//
+// Same injected-storage + mutation-queue shape as the operation log.
+
+export const ENGINE_LIVENESS_KEY = 'peerd.lifecycle.engineLiveness';
+
+/**
+ * @typedef {Object} LivenessEntry
+ * @property {string} kind    'vm' | 'notebook' | 'app'
+ * @property {string} id      instance id
+ * @property {number} tabId
+ * @property {number} at      adopt time, epoch ms
+ */
+
+/**
+ * @param {Object} deps
+ * @param {{ get: (key: string) => Promise<any>,
+ *   set: (key: string, value: any) => Promise<void> }} deps.storage
+ * @param {() => number} [deps.now]
+ */
+export const makeEngineLiveness = ({ storage, now = Date.now }) => {
+  /** @type {Promise<unknown>} */
+  let queueTail = Promise.resolve();
+  /** @template T @param {() => Promise<T>} job @returns {Promise<T>} */
+  const enqueue = (job) => {
+    const run = queueTail.then(job, job);
+    queueTail = run.then(() => undefined, () => undefined);
+    return run;
+  };
+
+  /** @returns {Promise<Record<string, LivenessEntry>>} */
+  const load = async () => {
+    const raw = await storage.get(ENGINE_LIVENESS_KEY).catch(() => null);
+    return raw && typeof raw === 'object' && !Array.isArray(raw) ? raw : {};
+  };
+
+  /** @param {string} kind @param {string} id */
+  const keyOf = (kind, id) => `${kind}:${id}`;
+
+  /**
+   * Record that an instance is hosted in a live tab. Idempotent;
+   * best-effort (a failed write costs a missed reap notice, never a
+   * broken adopt — the tracker's own bookkeeping is the live truth).
+   * @param {string} kind @param {string} id @param {number} tabId
+   */
+  const adopt = (kind, id, tabId) => enqueue(async () => {
+    const map = await load();
+    map[keyOf(kind, id)] = { kind, id, tabId, at: now() };
+    await storage.set(ENGINE_LIVENESS_KEY, map).catch(() => {});
+  }).catch(() => {});
+
+  /** Clean drop (tab closed while the SW watched). @param {string} kind @param {string} id */
+  const drop = (kind, id) => enqueue(async () => {
+    const map = await load();
+    delete map[keyOf(kind, id)];
+    await storage.set(ENGINE_LIVENESS_KEY, map).catch(() => {});
+  }).catch(() => {});
+
+  /**
+   * The boot sweep: entries whose instance is NOT in the survivor set lost
+   * their process to the interruption. The ledger is rewritten to exactly
+   * the survivors, so a stale/corrupt ledger heals in one boot.
+   *
+   * @param {{ surviving: Iterable<string> }} input  keys as `${kind}:${id}`
+   * @returns {Promise<LivenessEntry[]>} the lost instances
+   */
+  const sweep = ({ surviving }) => enqueue(async () => {
+    const map = await load();
+    const survivorKeys = new Set(surviving);
+    /** @type {LivenessEntry[]} */
+    const lost = [];
+    /** @type {Record<string, LivenessEntry>} */
+    const next = {};
+    for (const [key, entry] of Object.entries(map)) {
+      if (!entry || typeof entry !== 'object' || typeof entry.id !== 'string') continue;
+      if (survivorKeys.has(key)) next[key] = entry;
+      else lost.push(entry);
+    }
+    await storage.set(ENGINE_LIVENESS_KEY, next).catch(() => {});
+    return lost;
+  });
+
+  return { adopt, drop, sweep };
+};

--- a/extension/peerd-runtime/lifecycle/failure-taxonomy.js
+++ b/extension/peerd-runtime/lifecycle/failure-taxonomy.js
@@ -1,0 +1,79 @@
+// @ts-check
+// Typed failure outcomes — deterministic recovery classification.
+//
+// The settle path's string heuristics (transport regexes, the observability
+// taxonomy) exist because most failures arrive as bare strings. This module
+// is the typed protocol that OUTRANKS them: a throw site that knows what
+// happened stamps `outcomeKind` on the error (or a tool returns it on its
+// result), and the recovery decision becomes a table lookup instead of a
+// pattern match. Adoption is incremental — an unstamped failure still takes
+// the heuristic path — but every stamped site is one less guess.
+//
+// The three kinds mirror the contract's evidence semantics:
+//   transport-lost       the wire died with the request possibly delivered
+//                        (ambiguous for a side effect — never `failed`)
+//   host-lost            the execution host (worker, engine tab, message
+//                        port) died mid-work (equally ambiguous)
+//   pre-effect-failure   the action was refused BEFORE any effect — the one
+//                        shape that is positive failure evidence
+//
+// why plain string kinds + an own-property marker rather than instanceof:
+// errors cross realm and relay boundaries (offscreen worker → SW) where
+// prototypes don't survive; a string field does. The classes below are for
+// runtime-side throw sites; layers below peerd-runtime (egress, engines)
+// stamp the field on their own error types without importing anything.
+
+/**
+ * @typedef {'transport-lost' | 'host-lost' | 'pre-effect-failure'} FailureOutcomeKind
+ */
+
+export const FAILURE_OUTCOMES = Object.freeze({
+  TRANSPORT_LOST: /** @type {const} */ ('transport-lost'),
+  HOST_LOST: /** @type {const} */ ('host-lost'),
+  PRE_EFFECT_FAILURE: /** @type {const} */ ('pre-effect-failure'),
+});
+
+const VALID_OUTCOME_KINDS = Object.freeze(new Set(Object.values(FAILURE_OUTCOMES)));
+
+/** @param {unknown} v @returns {v is FailureOutcomeKind} */
+export const isFailureOutcomeKind = (v) =>
+  typeof v === 'string' && VALID_OUTCOME_KINDS.has(/** @type {any} */ (v));
+
+/**
+ * Read a stamped outcome kind off a thrown error or a tool result.
+ * Unknown/missing → undefined (heuristics take over). Fail closed against
+ * garbage: only the three known kinds pass.
+ * @param {unknown} carrier
+ * @returns {FailureOutcomeKind | undefined}
+ */
+export const outcomeKindOf = (carrier) => {
+  const kind = /** @type {{ outcomeKind?: unknown }} */ (carrier)?.outcomeKind;
+  return isFailureOutcomeKind(kind) ? kind : undefined;
+};
+
+export class TransportLostError extends Error {
+  /** @param {string} message */
+  constructor(message) {
+    super(message);
+    this.name = 'TransportLostError';
+    this.outcomeKind = FAILURE_OUTCOMES.TRANSPORT_LOST;
+  }
+}
+
+export class ExecutionHostLostError extends Error {
+  /** @param {string} message */
+  constructor(message) {
+    super(message);
+    this.name = 'ExecutionHostLostError';
+    this.outcomeKind = FAILURE_OUTCOMES.HOST_LOST;
+  }
+}
+
+export class PreEffectFailureError extends Error {
+  /** @param {string} message */
+  constructor(message) {
+    super(message);
+    this.name = 'PreEffectFailureError';
+    this.outcomeKind = FAILURE_OUTCOMES.PRE_EFFECT_FAILURE;
+  }
+}

--- a/extension/peerd-runtime/lifecycle/generation.js
+++ b/extension/peerd-runtime/lifecycle/generation.js
@@ -1,0 +1,112 @@
+// @ts-check
+// Service-worker generations — the "authority does not survive restart" lever.
+//
+// Every SW start mints a new generation; every piece of transient authority
+// (actor grants, relay tokens, approval tokens, resource leases, tab
+// ownership) is stamped with the generation that minted it. After a
+// restart, authority from any other generation is refused — re-derived from
+// durable policy, never resumed by assumption. This is contract guarantee 3
+// (security authority does not expand after recovery) and 7 (a SW restart
+// never silently extends credential/approval/capability lifetimes).
+//
+// Pure: the nonce is injected (the shell passes crypto.randomUUID()), the
+// clock is a parameter. No IO.
+
+/**
+ * @typedef {Object} Generation
+ * @property {number} seq   monotonic across restarts (persisted by the shell)
+ * @property {string} id    unguessable per-start identifier
+ * @property {number} mintedAt  epoch ms
+ */
+
+/**
+ * Mint the next generation. `previous` is the durable record of the last
+ * generation (or null on first run); `nonce` is injected entropy so two
+ * restarts can never collide even if the persisted seq write was lost.
+ *
+ * @param {Generation | null | undefined} previous
+ * @param {{ nonce: string, now: number }} deps
+ * @returns {Generation}
+ */
+export const mintGeneration = (previous, { nonce, now }) => {
+  if (typeof nonce !== 'string' || nonce.length < 8) {
+    throw new TypeError('mintGeneration: nonce must be at least 8 chars of injected entropy');
+  }
+  const prevSeq = typeof previous?.seq === 'number' && Number.isFinite(previous.seq)
+    ? previous.seq
+    : 0;
+  const seq = Math.max(0, Math.floor(prevSeq)) + 1;
+  return Object.freeze({ seq, id: `gen-${seq}-${nonce}`, mintedAt: now });
+};
+
+/**
+ * Authority stamped by a generation: grants, approval tokens, leases,
+ * ownership records. Validity is exact-id equality — a seq match alone is
+ * not enough (a lost seq write could repeat a number; the nonce cannot).
+ *
+ * @typedef {Object} StampedAuthority
+ * @property {string} generationId
+ * @property {number} [expiresAt]  epoch ms; absent = no time bound
+ */
+
+/**
+ * Is a piece of stamped authority still valid under the current generation?
+ * Fails closed: missing stamp, unknown generation, or an expired window all
+ * refuse. A SW restart therefore cannot extend any lifetime — the new
+ * generation invalidates every prior stamp wholesale.
+ *
+ * @param {StampedAuthority | null | undefined} authority
+ * @param {{ generation: Generation, now: number }} ctx
+ * @returns {{ valid: boolean, reason: string }}
+ */
+export const authorityValid = (authority, { generation, now }) => {
+  if (!authority || typeof authority.generationId !== 'string') {
+    return { valid: false, reason: 'no generation stamp; authority refused' };
+  }
+  if (authority.generationId !== generation.id) {
+    return {
+      valid: false,
+      reason: `stale generation (${authority.generationId} != ${generation.id}); `
+        + 'authority must be re-derived from durable policy',
+    };
+  }
+  if (typeof authority.expiresAt === 'number' && now >= authority.expiresAt) {
+    return { valid: false, reason: 'authority window expired' };
+  }
+  return { valid: true, reason: 'current generation, within window' };
+};
+
+/**
+ * Partition a batch of stamped records into live and stale under the
+ * current generation — the startup sweep that releases prior-generation
+ * tab/actor/Worker/engine ownership (§5.3 step 5) and refuses stale relay/
+ * approval tokens (step 7).
+ *
+ * @template {StampedAuthority} T
+ * @param {T[]} records
+ * @param {{ generation: Generation, now: number }} ctx
+ * @returns {{ live: T[], stale: Array<{ record: T, reason: string }> }}
+ */
+export const sweepStaleAuthority = (records, ctx) => {
+  /** @type {T[]} */ const live = [];
+  /** @type {Array<{ record: T, reason: string }>} */ const stale = [];
+  for (const record of Array.isArray(records) ? records : []) {
+    const { valid, reason } = authorityValid(record, ctx);
+    if (valid) live.push(record);
+    else stale.push({ record, reason });
+  }
+  return { live, stale };
+};
+
+/**
+ * Actor-generation gate: messages/events from a prior actor generation are
+ * discarded, so an old run can never send events into a new one (§7.3).
+ * Exact match, fail closed on garbage.
+ *
+ * @param {{ generation?: unknown }} message
+ * @param {number} currentActorGeneration
+ */
+export const acceptActorMessage = (message, currentActorGeneration) =>
+  typeof message?.generation === 'number'
+  && Number.isFinite(currentActorGeneration)
+  && message.generation === currentActorGeneration;

--- a/extension/peerd-runtime/lifecycle/operation-log.js
+++ b/extension/peerd-runtime/lifecycle/operation-log.js
@@ -5,29 +5,67 @@
 // (contract §8): created before dispatch, dispatched marked before the
 // effect leaves peerd, results persisted before success is reported to the
 // agent. Storage is injected (the SW passes a chrome.storage.local
-// adapter), mirroring the other runtime stores; state changes go through
-// the operation-state legality table, and result metadata passes the audit
-// sanitizer so a bearer token or raw header can never reach disk.
+// adapter), mirroring the other runtime stores. State changes go through
+// the operation-state legality table for live transitions, canRecoverySettle
+// for reconcile verdicts, and resolveUnknownOutcome for evidence-gated
+// resolution — the three sanctioned regimes, nothing free-form. Result
+// metadata is digest-only and passes the audit sanitizer; full payloads and
+// raw headers are never accepted by this API, so they have no path to disk
+// through it.
+//
+// All mutations are serialized through an internal queue: begin/transition/
+// settle each do load → mutate → persist, and two interleaved callers (a
+// parallel tool batch, an actor relay racing the main turn) would otherwise
+// silently lose the first write. The queue makes the read-modify-write
+// atomic within this context; cross-context writers must share ONE log
+// instance (the SW owns it).
 
 import {
-  OPERATION_STATES, assertTransition, isTerminal,
+  OPERATION_STATES, assertTransition, isTerminal, canRecoverySettle,
+  resolveUnknownOutcome,
 } from './operation-state.js';
-import { normalizeRetryClass } from './retry-class.js';
+import { RETRY_CLASSES, normalizeRetryClass } from './retry-class.js';
 import { sanitizeDetail } from './audit-events.js';
 
 export const OPERATION_LOG_KEY = 'peerd.lifecycle.operations';
 
-// Terminal records kept for correlation before the oldest are pruned. why a
+// Settled records kept for correlation before the oldest are pruned. why a
 // cap: the log is a recovery + audit correlation surface, not history —
 // unbounded growth would make the startup reconcile scan pay for every
-// operation ever run.
+// operation ever run. outcome_unknown records are deliberately EXEMPT from
+// pruning: deleting one silently discards the uncertainty the contract
+// exists to surface — they leave only via resolveUnknown.
 export const OPERATION_LOG_MAX_TERMINAL = 500;
+
+const PRUNABLE_STATES = Object.freeze(
+  /** @type {ReadonlySet<import('./operation-state.js').OperationState>} */ (new Set([
+    OPERATION_STATES.COMPLETED, OPERATION_STATES.FAILED,
+    OPERATION_STATES.CANCELLED, OPERATION_STATES.INTERRUPTED,
+  ])));
 
 export class OperationNotFoundError extends Error {
   /** @param {string} operationId */
   constructor(operationId) {
     super(`no operation record: ${operationId}`);
     this.name = 'OperationNotFoundError';
+  }
+}
+
+export class OperationExistsError extends Error {
+  /** @param {string} operationId @param {string} state */
+  constructor(operationId, state) {
+    super(`operation ${operationId} already recorded (state: ${state}); `
+      + 'a re-drive needs a fresh operationId — overwriting would erase the '
+      + 'dispatch evidence the recovery contract rides on');
+    this.name = 'OperationExistsError';
+  }
+}
+
+export class RetryRefusedError extends Error {
+  /** @param {string} operationId @param {string} reason */
+  constructor(operationId, reason) {
+    super(`retry refused for ${operationId}: ${reason}`);
+    this.name = 'RetryRefusedError';
   }
 }
 
@@ -42,6 +80,17 @@ export const createOperationLog = ({ storage, now = Date.now }) => {
     throw new TypeError('createOperationLog: storage adapter is required');
   }
 
+  // The mutation queue. Every writer runs load → mutate → persist inside
+  // one slot; reads outside the queue are fine (they see a committed map).
+  /** @type {Promise<unknown>} */
+  let queueTail = Promise.resolve();
+  /** @template T @param {() => Promise<T>} job @returns {Promise<T>} */
+  const enqueue = (job) => {
+    const run = queueTail.then(job, job);
+    queueTail = run.then(() => undefined, () => undefined);
+    return run;
+  };
+
   /** @returns {Promise<Record<string, import('./reconcile.js').OperationRecord>>} */
   const load = async () => {
     const map = await storage.get(OPERATION_LOG_KEY);
@@ -50,19 +99,21 @@ export const createOperationLog = ({ storage, now = Date.now }) => {
 
   /** @param {Record<string, import('./reconcile.js').OperationRecord>} map */
   const persist = async (map) => {
-    const terminal = Object.values(map)
-      .filter((record) => isTerminal(record.state))
+    const prunable = Object.values(map)
+      .filter((record) => PRUNABLE_STATES.has(record.state))
       .sort((a, b) => a.createdAt - b.createdAt);
-    const excess = terminal.length - OPERATION_LOG_MAX_TERMINAL;
+    const excess = prunable.length - OPERATION_LOG_MAX_TERMINAL;
     if (excess > 0) {
-      for (const record of terminal.slice(0, excess)) delete map[record.operationId];
+      for (const record of prunable.slice(0, excess)) delete map[record.operationId];
     }
     await storage.set(OPERATION_LOG_KEY, map);
   };
 
   /**
    * Record a new operation BEFORE dispatch (§8.1). Persists, then returns
-   * the stored record.
+   * the stored record. An operationId already on record — live OR settled —
+   * refuses (OperationExistsError): overwriting would erase the dispatched/
+   * evidence flags that decide interrupted vs outcome_unknown on recovery.
    *
    * @param {Object} input
    * @param {string} input.operationId
@@ -75,11 +126,13 @@ export const createOperationLog = ({ storage, now = Date.now }) => {
    * @param {string} [input.target]
    * @param {string} [input.confirmationRef]
    */
-  const begin = async (input) => {
+  const begin = (input) => enqueue(async () => {
     if (!input?.operationId || !input.sessionId || !input.toolName || !input.generationId) {
       throw new TypeError('operationLog.begin: operationId, sessionId, toolName and generationId are required');
     }
     const map = await load();
+    const existing = map[input.operationId];
+    if (existing) throw new OperationExistsError(input.operationId, existing.state);
     /** @type {import('./reconcile.js').OperationRecord} */
     const record = {
       operationId: input.operationId,
@@ -99,7 +152,7 @@ export const createOperationLog = ({ storage, now = Date.now }) => {
     map[record.operationId] = record;
     await persist(map);
     return record;
-  };
+  });
 
   /** @param {string} operationId */
   const get = async (operationId) => (await load())[operationId];
@@ -108,56 +161,114 @@ export const createOperationLog = ({ storage, now = Date.now }) => {
   const listNonterminal = async () =>
     Object.values(await load()).filter((record) => !isTerminal(record.state));
 
+  /** @param {import('./reconcile.js').OperationRecord} record
+   *  @param {import('./operation-state.js').OperationState} to
+   *  @param {{ resultDigest?: string, lastDurableStep?: number,
+   *    dispatched?: boolean, cancelRequested?: boolean,
+   *    evidence?: { kind?: string } }} patch */
+  const patched = (record, to, patch) => ({
+    ...record,
+    state: to,
+    ...(patch.dispatched === true ? { dispatched: true } : {}),
+    ...(patch.cancelRequested === true ? { cancelRequested: true } : {}),
+    ...(patch.evidence ? { evidence: patch.evidence } : {}),
+    ...(typeof patch.lastDurableStep === 'number'
+      ? { lastDurableStep: patch.lastDurableStep } : {}),
+    // Result metadata is digest-only and scrubbed: the log stores
+    // correlation, never payloads (§8.2).
+    ...(typeof patch.resultDigest === 'string'
+      ? { resultDigest: String(sanitizeDetail(patch.resultDigest)) } : {}),
+  });
+
   /**
-   * Move an operation through the state machine. Illegal transitions throw
-   * (IllegalTransitionError) — recovery paths must go through the
-   * reconciler/resolver, not free-form writes. Persists before returning.
+   * Move a LIVE operation through the state machine. Illegal transitions
+   * throw (IllegalTransitionError) — recovery paths go through settle()/
+   * resolveUnknown(), not free-form writes. Persists before returning.
    *
    * @param {string} operationId
    * @param {import('./operation-state.js').OperationState} to
    * @param {{ resultDigest?: string, lastDurableStep?: number,
    *   dispatched?: boolean, cancelRequested?: boolean,
-   *   evidence?: { kind?: string }, detail?: unknown }} [patch]
+   *   evidence?: { kind?: string } }} [patch]
    */
-  const transition = async (operationId, to, patch = {}) => {
+  const transition = (operationId, to, patch = {}) => enqueue(async () => {
     const map = await load();
     const record = map[operationId];
     if (!record) throw new OperationNotFoundError(operationId);
     assertTransition(record.state, to);
-    const next = {
-      ...record,
-      state: to,
-      ...(patch.dispatched === true ? { dispatched: true } : {}),
-      ...(patch.cancelRequested === true ? { cancelRequested: true } : {}),
-      ...(patch.evidence ? { evidence: patch.evidence } : {}),
-      ...(typeof patch.lastDurableStep === 'number'
-        ? { lastDurableStep: patch.lastDurableStep } : {}),
-      // Result metadata is digest-only and scrubbed: the log stores
-      // correlation, never payloads or credentials (§8.2).
-      ...(typeof patch.resultDigest === 'string'
-        ? { resultDigest: String(sanitizeDetail(patch.resultDigest)) } : {}),
-    };
+    const next = patched(record, to, patch);
     map[operationId] = next;
     await persist(map);
     return next;
-  };
+  });
 
   /** Mark the moment the effect leaves peerd. @param {string} operationId */
   const markDispatched = (operationId) =>
     transition(operationId, OPERATION_STATES.AWAITING_REMOTE, { dispatched: true });
 
   /**
-   * Class B retries: a fresh attempt number on the same operation. Refused
-   * on terminal records other than `interrupted` — a retry re-drives an
-   * interrupted read, never a settled outcome.
+   * Apply a startup reconcile verdict (reconcileAtStartup's plan) to an
+   * orphaned record — the recovery regime. canRecoverySettle governs
+   * legality: any nonterminal state may settle to any terminal one, except
+   * awaiting_user → outcome_unknown.
+   *
+   * @param {string} operationId
+   * @param {import('./retry-class.js').RecoveryVerdict} verdict
+   */
+  const settle = (operationId, verdict) => enqueue(async () => {
+    const map = await load();
+    const record = map[operationId];
+    if (!record) throw new OperationNotFoundError(operationId);
+    if (!canRecoverySettle(record.state, verdict.state)) {
+      throw new TypeError(`recovery settle refused: ${record.state} -> ${String(verdict.state)}`);
+    }
+    const next = { ...record, state: verdict.state };
+    map[operationId] = next;
+    await persist(map);
+    return next;
+  });
+
+  /**
+   * The ONE exit from outcome_unknown: positive after-the-fact evidence
+   * (resolveUnknownOutcome throws on anything weaker, including timeouts).
+   * Persists the settled state together with the evidence that earned it.
+   *
+   * @param {string} operationId
+   * @param {{ kind?: string }} evidence
+   */
+  const resolveUnknown = (operationId, evidence) => enqueue(async () => {
+    const map = await load();
+    const record = map[operationId];
+    if (!record) throw new OperationNotFoundError(operationId);
+    if (record.state !== OPERATION_STATES.OUTCOME_UNKNOWN) {
+      throw new TypeError(`resolveUnknown requires outcome_unknown; got ${record.state}`);
+    }
+    const resolved = resolveUnknownOutcome(evidence);
+    const next = { ...record, state: resolved, evidence };
+    map[operationId] = next;
+    await persist(map);
+    return next;
+  });
+
+  /**
+   * Class A–D retries: a fresh attempt number on the same operation.
+   * Refused for Class E (a user-instructed repeat of a non-idempotent
+   * action is a NEW operation with a fresh confirmation, never a re-drive
+   * of the old record) and for any state but `interrupted` — settled
+   * outcomes are never re-driven.
    * @param {string} operationId
    */
-  const newAttempt = async (operationId) => {
+  const newAttempt = (operationId) => enqueue(async () => {
     const map = await load();
     const record = map[operationId];
     if (!record) throw new OperationNotFoundError(operationId);
     if (record.state !== OPERATION_STATES.INTERRUPTED) {
-      throw new TypeError(`newAttempt requires an interrupted operation; got ${record.state}`);
+      throw new RetryRefusedError(operationId,
+        `requires an interrupted operation; got ${record.state}`);
+    }
+    if (normalizeRetryClass(record.retryClass) === RETRY_CLASSES.SIDE_EFFECT) {
+      throw new RetryRefusedError(operationId,
+        'Class E repeats as a new operation with a fresh confirmation, never a re-drive');
     }
     const next = {
       ...record,
@@ -168,7 +279,10 @@ export const createOperationLog = ({ storage, now = Date.now }) => {
     map[operationId] = next;
     await persist(map);
     return next;
-  };
+  });
 
-  return { begin, get, listNonterminal, transition, markDispatched, newAttempt };
+  return {
+    begin, get, listNonterminal, transition, markDispatched,
+    settle, resolveUnknown, newAttempt,
+  };
 };

--- a/extension/peerd-runtime/lifecycle/operation-log.js
+++ b/extension/peerd-runtime/lifecycle/operation-log.js
@@ -100,7 +100,21 @@ export const createOperationLog = ({ storage, now = Date.now }) => {
   /** @returns {Promise<Record<string, import('./reconcile.js').OperationRecord>>} */
   const load = async () => {
     const map = await storage.get(OPERATION_LOG_KEY);
-    return map && typeof map === 'object' ? map : {};
+    if (!map || typeof map !== 'object' || Array.isArray(map)) return {};
+    // Entry-level validation: one corrupted/adversarial value (null, a
+    // primitive, a record with no identity) must not crash listNonterminal
+    // and take the whole recovery sweep down with it. Invalid entries are
+    // dropped — self-healing on the next persist, and infinitely better
+    // than a boot with no reconciliation at all.
+    /** @type {Record<string, import('./reconcile.js').OperationRecord>} */
+    const clean = {};
+    for (const [key, record] of Object.entries(map)) {
+      if (record && typeof record === 'object' && !Array.isArray(record)
+          && typeof (/** @type {any} */ (record).operationId) === 'string') {
+        clean[key] = /** @type {any} */ (record);
+      }
+    }
+    return clean;
   };
 
   /** @param {Record<string, import('./reconcile.js').OperationRecord>} map */

--- a/extension/peerd-runtime/lifecycle/operation-log.js
+++ b/extension/peerd-runtime/lifecycle/operation-log.js
@@ -43,6 +43,25 @@ export const OPERATION_LOG_KEY = 'peerd.lifecycle.operations';
 export const OPERATION_LOG_MAX_TERMINAL = 500;
 export const OPERATION_LOG_MAX_UNKNOWN = 200;
 
+// Replay tombstones — compact identity that OUTLIVES the full record. why:
+// pruning a completed Class D/E record would otherwise age its replay
+// protection out (the same call id re-presented after 500 later operations
+// would read as new and re-execute the side effect), and pruning an
+// unresolved outcome_unknown would silently forget that an external effect
+// may have occurred. A tombstone is four small fields; thousands are
+// cheaper than one duplicate payment. Only D/E mint them — A/B/C
+// duplicates are invisible or idempotent by classification.
+export const TOMBSTONES_KEY = 'peerd.lifecycle.tombstones';
+export const TOMBSTONES_MAX = 5000;
+// The §14-honest overflow accumulator: when unresolved unknowns are
+// compacted past their cap, the DISCARD ITSELF is recorded (count, oldest,
+// affected sessions) and surfaced by the next boot — a documented compaction
+// with evidence, never a silent forget.
+export const UNKNOWN_OVERFLOW_KEY = 'peerd.lifecycle.unknownOverflow';
+
+/** @param {unknown} v */
+const isConservativeClass = (v) => v === 'D' || v === 'E';
+
 const PRUNABLE_STATES = Object.freeze(
   /** @type {ReadonlySet<import('./operation-state.js').OperationState>} */ (new Set([
     OPERATION_STATES.COMPLETED, OPERATION_STATES.FAILED,
@@ -117,24 +136,107 @@ export const createOperationLog = ({ storage, now = Date.now }) => {
     return clean;
   };
 
+  /** @param {import('./reconcile.js').OperationRecord[]} pruned */
+  const mintTombstones = async (pruned) => {
+    const candidates = pruned.filter((r) => isConservativeClass(r.retryClass));
+    if (candidates.length === 0) return;
+    const raw = await storage.get(TOMBSTONES_KEY).catch(() => null);
+    /** @type {Record<string, { terminalState: string, retryClass: string, completedAt: number }>} */
+    const tombs = raw && typeof raw === 'object' && !Array.isArray(raw) ? raw : {};
+    for (const record of candidates) {
+      tombs[record.operationId] = {
+        terminalState: record.state,
+        retryClass: String(record.retryClass),
+        completedAt: now(),
+      };
+    }
+    const keys = Object.keys(tombs);
+    if (keys.length > TOMBSTONES_MAX) {
+      keys.sort((a, b) => tombs[a].completedAt - tombs[b].completedAt);
+      for (const key of keys.slice(0, keys.length - TOMBSTONES_MAX)) delete tombs[key];
+    }
+    await storage.set(TOMBSTONES_KEY, tombs).catch(() => {});
+  };
+
+  /** @param {import('./reconcile.js').OperationRecord[]} droppedUnknowns */
+  const recordUnknownOverflow = async (droppedUnknowns) => {
+    if (droppedUnknowns.length === 0) return;
+    const raw = await storage.get(UNKNOWN_OVERFLOW_KEY).catch(() => null);
+    const prior = raw && typeof raw === 'object' && !Array.isArray(raw)
+      ? /** @type {{ droppedCount?: number, oldestDroppedAt?: number, sessionsAffected?: string[] }} */ (raw)
+      : {};
+    const sessions = new Set(Array.isArray(prior.sessionsAffected) ? prior.sessionsAffected : []);
+    for (const record of droppedUnknowns) sessions.add(record.sessionId);
+    await storage.set(UNKNOWN_OVERFLOW_KEY, {
+      droppedCount: (typeof prior.droppedCount === 'number' ? prior.droppedCount : 0)
+        + droppedUnknowns.length,
+      oldestDroppedAt: typeof prior.oldestDroppedAt === 'number'
+        ? prior.oldestDroppedAt
+        : Math.min(...droppedUnknowns.map((r) => r.createdAt)),
+      sessionsAffected: [...sessions].slice(0, 32),
+    }).catch(() => {});
+  };
+
   /** @param {Record<string, import('./reconcile.js').OperationRecord>} map */
   const persist = async (map) => {
     const prunable = Object.values(map)
       .filter((record) => PRUNABLE_STATES.has(record.state))
       .sort((a, b) => a.createdAt - b.createdAt);
     const excess = prunable.length - OPERATION_LOG_MAX_TERMINAL;
+    /** @type {import('./reconcile.js').OperationRecord[]} */
+    const prunedTerminal = [];
     if (excess > 0) {
-      for (const record of prunable.slice(0, excess)) delete map[record.operationId];
+      for (const record of prunable.slice(0, excess)) {
+        prunedTerminal.push(record);
+        delete map[record.operationId];
+      }
     }
     const unknowns = Object.values(map)
       .filter((record) => record.state === OPERATION_STATES.OUTCOME_UNKNOWN)
       .sort((a, b) => a.createdAt - b.createdAt);
     const unknownExcess = unknowns.length - OPERATION_LOG_MAX_UNKNOWN;
+    /** @type {import('./reconcile.js').OperationRecord[]} */
+    const prunedUnknowns = [];
     if (unknownExcess > 0) {
-      for (const record of unknowns.slice(0, unknownExcess)) delete map[record.operationId];
+      for (const record of unknowns.slice(0, unknownExcess)) {
+        prunedUnknowns.push(record);
+        delete map[record.operationId];
+      }
     }
     await storage.set(OPERATION_LOG_KEY, map);
+    // Tombstones + overflow evidence ride the same queue slot as the prune
+    // that made them necessary (persist only runs inside enqueue).
+    await mintTombstones([...prunedTerminal, ...prunedUnknowns]);
+    await recordUnknownOverflow(prunedUnknowns);
   };
+
+  /**
+   * Compact replay identity for a pruned D/E operation. Consulted by the
+   * tracker BEFORE begin(), so a call id whose full record aged out still
+   * refuses re-execution.
+   * @param {string} operationId
+   */
+  const getTombstone = async (operationId) => {
+    const raw = await storage.get(TOMBSTONES_KEY).catch(() => null);
+    const tombs = raw && typeof raw === 'object' && !Array.isArray(raw) ? raw : {};
+    const entry = /** @type {Record<string, unknown>} */ (tombs)[operationId];
+    return entry && typeof entry === 'object'
+      ? /** @type {{ terminalState: string, retryClass: string, completedAt: number }} */ (entry)
+      : undefined;
+  };
+
+  /**
+   * Read-and-clear the unknown-compaction evidence (the boot surfaces it).
+   */
+  const drainUnknownOverflow = () => enqueue(async () => {
+    const raw = await storage.get(UNKNOWN_OVERFLOW_KEY).catch(() => null);
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+    await storage.set(UNKNOWN_OVERFLOW_KEY, null).catch(() => {});
+    const overflow = /** @type {{ droppedCount?: number }} */ (raw);
+    return typeof overflow.droppedCount === 'number' && overflow.droppedCount > 0
+      ? /** @type {{ droppedCount: number, oldestDroppedAt?: number, sessionsAffected?: string[] }} */ (raw)
+      : null;
+  });
 
   /**
    * Record a new operation BEFORE dispatch (§8.1). Persists, then returns
@@ -152,6 +254,9 @@ export const createOperationLog = ({ storage, now = Date.now }) => {
    * @param {string} [input.idempotencyKey]
    * @param {string} [input.target]
    * @param {string} [input.confirmationRef]
+   * @param {Record<string, unknown>} [input.confirmationProof]  the consumed
+   *   single-use approval proof (no secrets — action/target/generation/
+   *   window/consumed), persisted for the §8.3 forensic chain
    */
   const begin = (input) => enqueue(async () => {
     if (!input?.operationId || !input.sessionId || !input.toolName || !input.generationId) {
@@ -175,6 +280,7 @@ export const createOperationLog = ({ storage, now = Date.now }) => {
       ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
       ...(input.target ? { target: input.target } : {}),
       ...(input.confirmationRef ? { confirmationRef: input.confirmationRef } : {}),
+      ...(input.confirmationProof ? { confirmationProof: input.confirmationProof } : {}),
     };
     map[record.operationId] = record;
     await persist(map);
@@ -318,5 +424,6 @@ export const createOperationLog = ({ storage, now = Date.now }) => {
   return {
     begin, get, listNonterminal, transition, markDispatched,
     settle, resolveUnknown, newAttempt,
+    getTombstone, drainUnknownOverflow,
   };
 };

--- a/extension/peerd-runtime/lifecycle/operation-log.js
+++ b/extension/peerd-runtime/lifecycle/operation-log.js
@@ -1,0 +1,174 @@
+// @ts-check
+// The durable operation log — persist-before-report over injected storage.
+//
+// Every operation that can outlive one synchronous call gets a record here
+// (contract §8): created before dispatch, dispatched marked before the
+// effect leaves peerd, results persisted before success is reported to the
+// agent. Storage is injected (the SW passes a chrome.storage.local
+// adapter), mirroring the other runtime stores; state changes go through
+// the operation-state legality table, and result metadata passes the audit
+// sanitizer so a bearer token or raw header can never reach disk.
+
+import {
+  OPERATION_STATES, assertTransition, isTerminal,
+} from './operation-state.js';
+import { normalizeRetryClass } from './retry-class.js';
+import { sanitizeDetail } from './audit-events.js';
+
+export const OPERATION_LOG_KEY = 'peerd.lifecycle.operations';
+
+// Terminal records kept for correlation before the oldest are pruned. why a
+// cap: the log is a recovery + audit correlation surface, not history —
+// unbounded growth would make the startup reconcile scan pay for every
+// operation ever run.
+export const OPERATION_LOG_MAX_TERMINAL = 500;
+
+export class OperationNotFoundError extends Error {
+  /** @param {string} operationId */
+  constructor(operationId) {
+    super(`no operation record: ${operationId}`);
+    this.name = 'OperationNotFoundError';
+  }
+}
+
+/**
+ * @param {Object} deps
+ * @param {{ get: (key: string) => Promise<any>,
+ *   set: (key: string, value: any) => Promise<void> }} deps.storage
+ * @param {() => number} [deps.now]
+ */
+export const createOperationLog = ({ storage, now = Date.now }) => {
+  if (!storage || typeof storage.get !== 'function' || typeof storage.set !== 'function') {
+    throw new TypeError('createOperationLog: storage adapter is required');
+  }
+
+  /** @returns {Promise<Record<string, import('./reconcile.js').OperationRecord>>} */
+  const load = async () => {
+    const map = await storage.get(OPERATION_LOG_KEY);
+    return map && typeof map === 'object' ? map : {};
+  };
+
+  /** @param {Record<string, import('./reconcile.js').OperationRecord>} map */
+  const persist = async (map) => {
+    const terminal = Object.values(map)
+      .filter((record) => isTerminal(record.state))
+      .sort((a, b) => a.createdAt - b.createdAt);
+    const excess = terminal.length - OPERATION_LOG_MAX_TERMINAL;
+    if (excess > 0) {
+      for (const record of terminal.slice(0, excess)) delete map[record.operationId];
+    }
+    await storage.set(OPERATION_LOG_KEY, map);
+  };
+
+  /**
+   * Record a new operation BEFORE dispatch (§8.1). Persists, then returns
+   * the stored record.
+   *
+   * @param {Object} input
+   * @param {string} input.operationId
+   * @param {string} input.sessionId
+   * @param {string} [input.actorId]
+   * @param {string} input.toolName
+   * @param {unknown} input.retryClass
+   * @param {string} input.generationId
+   * @param {string} [input.idempotencyKey]
+   * @param {string} [input.target]
+   * @param {string} [input.confirmationRef]
+   */
+  const begin = async (input) => {
+    if (!input?.operationId || !input.sessionId || !input.toolName || !input.generationId) {
+      throw new TypeError('operationLog.begin: operationId, sessionId, toolName and generationId are required');
+    }
+    const map = await load();
+    /** @type {import('./reconcile.js').OperationRecord} */
+    const record = {
+      operationId: input.operationId,
+      sessionId: input.sessionId,
+      ...(input.actorId ? { actorId: input.actorId } : {}),
+      toolName: input.toolName,
+      retryClass: normalizeRetryClass(input.retryClass),
+      createdAt: now(),
+      attempt: 1,
+      state: OPERATION_STATES.CREATED,
+      generationId: input.generationId,
+      dispatched: false,
+      ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
+      ...(input.target ? { target: input.target } : {}),
+      ...(input.confirmationRef ? { confirmationRef: input.confirmationRef } : {}),
+    };
+    map[record.operationId] = record;
+    await persist(map);
+    return record;
+  };
+
+  /** @param {string} operationId */
+  const get = async (operationId) => (await load())[operationId];
+
+  /** All records still in a nonterminal state — the reconciler's input. */
+  const listNonterminal = async () =>
+    Object.values(await load()).filter((record) => !isTerminal(record.state));
+
+  /**
+   * Move an operation through the state machine. Illegal transitions throw
+   * (IllegalTransitionError) — recovery paths must go through the
+   * reconciler/resolver, not free-form writes. Persists before returning.
+   *
+   * @param {string} operationId
+   * @param {import('./operation-state.js').OperationState} to
+   * @param {{ resultDigest?: string, lastDurableStep?: number,
+   *   dispatched?: boolean, cancelRequested?: boolean,
+   *   evidence?: { kind?: string }, detail?: unknown }} [patch]
+   */
+  const transition = async (operationId, to, patch = {}) => {
+    const map = await load();
+    const record = map[operationId];
+    if (!record) throw new OperationNotFoundError(operationId);
+    assertTransition(record.state, to);
+    const next = {
+      ...record,
+      state: to,
+      ...(patch.dispatched === true ? { dispatched: true } : {}),
+      ...(patch.cancelRequested === true ? { cancelRequested: true } : {}),
+      ...(patch.evidence ? { evidence: patch.evidence } : {}),
+      ...(typeof patch.lastDurableStep === 'number'
+        ? { lastDurableStep: patch.lastDurableStep } : {}),
+      // Result metadata is digest-only and scrubbed: the log stores
+      // correlation, never payloads or credentials (§8.2).
+      ...(typeof patch.resultDigest === 'string'
+        ? { resultDigest: String(sanitizeDetail(patch.resultDigest)) } : {}),
+    };
+    map[operationId] = next;
+    await persist(map);
+    return next;
+  };
+
+  /** Mark the moment the effect leaves peerd. @param {string} operationId */
+  const markDispatched = (operationId) =>
+    transition(operationId, OPERATION_STATES.AWAITING_REMOTE, { dispatched: true });
+
+  /**
+   * Class B retries: a fresh attempt number on the same operation. Refused
+   * on terminal records other than `interrupted` — a retry re-drives an
+   * interrupted read, never a settled outcome.
+   * @param {string} operationId
+   */
+  const newAttempt = async (operationId) => {
+    const map = await load();
+    const record = map[operationId];
+    if (!record) throw new OperationNotFoundError(operationId);
+    if (record.state !== OPERATION_STATES.INTERRUPTED) {
+      throw new TypeError(`newAttempt requires an interrupted operation; got ${record.state}`);
+    }
+    const next = {
+      ...record,
+      attempt: record.attempt + 1,
+      state: OPERATION_STATES.QUEUED,
+      dispatched: false,
+    };
+    map[operationId] = next;
+    await persist(map);
+    return next;
+  };
+
+  return { begin, get, listNonterminal, transition, markDispatched, newAttempt };
+};

--- a/extension/peerd-runtime/lifecycle/operation-log.js
+++ b/extension/peerd-runtime/lifecycle/operation-log.js
@@ -32,10 +32,16 @@ export const OPERATION_LOG_KEY = 'peerd.lifecycle.operations';
 // Settled records kept for correlation before the oldest are pruned. why a
 // cap: the log is a recovery + audit correlation surface, not history —
 // unbounded growth would make the startup reconcile scan pay for every
-// operation ever run. outcome_unknown records are deliberately EXEMPT from
-// pruning: deleting one silently discards the uncertainty the contract
-// exists to surface — they leave only via resolveUnknown.
+// operation ever run. outcome_unknown records are EXEMPT from this cap
+// (deleting one silently discards the uncertainty the contract exists to
+// surface — they leave via resolveUnknown) but carry their own, larger
+// bound below: a store that can grow without limit from attacker-
+// influenceable error text is its own failure mode, so past that bound the
+// OLDEST unknowns are dropped — a documented, bounded discard, not a
+// silent one (and 200 unresolved unknowns already signals something far
+// worse than log pressure).
 export const OPERATION_LOG_MAX_TERMINAL = 500;
+export const OPERATION_LOG_MAX_UNKNOWN = 200;
 
 const PRUNABLE_STATES = Object.freeze(
   /** @type {ReadonlySet<import('./operation-state.js').OperationState>} */ (new Set([
@@ -105,6 +111,13 @@ export const createOperationLog = ({ storage, now = Date.now }) => {
     const excess = prunable.length - OPERATION_LOG_MAX_TERMINAL;
     if (excess > 0) {
       for (const record of prunable.slice(0, excess)) delete map[record.operationId];
+    }
+    const unknowns = Object.values(map)
+      .filter((record) => record.state === OPERATION_STATES.OUTCOME_UNKNOWN)
+      .sort((a, b) => a.createdAt - b.createdAt);
+    const unknownExcess = unknowns.length - OPERATION_LOG_MAX_UNKNOWN;
+    if (unknownExcess > 0) {
+      for (const record of unknowns.slice(0, unknownExcess)) delete map[record.operationId];
     }
     await storage.set(OPERATION_LOG_KEY, map);
   };
@@ -256,9 +269,14 @@ export const createOperationLog = ({ storage, now = Date.now }) => {
    * action is a NEW operation with a fresh confirmation, never a re-drive
    * of the old record) and for any state but `interrupted` — settled
    * outcomes are never re-driven.
+   *
    * @param {string} operationId
+   * @param {{ generationId?: string }} [patch]  re-stamp the LIVE generation
+   *   driving the retry — leaving the dead generation's stamp would
+   *   misattribute the attempt in audit and make the reconciler skip it as
+   *   "current" never again.
    */
-  const newAttempt = (operationId) => enqueue(async () => {
+  const newAttempt = (operationId, patch = {}) => enqueue(async () => {
     const map = await load();
     const record = map[operationId];
     if (!record) throw new OperationNotFoundError(operationId);
@@ -275,6 +293,8 @@ export const createOperationLog = ({ storage, now = Date.now }) => {
       attempt: record.attempt + 1,
       state: OPERATION_STATES.QUEUED,
       dispatched: false,
+      ...(typeof patch.generationId === 'string' && patch.generationId
+        ? { generationId: patch.generationId } : {}),
     };
     map[operationId] = next;
     await persist(map);

--- a/extension/peerd-runtime/lifecycle/operation-state.js
+++ b/extension/peerd-runtime/lifecycle/operation-state.js
@@ -1,0 +1,191 @@
+// @ts-check
+// Canonical operation states — the lifecycle contract's state vocabulary.
+//
+// Every operation that can outlive one synchronous call carries exactly one
+// of these states. The contract's core guarantee lives here: peerd never
+// silently reports an uncertain side effect as definitely failed or
+// definitely completed. `outcome_unknown` is a real terminal state with its
+// own resolution rules — it can only leave via positive evidence, never by
+// an automatic timeout-to-failed conversion.
+//
+// Functional core: values in, verdicts out. No IO, no clock. The imperative
+// shells (SW dispatcher, operation log, reconciler) enforce these tables at
+// every transition.
+
+/**
+ * @typedef {'created' | 'queued' | 'running' | 'awaiting_user'
+ *   | 'awaiting_remote' | 'cancelling' | 'completed' | 'failed'
+ *   | 'cancelled' | 'interrupted' | 'outcome_unknown'} OperationState
+ */
+
+export const OPERATION_STATES = Object.freeze({
+  CREATED: /** @type {const} */ ('created'),
+  QUEUED: /** @type {const} */ ('queued'),
+  RUNNING: /** @type {const} */ ('running'),
+  AWAITING_USER: /** @type {const} */ ('awaiting_user'),
+  AWAITING_REMOTE: /** @type {const} */ ('awaiting_remote'),
+  CANCELLING: /** @type {const} */ ('cancelling'),
+  COMPLETED: /** @type {const} */ ('completed'),
+  FAILED: /** @type {const} */ ('failed'),
+  CANCELLED: /** @type {const} */ ('cancelled'),
+  INTERRUPTED: /** @type {const} */ ('interrupted'),
+  OUTCOME_UNKNOWN: /** @type {const} */ ('outcome_unknown'),
+});
+
+// Terminal states — nothing moves OUT of these through the transition
+// table. The two sanctioned exits live elsewhere and are deliberate:
+// resolveUnknownOutcome (below) settles outcome_unknown on positive
+// evidence, and the operation log's newAttempt re-queues an `interrupted`
+// record with an incremented attempt number (contract §4 Class B: "the
+// retry must receive a new operation attempt number"). why: free-form
+// rewinds would erase the evidence trail the contract exists to preserve.
+export const TERMINAL_STATES = Object.freeze(
+  /** @type {ReadonlySet<OperationState>} */ (new Set([
+  OPERATION_STATES.COMPLETED,
+  OPERATION_STATES.FAILED,
+  OPERATION_STATES.CANCELLED,
+  OPERATION_STATES.INTERRUPTED,
+  OPERATION_STATES.OUTCOME_UNKNOWN,
+])));
+
+/** @param {unknown} state */
+export const isTerminal = (state) =>
+  isOperationState(state) && TERMINAL_STATES.has(state);
+
+/** @param {unknown} v @returns {v is OperationState} */
+export const isOperationState = (v) =>
+  typeof v === 'string' && Object.values(OPERATION_STATES).includes(
+    /** @type {OperationState} */ (v),
+  );
+
+// The legality table. Keys are source states; values are the states a
+// running system may move them to. Terminal states are absent on purpose —
+// nothing transitions OUT of a terminal state through this table.
+// `outcome_unknown` resolution is the ONE sanctioned exception and goes
+// through resolveUnknownOutcome below, which demands positive evidence.
+/** @type {Readonly<Record<string, ReadonlySet<OperationState>>>} */
+const TRANSITIONS = Object.freeze({
+  [OPERATION_STATES.CREATED]: new Set([
+    OPERATION_STATES.QUEUED, OPERATION_STATES.RUNNING,
+    OPERATION_STATES.CANCELLED, OPERATION_STATES.FAILED,
+    OPERATION_STATES.INTERRUPTED,
+  ]),
+  [OPERATION_STATES.QUEUED]: new Set([
+    OPERATION_STATES.RUNNING, OPERATION_STATES.CANCELLED,
+    OPERATION_STATES.FAILED, OPERATION_STATES.INTERRUPTED,
+  ]),
+  [OPERATION_STATES.RUNNING]: new Set([
+    OPERATION_STATES.AWAITING_USER, OPERATION_STATES.AWAITING_REMOTE,
+    OPERATION_STATES.CANCELLING, OPERATION_STATES.COMPLETED,
+    OPERATION_STATES.FAILED, OPERATION_STATES.CANCELLED,
+    OPERATION_STATES.INTERRUPTED, OPERATION_STATES.OUTCOME_UNKNOWN,
+  ]),
+  // awaiting_user cannot reach outcome_unknown: while an operation waits on
+  // the user no side effect is in flight, so an interruption there is always
+  // the safe `interrupted` (and the pending confirmation dies with it).
+  [OPERATION_STATES.AWAITING_USER]: new Set([
+    OPERATION_STATES.RUNNING, OPERATION_STATES.CANCELLING,
+    OPERATION_STATES.CANCELLED, OPERATION_STATES.FAILED,
+    OPERATION_STATES.INTERRUPTED,
+  ]),
+  [OPERATION_STATES.AWAITING_REMOTE]: new Set([
+    OPERATION_STATES.RUNNING, OPERATION_STATES.CANCELLING,
+    OPERATION_STATES.COMPLETED, OPERATION_STATES.FAILED,
+    OPERATION_STATES.INTERRUPTED, OPERATION_STATES.OUTCOME_UNKNOWN,
+  ]),
+  // cancelling → completed stays legal: a side effect can land between the
+  // user's Stop and the wire actually closing. Reporting it completed is
+  // truthful; reporting cancelled would hide a landed effect.
+  [OPERATION_STATES.CANCELLING]: new Set([
+    OPERATION_STATES.CANCELLED, OPERATION_STATES.COMPLETED,
+    OPERATION_STATES.FAILED, OPERATION_STATES.OUTCOME_UNKNOWN,
+  ]),
+});
+
+/**
+ * May a live operation move `from` → `to`? Pure table lookup; unknown
+ * states are never movable (fail closed).
+ * @param {unknown} from @param {unknown} to
+ */
+export const canTransition = (from, to) => {
+  if (!isOperationState(from) || !isOperationState(to)) return false;
+  const allowed = TRANSITIONS[from];
+  return allowed ? allowed.has(to) : false;
+};
+
+export class IllegalTransitionError extends Error {
+  /** @param {unknown} from @param {unknown} to */
+  constructor(from, to) {
+    super(`illegal operation-state transition: ${String(from)} -> ${String(to)}`);
+    this.name = 'IllegalTransitionError';
+  }
+}
+
+/** @param {unknown} from @param {unknown} to @returns {OperationState} */
+export const assertTransition = (from, to) => {
+  if (!canTransition(from, to)) throw new IllegalTransitionError(from, to);
+  return /** @type {OperationState} */ (to);
+};
+
+// --- Completion evidence ---------------------------------------------------
+//
+// `completed` and `failed` both require POSITIVE evidence (contract §3.1).
+// A timeout or dropped connection is not evidence of anything when a side
+// effect may already have occurred — that ambiguity is exactly what
+// `outcome_unknown` exists to name.
+
+/**
+ * Evidence kinds that positively prove COMPLETION of a side effect.
+ * @typedef {'success-response' | 'verified-state' | 'idempotency-key-lookup'
+ *   | 'durable-commit-check'} CompletionEvidence
+ */
+export const COMPLETION_EVIDENCE = Object.freeze(new Set([
+  'success-response', 'verified-state', 'idempotency-key-lookup',
+  'durable-commit-check',
+]));
+
+/**
+ * Evidence kinds that positively prove the operation did NOT complete.
+ * A definitive rejection before the effect (4xx validation refusal, a
+ * verified absence at the target) qualifies; 'timeout' and
+ * 'connection-lost' deliberately do not.
+ * @typedef {'error-response-before-effect' | 'verified-absent'
+ *   | 'user-verified-absent'} FailureEvidence
+ */
+export const FAILURE_EVIDENCE = Object.freeze(new Set([
+  'error-response-before-effect', 'verified-absent', 'user-verified-absent',
+]));
+
+/** @param {unknown} kind */
+export const provesCompletion = (kind) =>
+  COMPLETION_EVIDENCE.has(/** @type {any} */ (kind));
+
+/** @param {unknown} kind */
+export const provesFailure = (kind) =>
+  FAILURE_EVIDENCE.has(/** @type {any} */ (kind));
+
+export class UnknownOutcomeUnresolvedError extends Error {
+  /** @param {unknown} evidence */
+  constructor(evidence) {
+    super('outcome_unknown can only resolve on positive evidence; '
+      + `got: ${String(evidence)}`);
+    this.name = 'UnknownOutcomeUnresolvedError';
+  }
+}
+
+/**
+ * The ONLY way out of `outcome_unknown`: positive evidence gathered after
+ * the fact (an external-state check, an idempotency-key lookup, or the
+ * user's own verification). Anything else — including 'timeout',
+ * 'connection-lost', undefined, or a plea of "probably failed" — throws.
+ * There is deliberately no automatic path from outcome_unknown to failed.
+ *
+ * @param {{ kind?: unknown }} evidence
+ * @returns {OperationState} completed or failed
+ */
+export const resolveUnknownOutcome = (evidence) => {
+  const kind = evidence?.kind;
+  if (provesCompletion(kind)) return OPERATION_STATES.COMPLETED;
+  if (provesFailure(kind)) return OPERATION_STATES.FAILED;
+  throw new UnknownOutcomeUnresolvedError(kind);
+};

--- a/extension/peerd-runtime/lifecycle/operation-state.js
+++ b/extension/peerd-runtime/lifecycle/operation-state.js
@@ -33,12 +33,14 @@ export const OPERATION_STATES = Object.freeze({
 });
 
 // Terminal states — nothing moves OUT of these through the transition
-// table. The two sanctioned exits live elsewhere and are deliberate:
+// table. The sanctioned exits live elsewhere and are deliberate:
 // resolveUnknownOutcome (below) settles outcome_unknown on positive
-// evidence, and the operation log's newAttempt re-queues an `interrupted`
+// evidence, the operation log's newAttempt re-queues an `interrupted`
 // record with an incremented attempt number (contract §4 Class B: "the
-// retry must receive a new operation attempt number"). why: free-form
-// rewinds would erase the evidence trail the contract exists to preserve.
+// retry must receive a new operation attempt number"), and recovery
+// settling (canRecoverySettle below + the log's settle()) applies a
+// startup reconcile verdict. why: free-form rewinds would erase the
+// evidence trail the contract exists to preserve.
 export const TERMINAL_STATES = Object.freeze(
   /** @type {ReadonlySet<OperationState>} */ (new Set([
   OPERATION_STATES.COMPLETED,
@@ -163,6 +165,26 @@ export const provesCompletion = (kind) =>
 /** @param {unknown} kind */
 export const provesFailure = (kind) =>
   FAILURE_EVIDENCE.has(/** @type {any} */ (kind));
+
+// --- Recovery settling -----------------------------------------------------
+//
+// The transition table above governs a LIVE operation moving under its own
+// driver. Startup reconciliation is a different regime: a new generation
+// settling a dead generation's orphans, where the source state only says
+// where the record was parked when the driver died. A recovery settle may
+// take any nonterminal state to any terminal state, with one carve-out:
+// awaiting_user can never settle to outcome_unknown (no side effect is in
+// flight while waiting on the user). The operation log's settle() enforces
+// this instead of the live table.
+
+/** @param {unknown} from @param {unknown} to */
+export const canRecoverySettle = (from, to) => {
+  if (!isOperationState(from) || !isOperationState(to)) return false;
+  if (isTerminal(from) || !isTerminal(to)) return false;
+  if (from === OPERATION_STATES.AWAITING_USER
+      && to === OPERATION_STATES.OUTCOME_UNKNOWN) return false;
+  return true;
+};
 
 export class UnknownOutcomeUnresolvedError extends Error {
   /** @param {unknown} evidence */

--- a/extension/peerd-runtime/lifecycle/reconcile.js
+++ b/extension/peerd-runtime/lifecycle/reconcile.js
@@ -35,6 +35,8 @@ import { LIFECYCLE_EVENTS, lifecycleAuditEntry } from './audit-events.js';
  * @property {string} [idempotencyKey]
  * @property {string} [target]
  * @property {string} [confirmationRef]
+ * @property {Record<string, unknown>} [confirmationProof]  consumed
+ *   single-use approval proof (§8.3 forensic chain)
  * @property {number} [lastDurableStep]
  * @property {string} [resultDigest]
  * @property {string} [generationId]   generation that was driving it

--- a/extension/peerd-runtime/lifecycle/reconcile.js
+++ b/extension/peerd-runtime/lifecycle/reconcile.js
@@ -16,6 +16,7 @@
 
 import { OPERATION_STATES, isTerminal } from './operation-state.js';
 import { decideRecovery, normalizeRetryClass } from './retry-class.js';
+import { sweepStaleAuthority } from './generation.js';
 import { LIFECYCLE_EVENTS, lifecycleAuditEntry } from './audit-events.js';
 
 /**
@@ -75,6 +76,18 @@ export const buildTurnRecoveryRecord = (record, recoveryVerdict) => {
   };
 };
 
+// The audit event a reconcile verdict earns. An evidence-settled verdict is
+// COMPLETED, uncertainty is OUTCOME_UNKNOWN, everything else (interrupted,
+// cancelled, evidence-proven failed) records as the interruption it is —
+// labelling a completed operation "interrupted" would misfile the one
+// event chain audits reconstruct from.
+/** @param {import('./operation-state.js').OperationState} state */
+const auditEventFor = (state) => {
+  if (state === OPERATION_STATES.OUTCOME_UNKNOWN) return LIFECYCLE_EVENTS.OUTCOME_UNKNOWN;
+  if (state === OPERATION_STATES.COMPLETED) return LIFECYCLE_EVENTS.OPERATION_COMPLETED;
+  return LIFECYCLE_EVENTS.OPERATION_INTERRUPTED;
+};
+
 /**
  * @typedef {Object} ReconcilePlan
  * @property {Array<{ operationId: string,
@@ -101,14 +114,23 @@ export const buildTurnRecoveryRecord = (record, recoveryVerdict) => {
  *  - a record still stamped with the CURRENT generation is not an orphan
  *    (the shell may pass records mid-write) and is left alone;
  *  - each settled operation notifies its parent session with the §5.4
- *    recovery record and appends the matching audit entries.
+ *    recovery record and appends the matching audit entries;
+ *  - every stamped authority record passed in (grants, approval tokens,
+ *    leases, tab/actor ownership) is swept: prior-generation or expired
+ *    stamps land in staleAuthority with a STALE_GRANT_REFUSED audit entry
+ *    each — the shell releases them (§5.3 steps 5 and 7).
+ *
+ * The plan's transitions apply through operationLog.settle() — the recovery
+ * regime — never through the live transition table.
  *
  * @param {Object} input
  * @param {OperationRecord[]} input.records
  * @param {import('./generation.js').Generation} input.generation  freshly minted
+ * @param {import('./generation.js').StampedAuthority[]} [input.authorityRecords]
+ * @param {number} [input.now]  defaults to the new generation's mint time
  * @returns {ReconcilePlan}
  */
-export const reconcileAtStartup = ({ records, generation }) => {
+export const reconcileAtStartup = ({ records, generation, authorityRecords, now }) => {
   /** @type {ReconcilePlan} */
   const plan = {
     transitions: [], staleAuthority: [], notifications: [],
@@ -118,26 +140,37 @@ export const reconcileAtStartup = ({ records, generation }) => {
     })],
   };
 
+  const { stale } = sweepStaleAuthority(authorityRecords ?? [], {
+    generation, now: typeof now === 'number' ? now : generation.mintedAt,
+  });
+  for (const entry of stale) {
+    plan.staleAuthority.push(entry);
+    plan.auditEvents.push(lifecycleAuditEntry({
+      event: LIFECYCLE_EVENTS.STALE_GRANT_REFUSED,
+      generationId: generation.id,
+      detail: { reason: entry.reason },
+    }));
+  }
+
   for (const record of Array.isArray(records) ? records : []) {
     if (!record || typeof record.operationId !== 'string') continue;
     if (isTerminal(record.state) || !RECONCILABLE.has(record.state)) continue;
     if (record.generationId === generation.id) continue; // ours, in flight
 
-    const verdict = record.state === OPERATION_STATES.AWAITING_USER
-      // Waiting on the user = nothing dispatched; the pending confirmation
-      // is dead either way (generation changed). Force the safe shape.
-      ? decideRecovery({
-        retryClass: normalizeRetryClass(record.retryClass),
-        dispatched: false,
-        cancelRequested: record.cancelRequested,
-        evidence: record.evidence,
-      })
-      : decideRecovery({
-        retryClass: normalizeRetryClass(record.retryClass),
-        dispatched: record.dispatched,
-        cancelRequested: record.cancelRequested,
-        evidence: record.evidence,
-      });
+    // Waiting on the user = nothing dispatched; the pending confirmation is
+    // dead either way (generation changed). Force the safe shape onto BOTH
+    // the decision and the recovery record — a bogus dispatched flag on an
+    // awaiting_user record must not surface as "dispatched" to the parent.
+    const effective = record.state === OPERATION_STATES.AWAITING_USER
+      ? { ...record, dispatched: false }
+      : record;
+
+    const verdict = decideRecovery({
+      retryClass: normalizeRetryClass(effective.retryClass),
+      dispatched: effective.dispatched,
+      cancelRequested: effective.cancelRequested,
+      evidence: effective.evidence,
+    });
 
     plan.transitions.push({
       operationId: record.operationId,
@@ -146,7 +179,7 @@ export const reconcileAtStartup = ({ records, generation }) => {
       verdict,
     });
 
-    const recoveryRecord = buildTurnRecoveryRecord(record, verdict);
+    const recoveryRecord = buildTurnRecoveryRecord(effective, verdict);
     plan.notifications.push({
       sessionId: record.sessionId,
       ...(record.actorId ? { actorId: record.actorId } : {}),
@@ -154,9 +187,7 @@ export const reconcileAtStartup = ({ records, generation }) => {
     });
 
     plan.auditEvents.push(lifecycleAuditEntry({
-      event: verdict.state === OPERATION_STATES.OUTCOME_UNKNOWN
-        ? LIFECYCLE_EVENTS.OUTCOME_UNKNOWN
-        : LIFECYCLE_EVENTS.OPERATION_INTERRUPTED,
+      event: auditEventFor(verdict.state),
       sessionId: record.sessionId,
       actorId: record.actorId,
       operationId: record.operationId,

--- a/extension/peerd-runtime/lifecycle/reconcile.js
+++ b/extension/peerd-runtime/lifecycle/reconcile.js
@@ -1,0 +1,171 @@
+// @ts-check
+// Startup reconciliation — what a fresh service-worker generation does with
+// the durable operation records the last one left behind (contract §5.3).
+//
+// Given the durable records and the newly minted generation, produce — as
+// VALUES, no IO — the full recovery plan: per-operation terminal
+// transitions (via the retry-class decision), released ownership records,
+// refused stale authority, parent-session notifications carrying the §5.4
+// structured recovery record, and the audit entries for all of it. The
+// shell (service-worker.js) applies the plan; this module only decides it.
+//
+// A model turn is never resumed from the middle of a stream by this path —
+// reconciliation lands interrupted/outcome_unknown states and recovery
+// records; the separate auto-resume seam (loop/resume-detect.js) decides
+// whether a NEW continuation turn is warranted.
+
+import { OPERATION_STATES, isTerminal } from './operation-state.js';
+import { decideRecovery, normalizeRetryClass } from './retry-class.js';
+import { LIFECYCLE_EVENTS, lifecycleAuditEntry } from './audit-events.js';
+
+/**
+ * The durable operation record (contract §8). The operation log persists
+ * this shape; the reconciler consumes it.
+ *
+ * @typedef {Object} OperationRecord
+ * @property {string} operationId
+ * @property {string} sessionId
+ * @property {string} [actorId]
+ * @property {string} toolName
+ * @property {unknown} retryClass
+ * @property {number} createdAt
+ * @property {number} attempt
+ * @property {import('./operation-state.js').OperationState} state
+ * @property {string} [idempotencyKey]
+ * @property {string} [target]
+ * @property {string} [confirmationRef]
+ * @property {number} [lastDurableStep]
+ * @property {string} [resultDigest]
+ * @property {string} [generationId]   generation that was driving it
+ * @property {boolean} [dispatched]    the effect left peerd
+ * @property {boolean} [cancelRequested]
+ * @property {{ kind?: string }} [evidence]
+ */
+
+// Nonterminal states the reconciler must settle (§5.3 step 3 names
+// running/awaiting_user/awaiting_remote; created/queued/cancelling are the
+// same orphans caught earlier/later in their lifecycle).
+const RECONCILABLE = Object.freeze(
+  /** @type {ReadonlySet<import('./operation-state.js').OperationState>} */ (new Set([
+    OPERATION_STATES.CREATED, OPERATION_STATES.QUEUED, OPERATION_STATES.RUNNING,
+    OPERATION_STATES.AWAITING_USER, OPERATION_STATES.AWAITING_REMOTE,
+    OPERATION_STATES.CANCELLING,
+  ])));
+
+/**
+ * The §5.4 structured recovery record a parent session receives about one
+ * settled operation.
+ *
+ * @param {OperationRecord} record
+ * @param {import('./retry-class.js').RecoveryVerdict} recoveryVerdict
+ */
+export const buildTurnRecoveryRecord = (record, recoveryVerdict) => {
+  const unknown = recoveryVerdict.state === OPERATION_STATES.OUTCOME_UNKNOWN;
+  return {
+    operation: record.toolName,
+    operationId: record.operationId,
+    previousState: record.state,
+    recoveryState: recoveryVerdict.state,
+    ...(typeof record.lastDurableStep === 'number'
+      ? { lastDurableStep: record.lastDurableStep } : {}),
+    sideEffectStatus: unknown
+      ? 'outcome_unknown'
+      : (record.dispatched === true ? 'dispatched' : 'none attempted'),
+    ...(unknown ? { verificationRequired: true } : {}),
+  };
+};
+
+/**
+ * @typedef {Object} ReconcilePlan
+ * @property {Array<{ operationId: string,
+ *   from: import('./operation-state.js').OperationState,
+ *   to: import('./operation-state.js').OperationState,
+ *   verdict: import('./retry-class.js').RecoveryVerdict }>} transitions
+ * @property {Array<{ record: import('./generation.js').StampedAuthority,
+ *   reason: string }>} staleAuthority
+ * @property {Array<{ sessionId: string, actorId?: string,
+ *   recoveryRecord: ReturnType<typeof buildTurnRecoveryRecord> }>} notifications
+ * @property {Array<ReturnType<typeof lifecycleAuditEntry>>} auditEvents
+ */
+
+/**
+ * Decide the whole startup recovery plan for a new SW generation.
+ *
+ * Rules encoded (contract §5.3):
+ *  - only nonterminal records are touched; terminal history is immutable;
+ *  - an operation parked on a user approval (`awaiting_user`) is always
+ *    `interrupted` — its confirmation died with the old generation, and no
+ *    side effect can have been in flight while waiting on the user;
+ *  - everything else settles via the retry-class decision (Class E
+ *    dispatched-unproven → outcome_unknown, never auto-retry);
+ *  - a record still stamped with the CURRENT generation is not an orphan
+ *    (the shell may pass records mid-write) and is left alone;
+ *  - each settled operation notifies its parent session with the §5.4
+ *    recovery record and appends the matching audit entries.
+ *
+ * @param {Object} input
+ * @param {OperationRecord[]} input.records
+ * @param {import('./generation.js').Generation} input.generation  freshly minted
+ * @returns {ReconcilePlan}
+ */
+export const reconcileAtStartup = ({ records, generation }) => {
+  /** @type {ReconcilePlan} */
+  const plan = {
+    transitions: [], staleAuthority: [], notifications: [],
+    auditEvents: [lifecycleAuditEntry({
+      event: LIFECYCLE_EVENTS.SW_GENERATION_CHANGED,
+      generationId: generation.id,
+    })],
+  };
+
+  for (const record of Array.isArray(records) ? records : []) {
+    if (!record || typeof record.operationId !== 'string') continue;
+    if (isTerminal(record.state) || !RECONCILABLE.has(record.state)) continue;
+    if (record.generationId === generation.id) continue; // ours, in flight
+
+    const verdict = record.state === OPERATION_STATES.AWAITING_USER
+      // Waiting on the user = nothing dispatched; the pending confirmation
+      // is dead either way (generation changed). Force the safe shape.
+      ? decideRecovery({
+        retryClass: normalizeRetryClass(record.retryClass),
+        dispatched: false,
+        cancelRequested: record.cancelRequested,
+        evidence: record.evidence,
+      })
+      : decideRecovery({
+        retryClass: normalizeRetryClass(record.retryClass),
+        dispatched: record.dispatched,
+        cancelRequested: record.cancelRequested,
+        evidence: record.evidence,
+      });
+
+    plan.transitions.push({
+      operationId: record.operationId,
+      from: record.state,
+      to: verdict.state,
+      verdict,
+    });
+
+    const recoveryRecord = buildTurnRecoveryRecord(record, verdict);
+    plan.notifications.push({
+      sessionId: record.sessionId,
+      ...(record.actorId ? { actorId: record.actorId } : {}),
+      recoveryRecord,
+    });
+
+    plan.auditEvents.push(lifecycleAuditEntry({
+      event: verdict.state === OPERATION_STATES.OUTCOME_UNKNOWN
+        ? LIFECYCLE_EVENTS.OUTCOME_UNKNOWN
+        : LIFECYCLE_EVENTS.OPERATION_INTERRUPTED,
+      sessionId: record.sessionId,
+      actorId: record.actorId,
+      operationId: record.operationId,
+      attempt: record.attempt,
+      result: verdict.state,
+      generationId: generation.id,
+      detail: { toolName: record.toolName, reason: verdict.reason },
+    }));
+  }
+
+  return plan;
+};

--- a/extension/peerd-runtime/lifecycle/recovery-report.js
+++ b/extension/peerd-runtime/lifecycle/recovery-report.js
@@ -37,14 +37,29 @@ const USER_TEXT = Object.freeze({
     'This profile requires a newer or supported peerd version. No data was changed.',
 });
 
+// Recovery reports describe RECOVERY outcomes only. A verdict that settled
+// on positive evidence (completed/failed/cancelled) must never reach the
+// category mapper: labelling a COMPLETED Class E action "safe to retry"
+// would invite exactly the duplicate side effect the contract forbids, so
+// the mismatch throws instead of guessing.
+const RECOVERY_STATES = Object.freeze(
+  /** @type {ReadonlySet<import('./operation-state.js').OperationState>} */ (new Set([
+    OPERATION_STATES.INTERRUPTED, OPERATION_STATES.OUTCOME_UNKNOWN,
+  ])));
+
 /**
- * Map a recovery verdict (retry-class.js) to its §14 category.
+ * Map a recovery verdict (retry-class.js) to its §14 category. Only
+ * interrupted/outcome_unknown verdicts qualify; settled verdicts throw.
  *
  * @param {import('./retry-class.js').RecoveryVerdict} recoveryVerdict
  * @param {{ retryClass?: unknown }} [context]
  * @returns {typeof RECOVERY_CATEGORIES[keyof typeof RECOVERY_CATEGORIES]}
  */
 export const categorizeRecovery = (recoveryVerdict, context = {}) => {
+  if (!RECOVERY_STATES.has(recoveryVerdict.state)) {
+    throw new TypeError('recovery reports describe interrupted/outcome_unknown '
+      + `verdicts; got ${String(recoveryVerdict.state)}`);
+  }
   if (recoveryVerdict.state === OPERATION_STATES.OUTCOME_UNKNOWN
       || recoveryVerdict.verificationRequired) {
     return RECOVERY_CATEGORIES.VERIFY_BEFORE_RETRY;

--- a/extension/peerd-runtime/lifecycle/recovery-report.js
+++ b/extension/peerd-runtime/lifecycle/recovery-report.js
@@ -1,0 +1,120 @@
+// @ts-check
+// User-visible recovery semantics (contract §14).
+//
+// The UI and the agent must receive the SAME semantic distinction, not a
+// generic tool-error string. This module maps a recovery verdict to one of
+// the six documented categories, with the user-facing sentence and the
+// agent-facing structured record built from one source so they can never
+// disagree.
+//
+// Pure shaping; no IO.
+
+import { OPERATION_STATES } from './operation-state.js';
+import { RETRY_CLASSES, normalizeRetryClass } from './retry-class.js';
+
+export const RECOVERY_CATEGORIES = Object.freeze({
+  SAFE_TO_RETRY: /** @type {const} */ ('safe_to_retry'),
+  RETRY_REQUIRES_BUDGET: /** @type {const} */ ('retry_requires_budget'),
+  VERIFY_BEFORE_RETRY: /** @type {const} */ ('verify_before_retry'),
+  RESOURCE_LOST: /** @type {const} */ ('resource_lost'),
+  SECURITY_DEGRADATION: /** @type {const} */ ('security_degradation'),
+  MIGRATION_BLOCKED: /** @type {const} */ ('migration_blocked'),
+});
+
+const USER_TEXT = Object.freeze({
+  [RECOVERY_CATEGORIES.SAFE_TO_RETRY]:
+    'The operation was interrupted before making an external change. It is safe to retry.',
+  [RECOVERY_CATEGORIES.RETRY_REQUIRES_BUDGET]:
+    'The read or model call was interrupted. Retrying may incur additional network or model cost.',
+  [RECOVERY_CATEGORIES.VERIFY_BEFORE_RETRY]:
+    'This action may have completed, but peerd did not receive confirmation. '
+    + 'Check the target before repeating it.',
+  [RECOVERY_CATEGORIES.RESOURCE_LOST]:
+    'The execution environment stopped. Your saved files remain, but live process state was lost.',
+  [RECOVERY_CATEGORIES.SECURITY_DEGRADATION]:
+    'A secure isolated execution host could not be created. This operation was not run.',
+  [RECOVERY_CATEGORIES.MIGRATION_BLOCKED]:
+    'This profile requires a newer or supported peerd version. No data was changed.',
+});
+
+/**
+ * Map a recovery verdict (retry-class.js) to its §14 category.
+ *
+ * @param {import('./retry-class.js').RecoveryVerdict} recoveryVerdict
+ * @param {{ retryClass?: unknown }} [context]
+ * @returns {typeof RECOVERY_CATEGORIES[keyof typeof RECOVERY_CATEGORIES]}
+ */
+export const categorizeRecovery = (recoveryVerdict, context = {}) => {
+  if (recoveryVerdict.state === OPERATION_STATES.OUTCOME_UNKNOWN
+      || recoveryVerdict.verificationRequired) {
+    return RECOVERY_CATEGORIES.VERIFY_BEFORE_RETRY;
+  }
+  if (recoveryVerdict.recreateResource) return RECOVERY_CATEGORIES.RESOURCE_LOST;
+  if (normalizeRetryClass(context.retryClass) === RETRY_CLASSES.COSTED_READ) {
+    return RECOVERY_CATEGORIES.RETRY_REQUIRES_BUDGET;
+  }
+  return RECOVERY_CATEGORIES.SAFE_TO_RETRY;
+};
+
+/**
+ * Build the paired user/agent report for a settled operation. One source,
+ * two renderings — the agent gets structure (state, category, what a retry
+ * requires), the user gets the documented sentence.
+ *
+ * @param {import('./retry-class.js').RecoveryVerdict} recoveryVerdict
+ * @param {{ retryClass?: unknown, operationId?: string, toolName?: string }} [context]
+ */
+export const describeRecovery = (recoveryVerdict, context = {}) => {
+  const category = categorizeRecovery(recoveryVerdict, context);
+  return {
+    category,
+    user: USER_TEXT[category],
+    agent: {
+      category,
+      state: recoveryVerdict.state,
+      autoRetry: recoveryVerdict.autoRetry,
+      retryRequires: recoveryVerdict.retryRequires,
+      verificationRequired: recoveryVerdict.verificationRequired,
+      keepIdempotencyKey: recoveryVerdict.keepIdempotencyKey,
+      ...(context.operationId ? { operationId: context.operationId } : {}),
+      ...(context.toolName ? { toolName: context.toolName } : {}),
+      reason: recoveryVerdict.reason,
+    },
+  };
+};
+
+/**
+ * The two categories that don't arise from a retry-class verdict — a
+ * refused isolation host and a blocked migration — get explicit builders
+ * so their callers share the same report shape.
+ * @param {{ detail?: string }} [input]
+ */
+export const securityDegradationReport = ({ detail } = {}) => ({
+  category: RECOVERY_CATEGORIES.SECURITY_DEGRADATION,
+  user: USER_TEXT[RECOVERY_CATEGORIES.SECURITY_DEGRADATION],
+  agent: {
+    category: RECOVERY_CATEGORIES.SECURITY_DEGRADATION,
+    state: OPERATION_STATES.FAILED,
+    autoRetry: false,
+    retryRequires: ['isolation-host'],
+    verificationRequired: false,
+    keepIdempotencyKey: false,
+    reason: detail ?? 'isolated execution host could not be created; operation not run',
+  },
+});
+
+/** @param {{ diagnosticId?: string, reason?: string }} [input] */
+export const migrationBlockedReport = ({ diagnosticId, reason } = {}) => ({
+  category: RECOVERY_CATEGORIES.MIGRATION_BLOCKED,
+  user: USER_TEXT[RECOVERY_CATEGORIES.MIGRATION_BLOCKED],
+  agent: {
+    category: RECOVERY_CATEGORIES.MIGRATION_BLOCKED,
+    state: OPERATION_STATES.FAILED,
+    autoRetry: false,
+    retryRequires: ['compatible-peerd-version'],
+    verificationRequired: false,
+    keepIdempotencyKey: false,
+    ...(diagnosticId ? { diagnosticId } : {}),
+    reason: reason ?? 'store schema unsupported; no data was changed',
+  },
+});

--- a/extension/peerd-runtime/lifecycle/recovery-report.js
+++ b/extension/peerd-runtime/lifecycle/recovery-report.js
@@ -65,7 +65,11 @@ export const categorizeRecovery = (recoveryVerdict, context = {}) => {
     return RECOVERY_CATEGORIES.VERIFY_BEFORE_RETRY;
   }
   if (recoveryVerdict.recreateResource) return RECOVERY_CATEGORIES.RESOURCE_LOST;
-  if (normalizeRetryClass(context.retryClass) === RETRY_CLASSES.COSTED_READ) {
+  // The verdict's own preconditions outrank the class lookup: a verdict
+  // that names 'budget' is the budget case even when the caller forgot to
+  // pass the class in context.
+  if (recoveryVerdict.retryRequires.includes('budget')
+      || normalizeRetryClass(context.retryClass) === RETRY_CLASSES.COSTED_READ) {
     return RECOVERY_CATEGORIES.RETRY_REQUIRES_BUDGET;
   }
   return RECOVERY_CATEGORIES.SAFE_TO_RETRY;

--- a/extension/peerd-runtime/lifecycle/resource-recovery.js
+++ b/extension/peerd-runtime/lifecycle/resource-recovery.js
@@ -1,0 +1,426 @@
+// @ts-check
+// Engine-resource recovery (contract §9) — what a fresh service-worker
+// generation may REUSE from the engine resources the previous one left
+// behind, and what it must re-derive, re-verify, or refuse outright.
+//
+// The four resources each recover differently, and the difference is the
+// point: a tab is a live thing an attacker can have moved under us, a
+// notebook cell is a claim about a result we may no longer be able to
+// substantiate, a WebVM is a filesystem that may be half-written, and an App
+// is a sandbox whose whole authority was transient. So this file answers four
+// separate questions with four separate verdicts rather than one "restore".
+//
+// The invariant they share (contract guarantees 3 and 7): recovery never
+// EXPANDS authority. Nothing transient — a grant, a network tier, a
+// credentialed binding — survives a restart by assumption; it is either
+// re-derived from durable policy by the caller, or the resource is released.
+//
+// Functional core: values in, verdicts out. No IO, no clock, no `chrome.*`.
+// Collaborators (the origin-sensitivity classifier, the re-derived grant) are
+// passed in as plain values/functions, so this module stays self-contained
+// inside lifecycle/ and testable without a browser.
+
+import { authorityValid } from './generation.js';
+import { decideRecovery } from './retry-class.js';
+
+// --- §9.4 driven tabs ------------------------------------------------------
+
+/** @typedef {'adopt' | 'release' | 'refuse-actor'} TabDisposition */
+
+/**
+ * What the shell does with a tab the previous generation was driving.
+ *
+ *   adopt         re-bind the actor to this tab; it is provably the same page
+ *   release       drop the ownership record (the tab itself is left alone —
+ *                 the user's tab is not ours to close on a doubt)
+ *   refuse-actor  the tab is intact but now shows an origin where the user has
+ *                 an identity: the ACTOR is refused rather than the tab
+ *                 silently adopted, so a credentialed page is never inherited
+ *                 by a run that never asked for it
+ */
+export const TAB_DISPOSITIONS = Object.freeze({
+  ADOPT: /** @type {const} */ ('adopt'),
+  RELEASE: /** @type {const} */ ('release'),
+  REFUSE_ACTOR: /** @type {const} */ ('refuse-actor'),
+});
+
+/**
+ * The durable record of a tab the previous generation owned.
+ * @typedef {Object} TabOwnership
+ * @property {number} tabId
+ * @property {string} [sessionId]
+ * @property {string} [generationId]  the generation that minted the binding
+ * @property {string} [boundOrigin]   set when the actor was BOUND to one
+ *   credentialed origin; absent for a roaming actor
+ */
+
+/**
+ * @typedef {Object} TabRevalidation
+ * @property {boolean} adopt
+ * @property {string} reason
+ * @property {TabDisposition} disposition
+ */
+
+/**
+ * why frozen: a verdict is passed to the shell and rendered into audit;
+ * nothing downstream should edit it after the decision was made.
+ * @param {TabDisposition} disposition @param {string} reason
+ * @returns {TabRevalidation}
+ */
+const tabVerdict = (disposition, reason) => Object.freeze({
+  adopt: disposition === TAB_DISPOSITIONS.ADOPT,
+  reason,
+  disposition,
+});
+
+/**
+ * A URL's origin, or null when there isn't a usable one.
+ *
+ * why the local parse instead of the actor module's normalizer: this module
+ * is self-contained inside lifecycle/ by design, and the comparison it needs
+ * is exactly `new URL(x).origin` (lowercased host, default ports dropped).
+ * An opaque origin (`about:blank`, `data:`) parses to the STRING 'null',
+ * which would happily compare equal to another opaque origin — so it is
+ * rejected here rather than allowed to match.
+ *
+ * @param {unknown} url @returns {string | null}
+ */
+const originOf = (url) => {
+  if (typeof url !== 'string' || url === '') return null;
+  try {
+    const { origin } = new URL(url);
+    return origin && origin !== 'null' ? origin : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * §9.4 — revalidate a tab that survived the service worker.
+ *
+ * A tab outliving the SW is NOT evidence that the binding still holds: the
+ * page could have navigated, been replaced, or landed somewhere the user is
+ * signed in, all while nothing was watching. So the surviving tab is treated
+ * as an untrusted claim and re-checked from scratch. Every refusal releases
+ * the OWNERSHIP, never the user's tab.
+ *
+ * Checks, in order — the grant check is deliberately LAST so a stale-generation
+ * re-adoption can only happen once identity, origin, and sensitivity have all
+ * already passed:
+ *   1. the tab is gone, or its id no longer matches → release
+ *   2. the live URL has no usable origin → release
+ *   3. a bound actor's page has navigated off its origin → release
+ *   4. the live origin is one the user has an identity on → refuse-actor
+ *   5. the ownership was stamped by a PRIOR generation → adopt only if the
+ *      caller re-derived the grant (`allowedByGrant === true`); absent or
+ *      false fails closed to release
+ *
+ * @param {Object} input
+ * @param {TabOwnership} input.ownership
+ * @param {{ id?: number, url?: string } | null} [input.liveTab]  the tab as the
+ *   browser reports it NOW (null when it no longer exists)
+ * @param {import('./generation.js').Generation} input.generation  current
+ * @param {(origin: string) => boolean} [input.isSensitiveOrigin]  injected
+ *   classifier (the actor module's classifyOriginSensitivity, wrapped by the
+ *   shell) — a signal, not a hard dependency
+ * @param {boolean} [input.allowedByGrant]  did the caller RE-DERIVE a grant
+ *   for this binding from durable policy? Absent = no, and no is a release.
+ * @param {number} [input.now]  epoch ms; defaults to the generation's mint time
+ * @returns {TabRevalidation}
+ */
+export const revalidateDrivenTab = (input) => {
+  const ownership = input?.ownership;
+  const liveTab = input?.liveTab;
+  const generation = input?.generation;
+
+  if (!ownership || typeof ownership.tabId !== 'number') {
+    // why: with no durable ownership record there is nothing to re-adopt —
+    // an unowned tab is the user's, not ours.
+    return tabVerdict(TAB_DISPOSITIONS.RELEASE,
+      'no usable ownership record; nothing to revalidate');
+  }
+
+  // 1. Identity. A tab id is reused by the browser after a close, so "a tab
+  // with this id exists" is not the same claim as "our tab survived".
+  if (!liveTab || liveTab.id !== ownership.tabId) {
+    return tabVerdict(TAB_DISPOSITIONS.RELEASE,
+      'the tab is gone or identity changed');
+  }
+
+  // 2. A tab we cannot name an origin for cannot be checked against policy,
+  // and an unnameable page is never adopted on trust.
+  const liveOrigin = originOf(liveTab.url);
+  if (liveOrigin === null) {
+    return tabVerdict(TAB_DISPOSITIONS.RELEASE,
+      'the live tab URL has no usable origin; cannot revalidate the binding');
+  }
+
+  // 3. A BOUND actor owns exactly one credentialed origin. If the page moved,
+  // the binding is void: re-adopting would silently point an actor holding
+  // one origin's authority at a different site.
+  if (ownership.boundOrigin !== undefined) {
+    const boundOrigin = originOf(ownership.boundOrigin);
+    if (boundOrigin === null || boundOrigin !== liveOrigin) {
+      return tabVerdict(TAB_DISPOSITIONS.RELEASE,
+        `the page navigated away from the actor's bound origin `
+        + `(${String(ownership.boundOrigin)} -> ${liveOrigin})`);
+    }
+  }
+
+  // 4. Sensitivity. why a distinct disposition rather than a release: the tab
+  // is fine and the user may well want it — what must not happen is an ACTOR
+  // inheriting a signed-in page across a restart it never consented to. The
+  // shell refuses the actor and hands the decision back up.
+  if (input?.isSensitiveOrigin?.(liveOrigin) === true) {
+    return tabVerdict(TAB_DISPOSITIONS.REFUSE_ACTOR,
+      `the tab now shows a sensitive origin (${liveOrigin}); `
+      + 'the actor is refused rather than silently adopting a credentialed page');
+  }
+
+  // 5. Generation + grant. Everything above passed, so the only question left
+  // is authority — and transient authority never survives a restart by
+  // assumption (contract guarantees 3 and 7).
+  const currentGenerationId = typeof generation?.id === 'string' ? generation.id : null;
+  const stamp = currentGenerationId === null
+    ? { valid: false, reason: 'no current generation to validate the stamp against' }
+    : authorityValid(
+      typeof ownership.generationId === 'string'
+        ? { generationId: ownership.generationId }
+        : null,
+      { generation, now: typeof input?.now === 'number' ? input.now : generation.mintedAt },
+    );
+
+  if (stamp.valid) {
+    return tabVerdict(TAB_DISPOSITIONS.ADOPT,
+      'current-generation ownership; identity, origin and sensitivity all re-checked');
+  }
+  if (input?.allowedByGrant !== true) {
+    // why fail closed on absent: "the caller didn't say" and "the caller said
+    // no" must land in the same place, or a forgotten argument silently
+    // extends a capability past the restart that was supposed to end it.
+    return tabVerdict(TAB_DISPOSITIONS.RELEASE,
+      `${stamp.reason}; no re-derived grant was supplied`);
+  }
+  return tabVerdict(TAB_DISPOSITIONS.ADOPT,
+    `${stamp.reason}; re-adopted under a freshly re-derived grant after all checks passed`);
+};
+
+// --- §9.2 notebook cells ---------------------------------------------------
+
+/**
+ * @typedef {'persisted-source' | 'completed-result' | 'interrupted'
+ *   | 'stale-output'} NotebookCellState
+ */
+
+/**
+ * The four things a notebook cell can honestly claim after a restart. The UI
+ * must render them DIFFERENTLY: showing an interrupted run or an output from
+ * a dead heap as a current result is exactly the false-certainty the
+ * lifecycle contract exists to prevent.
+ */
+export const NOTEBOOK_CELL_STATES = Object.freeze({
+  PERSISTED_SOURCE: /** @type {const} */ ('persisted-source'),
+  COMPLETED_RESULT: /** @type {const} */ ('completed-result'),
+  INTERRUPTED: /** @type {const} */ ('interrupted'),
+  STALE_OUTPUT: /** @type {const} */ ('stale-output'),
+});
+
+/**
+ * §9.2 — label one notebook cell for the UI.
+ *
+ * Precedence, and why each rank sits where it does:
+ *   running       → 'interrupted'. The worker heap died mid-run. Nothing that
+ *                   cell was computing survived, so whatever output is also
+ *                   sitting there describes an earlier, unrelated run.
+ *   output + same generation → 'completed-result'. The result was produced by
+ *                   the heap that is still the current one; it can be shown as
+ *                   a live result.
+ *   output + any other/missing generation → 'stale-output'. The bytes are
+ *                   real, but the heap that produced them is gone, so the
+ *                   variables the output refers to no longer exist. Shown, and
+ *                   marked stale — never silently promoted.
+ *   otherwise     → 'persisted-source'. The only claim needing no evidence:
+ *                   the source text is on disk. Garbage input lands here too.
+ *
+ * @param {Object} input
+ * @param {{ source?: unknown, running?: unknown, completedGeneration?: unknown,
+ *   output?: unknown }} [input.cell]
+ * @param {unknown} [input.currentGeneration]  the notebook's live worker
+ *   generation number
+ * @returns {NotebookCellState}
+ */
+export const notebookCellState = (input) => {
+  const cell = input?.cell;
+  if (!cell || typeof cell !== 'object') return NOTEBOOK_CELL_STATES.PERSISTED_SOURCE;
+
+  if (cell.running === true) return NOTEBOOK_CELL_STATES.INTERRUPTED;
+
+  // why null/undefined only: an empty-string output is a REAL result (a cell
+  // that ran and printed nothing), and collapsing it into "no output" would
+  // relabel a completed run as unrun source.
+  const hasOutput = cell.output !== undefined && cell.output !== null;
+  if (!hasOutput) return NOTEBOOK_CELL_STATES.PERSISTED_SOURCE;
+
+  const current = input?.currentGeneration;
+  const matches = typeof current === 'number' && Number.isFinite(current)
+    && typeof cell.completedGeneration === 'number'
+    && cell.completedGeneration === current;
+  return matches
+    ? NOTEBOOK_CELL_STATES.COMPLETED_RESULT
+    : NOTEBOOK_CELL_STATES.STALE_OUTPUT;
+};
+
+// --- §9.1 WebVMs -----------------------------------------------------------
+
+/**
+ * @typedef {Object} InterruptedCommand
+ * @property {string} commandId
+ * @property {unknown} [retryClass]
+ * @property {boolean} [dispatched]
+ * @property {boolean} [cancelRequested]
+ * @property {{ kind?: string }} [evidence]
+ */
+
+/**
+ * @typedef {Object} VmRecoveryPlan
+ * @property {boolean} verifyFilesystem
+ * @property {true} processStateLost
+ * @property {true} revalidateImports
+ * @property {false} credentialsResident
+ * @property {ReadonlyArray<{ commandId: string,
+ *   verdict: import('./retry-class.js').RecoveryVerdict }>} commands
+ */
+
+/**
+ * §9.1 — what recreating a WebVM restores, and what it must NOT assume.
+ *
+ * A WebVM's disk is persisted but its process state is not, so recovery is
+ * asymmetric by construction:
+ *   verifyFilesystem     a PERSISTED filesystem is the dangerous case, not the
+ *                        safe one — it may be PARTIALLY committed (a write
+ *                        that started before the eviction), so it is verified
+ *                        rather than trusted. A non-persisted VM has nothing
+ *                        to verify: it comes back empty.
+ *   processStateLost     always. Shells, env, background processes, mounts,
+ *                        and anything else living only in the heap are gone;
+ *                        a command is never "continued".
+ *   revalidateImports    always. Modules/packages resolved by the dead run are
+ *                        re-resolved, never inherited from a cache the new
+ *                        generation cannot vouch for.
+ *   credentialsResident  always false. Nothing credentialed is resident in a
+ *                        recreated VM; anything it needs is re-derived at the
+ *                        egress boundary.
+ *
+ * Each interrupted command is settled by `decideRecovery`, which fails an
+ * UNCLASSIFIED command closed to Class E. why that matters here specifically:
+ * a shell command is opaque — `curl`, `git push`, a script that mails
+ * something — so "we don't know what it was" and "it may have changed the
+ * outside world" are the same statement, and outcome_unknown is the only
+ * honest verdict.
+ *
+ * @param {Object} input
+ * @param {{ instanceId?: string, filesystemPersisted?: boolean }} [input.vmRecord]
+ * @param {InterruptedCommand[]} [input.interruptedCommands]
+ * @returns {VmRecoveryPlan}
+ */
+export const vmRecoveryPlan = (input) => {
+  const commandList = Array.isArray(input?.interruptedCommands)
+    ? input.interruptedCommands
+    : [];
+  const commands = commandList
+    .filter((command) => typeof command?.commandId === 'string')
+    .map((command) => Object.freeze({
+      commandId: command.commandId,
+      verdict: decideRecovery({
+        retryClass: command.retryClass,
+        dispatched: command.dispatched,
+        cancelRequested: command.cancelRequested,
+        evidence: command.evidence,
+      }),
+    }));
+
+  return Object.freeze({
+    verifyFilesystem: input?.vmRecord?.filesystemPersisted === true,
+    processStateLost: /** @type {true} */ (true),
+    revalidateImports: /** @type {true} */ (true),
+    credentialsResident: /** @type {false} */ (false),
+    commands: Object.freeze(commands),
+  });
+};
+
+// --- §9.3 App sandboxes ----------------------------------------------------
+
+/** OPFS root every App's files live under: `peerd-apps/<appId>/…`. */
+const APP_FILE_ROOT = 'peerd-apps/';
+
+/**
+ * Does this path belong to THIS app? Recreation restores an app's own files
+ * and nothing else — a rebuild is not an opportunity to widen what a sandbox
+ * can read, so a traversal, an absolute path, or another app's namespace is
+ * dropped rather than repaired.
+ *
+ * @param {unknown} file @param {string} appId
+ */
+const isOwnFile = (file, appId) => {
+  if (typeof file !== 'string' || file === '') return false;
+  if (file.includes('..')) return false;
+  if (file.startsWith('/')) return false;
+  if (!file.startsWith(APP_FILE_ROOT)) return true; // app-relative name
+  return file.startsWith(`${APP_FILE_ROOT}${appId}/`);
+};
+
+/**
+ * @typedef {Object} AppSandboxRebuild
+ * @property {ReadonlyArray<string>} restoredFiles
+ * @property {'re-derive'} networkTier
+ * @property {'regenerate'} blobUrls
+ * @property {'not-restored'} popups
+ * @property {'not-restored'} downloads
+ * @property {'not-replayed'} inFlightActions
+ */
+
+/**
+ * §9.3 — a declarative statement of what recreating an App sandbox restores,
+ * re-derives, and refuses. Deliberately a flat value rather than an
+ * imperative rebuild, so the policy is readable and testable on its own.
+ *
+ *   restoredFiles   the app's OWN durable files, and only those
+ *   networkTier     RE-DERIVED from policy. why never carried over: the tier
+ *                   is transient authority, and reading it back off a stored
+ *                   record is precisely "a capability survived a restart
+ *                   because it was written down" (contract guarantee 3)
+ *   blobUrls        regenerated — a blob URL is bound to a dead document and
+ *                   is meaningless in the new one
+ *   popups          NOT restored; a window is a user-visible act
+ *   downloads       NOT restored; a re-issued download is a duplicate side
+ *                   effect with no proof the first one failed
+ *   inFlightActions NOT replayed — the app's interrupted calls settle through
+ *                   the same retry-class path as anything else, never by
+ *                   optimistic replay
+ *
+ * The `tier` input is accepted for call-site symmetry and DELIBERATELY
+ * dropped: honoring it would defeat the re-derivation above.
+ *
+ * @param {Object} input
+ * @param {{ appId?: string, files?: unknown }} [input.appRecord]
+ * @param {string} [input.tier]
+ * @returns {AppSandboxRebuild}
+ */
+export const appSandboxRebuild = (input) => {
+  const appId = input?.appRecord?.appId;
+  const files = input?.appRecord?.files;
+  // why an unnamed app restores nothing: ownership of a file cannot be proven
+  // without an app id, and an unprovable file is not restored.
+  const restoredFiles = typeof appId === 'string' && appId !== '' && Array.isArray(files)
+    ? files.filter((file) => isOwnFile(file, appId))
+    : [];
+
+  return Object.freeze({
+    restoredFiles: Object.freeze(restoredFiles),
+    networkTier: /** @type {const} */ ('re-derive'),
+    blobUrls: /** @type {const} */ ('regenerate'),
+    popups: /** @type {const} */ ('not-restored'),
+    downloads: /** @type {const} */ ('not-restored'),
+    inFlightActions: /** @type {const} */ ('not-replayed'),
+  });
+};

--- a/extension/peerd-runtime/lifecycle/retry-class.js
+++ b/extension/peerd-runtime/lifecycle/retry-class.js
@@ -164,6 +164,12 @@ export const decideRecovery = (input) => {
           + '— verify before treating it as cancelled',
       });
     }
+    if (retryClass === RETRY_CLASSES.RESOURCE) {
+      return verdict({
+        state: OPERATION_STATES.CANCELLED,
+        reason: 'cancelled; any partially created resource is settled by orphan reaping',
+      });
+    }
     return verdict({
       state: OPERATION_STATES.CANCELLED,
       reason: 'cancelled; any in-flight effect is idempotent or invisible',

--- a/extension/peerd-runtime/lifecycle/retry-class.js
+++ b/extension/peerd-runtime/lifecycle/retry-class.js
@@ -1,0 +1,251 @@
+// @ts-check
+// Retry classification (Class A–F) + the recovery decision.
+//
+// Every tool and engine action carries one retry class; after an
+// interruption, `decideRecovery` is the single pure function that turns
+// (class, how far the dispatch got, any evidence, whether the user asked to
+// cancel) into the operation's terminal state and what peerd may do next.
+//
+// The two guarantees this file carries:
+//   1. a non-idempotent action (Class E) is NEVER retried automatically
+//      after peerd loses proof of its result — it lands in outcome_unknown
+//      with verification required;
+//   2. explicit user cancellation dominates concurrent recovery — a
+//      cancel-requested operation never resumes, and is only reported
+//      `cancelled` when the irreversible effect provably did not happen.
+//
+// Functional core, no IO, no clock.
+
+import {
+  OPERATION_STATES, provesCompletion, provesFailure,
+} from './operation-state.js';
+
+/**
+ * @typedef {'A' | 'B' | 'C' | 'D' | 'E' | 'F'} RetryClass
+ *
+ *   A  pure read            — retry freely; duplicates are invisible
+ *   B  costed read          — retry needs budget + a new attempt number +
+ *                             fresh (non-expired) credentials
+ *   C  idempotent write     — retry with the SAME idempotency key
+ *   D  conditionally        — verify external state (or ask the user)
+ *      idempotent action      before retrying; keep the original key
+ *   E  non-idempotent       — never auto-retry; unproven completion is
+ *      side effect            outcome_unknown
+ *   F  long-lived resource  — recreate, never continue; grants re-derived
+ */
+export const RETRY_CLASSES = Object.freeze({
+  PURE_READ: /** @type {const} */ ('A'),
+  COSTED_READ: /** @type {const} */ ('B'),
+  IDEMPOTENT_WRITE: /** @type {const} */ ('C'),
+  CONDITIONAL_ACTION: /** @type {const} */ ('D'),
+  SIDE_EFFECT: /** @type {const} */ ('E'),
+  RESOURCE: /** @type {const} */ ('F'),
+});
+
+const VALID_CLASSES = Object.freeze(new Set(Object.values(RETRY_CLASSES)));
+
+/** @param {unknown} v @returns {v is RetryClass} */
+export const isRetryClass = (v) =>
+  typeof v === 'string' && VALID_CLASSES.has(/** @type {RetryClass} */ (v));
+
+/**
+ * Coerce a stored/declared retry class. Garbage or missing → Class E:
+ * an UNCLASSIFIED action must be treated as a non-idempotent side effect,
+ * because guessing "safe to retry" is exactly the unsafe-replay failure
+ * the contract forbids. Fail closed.
+ * @param {unknown} v @returns {RetryClass}
+ */
+export const normalizeRetryClass = (v) =>
+  isRetryClass(v) ? v : RETRY_CLASSES.SIDE_EFFECT;
+
+/**
+ * What the recovery decision needs to know about how far a call got.
+ *
+ * @typedef {Object} RecoveryInput
+ * @property {unknown} retryClass          normalized via normalizeRetryClass
+ * @property {boolean} [dispatched]        the request/effect left peerd
+ * @property {{ kind?: unknown }} [evidence]  positive completion/failure
+ *                                         evidence, if any arrived
+ * @property {boolean} [cancelRequested]   the user explicitly cancelled
+ * @property {boolean} [budgetRemaining]   Class B: may a retry spend at all
+ */
+
+/**
+ * @typedef {Object} RecoveryVerdict
+ * @property {import('./operation-state.js').OperationState} state
+ * @property {boolean} autoRetry           peerd may retry with no human in
+ *                                         the loop (fresh attempt number)
+ * @property {string[]} retryRequires      preconditions for ANY retry beyond
+ *                                         autoRetry ('budget',
+ *                                         'fresh-credentials',
+ *                                         'external-verification',
+ *                                         'user-instruction', …)
+ * @property {boolean} keepIdempotencyKey  C/D: a retry MUST reuse the
+ *                                         original key, never mint a new one
+ * @property {boolean} verificationRequired  the target must be checked
+ *                                         before any repeat
+ * @property {boolean} recreateResource    F: the resource may be recreated
+ *                                         (continuation is NOT implied)
+ * @property {string} reason               human-readable; rendered in
+ *                                         lineage/audit
+ */
+
+/** @param {Partial<RecoveryVerdict> & { state: RecoveryVerdict['state'], reason: string }} v
+ *  @returns {RecoveryVerdict} */
+const verdict = (v) => ({
+  autoRetry: false,
+  retryRequires: [],
+  keepIdempotencyKey: false,
+  verificationRequired: false,
+  recreateResource: false,
+  ...v,
+});
+
+/**
+ * The recovery decision. Evidence outranks everything except its own
+ * absence; explicit cancellation outranks recovery; the retry class decides
+ * the rest.
+ *
+ * @param {RecoveryInput} input
+ * @returns {RecoveryVerdict}
+ */
+export const decideRecovery = (input) => {
+  const retryClass = normalizeRetryClass(input?.retryClass);
+  const dispatched = input?.dispatched === true;
+  const cancelRequested = input?.cancelRequested === true;
+  const kind = input?.evidence?.kind;
+
+  // Positive evidence settles the operation regardless of class or cancel:
+  // a landed effect is completed even if the user pressed Stop after the
+  // fact — reporting it cancelled would hide a real external change.
+  if (provesCompletion(kind)) {
+    return verdict({
+      state: OPERATION_STATES.COMPLETED,
+      reason: `positive completion evidence (${String(kind)})`,
+    });
+  }
+  if (provesFailure(kind)) {
+    // Proven not-to-have-happened + an explicit cancel is a clean cancel;
+    // without the cancel it is an honest failure.
+    return cancelRequested
+      ? verdict({
+        state: OPERATION_STATES.CANCELLED,
+        reason: 'cancelled; effect positively did not occur',
+      })
+      : verdict({
+        state: OPERATION_STATES.FAILED,
+        reason: `positive failure evidence (${String(kind)})`,
+      });
+  }
+
+  // No positive evidence from here on.
+
+  if (cancelRequested) {
+    if (!dispatched) {
+      // Cancel won the race outright: nothing left peerd.
+      return verdict({
+        state: OPERATION_STATES.CANCELLED,
+        reason: 'cancelled before dispatch; no external effect attempted',
+      });
+    }
+    // Dispatched, unacknowledged, cancel requested. For classes whose
+    // duplicate execution is invisible or idempotent the honest state is
+    // still `cancelled` (the effect, if it landed, is harmless to ignore or
+    // repeat). For D/E the effect may have landed and matters:
+    // outcome_unknown, with the cancel recorded in the reason.
+    if (retryClass === RETRY_CLASSES.CONDITIONAL_ACTION
+        || retryClass === RETRY_CLASSES.SIDE_EFFECT) {
+      return verdict({
+        state: OPERATION_STATES.OUTCOME_UNKNOWN,
+        verificationRequired: true,
+        keepIdempotencyKey: retryClass === RETRY_CLASSES.CONDITIONAL_ACTION,
+        retryRequires: ['external-verification', 'user-instruction'],
+        reason: 'cancel requested after dispatch; the effect may have landed '
+          + '— verify before treating it as cancelled',
+      });
+    }
+    return verdict({
+      state: OPERATION_STATES.CANCELLED,
+      reason: 'cancelled; any in-flight effect is idempotent or invisible',
+    });
+  }
+
+  switch (retryClass) {
+    case RETRY_CLASSES.PURE_READ:
+      return verdict({
+        state: OPERATION_STATES.INTERRUPTED,
+        autoRetry: true,
+        reason: 'pure read; duplicate execution has no observable effect',
+      });
+
+    case RETRY_CLASSES.COSTED_READ: {
+      const hasBudget = input?.budgetRemaining !== false;
+      return verdict({
+        state: OPERATION_STATES.INTERRUPTED,
+        autoRetry: hasBudget,
+        retryRequires: hasBudget
+          ? ['new-attempt', 'fresh-credentials']
+          : ['budget', 'new-attempt', 'fresh-credentials'],
+        reason: hasBudget
+          ? 'repeatable read; retry as a new attempt within budget'
+          : 'repeatable read; budget exhausted — retry needs user budget approval',
+      });
+    }
+
+    case RETRY_CLASSES.IDEMPOTENT_WRITE:
+      return verdict({
+        state: OPERATION_STATES.INTERRUPTED,
+        autoRetry: true,
+        keepIdempotencyKey: true,
+        reason: 'idempotent write; retry with the SAME idempotency key',
+      });
+
+    case RETRY_CLASSES.CONDITIONAL_ACTION:
+      if (!dispatched) {
+        return verdict({
+          state: OPERATION_STATES.INTERRUPTED,
+          autoRetry: true,
+          keepIdempotencyKey: true,
+          reason: 'conditionally idempotent action; never dispatched, retry '
+            + 'with the original key',
+        });
+      }
+      return verdict({
+        state: OPERATION_STATES.OUTCOME_UNKNOWN,
+        verificationRequired: true,
+        keepIdempotencyKey: true,
+        retryRequires: ['external-verification'],
+        reason: 'dispatched without acknowledgement; check the external state '
+          + '(original idempotency key retained) before retrying',
+      });
+
+    case RETRY_CLASSES.SIDE_EFFECT:
+      if (!dispatched) {
+        // Interrupted before any external change: safe, but STILL not
+        // auto-retried — Class E repeats only on explicit instruction.
+        return verdict({
+          state: OPERATION_STATES.INTERRUPTED,
+          retryRequires: ['user-instruction'],
+          reason: 'non-idempotent side effect interrupted before dispatch; '
+            + 'safe to retry on explicit instruction only',
+        });
+      }
+      return verdict({
+        state: OPERATION_STATES.OUTCOME_UNKNOWN,
+        verificationRequired: true,
+        retryRequires: ['external-verification', 'user-instruction'],
+        reason: 'non-idempotent side effect dispatched without proof of '
+          + 'result; may have completed — verify before repeating',
+      });
+
+    case RETRY_CLASSES.RESOURCE:
+    default:
+      return verdict({
+        state: OPERATION_STATES.INTERRUPTED,
+        recreateResource: true,
+        retryRequires: ['rederive-grants'],
+        reason: 'long-lived resource lost; recreate from durable records — '
+          + 'continuation is not implied and grants are re-derived',
+      });
+  }
+};

--- a/extension/peerd-runtime/lifecycle/store-registry.js
+++ b/extension/peerd-runtime/lifecycle/store-registry.js
@@ -52,6 +52,14 @@ export const DURABILITY_TIERS = Object.freeze({
  * @property {DurabilityTier} tier   §12 durability tier
  * @property {boolean} portable      may this surface cross installs?
  * @property {boolean} [deviceBound] structurally untransferable state
+ * @property {{ kvKeys?: string[], kvPrefixes?: string[], idbStores?: string[],
+ *   selfHosted?: string[] }} [physical]
+ *   where the surface's bytes actually live — the write guard
+ *   (write-guard.js) maps a read-only verdict onto these locations.
+ *   kvKeys/kvPrefixes: chrome.storage.local via the egress kv adapter;
+ *   idbStores: object stores in the `peerd` IndexedDB; selfHosted: whole
+ *   DATABASES a module opens itself, which the guard cannot reach through
+ *   the injected adapters (documented enforcement gap).
  */
 
 /**
@@ -71,31 +79,80 @@ export const DURABILITY_TIERS = Object.freeze({
 export const STORE_REGISTRY = Object.freeze([
   // Conversation state: durable across service-worker generations, but
   // its meaning dies with the session it belongs to.
-  Object.freeze({ store: 'sessions', version: 1, tier: DURABILITY_TIERS.SESSION, portable: false }),
+  Object.freeze({
+    store: 'sessions', version: 1, tier: DURABILITY_TIERS.SESSION, portable: false,
+    physical: Object.freeze({ idbStores: ['sessions', 'session_messages'] }),
+  }),
   // The encrypted blob travels; the DK does not (transfer re-encrypts the
   // plaintext secrets under a passphrase the user types at export time).
-  Object.freeze({ store: 'vault', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: true }),
-  Object.freeze({ store: 'memory', version: 1, tier: DURABILITY_TIERS.PORTABLE, portable: true }),
-  // Skill METADATA travels; bodies reinstall from their origin.
-  Object.freeze({ store: 'skills', version: 1, tier: DURABILITY_TIERS.PORTABLE, portable: true }),
-  Object.freeze({ store: 'hooks', version: 1, tier: DURABILITY_TIERS.PORTABLE, portable: true }),
+  // The session DK mirror lives in chrome.storage.session — session-tier
+  // by definition, outside the guard's remit.
+  Object.freeze({
+    store: 'vault', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: true,
+    physical: Object.freeze({ idbStores: ['vault'], kvKeys: ['vault.v1'], kvPrefixes: ['secret:'] }),
+  }),
+  Object.freeze({
+    store: 'memory', version: 1, tier: DURABILITY_TIERS.PORTABLE, portable: true,
+    physical: Object.freeze({ idbStores: ['agents_memory'], kvKeys: ['memory_suggestions.v1'] }),
+  }),
+  // Skill METADATA travels; bodies reinstall from their origin. The store
+  // opens its OWN database (peerd-skills) — unreachable through the
+  // injected adapters, so read-only enforcement is a per-module follow-up.
+  Object.freeze({
+    store: 'skills', version: 1, tier: DURABILITY_TIERS.PORTABLE, portable: true,
+    physical: Object.freeze({ selfHosted: ['peerd-skills'] }),
+  }),
+  Object.freeze({
+    store: 'hooks', version: 1, tier: DURABILITY_TIERS.PORTABLE, portable: true,
+    physical: Object.freeze({ kvKeys: ['hooks.user.v1'] }),
+  }),
   // Consent is granted to THIS install by THIS user; a transplanted grant
-  // would be consent nobody gave here, so it never travels.
-  Object.freeze({ store: 'permission-grants', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: false }),
+  // would be consent nobody gave here, so it never travels. (The durable
+  // tool_grants object store exists in the schema but nothing writes it
+  // yet — live grants are in-memory; the entry is the reserved seat.)
+  Object.freeze({
+    store: 'permission-grants', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: false,
+    physical: Object.freeze({ idbStores: ['tool_grants'], kvKeys: ['learnedOrigins.v1'] }),
+  }),
   // Append-only local record; importing one elsewhere would misattribute
   // history to a device that never did it.
-  Object.freeze({ store: 'audit', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: false }),
+  Object.freeze({
+    store: 'audit', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: false,
+    physical: Object.freeze({ idbStores: ['audit_log', 'audit_meta'] }),
+  }),
   // Rung 2 of the credential ladder: non-extractable keypair HANDLES. Not
   // "policy says no" — the platform cannot export the key material at all.
-  Object.freeze({ store: 'dpop-keys', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: false, deviceBound: true }),
+  Object.freeze({
+    store: 'dpop-keys', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: false, deviceBound: true,
+    physical: Object.freeze({ idbStores: ['dpop_keys'] }),
+  }),
   // Live instance bookkeeping (tab ids, engine handles) — valid only for
-  // the browser session that minted it.
-  Object.freeze({ store: 'engine-registries', version: 1, tier: DURABILITY_TIERS.SESSION, portable: false, deviceBound: true }),
+  // the browser session that minted it. NOTE: the `apps` blob is shared
+  // with app-manifests below — the two surfaces version independently but
+  // physically co-locate, so blocking either blocks the shared blob.
+  Object.freeze({
+    store: 'engine-registries', version: 1, tier: DURABILITY_TIERS.SESSION, portable: false, deviceBound: true,
+    physical: Object.freeze({ idbStores: ['vms', 'notebooks', 'apps'] }),
+  }),
   // Workspace METADATA outlives sessions, but it points at OPFS roots that
-  // exist only in this browser profile's origin storage.
-  Object.freeze({ store: 'opfs-workspaces', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: false, deviceBound: true }),
-  Object.freeze({ store: 'app-manifests', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: false }),
-  Object.freeze({ store: 'dweb-identity', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: false }),
+  // exist only in this browser profile's origin storage. The bytes
+  // themselves are OPFS — outside both adapters.
+  Object.freeze({
+    store: 'opfs-workspaces', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: false, deviceBound: true,
+    physical: Object.freeze({ selfHosted: ['opfs'] }),
+  }),
+  // Manifest metadata shares the `apps` blob (see engine-registries); the
+  // HTML bodies live in the self-opened peerd-app-bodies database.
+  Object.freeze({
+    store: 'app-manifests', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: false,
+    physical: Object.freeze({ idbStores: ['apps'], selfHosted: ['peerd-app-bodies'] }),
+  }),
+  // The did:key keypair is a vault secret — physically under the vault's
+  // secret: prefix, encrypted under the DK.
+  Object.freeze({
+    store: 'dweb-identity', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: false,
+    physical: Object.freeze({ kvKeys: ['secret:distributed/identity/v1', 'dweb.seededApps'] }),
+  }),
 ]);
 
 /**

--- a/extension/peerd-runtime/lifecycle/store-registry.js
+++ b/extension/peerd-runtime/lifecycle/store-registry.js
@@ -1,0 +1,223 @@
+// @ts-check
+// The durable-surface registry (contract §11.1 + §12) — WHICH stores are
+// durable, what schema version this build speaks for each, and how far
+// each one's data is allowed to travel.
+//
+// §11.1: every durable surface carries its OWN schema version. The
+// numbers here ratchet INDEPENDENTLY — bumping `sessions` says nothing
+// about `memory`, so a change to one surface never forces a lockstep
+// migration of the rest. `guardStore` (store-version.js) consumes these
+// numbers as its `supported` input; this file is the only place they are
+// declared.
+//
+// §12: durability tiers say how long a surface's data is scoped to live,
+// and `portable` says whether it may cross installs at all. Device-bound
+// state (a non-extractable key handle, an OPFS root, a tab id) is
+// STRUCTURALLY untransferable — so the export must NAME what it left
+// behind rather than silently shipping a profile that is missing it.
+//
+// Pure: values + lookups only. `checkStores`/`stampStores` take their IO
+// as an injected read/write pair; nothing here touches chrome.* storage.
+
+import { guardStore } from './store-version.js';
+
+/**
+ * §12 durability tiers.
+ *
+ * why these four: they are the four answers to "what does this data
+ * outlive?" —
+ *   EPHEMERAL  dies with the process that made it (a turn, a worker
+ *              heap, a service-worker generation); never persisted, so
+ *              never in this registry.
+ *   SESSION    outlives the process but is scoped to one conversation /
+ *              engine session; meaningless once that session is gone.
+ *   PROFILE    outlives every session, scoped to this install's profile;
+ *              the default for durable state.
+ *   PORTABLE   scoped to the USER, not the install — designed to be
+ *              carried to another peerd via export/import.
+ */
+export const DURABILITY_TIERS = Object.freeze({
+  EPHEMERAL: 'ephemeral',
+  SESSION: 'session',
+  PROFILE: 'profile',
+  PORTABLE: 'portable',
+});
+
+/** @typedef {'ephemeral' | 'session' | 'profile' | 'portable'} DurabilityTier */
+
+/**
+ * @typedef {Object} StoreEntry
+ * @property {string} store          lowercase-hyphenated surface name
+ * @property {number} version        schema version THIS build speaks
+ * @property {DurabilityTier} tier   §12 durability tier
+ * @property {boolean} portable      may this surface cross installs?
+ * @property {boolean} [deviceBound] structurally untransferable state
+ */
+
+/**
+ * The durable surfaces.
+ *
+ * why `tier` and `portable` are separate axes: tier answers "what does
+ * this outlive", portable answers "may it leave this install" — and they
+ * genuinely disagree. The vault is PROFILE-tier (the DK never leaves it)
+ * yet its secrets are portable-where-policy-permits, re-encrypted under a
+ * user passphrase by the transfer surface. A device-bound entry is never
+ * portable: no policy can make a non-extractable key handle travel.
+ *
+ * All versions start at 1 and move independently (§11.1).
+ *
+ * @type {readonly StoreEntry[]}
+ */
+export const STORE_REGISTRY = Object.freeze([
+  // Conversation state: durable across service-worker generations, but
+  // its meaning dies with the session it belongs to.
+  Object.freeze({ store: 'sessions', version: 1, tier: DURABILITY_TIERS.SESSION, portable: false }),
+  // The encrypted blob travels; the DK does not (transfer re-encrypts the
+  // plaintext secrets under a passphrase the user types at export time).
+  Object.freeze({ store: 'vault', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: true }),
+  Object.freeze({ store: 'memory', version: 1, tier: DURABILITY_TIERS.PORTABLE, portable: true }),
+  // Skill METADATA travels; bodies reinstall from their origin.
+  Object.freeze({ store: 'skills', version: 1, tier: DURABILITY_TIERS.PORTABLE, portable: true }),
+  Object.freeze({ store: 'hooks', version: 1, tier: DURABILITY_TIERS.PORTABLE, portable: true }),
+  // Consent is granted to THIS install by THIS user; a transplanted grant
+  // would be consent nobody gave here, so it never travels.
+  Object.freeze({ store: 'permission-grants', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: false }),
+  // Append-only local record; importing one elsewhere would misattribute
+  // history to a device that never did it.
+  Object.freeze({ store: 'audit', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: false }),
+  // Rung 2 of the credential ladder: non-extractable keypair HANDLES. Not
+  // "policy says no" — the platform cannot export the key material at all.
+  Object.freeze({ store: 'dpop-keys', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: false, deviceBound: true }),
+  // Live instance bookkeeping (tab ids, engine handles) — valid only for
+  // the browser session that minted it.
+  Object.freeze({ store: 'engine-registries', version: 1, tier: DURABILITY_TIERS.SESSION, portable: false, deviceBound: true }),
+  // Workspace METADATA outlives sessions, but it points at OPFS roots that
+  // exist only in this browser profile's origin storage.
+  Object.freeze({ store: 'opfs-workspaces', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: false, deviceBound: true }),
+  Object.freeze({ store: 'app-manifests', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: false }),
+  Object.freeze({ store: 'dweb-identity', version: 1, tier: DURABILITY_TIERS.PROFILE, portable: false }),
+]);
+
+/**
+ * The single kv key the service-worker adapter stores the stamps under.
+ *
+ * Shape: a `{ [store]: number }` map — one record holding every surface's
+ * stamped version, absent entirely until the first `stampStores` run.
+ *
+ * why the WHOLE map through one key (and why `read`/`write` below take no
+ * store name): stamping is a cross-surface decision made once at startup,
+ * and a single read/write keeps it atomic — a per-store key layout would
+ * let a crash land a half-stamped profile, which is exactly the state
+ * §11's guard cannot tell apart from a genuine version skew.
+ */
+export const VERSION_STAMP_KEY = 'peerd.lifecycle.storeVersions';
+
+/**
+ * Look a surface up by name.
+ *
+ * @param {string} name
+ * @returns {StoreEntry | undefined}
+ */
+export const storeEntry = (name) => STORE_REGISTRY.find((entry) => entry.store === name);
+
+/** @returns {readonly StoreEntry[]} surfaces an export may carry */
+export const portableStores = () => STORE_REGISTRY.filter((entry) => entry.portable);
+
+/**
+ * The §12 disclosure list: names of the surfaces an export STRUCTURALLY
+ * cannot carry. The export format must identify these — a profile that
+ * silently arrives without its device-bound state looks corrupt, not
+ * incomplete.
+ *
+ * @returns {string[]}
+ */
+export const omittedDeviceBoundStores = () =>
+  STORE_REGISTRY.filter((entry) => entry.deviceBound).map((entry) => entry.store);
+
+/**
+ * @typedef {Object} StoreCheck
+ * @property {string} store
+ * @property {unknown} stamped        the version found on disk (undefined = never stamped)
+ * @property {'read-write' | 'migrate' | 'read-only'} mode
+ * @property {import('./store-version.js').VersionClass} versionClass
+ * @property {string} reason
+ * @property {string} [diagnosticId]
+ * @property {true} [firstRun]        unstamped: a fresh profile, about to be stamped
+ */
+
+/**
+ * Classify every registered surface against the stamps on disk.
+ *
+ * An UNSTAMPED store is a fresh profile, not a skew: it is classified as
+ * current (nothing has been written under an older schema yet) and marked
+ * `firstRun` so the caller can tell "brand new" from "verified current" —
+ * only the former should be stamped without a migration having run.
+ *
+ * @param {Object} io
+ * @param {() => Promise<Record<string, number> | undefined>} io.read  the whole stamp map
+ * @returns {Promise<{ ok: boolean, stores: StoreCheck[] }>}
+ */
+export const checkStores = async ({ read }) => {
+  const stamps = (await read()) ?? {};
+  const stores = STORE_REGISTRY.map((entry) => {
+    const stamped = stamps[entry.store];
+    const firstRun = stamped === undefined;
+    const guard = guardStore({
+      store: entry.store,
+      found: firstRun ? entry.version : stamped,
+      supported: entry.version,
+    });
+    return /** @type {StoreCheck} */ ({
+      store: entry.store,
+      stamped,
+      ...guard,
+      ...(firstRun ? { firstRun: true } : {}),
+    });
+  });
+  // why mode !== 'read-only' is the bar: 'migrate' is a healthy startup
+  // (the migration driver runs and stamps after), 'read-only' is the
+  // §11.5 refusal — newer, unsupported, or malformed — and any single one
+  // of those means this build must not mutate the profile.
+  return { ok: stores.every((check) => check.mode !== 'read-only'), stores };
+};
+
+/**
+ * Stamp this build's versions for every surface that is unstamped or
+ * already current.
+ *
+ * The two refusals are the whole point:
+ *   - a NEWER stamp is never lowered — that is the §11.5 downgrade
+ *     refusal; overwriting it would tell the next (newer) build that its
+ *     own data is old and invite a destructive "migration".
+ *   - an OLDER stamp is never raised — stamping is a migration's final
+ *     act, and only after it succeeded. Raising it here would declare
+ *     data migrated that nobody migrated.
+ * A malformed stamp is left alone for the same reason: unclassifiable
+ * data is retained for diagnosis, never clobbered.
+ *
+ * @param {Object} io
+ * @param {() => Promise<Record<string, number> | undefined>} io.read
+ * @param {(map: Record<string, number>) => Promise<void>} io.write
+ * @returns {Promise<string[]>} names now stamped at this build's version
+ */
+export const stampStores = async ({ read, write }) => {
+  const stamps = (await read()) ?? {};
+  /** @type {Record<string, number>} */
+  const next = { ...stamps };
+  /** @type {string[]} */
+  const stamped = [];
+  let changed = false;
+  for (const entry of STORE_REGISTRY) {
+    const found = stamps[entry.store];
+    if (found !== undefined && found !== entry.version) continue;
+    if (found === undefined) {
+      next[entry.store] = entry.version;
+      changed = true;
+    }
+    stamped.push(entry.store);
+  }
+  // why only on change: a rerun of an already-stamped profile is a no-op
+  // write that would still wake every storage listener.
+  if (changed) await write(next);
+  return stamped;
+};

--- a/extension/peerd-runtime/lifecycle/store-version.js
+++ b/extension/peerd-runtime/lifecycle/store-version.js
@@ -1,0 +1,215 @@
+// @ts-check
+// Versioned durable stores — the migration/downgrade guard (contract §11).
+//
+// Each durable surface carries its OWN schema version. This module is the
+// pure decision + the pure migration driver:
+//   - classify a found version against what this build supports;
+//   - refuse-newer fails READ-ONLY (never reinterpret as empty or corrupt);
+//   - migration is forward-only, restart-safe (checkpointed per step),
+//     idempotent on rerun, version-stamped only after success;
+//   - a step that silently drops fields it did not declare fails the run;
+//   - failure preserves the original data byte-for-byte and surfaces a
+//     deterministic diagnostic identifier — never an empty replacement.
+//
+// Pure: steps are injected functions; no IO, no clock.
+
+export class StoreVersionError extends Error {
+  /** @param {string} message @param {string} diagnosticId */
+  constructor(message, diagnosticId) {
+    super(message);
+    this.name = 'StoreVersionError';
+    this.diagnosticId = diagnosticId;
+  }
+}
+
+/**
+ * @typedef {'current' | 'migratable' | 'newer' | 'unsupported' | 'malformed'}
+ *   VersionClass
+ */
+
+/**
+ * Classify a store's found schema version.
+ *
+ * @param {Object} input
+ * @param {unknown} input.found        version stamped on the stored data
+ * @param {number} input.supported     the version this build reads/writes
+ * @param {number} [input.oldestMigratable]  floor we still migrate from
+ *                                     (defaults to every version <= supported)
+ * @returns {VersionClass}
+ */
+export const classifyStoreVersion = ({ found, supported, oldestMigratable }) => {
+  if (typeof found !== 'number' || !Number.isInteger(found) || found < 0) {
+    return 'malformed';
+  }
+  if (found === supported) return 'current';
+  if (found > supported) return 'newer';
+  const floor = typeof oldestMigratable === 'number' ? oldestMigratable : 0;
+  return found >= floor ? 'migratable' : 'unsupported';
+};
+
+/**
+ * Turn a classification into an access mode. The downgrade contract
+ * (§11.5) lands here: a newer schema is REFUSED for mutation but never
+ * reinterpreted — 'read-only' with an unsupported-newer-profile reason,
+ * data untouched. Unsupported-old and malformed stores fail closed the
+ * same way (original retained, diagnostic id exposed).
+ *
+ * @param {Object} input
+ * @param {string} input.store   store name (diagnostics only)
+ * @param {unknown} input.found
+ * @param {number} input.supported
+ * @param {number} [input.oldestMigratable]
+ * @returns {{ mode: 'read-write' | 'migrate' | 'read-only',
+ *   versionClass: VersionClass, reason: string, diagnosticId?: string }}
+ */
+export const guardStore = ({ store, found, supported, oldestMigratable }) => {
+  const versionClass = classifyStoreVersion({ found, supported, oldestMigratable });
+  switch (versionClass) {
+    case 'current':
+      return { mode: 'read-write', versionClass, reason: 'schema current' };
+    case 'migratable':
+      return { mode: 'migrate', versionClass, reason: `schema v${String(found)} migrates to v${supported}` };
+    case 'newer':
+      return {
+        mode: 'read-only',
+        versionClass,
+        reason: `profile schema v${String(found)} is newer than this peerd supports (v${supported}); `
+          + 'refusing to mutate — upgrade peerd or restore a compatible backup',
+        diagnosticId: `store-${store}-newer-v${String(found)}`,
+      };
+    case 'unsupported':
+      return {
+        mode: 'read-only',
+        versionClass,
+        reason: `schema v${String(found)} predates the oldest supported migration source`,
+        diagnosticId: `store-${store}-unsupported-v${String(found)}`,
+      };
+    case 'malformed':
+    default:
+      return {
+        mode: 'read-only',
+        versionClass,
+        reason: 'schema version missing or malformed; original data retained for diagnosis',
+        diagnosticId: `store-${store}-malformed-version`,
+      };
+  }
+};
+
+/**
+ * @typedef {Object} MigrationStep
+ * @property {number} from
+ * @property {number} to             must be > from (forward-only)
+ * @property {(data: Record<string, unknown>) => Record<string, unknown>} migrate
+ * @property {string[]} [drops]      top-level keys this step is ALLOWED to
+ *                                   remove; any other disappearance fails
+ */
+
+/**
+ * @typedef {{ ok: true, data: Record<string, unknown>, version: number,
+ *   completedSteps: number[] }
+ * | { ok: false, diagnosticId: string, failedStep: { from: number, to: number } | null,
+ *   data: unknown, version: unknown, resumeFrom: number, reason: string }}
+ *   MigrationResult
+ */
+
+/**
+ * Run a store's migration chain. Restart-safe: `checkpointVersion` is the
+ * last version a previous (possibly interrupted) run durably reached —
+ * steps at or below it are skipped, which is also what makes a full rerun
+ * idempotent. On ANY failure the ORIGINAL input data is returned
+ * untouched with a deterministic diagnostic id; the caller must not stamp
+ * a version or replace the store.
+ *
+ * @param {Object} input
+ * @param {string} input.store            store name (diagnostics)
+ * @param {unknown} input.data            the stored payload
+ * @param {unknown} input.fromVersion     version stamped on the payload
+ * @param {number} input.toVersion        target (this build's supported)
+ * @param {MigrationStep[]} input.steps
+ * @param {number} [input.checkpointVersion]  durable resume cursor
+ * @returns {MigrationResult}
+ */
+export const runMigration = ({ store, data, fromVersion, toVersion, steps, checkpointVersion }) => {
+  /** @param {string} suffix @param {string} reason
+   *  @param {{ from: number, to: number } | null} [failedStep]
+   *  @returns {MigrationResult} */
+  const fail = (suffix, reason, failedStep = null) => ({
+    ok: false,
+    diagnosticId: `migrate-${store}-${suffix}`,
+    failedStep,
+    data,               // the original, untouched
+    version: fromVersion,
+    resumeFrom: typeof checkpointVersion === 'number'
+      ? Math.max(checkpointVersion, typeof fromVersion === 'number' ? fromVersion : 0)
+      : (typeof fromVersion === 'number' ? fromVersion : 0),
+    reason,
+  });
+
+  if (typeof fromVersion !== 'number' || !Number.isInteger(fromVersion)) {
+    return fail('malformed-version', 'stored version is not an integer');
+  }
+  if (fromVersion > toVersion) {
+    return fail(`downgrade-v${fromVersion}`, 'downgrade migration refused; store is newer than target');
+  }
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    return fail('malformed-data', 'stored payload is not a record; retained for diagnosis');
+  }
+
+  const start = Math.max(fromVersion,
+    typeof checkpointVersion === 'number' ? checkpointVersion : fromVersion);
+
+  // Order and validate the chain before touching data: forward-only,
+  // contiguous from `start` to `toVersion`.
+  const chain = (Array.isArray(steps) ? [...steps] : [])
+    .filter((step) => step && step.to > start && step.from >= fromVersion)
+    .sort((a, b) => a.from - b.from);
+  for (const step of chain) {
+    if (step.to <= step.from) {
+      return fail(`backward-step-${step.from}`, 'migration steps must be forward-only');
+    }
+  }
+
+  let current = /** @type {Record<string, unknown>} */ ({ ...data });
+  let version = start;
+  /** @type {number[]} */ const completedSteps = [];
+
+  for (const step of chain) {
+    if (step.from !== version) {
+      return fail(`gap-at-v${version}`, `no migration step from v${version}`);
+    }
+    const before = current;
+    let after;
+    try {
+      after = step.migrate({ ...before });
+    } catch (error) {
+      return fail(`step-v${step.from}-threw`,
+        `migration step v${step.from}->v${step.to} threw: ${error instanceof Error ? error.message : String(error)}`,
+        { from: step.from, to: step.to });
+    }
+    if (after === null || typeof after !== 'object' || Array.isArray(after)) {
+      return fail(`step-v${step.from}-shape`,
+        `migration step v${step.from}->v${step.to} did not return a record`,
+        { from: step.from, to: step.to });
+    }
+    // Unknown-field guard: a step may only remove keys it declared. This is
+    // what makes "silently discard unknown fields" structurally impossible
+    // rather than a review convention.
+    const allowedDrops = new Set(step.drops ?? []);
+    for (const key of Object.keys(before)) {
+      if (!Object.hasOwn(after, key) && !allowedDrops.has(key)) {
+        return fail(`step-v${step.from}-dropped-${key}`,
+          `migration step v${step.from}->v${step.to} dropped undeclared field "${key}"`,
+          { from: step.from, to: step.to });
+      }
+    }
+    current = /** @type {Record<string, unknown>} */ (after);
+    version = step.to;
+    completedSteps.push(step.to);
+  }
+
+  if (version !== toVersion) {
+    return fail(`incomplete-at-v${version}`, `migration chain ends at v${version}, target v${toVersion}`);
+  }
+
+  return { ok: true, data: current, version, completedSteps };
+};

--- a/extension/peerd-runtime/lifecycle/store-version.js
+++ b/extension/peerd-runtime/lifecycle/store-version.js
@@ -13,15 +13,6 @@
 //
 // Pure: steps are injected functions; no IO, no clock.
 
-export class StoreVersionError extends Error {
-  /** @param {string} message @param {string} diagnosticId */
-  constructor(message, diagnosticId) {
-    super(message);
-    this.name = 'StoreVersionError';
-    this.diagnosticId = diagnosticId;
-  }
-}
-
 /**
  * @typedef {'current' | 'migratable' | 'newer' | 'unsupported' | 'malformed'}
  *   VersionClass
@@ -139,8 +130,9 @@ export const runMigration = ({ store, data, fromVersion, toVersion, steps, check
     failedStep,
     data,               // the original, untouched
     version: fromVersion,
-    resumeFrom: typeof checkpointVersion === 'number'
-      ? Math.max(checkpointVersion, typeof fromVersion === 'number' ? fromVersion : 0)
+    resumeFrom: Number.isInteger(checkpointVersion)
+      ? Math.max(/** @type {number} */ (checkpointVersion),
+        typeof fromVersion === 'number' ? fromVersion : 0)
       : (typeof fromVersion === 'number' ? fromVersion : 0),
     reason,
   });
@@ -154,9 +146,15 @@ export const runMigration = ({ store, data, fromVersion, toVersion, steps, check
   if (data === null || typeof data !== 'object' || Array.isArray(data)) {
     return fail('malformed-data', 'stored payload is not a record; retained for diagnosis');
   }
+  // A malformed checkpoint fails closed rather than being coerced: treating
+  // it as absent would RE-RUN steps against already-migrated data, and NaN
+  // arithmetic would corrupt the resume cursor.
+  if (checkpointVersion !== undefined
+      && (typeof checkpointVersion !== 'number' || !Number.isInteger(checkpointVersion))) {
+    return fail('malformed-checkpoint', 'checkpoint cursor is not an integer; retained for diagnosis');
+  }
 
-  const start = Math.max(fromVersion,
-    typeof checkpointVersion === 'number' ? checkpointVersion : fromVersion);
+  const start = Math.max(fromVersion, checkpointVersion ?? fromVersion);
 
   // Order and validate the chain before touching data: forward-only,
   // contiguous from `start` to `toVersion`.
@@ -169,7 +167,11 @@ export const runMigration = ({ store, data, fromVersion, toVersion, steps, check
     }
   }
 
-  let current = /** @type {Record<string, unknown>} */ ({ ...data });
+  // Deep-cloned at entry: steps receive an isolated copy, so a step that
+  // mutates a NESTED object cannot reach back into the caller's original —
+  // "failure preserves the original data" has to hold at every depth, not
+  // just the top level.
+  let current = /** @type {Record<string, unknown>} */ (structuredClone(data));
   let version = start;
   /** @type {number[]} */ const completedSteps = [];
 
@@ -191,12 +193,17 @@ export const runMigration = ({ store, data, fromVersion, toVersion, steps, check
         `migration step v${step.from}->v${step.to} did not return a record`,
         { from: step.from, to: step.to });
     }
-    // Unknown-field guard: a step may only remove keys it declared. This is
-    // what makes "silently discard unknown fields" structurally impossible
+    // Unknown-field guard: a step may only remove keys it declared. A key
+    // set to `undefined` counts as dropped too — undefined does not survive
+    // structured-clone/JSON persistence, so `{ ...d, field: undefined }`
+    // would be a silent discard the moment it hits storage. This is what
+    // makes "silently discard unknown fields" structurally impossible
     // rather than a review convention.
     const allowedDrops = new Set(step.drops ?? []);
     for (const key of Object.keys(before)) {
-      if (!Object.hasOwn(after, key) && !allowedDrops.has(key)) {
+      const removed = !Object.hasOwn(after, key)
+        || (after[key] === undefined && before[key] !== undefined);
+      if (removed && !allowedDrops.has(key)) {
         return fail(`step-v${step.from}-dropped-${key}`,
           `migration step v${step.from}->v${step.to} dropped undeclared field "${key}"`,
           { from: step.from, to: step.to });

--- a/extension/peerd-runtime/lifecycle/tool-retry-class.js
+++ b/extension/peerd-runtime/lifecycle/tool-retry-class.js
@@ -1,0 +1,179 @@
+// @ts-check
+// Tool → retry class. The lifecycle contract's §16.1 obligation — "every
+// side-effecting tool has a retry classification" — realized as ONE pure
+// function over a tool DESCRIPTOR.
+//
+// why a descriptor and not the tool objects themselves: importing
+// BUILTIN_TOOLS here would drag every def's chrome.* / engine-client import
+// graph into a module that must stay pure, IO-free and browser-free
+// (functional core, imperative shell). The classifier reads only
+// { name, sideEffect, primitive, retryClass } — the shape every tool already
+// declares in /shared/tool-types.js — so the dispatcher can classify a
+// registered tool and a Bun test can classify the entire live inventory
+// without a browser.
+//
+// The decision order, and why it is that order:
+//   1. an explicit, VALID `tool.retryClass`. A def may state its own class.
+//      An INVALID one is IGNORED and falls through to derivation — silently
+//      accepting garbage that looked authoritative is the worst outcome
+//      available here, because it would license a replay nobody sanctioned.
+//   2. `destructive` → Class E, unconditionally. The one declaration no name
+//      override may soften: an irreversible delete is never auto-repeated.
+//   3. the by-NAME override table below — the knowledge the (sideEffect,
+//      primitive) pair structurally cannot carry: a `read` that costs a
+//      network round trip, a "workspace write" whose payload is arbitrary
+//      code, a call that BOOTS something outliving it.
+//   4. the declared taxonomy, failing CLOSED. Anything the rules do not
+//      positively recognize as safe is Class E — the same posture
+//      normalizeRetryClass takes for a missing class, for the same reason:
+//      guessing "safe to retry" is the unsafe-replay failure the contract
+//      forbids.
+
+import { RETRY_CLASSES, isRetryClass } from './retry-class.js';
+
+/** @typedef {import('./retry-class.js').RetryClass} RetryClass */
+
+/**
+ * The classifier's whole input surface — a structural subset of
+ * /shared/tool-types.js `Tool`, plus the optional self-declaration.
+ *
+ * @typedef {Object} ToolDescriptor
+ * @property {string} [name]
+ * @property {string} [sideEffect]   'read' | 'write' | 'mutate_external' | 'destructive'
+ * @property {string} [primitive]    tab | web | webvm | notebook | app | engine | dweb | …
+ * @property {unknown} [retryClass]  an explicit declaration; validated, never trusted
+ */
+
+// Primitives whose WRITES land in the agent's own sandbox (WebVM disk,
+// Notebook OPFS, App bodies, the cross-kind engine create) or the dweb node's
+// own local state — not on the user's live web session.
+//
+// why the set is duplicated instead of imported: this is the same taxonomy
+// permissions/policy.js draws for WORKSPACE_PRIMITIVES (that one is
+// module-private there), and the two answer different questions from it —
+// policy asks "must the user confirm", this asks "is a repeat harmless". They
+// are deliberately read twice from one shared vocabulary; if the list moves,
+// both sites move together.
+const WORKSPACE_PRIMITIVES = Object.freeze(
+  new Set(['webvm', 'notebook', 'app', 'engine', 'dweb']),
+);
+
+/**
+ * The explicit by-name inventory. Everything here is a case the declared
+ * (sideEffect, primitive) pair gets WRONG — kept in one frozen table so the
+ * exceptions are countable and reviewable rather than scattered through
+ * branches.
+ *
+ * @type {Readonly<Record<string, RetryClass>>}
+ */
+export const RETRY_CLASS_OVERRIDES = Object.freeze(
+  /** @type {Record<string, RetryClass>} */ ({
+    // --- Class B · repeatable reads that COST something outside peerd -------
+    // why: a `read` that crosses the network still has no observable effect on
+    // the far side, so repeating it is safe — but a repeat spends bandwidth, a
+    // rate-limit budget, and possibly a credential that has since expired.
+    // That is exactly what Class B's "new attempt + fresh credentials (+
+    // budget)" preconditions exist for. A LOCAL read (inspect, a page already
+    // in the tab, a cache, a stored record) has none of that cost and stays A.
+    fetch_url: 'B',
+    read_pdf: 'B',
+    read_doc: 'B',
+    // why: site_client_run reads at the tool boundary but EXECUTES the stored
+    // client, whose every op is an origin-pinned fetch — requests on the wire,
+    // carried by the user's live session.
+    site_client_run: 'B',
+    // why: dweb_discover queries peers and the DHT over the mesh. Nothing is
+    // published, but the round trip is remote work on other people's nodes.
+    dweb_discover: 'B',
+
+    // --- Class D · conditionally idempotent external mutations --------------
+    // why: dweb_share publishes a CONTENT-ADDRESSED signed bundle, so
+    // republishing the same app converges on the same hash/URI instead of
+    // duplicating it — the repeat is safe ONCE the external state is checked
+    // (did the announce/DHT store actually land?). "Verify, then reuse the
+    // original key" is Class D precisely; it is not the blind-safe Class C.
+    dweb_share: 'D',
+
+    // --- Class E · declared writes that are NOT idempotent ------------------
+    // why: js_notebook and script sit on workspace primitives, so the taxonomy
+    // below would call them local Class C writes — but their payload is
+    // ARBITRARY CODE (permissions/policy.js draws the same line with
+    // SHELL_TOOLS). A half-run eval may already have written files or made a
+    // request, and `script` additionally holds egress and delegation. Silently
+    // re-running one is the textbook unsafe replay.
+    js_notebook: 'E',
+    script: 'E',
+    // why: a2a_run's `dweb` primitive reads as workspace-local, but the mesh
+    // bridge SENDS signed messages to other agents — the effect lands in a
+    // peer's inbox, on another machine, and a duplicate cannot be recalled.
+    a2a_run: 'E',
+
+    // --- Class F · long-lived resources: recreate, never continue -----------
+    // why: each of these BOOTS or CREATES something that outlives the call — a
+    // sandbox, a Linux VM, a child agent session. After an interruption the
+    // handle is dangling and its grants are stale, so the contract's answer is
+    // to recreate from durable records with grants re-derived. Auto-retrying
+    // them as ordinary writes would instead mint a SECOND orphan.
+    sandbox_create: 'F',
+    vm_boot: 'F',
+    actor_create: 'F',
+    // why: request_review declares `read` (the reviewer is read-only and
+    // cannot edit), but it SPAWNS a second agent session. The resource — not
+    // the read — is what recovery has to reason about.
+    request_review: 'F',
+  }),
+);
+
+/**
+ * Classify a tool for recovery. Pure: same descriptor in, same class out; no
+ * IO, no clock, no registry lookup.
+ *
+ * @param {ToolDescriptor | null | undefined} tool
+ * @returns {RetryClass}
+ */
+export const retryClassForTool = (tool) => {
+  // 1. A def's own declaration wins — but only when it is a real class.
+  // An invalid one falls through to derivation rather than being coerced,
+  // so a typo degrades to the honest taxonomy instead of to a lie.
+  const declared = tool?.retryClass;
+  if (isRetryClass(declared)) return declared;
+
+  const sideEffect = tool?.sideEffect;
+
+  // 2. Irreversible by declaration. No name override, no primitive, and no
+  // convenience softens a delete: unproven completion must land in
+  // outcome_unknown, never in an automatic second attempt.
+  if (sideEffect === 'destructive') return RETRY_CLASSES.SIDE_EFFECT;
+
+  // 3. The explicit inventory — what the declaration cannot express.
+  const name = tool?.name;
+  if (typeof name === 'string' && Object.hasOwn(RETRY_CLASS_OVERRIDES, name)) {
+    return RETRY_CLASS_OVERRIDES[name];
+  }
+
+  // 4. Derivation from the declared taxonomy.
+
+  // A read the table did not name touches nothing outside peerd: an
+  // introspection call, a page already loaded in a tab it owns, a cache, a
+  // stored record. Duplicates are invisible.
+  if (sideEffect === 'read') return RETRY_CLASSES.PURE_READ;
+
+  if (sideEffect === 'write') {
+    // A write to the agent's OWN sandbox is deterministic and re-appliable:
+    // same path, same bytes, same resulting state, so a retry under the
+    // ORIGINAL idempotency key converges (Class C). A write to a `tab` is
+    // not — a click on a live page is a click, twice clicked is twice, and
+    // the page has moved on underneath the selector. Every other primitive
+    // (web / spawned / memory / schedule / time) is unproven in either
+    // direction, so it fails closed alongside `tab`.
+    return WORKSPACE_PRIMITIVES.has(tool?.primitive ?? '')
+      ? RETRY_CLASSES.IDEMPOTENT_WRITE
+      : RETRY_CLASSES.SIDE_EFFECT;
+  }
+
+  // `mutate_external` (form submits, downloads, cross-origin writes, tab
+  // opens, installs) and anything unrecognized land here. Class E is the
+  // floor of the whole function: an unclassified action is a non-idempotent
+  // side effect until someone proves otherwise, in this table, by name.
+  return RETRY_CLASSES.SIDE_EFFECT;
+};

--- a/extension/peerd-runtime/lifecycle/write-guard.js
+++ b/extension/peerd-runtime/lifecycle/write-guard.js
@@ -39,6 +39,10 @@ export const makeWriteGuard = () => {
   /** @type {Map<string, string>} idb object store → store */
   const blockedIdbStores = new Map();
 
+  /** @type {Set<string>} every blocked registry store, by NAME — the
+   *  assertWritable gate for self-hosted stores keys on this. */
+  const blockedNames = new Set();
+
   /**
    * Block the named registry stores. Unknown names are ignored (the check
    * that produced them is the authority); calling again is additive.
@@ -47,6 +51,8 @@ export const makeWriteGuard = () => {
   const block = (storeNames) => {
     for (const name of Array.isArray(storeNames) ? storeNames : []) {
       const entry = STORE_REGISTRY.find((s) => s.store === name);
+      if (!entry) continue; // unknown names are ignored — the check is the authority
+      blockedNames.add(name);
       const physical = /** @type {{ kvKeys?: string[], kvPrefixes?: string[],
         idbStores?: string[] } | undefined} */ (
         /** @type {any} */ (entry)?.physical);
@@ -127,11 +133,19 @@ export const makeWriteGuard = () => {
     },
   });
 
-  const blockedStores = () => [...new Set([
-    ...blockedKvKeys.values(),
-    ...blockedKvPrefixes.map(([, s]) => s),
-    ...blockedIdbStores.values(),
-  ])];
+  const blockedStores = () => [...blockedNames];
 
-  return { block, wrapKv, wrapIdb, wrapIdbKvAdapter, blockedStores };
+  /**
+   * The gate for SELF-HOSTED stores (own databases the adapters can't
+   * reach — skills, app bodies): injected into those stores' mutators so
+   * the same schema verdict refuses their writes too. Throws when blocked.
+   * @param {string} storeName
+   */
+  const assertWritable = (storeName) => {
+    if (blockedNames.has(storeName)) {
+      throw new StoreReadOnlyError(storeName, `self-hosted:${storeName}`);
+    }
+  };
+
+  return { block, wrapKv, wrapIdb, wrapIdbKvAdapter, blockedStores, assertWritable };
 };

--- a/extension/peerd-runtime/lifecycle/write-guard.js
+++ b/extension/peerd-runtime/lifecycle/write-guard.js
@@ -1,0 +1,137 @@
+// @ts-check
+// The store write guard — §11.5's "refuse to mutate" made universal.
+//
+// checkStores can mark a durable surface read-only (a NEWER schema stamp
+// than this build supports). Detection alone is a log line; this module is
+// the enforcement: the SW wraps its kv and idb adapters through the guard
+// ONCE at construction, and every store built on those adapters — sessions,
+// vault, memory, hooks, audit, dpop, engine registries — inherits the
+// refusal with zero per-store wiring. The blocked set starts empty (all
+// writes allowed) and is filled from the §11.1 check at boot; reads always
+// pass (read-only means READABLE).
+//
+// Physical mapping lives on STORE_REGISTRY entries (store-registry.js
+// `physical`): registry store name → kv keys/prefixes + idb object stores.
+// Two surfaces open their OWN IndexedDB databases and cannot be guarded
+// through the injected adapters — skills (peerd-skills) and App bodies
+// (peerd-app-bodies); the registry marks them selfHosted and their
+// enforcement rides those modules (documented gap, THREAT-MODEL follow-up).
+//
+// Pure factory; the wrappers close over the mutable blocked set.
+
+import { STORE_REGISTRY } from './store-registry.js';
+
+export class StoreReadOnlyError extends Error {
+  /** @param {string} store @param {string} target */
+  constructor(store, target) {
+    super(`store '${store}' is read-only (newer schema than this peerd supports); `
+      + `refusing write to ${target}. Upgrade peerd or restore a compatible backup — no data was changed.`);
+    this.name = 'StoreReadOnlyError';
+    this.store = store;
+  }
+}
+
+export const makeWriteGuard = () => {
+  /** @type {Map<string, string>} kv exact key → store */
+  const blockedKvKeys = new Map();
+  /** @type {Array<[string, string]>} kv key prefix → store */
+  let blockedKvPrefixes = [];
+  /** @type {Map<string, string>} idb object store → store */
+  const blockedIdbStores = new Map();
+
+  /**
+   * Block the named registry stores. Unknown names are ignored (the check
+   * that produced them is the authority); calling again is additive.
+   * @param {string[]} storeNames
+   */
+  const block = (storeNames) => {
+    for (const name of Array.isArray(storeNames) ? storeNames : []) {
+      const entry = STORE_REGISTRY.find((s) => s.store === name);
+      const physical = /** @type {{ kvKeys?: string[], kvPrefixes?: string[],
+        idbStores?: string[] } | undefined} */ (
+        /** @type {any} */ (entry)?.physical);
+      if (!physical) continue;
+      for (const key of physical.kvKeys ?? []) blockedKvKeys.set(key, name);
+      blockedKvPrefixes = blockedKvPrefixes.concat(
+        (physical.kvPrefixes ?? []).map((p) => /** @type {[string, string]} */ ([p, name])));
+      for (const os of physical.idbStores ?? []) blockedIdbStores.set(os, name);
+    }
+  };
+
+  /** @param {string} key @returns {string | undefined} blocking store name */
+  const kvBlockedBy = (key) => {
+    const exact = blockedKvKeys.get(key);
+    if (exact) return exact;
+    const prefix = blockedKvPrefixes.find(([p]) => key.startsWith(p));
+    return prefix?.[1];
+  };
+
+  /**
+   * Wrap the chrome.storage.local kv adapter. set/delete refuse for blocked
+   * targets; get/list/clear pass through (clear is the user's own explicit
+   * reset surface, not a store mutation this guard arbitrates).
+   * @template {{ set: Function, delete?: Function }} KV
+   * @param {KV} kv @returns {KV}
+   */
+  const wrapKv = (kv) => /** @type {KV} */ ({
+    ...kv,
+    set: (/** @type {string} */ key, /** @type {unknown} */ value) => {
+      const store = kvBlockedBy(key);
+      if (store) throw new StoreReadOnlyError(store, `kv:${key}`);
+      return kv.set(key, value);
+    },
+    ...(typeof kv.delete === 'function' ? {
+      delete: (/** @type {string} */ key) => {
+        const store = kvBlockedBy(key);
+        if (store) throw new StoreReadOnlyError(store, `kv:${key}`);
+        return /** @type {Function} */ (kv.delete)(key);
+      },
+    } : {}),
+  });
+
+  // The idb namespace's write verbs, all (storeName, ...) shaped.
+  const IDB_WRITE_VERBS = Object.freeze(['put', 'del', 'clear', 'delUpTo', 'write']);
+
+  /**
+   * Wrap the idb module namespace (or any object exposing the same
+   * (store, ...) verbs). Write verbs refuse for blocked object stores.
+   * @template {Record<string, any>} IDB
+   * @param {IDB} idb @returns {IDB}
+   */
+  const wrapIdb = (idb) => {
+    /** @type {Record<string, any>} */
+    const wrapped = { ...idb };
+    for (const verb of IDB_WRITE_VERBS) {
+      const original = idb[verb];
+      if (typeof original !== 'function') continue;
+      wrapped[verb] = (/** @type {string} */ objectStore, /** @type {any[]} */ ...rest) => {
+        const store = blockedIdbStores.get(objectStore);
+        if (store) throw new StoreReadOnlyError(store, `idb:${objectStore}`);
+        return original(objectStore, ...rest);
+      };
+    }
+    return /** @type {IDB} */ (wrapped);
+  };
+
+  /**
+   * Wrap an idbKV single-blob adapter for a given object store.
+   * @param {string} objectStore
+   * @param {{ get: (key: string) => Promise<any>, set: (key: string, value: any) => Promise<void> }} adapter
+   */
+  const wrapIdbKvAdapter = (objectStore, adapter) => ({
+    ...adapter,
+    set: (/** @type {string} */ key, /** @type {unknown} */ value) => {
+      const store = blockedIdbStores.get(objectStore);
+      if (store) throw new StoreReadOnlyError(store, `idb:${objectStore}/${key}`);
+      return adapter.set(key, value);
+    },
+  });
+
+  const blockedStores = () => [...new Set([
+    ...blockedKvKeys.values(),
+    ...blockedKvPrefixes.map(([, s]) => s),
+    ...blockedIdbStores.values(),
+  ])];
+
+  return { block, wrapKv, wrapIdb, wrapIdbKvAdapter, blockedStores };
+};

--- a/extension/peerd-runtime/loop/agent-loop.js
+++ b/extension/peerd-runtime/loop/agent-loop.js
@@ -862,7 +862,13 @@ export async function* runUserTurn(ctx) {
               meta: { toolName: tu.name, primitive: 'unknown', gates: [], durationMs: 0 },
             });
           };
-          const onAbort = () => failWith('tool call aborted (Stop / steer / halt) before it settled', 'aborted');
+          // why "may still settle": the loser of this race keeps running
+          // detached — a tracked side effect can land AFTER the abort, and
+          // the durable operation log records that truth. Asserting a
+          // definite "never happened" here would contradict it.
+          const onAbort = () => failWith('tool call aborted (Stop / steer / halt) before it settled — '
+            + 'it may still settle in the background; a side effect\'s recorded outcome '
+            + 'arrives via interruption-recovery if it does', 'aborted');
           const deadline = setTimeout(
             () => failWith(`tool call did not settle within ${Math.round(DISPATCH_DEADLINE_MS / 60_000)} minutes — treating it as hung and moving on`, 'timeout'),
             DISPATCH_DEADLINE_MS,

--- a/extension/peerd-runtime/loop/turn-driver.js
+++ b/extension/peerd-runtime/loop/turn-driver.js
@@ -65,6 +65,12 @@ export const makeTurnDriver = (/** @type {any} */ deps) => {
     // Engine-actor prewalk: swaps a VM/Notebook/App actor to its cheap executor
     // from its second turn onward. Optional so actor/test drivers stay inert.
     reconcileEngineActor = null,
+    // Lifecycle recovery notices (lifecycle/boot.js drainNoticesFor):
+    // read-once per session, folded into the leading <context> message so the
+    // AGENT hears the same §14 semantic distinction the user's chat note
+    // carried — including the do-not-repeat instruction for outcome_unknown.
+    // Optional so actor/test drivers stay inert.
+    drainRecoveryNotices = null,
   } = deps;
 
 /**
@@ -231,9 +237,18 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
   // workspace) — a mid-session origin switch re-renders the memory block and
   // costs one cache write before it caches again. Acceptable; the volatile
   // seconds-clock (the real per-turn bust) is what moved out.
+  // Interruption-recovery notices ride the same per-turn context message:
+  // volatile, delivered once, never part of the cached system prefix. An
+  // actor turn skips them (notices are parented to the CHAT session).
+  let recoveryBlock = '';
+  if (!isActor && typeof drainRecoveryNotices === 'function') {
+    recoveryBlock = await Promise.resolve(drainRecoveryNotices(sessionId))
+      .catch(() => '');
+  }
   const contextMessage = isActor
     ? ''
-    : buildTemporalContext({ temporalBlock, activeTab: activeTabContext });
+    : [buildTemporalContext({ temporalBlock, activeTab: activeTabContext }), recoveryBlock]
+      .filter(Boolean).join('\n\n');
 
   const getSystemPrompt = async () => {
     // why: re-read the session record at render time so a /system change

--- a/extension/peerd-runtime/observability/failure-classify.js
+++ b/extension/peerd-runtime/observability/failure-classify.js
@@ -44,6 +44,16 @@ const RULES = [
   // auth beats provider (a 401 is a key problem before an API problem).
   { kind: 'aborted', test: /^script_aborted:|stopped before the (actor|run)|aborted \(Stop\)|aborted \(timeout or cancel\)|\bstop was pressed\b/i },
   { kind: 'aborted', test: /^the turn was stopped\b|\bcancelled by the user\b/i },
+  // Lifecycle recovery outcomes (PR #314, dispatch-tracking.js) — the
+  // contract's stable result prefixes. Precedence: the replay-guard and
+  // fail-closed REFUSALS are peerd's own policy speaking ('not
+  // re-executing' / 'was NOT executed'), before the settled-state rows;
+  // 'cancelled:' is a Stop shape; 'outcome_unknown:'/'interrupted:' are
+  // the world not cooperating (transport/host loss), with the raw cause
+  // in the parenthetical right next to the chip.
+  { kind: 'policy', test: /^(outcome_unknown|interrupted|completed):.*\bnot re-executing\b|^failed: .*\bNOT executed\b/i },
+  { kind: 'aborted', test: /^cancelled: / },
+  { kind: 'environment', test: /^(outcome_unknown|interrupted): / },
   // why gate_blocked/hook_blocked (not 'tool_blocked'): these are the
   // dispatcher's ACTUAL refusal prefixes in tool results (dispatcher.js);
   // tool_blocked is only the audit event's type and never reaches a card.

--- a/extension/peerd-runtime/permissions/policy.js
+++ b/extension/peerd-runtime/permissions/policy.js
@@ -284,12 +284,23 @@ export const normalizeConfirmActions = (v) => v !== false;
 /**
  * Read the effective confirmActions off a stored record (session record,
  * sessionCache snapshot). An explicit `confirmActions` boolean wins;
- * otherwise undefined, so callers can fall through their resolution chain.
+ * otherwise a LEGACY `actTier` (the pre-collapse Codex tiers, DECISIONS
+ * §18: "read forever, a migration must never widen authority") maps
+ * conservatively — 'full-auto' was the only tier that ran unconfirmed, so
+ * only it maps to OFF; 'suggest'/'auto-edit' (and any unknown tier value)
+ * map to ON. Otherwise undefined, so callers fall through their chain.
  *
- * @param {{ confirmActions?: unknown } | null | undefined} record
+ * why this matters for recovery: the SW's fallthrough lands on
+ * confirm-OFF, so dropping the tier's meaning silently widened an old
+ * profile's authority — the historical-fixture suite caught it.
+ *
+ * @param {{ confirmActions?: unknown, actTier?: unknown } | null | undefined} record
  * @returns {boolean | undefined}
  */
 export const confirmActionsFromRecord = (record) => {
   const v = record?.confirmActions;
-  return v === true || v === false ? v : undefined;
+  if (v === true || v === false) return v;
+  const tier = record?.actTier;
+  if (typeof tier === 'string' && tier) return tier !== 'full-auto';
+  return undefined;
 };

--- a/extension/peerd-runtime/skills/store.js
+++ b/extension/peerd-runtime/skills/store.js
@@ -50,9 +50,18 @@ const BODY_STORE = 'bodies';
  *
  * @param {Object} [deps]
  * @param {IDBFactory} [deps.idbFactory]  defaults to globalThis.indexedDB
+ * @param {() => void} [deps.canWrite]  the 11.5 write gate — throws
+ *   StoreReadOnlyError when the profile schema is newer than this build
+ *   supports; the SW injects the shared verdict (self-hosted DB, see
+ *   lifecycle/write-guard.js)
  */
 export const createSkillStore = (deps = {}) => {
   const idbFactory = deps.idbFactory ?? globalThis.indexedDB;
+  // the 11.5 write gate: skills live in their OWN database (peerd-skills), so
+  // the shared kv/idb write guard cannot reach them — the SW injects the
+  // same schema verdict here instead (throws StoreReadOnlyError when the
+  // profile is newer than this build supports). Absent → always writable.
+  const canWrite = typeof deps.canWrite === 'function' ? deps.canWrite : null;
   /** @type {Promise<IDBDatabase> | null} */
   let openPromise = null;
 
@@ -125,10 +134,13 @@ export const createSkillStore = (deps = {}) => {
      * @param {SkillMeta} meta
      * @param {string} body
      */
-    put: (meta, body) => tx([META_STORE, BODY_STORE], 'readwrite', (t) => {
-      t.objectStore(META_STORE).put(meta);
-      t.objectStore(BODY_STORE).put({ id: meta.id, body });
-    }),
+    put: (meta, body) => {
+      canWrite?.();
+      return tx([META_STORE, BODY_STORE], 'readwrite', (t) => {
+        t.objectStore(META_STORE).put(meta);
+        t.objectStore(BODY_STORE).put({ id: meta.id, body });
+      });
+    },
 
     /**
      * List ALL skill metas. This is the startup hot path — it touches the
@@ -153,10 +165,13 @@ export const createSkillStore = (deps = {}) => {
      * uninstallable). Drops both records.
      * @param {string} id
      */
-    remove: (id) => tx([META_STORE, BODY_STORE], 'readwrite', (t) => {
-      t.objectStore(META_STORE).delete(id);
-      t.objectStore(BODY_STORE).delete(id);
-    }),
+    remove: (id) => {
+      canWrite?.();
+      return tx([META_STORE, BODY_STORE], 'readwrite', (t) => {
+        t.objectStore(META_STORE).delete(id);
+        t.objectStore(BODY_STORE).delete(id);
+      });
+    },
   };
 };
 

--- a/extension/peerd-runtime/tools/defs/click.js
+++ b/extension/peerd-runtime/tools/defs/click.js
@@ -82,7 +82,7 @@ export const clickTool = {
 
   execute: async (args, ctx) => {
     const tab = await resolveTargetTab(args, ctx);
-    if (!tab?.id) return { ok: false, error: 'no_target_tab' };
+    if (!tab?.id) return { ok: false, error: 'no_target_tab', outcomeKind: 'pre-effect-failure' };
 
     // why: domRefs/debuggerPool are SW-injected onto ctx but absent from the
     // ToolContext typedef; scripting is typed opaquely — narrow all three.
@@ -105,7 +105,7 @@ export const clickTool = {
     if (typeof args?.ref === 'string' && args.ref.trim()) {
       const ref = args.ref.trim();
       const entry = domRefs?.resolve?.(tab.id, ref);
-      if (!entry) return { ok: false, error: `stale_ref: ${ref} — re-run snapshot on this tab first` };
+      if (!entry) return { ok: false, error: `stale_ref: ${ref} — re-run snapshot on this tab first`, outcomeKind: 'pre-effect-failure' };
 
       if (entry.backendDOMNodeId != null && typeof debuggerPool?.clickBackendNode === 'function') {
         // Cardinality guard on the CDP channel too (#36 consistency): a resolved
@@ -113,7 +113,7 @@ export const clickTool = {
         // than 1 is a mismatch — same shape the walk-ref/selector paths return,
         // so the guard the schema promises holds identically across channels.
         if (expectedCount != null && expectedCount !== 1) {
-          return { ok: false, error: 'matched_count_mismatch', matchedCount: 1, expectedCount };
+          return { ok: false, error: 'matched_count_mismatch', matchedCount: 1, expectedCount, outcomeKind: 'pre-effect-failure' };
         }
         try {
           const r = await debuggerPool.clickBackendNode(tab.id, entry.backendDOMNodeId);
@@ -142,7 +142,7 @@ export const clickTool = {
           });
           scriptResult = results[0]?.result;
         } catch (e) {
-          return { ok: false, error: `script_inject_failed: ${/** @type {{ message?: string }} */ (e)?.message ?? String(e)}` };
+          return { ok: false, error: `script_inject_failed: ${/** @type {{ message?: string }} */ (e)?.message ?? String(e)}`, outcomeKind: 'pre-effect-failure' };
         }
         if (!scriptResult) return { ok: false, error: 'script_returned_nothing' };
         if (!scriptResult.ok) return { ok: false, error: scriptResult.error ?? 'ref_click_failed' };
@@ -188,7 +188,7 @@ export const clickTool = {
       });
       scriptResult = results[0]?.result;
     } catch (e) {
-      return { ok: false, error: `script_inject_failed: ${/** @type {{ message?: string }} */ (e)?.message ?? String(e)}` };
+      return { ok: false, error: `script_inject_failed: ${/** @type {{ message?: string }} */ (e)?.message ?? String(e)}`, outcomeKind: 'pre-effect-failure' };
     }
 
     if (!scriptResult) {

--- a/extension/peerd-runtime/tools/defs/fetch-url.js
+++ b/extension/peerd-runtime/tools/defs/fetch-url.js
@@ -290,9 +290,22 @@ export const fetchUrlTool = {
           error: `blocked: ${args.url} is a private/loopback host, which fetch_url cannot reach (SSRF defense) — `
             + 'this does NOT mean the site is unreachable. Open it with navigate and read the rendered page '
             + 'with snapshot/read_page instead. If you already rendered the page, read that DOM — do not re-fetch it.',
+          // The SSRF guard refuses BEFORE any request leaves peerd — typed
+          // positive failure evidence for the lifecycle settle path.
+          outcomeKind: 'pre-effect-failure',
         };
       }
-      return { ok: false, error: err?.message ?? 'fetch_failed' };
+      // A bare network throw (TypeError: Failed to fetch / AbortError) is
+      // the wire dying with the request possibly delivered — stamp the
+      // typed ambiguous outcome so the lifecycle settle path decides
+      // deterministically instead of regex-matching the message.
+      const name = /** @type {{ name?: string }} */ (e)?.name;
+      const transportLost = name === 'AbortError' || name === 'TypeError';
+      return {
+        ok: false,
+        error: err?.message ?? 'fetch_failed',
+        ...(transportLost ? { outcomeKind: 'transport-lost' } : {}),
+      };
     }
   },
 };

--- a/extension/peerd-runtime/tools/defs/type.js
+++ b/extension/peerd-runtime/tools/defs/type.js
@@ -82,7 +82,7 @@ export const typeTool = {
       return { ok: false, error: 'text_required' };
     }
     const tab = await resolveTargetTab(args, ctx);
-    if (!tab?.id) return { ok: false, error: 'no_target_tab' };
+    if (!tab?.id) return { ok: false, error: 'no_target_tab', outcomeKind: 'pre-effect-failure' };
 
     // why: domRefs/debuggerPool are SW-injected onto ctx but absent from the
     // ToolContext typedef; scripting is typed opaquely — narrow all three.
@@ -104,14 +104,14 @@ export const typeTool = {
     if (typeof args?.ref === 'string' && args.ref.trim()) {
       const ref = args.ref.trim();
       const entry = domRefs?.resolve?.(tab.id, ref);
-      if (!entry) return { ok: false, error: `stale_ref: ${ref} — re-run snapshot on this tab first` };
+      if (!entry) return { ok: false, error: `stale_ref: ${ref} — re-run snapshot on this tab first`, outcomeKind: 'pre-effect-failure' };
 
       if (entry.backendDOMNodeId != null && typeof debuggerPool?.setValueBackendNode === 'function') {
         // Cardinality guard on the CDP channel too (#36 consistency): a resolved
         // backendDOMNodeId ref IS exactly one node, so any expectedCount other
         // than 1 is a mismatch — same shape the walk-ref/selector paths return.
         if (expectedCount != null && expectedCount !== 1) {
-          return { ok: false, error: 'matched_count_mismatch', matchedCount: 1, expectedCount };
+          return { ok: false, error: 'matched_count_mismatch', matchedCount: 1, expectedCount, outcomeKind: 'pre-effect-failure' };
         }
         try {
           const r = await debuggerPool.setValueBackendNode(tab.id, entry.backendDOMNodeId, args.text, !!args.submit);
@@ -141,7 +141,7 @@ export const typeTool = {
           });
           scriptResult = results[0]?.result;
         } catch (e) {
-          return { ok: false, error: `script_inject_failed: ${/** @type {{ message?: string }} */ (e)?.message ?? String(e)}` };
+          return { ok: false, error: `script_inject_failed: ${/** @type {{ message?: string }} */ (e)?.message ?? String(e)}`, outcomeKind: 'pre-effect-failure' };
         }
         if (!scriptResult) return { ok: false, error: 'script_returned_nothing' };
         if (!scriptResult.ok) return { ok: false, error: scriptResult.error ?? 'ref_type_failed' };
@@ -186,7 +186,7 @@ export const typeTool = {
       });
       scriptResult = results[0]?.result;
     } catch (e) {
-      return { ok: false, error: `script_inject_failed: ${/** @type {{ message?: string }} */ (e)?.message ?? String(e)}` };
+      return { ok: false, error: `script_inject_failed: ${/** @type {{ message?: string }} */ (e)?.message ?? String(e)}`, outcomeKind: 'pre-effect-failure' };
     }
     if (!scriptResult) return { ok: false, error: 'script_returned_nothing' };
     if (!scriptResult.ok) return { ok: false, error: scriptResult.error ?? 'type_failed' };

--- a/extension/peerd-runtime/tools/dispatcher.js
+++ b/extension/peerd-runtime/tools/dispatcher.js
@@ -253,6 +253,9 @@ export const dispatchToolCall = async (call, ctx) => {
     })
     : null;
 
+  // Whether the USER approved this exact dispatch via a confirm round-trip
+  // — the lifecycle tracker turns it into a durable single-use proof.
+  let userApprovedThisDispatch = false;
   if (verdict.allowed && (verdict.confirm || ugcRuleId) && !selfConfirms) {
     const confirmEntry = gateResults.find((g) => g.name === 'confirmation');
     /** @type {import('/shared/tool-types.js').ConfirmAnswer | undefined} */
@@ -281,6 +284,7 @@ export const dispatchToolCall = async (call, ctx) => {
       answer = 'no';  // fail closed — a broken confirm channel blocks the action
     }
     const approved = answer === 'yes_once' || answer === 'yes_session';
+    userApprovedThisDispatch = approved;
     if (confirmEntry) {
       confirmEntry.allowed = approved;
       // why the ruleId rides in the reason: the lineage chip in the transcript
@@ -375,6 +379,13 @@ export const dispatchToolCall = async (call, ctx) => {
       sessionId: ctx.session?.sessionId ?? undefined,
       actorId: /** @type {{ actorInstanceId?: string }} */ (ctx).actorInstanceId,
       target: safeOrigins(tool, args, ctx)[0],
+      // The user's approval, if a confirm round-trip ran above — the
+      // tracker mints + consumes the single-use, generation-bound proof
+      // and persists it on the durable record (§8.3).
+      confirmed: userApprovedThisDispatch,
+      // Post-hook args: Class C/D records derive their deterministic
+      // idempotency key from these.
+      args,
     }).catch(() => null);
     if (begun && 'refuse' in begun && begun.refuse) {
       ctx.audit({

--- a/extension/peerd-runtime/tools/dispatcher.js
+++ b/extension/peerd-runtime/tools/dispatcher.js
@@ -24,6 +24,11 @@ import {
   DEFAULT_CONFIRM_ACTIONS,
   normalizeMode,
 } from '../permissions/index.js';
+// The lifecycle classifier — pure, no IO. Used ONLY by the fail-closed
+// backstop below, so the dispatcher never has to duplicate (and drift
+// from) the retry-class taxonomy.
+import { retryClassForTool } from '../lifecycle/tool-retry-class.js';
+import { RETRY_CLASSES } from '../lifecycle/retry-class.js';
 
 /** @typedef {import('/shared/tool-types.js').Tool} Tool */
 
@@ -386,7 +391,44 @@ export const dispatchToolCall = async (call, ctx) => {
       // Post-hook args: Class C/D records derive their deterministic
       // idempotency key from these.
       args,
-    }).catch(() => null);
+    }).catch((error) => {
+      // beginTracking is a TOTAL function (see its wrapper) — reaching this
+      // catch means something violated that contract. The old behavior here
+      // was `() => null`, i.e. "run untracked", which for a non-idempotent
+      // action is the one degradation the contract cannot allow: no record
+      // means a later interruption is unreportable AND unguarded.
+      //
+      // So this is an INDEPENDENT fail-closed decision, deliberately not
+      // routed through the tracker that just failed: classify the tool
+      // directly and refuse D/E. A/B/C keep the historical degradation —
+      // duplicate reads are invisible and idempotent writes are safe to
+      // repeat, so a broken tracker must not take the read surface down
+      // with it.
+      const retryClass = (() => {
+        try { return retryClassForTool(tool); }
+        catch { return RETRY_CLASSES.SIDE_EFFECT; } // classification threw: assume the worst
+      })();
+      if (retryClass !== RETRY_CLASSES.SIDE_EFFECT
+          && retryClass !== RETRY_CLASSES.CONDITIONAL_ACTION) return null;
+      const detail = error instanceof Error ? error.message : String(error);
+      return {
+        refuse: {
+          error: `failed: ${call.name} was NOT executed — lifecycle tracking `
+            + `failed unexpectedly (${detail}) and a non-idempotent action must `
+            + 'not run untracked: an interruption could then never be reported '
+            + 'or guarded against.',
+          recovery: {
+            category: 'security_degradation',
+            state: 'failed',
+            autoRetry: false,
+            retryRequires: ['lifecycle-storage'],
+            verificationRequired: false,
+            keepIdempotencyKey: false,
+            reason: `tracking rejected unexpectedly: ${detail}`,
+          },
+        },
+      };
+    });
     if (begun && 'refuse' in begun && begun.refuse) {
       ctx.audit({
         type: 'tool_blocked',

--- a/extension/peerd-runtime/tools/dispatcher.js
+++ b/extension/peerd-runtime/tools/dispatcher.js
@@ -462,6 +462,9 @@ export const dispatchToolCall = async (call, ctx) => {
       recoveryRewrite = await ctx.lifecycle.settleTracking(tracking, {
         ok: result?.ok !== false,
         error: result?.ok === false ? String(result.error ?? '') : undefined,
+        // A typed failure outcome a tool stamped on its result — the
+        // deterministic path (lifecycle/failure-taxonomy.js).
+        outcomeKind: /** @type {{ outcomeKind?: any }} */ (result)?.outcomeKind,
       }).catch(() => null);
     }
     // A rewrite replaces the failure shape wholesale (it only ever fires on
@@ -520,6 +523,9 @@ export const dispatchToolCall = async (call, ctx) => {
         ok: false,
         error: message,
         aborted: /** @type {{ name?: string }} */ (e)?.name === 'AbortError',
+        // A typed outcome stamped on the thrown error (survives relay
+        // boundaries as a plain field — see lifecycle/failure-taxonomy.js).
+        outcomeKind: /** @type {{ outcomeKind?: any }} */ (e)?.outcomeKind,
       }).catch(() => null);
     }
     return {

--- a/extension/peerd-runtime/tools/dispatcher.js
+++ b/extension/peerd-runtime/tools/dispatcher.js
@@ -120,6 +120,7 @@ const liveTabUrl = async (ctx) => {
  *     begin: (tabId: number, label: string, origin: string) => unknown,
  *     end: (tabId: number) => unknown,
  *   } | null,
+ *   lifecycle?: ReturnType<import('../lifecycle/dispatch-tracking.js').makeDispatchTracker> | null,
  * }} DispatchContext
  */
 
@@ -129,7 +130,12 @@ const liveTabUrl = async (ctx) => {
  * UI hint, off the wire), so we widen locally; the widened meta is still
  * structurally a ToolMeta where the result type needs one.
  *
- * @typedef {ToolMeta & { dispatch?: 'inline' | 'spawned' }} DispatchMeta
+ * @typedef {ToolMeta & { dispatch?: 'inline' | 'spawned',
+ *   recovery?: Record<string, unknown> }} DispatchMeta
+ *   `recovery` is the lifecycle contract's agent-facing semantic record —
+ *   present only when a dispatch settled as interrupted/outcome_unknown/
+ *   refused-replay, so the agent hears the recovery category, not a
+ *   generic error string.
  */
 
 /**
@@ -351,6 +357,46 @@ export const dispatchToolCall = async (call, ctx) => {
   // Adopt any args the pre-hooks rewrote. execute() + the audit see these.
   args = pre.args;
 
+  // ---- Lifecycle tracking (the recovery contract) ------------------------
+  // why HERE: every gate/confirm/hook has passed, so what follows is a real
+  // dispatch — the durable operation record must exist BEFORE execute() so
+  // an SW eviction mid-effect leaves evidence (interrupted vs
+  // outcome_unknown) instead of silence. beginTracking may also REFUSE the
+  // call outright: the auto-resume path re-drives pending tool calls with
+  // their original tool_use ids, and re-running a non-idempotent action
+  // whose first dispatch has no proven outcome is the unsafe replay the
+  // contract forbids. Absent ctx.lifecycle (tests, Firefox pre-init), the
+  // dispatch is byte-for-byte unchanged.
+  let tracking = null;
+  if (ctx.lifecycle?.beginTracking) {
+    const begun = await ctx.lifecycle.beginTracking({
+      callId: call.id,
+      tool,
+      sessionId: ctx.session?.sessionId ?? undefined,
+      actorId: /** @type {{ actorInstanceId?: string }} */ (ctx).actorInstanceId,
+      target: safeOrigins(tool, args, ctx)[0],
+    }).catch(() => null);
+    if (begun && 'refuse' in begun && begun.refuse) {
+      ctx.audit({
+        type: 'tool_blocked',
+        details: { tool: call.name, gate: 'lifecycle-replay-guard', reason: begun.refuse.error },
+      }).catch(() => {});
+      return {
+        ok: false,
+        error: begun.refuse.error,
+        meta: /** @type {DispatchMeta} */ ({
+          toolName: call.name,
+          primitive: tool.primitive, dispatch: tool.dispatch,
+          gates: gateResults,
+          hooks: hookOutcomes,
+          durationMs: 0,
+          recovery: begun.refuse.recovery,
+        }),
+      };
+    }
+    tracking = begun && 'handle' in begun ? begun.handle : null;
+  }
+
   // ---- Execute -----------------------------------------------------------
   // why: thread the call's tool_use_id into ctx so tools that stream
   // intermediate state back to the UI (currently vm_boot) can key their
@@ -406,9 +452,27 @@ export const dispatchToolCall = async (call, ctx) => {
     // here would mean misreporting an effect that already occurred).
     const post = await runPostToolUse({ hooks, toolName: call.name, args, result, ctx: hookCtx });
     hookOutcomes.push(...post.outcomes);
+    // Settle the lifecycle record from the tool's own outcome. A returned
+    // failure whose error is an ambiguous transport loss is REWRITTEN to
+    // the semantic state (interrupted / outcome_unknown) — §16.2: the agent
+    // never sees a bare timeout on a tracked side effect.
+    /** @type {{ error: string, recovery: Record<string, unknown> } | null} */
+    let recoveryRewrite = null;
+    if (tracking && ctx.lifecycle?.settleTracking) {
+      recoveryRewrite = await ctx.lifecycle.settleTracking(tracking, {
+        ok: result?.ok !== false,
+        error: result?.ok === false ? String(result.error ?? '') : undefined,
+      }).catch(() => null);
+    }
+    // A rewrite replaces the failure shape wholesale (it only ever fires on
+    // an already-failed result) so the discriminated ok:false stays literal.
+    /** @type {ToolResult} */
+    const settled = recoveryRewrite
+      ? { ok: false, error: recoveryRewrite.error }
+      : result;
     /** @type {ToolResult} */
     const enriched = {
-      ...result,
+      ...settled,
       meta: /** @type {DispatchMeta} */ ({
         toolName: call.name,
         primitive: tool.primitive, dispatch: tool.dispatch,
@@ -421,6 +485,7 @@ export const dispatchToolCall = async (call, ctx) => {
         gates: gateResults,
         hooks: hookOutcomes,
         durationMs,
+        ...(recoveryRewrite ? { recovery: recoveryRewrite.recovery } : {}),
       }),
     };
     return enriched;
@@ -446,9 +511,20 @@ export const dispatchToolCall = async (call, ctx) => {
       hooks, toolName: call.name, args, result: { ok: false, error: message }, ctx: hookCtx,
     });
     hookOutcomes.push(...post.outcomes);
+    // A THROW after dispatch is the most ambiguous shape of all — settle
+    // the lifecycle record and adopt the semantic error where it applies.
+    /** @type {{ error: string, recovery: Record<string, unknown> } | null} */
+    let recoveryRewrite = null;
+    if (tracking && ctx.lifecycle?.settleTracking) {
+      recoveryRewrite = await ctx.lifecycle.settleTracking(tracking, {
+        ok: false,
+        error: message,
+        aborted: /** @type {{ name?: string }} */ (e)?.name === 'AbortError',
+      }).catch(() => null);
+    }
     return {
       ok: false,
-      error: message,
+      error: recoveryRewrite?.error ?? message,
       meta: /** @type {DispatchMeta} */ ({
         toolName: call.name,
         primitive: tool.primitive, dispatch: tool.dispatch,
@@ -459,6 +535,7 @@ export const dispatchToolCall = async (call, ctx) => {
         gates: gateResults,
         hooks: hookOutcomes,
         durationMs,
+        ...(recoveryRewrite ? { recovery: recoveryRewrite.recovery } : {}),
       }),
     };
   }

--- a/extension/peerd-runtime/transfer/transfer.js
+++ b/extension/peerd-runtime/transfer/transfer.js
@@ -35,6 +35,13 @@
 //                      notice. (This comment says "the dweb module"
 //                      because this file ships in store packages and the
 //                      artifact verifier greps everything.)
+//   durability         §12 labels for THIS file: the durability tier of
+//                      each section actually included, plus the names of
+//                      the device-bound surfaces an export structurally
+//                      cannot carry. Purely additive (older files simply
+//                      lack it), so EXPORT_VERSION is unchanged.
+
+import { omittedDeviceBoundStores, portableStores } from '../lifecycle/store-registry.js';
 
 export const EXPORT_VERSION = 1;
 export const EXPORT_FORMAT = 'peerd-export';
@@ -124,6 +131,39 @@ export const decryptWithPassphrase = async (passphrase, box) => {
 
 // ── export ───────────────────────────────────────────────────────────
 
+// why this map lives here and not in the registry: the registry names
+// durable SURFACES, this file names payload SECTIONS. Keeping the
+// translation on the transfer side lets §12's tier labels ride along
+// without the lifecycle registry knowing a thing about this file format.
+/** @type {Readonly<Record<string, string>>} */
+const SECTION_OF_STORE = Object.freeze({
+  vault: 'secrets',
+  memory: 'memory',
+  skills: 'skills',
+  hooks: 'hooks',
+});
+
+/**
+ * The §12 durability block for a shaped payload: tier labels for the
+ * sections this file actually carries, and the device-bound surfaces it
+ * left behind ("the export format must identify omitted device-bound
+ * state" — a profile arriving without them is incomplete, not corrupt).
+ *
+ * @param {Record<string, unknown>} payload  the shaped export, pre-durability
+ */
+const durabilitySection = (payload) => {
+  /** @type {Record<string, string>} */
+  const tiers = {};
+  for (const entry of portableStores()) {
+    const section = SECTION_OF_STORE[entry.store];
+    if (!section) continue;
+    const value = payload[section];
+    const present = value != null && !(Array.isArray(value) && value.length === 0);
+    if (present) tiers[entry.store] = entry.tier;
+  }
+  return { tiers, omittedDeviceBound: omittedDeviceBoundStores() };
+};
+
 /**
  * Assemble the export payload. The SW gathers the pieces (vault must be
  * unlocked to read secrets) and passes them in; this function only
@@ -146,7 +186,7 @@ export const buildExport = async ({
   if (secretNames.length > 0 && !passphrase) {
     throw new ExportPassphraseError();
   }
-  return {
+  const payload = {
     format: EXPORT_FORMAT,
     version: EXPORT_VERSION,
     exportedAt: new Date().toISOString(),
@@ -158,6 +198,7 @@ export const buildExport = async ({
     hooks: hooks ?? [],
     skills: skills ?? [],
   };
+  return { ...payload, durability: durabilitySection(payload) };
 };
 
 // ── import ───────────────────────────────────────────────────────────
@@ -174,6 +215,8 @@ export const buildExport = async ({
  * @property {string[]} skills
  * @property {boolean} dwebPresent
  * @property {boolean} dwebDropped
+ * @property {Record<string, string>} durabilityTiers  §12 labels ({} on older files)
+ * @property {string[]} omittedDeviceBound             device-bound surfaces not carried
  * @property {string[]} notices
  */
 
@@ -227,6 +270,18 @@ export const inspectImport = ({ payload, channel, knownSettingKeys }) => {
   if (hookIds.length > 0) {
     notices.push(`${hookIds.length} hook(s) will be imported DISABLED and untrusted (${hookIds.join(', ')}) — review and re-enable them in Settings → Hooks.`);
   }
+  // §12 durability labels. Additive to the format, so an export written
+  // before this section existed is fully valid: absent means "unlabelled",
+  // never "nothing was omitted" — hence the empty defaults and no notice.
+  const durability = (payload.durability && typeof payload.durability === 'object') ? payload.durability : null;
+  const durabilityTiers = (durability?.tiers && typeof durability.tiers === 'object') ? durability.tiers : {};
+  /** @type {string[]} */
+  const omittedDeviceBound = Array.isArray(durability?.omittedDeviceBound)
+    ? durability.omittedDeviceBound.map((/** @type {unknown} */ s) => String(s))
+    : [];
+  if (omittedDeviceBound.length > 0) {
+    notices.push(`Device-bound state cannot travel and was not exported (${omittedDeviceBound.join(', ')}) — this build re-creates it locally.`);
+  }
   return {
     ok: true,
     summary: {
@@ -242,6 +297,8 @@ export const inspectImport = ({ payload, channel, knownSettingKeys }) => {
       skills: skills.map((s) => s?.name ?? s?.id ?? 'unknown'),
       dwebPresent,
       dwebDropped: channel === 'store' && dwebPresent,
+      durabilityTiers,
+      omittedDeviceBound,
       notices,
     },
   };

--- a/extension/shared/tool-types.js
+++ b/extension/shared/tool-types.js
@@ -103,6 +103,11 @@
  * @property {any} [content]  optional human-readable explanation authored
  *   alongside the machine `error` code (e.g. "User declined the outbound
  *   write."); the loop surfaces it on the failure path — see agent-loop.js.
+ * @property {'transport-lost' | 'host-lost' | 'pre-effect-failure'} [outcomeKind]
+ *   typed failure outcome for the lifecycle recovery contract
+ *   (peerd-runtime/lifecycle/failure-taxonomy.js): a tool that KNOWS how it
+ *   failed stamps this so the recovery decision is deterministic instead of
+ *   string-matched. Optional — unstamped failures take the heuristic path.
  * @property {ToolMeta} [meta]
  */
 

--- a/extension/tests/index.js
+++ b/extension/tests/index.js
@@ -50,6 +50,9 @@ import './unit/peerd-runtime/prompt-wrap.test.js';
 import './unit/peerd-runtime/system-prompt.test.js';
 import './unit/peerd-runtime/tool-manifests.test.js';
 import './unit/peerd-runtime/redact.test.js';
+// Lifecycle recovery contract — the SW-eviction sequence over REAL
+// chrome.storage (the bun suite proves the decisions; this proves the IO).
+import './unit/peerd-runtime/lifecycle-recovery.test.js';
 import './unit/peerd-runtime/trim.test.js';
 import './unit/peerd-runtime/clock/now.test.js';
 import './unit/peerd-runtime/clock/context.test.js';

--- a/extension/tests/unit/peerd-runtime/lifecycle-recovery.test.js
+++ b/extension/tests/unit/peerd-runtime/lifecycle-recovery.test.js
@@ -1,0 +1,180 @@
+// @ts-check
+// Lifecycle recovery — REAL-BROWSER execution of the contract's SW-eviction
+// sequence (§15). The bun suite proves the decisions; this file proves them
+// over the storage that actually survives an eviction: chrome.storage.local
+// through the same adapters the SW wires. An "eviction" here is what the
+// contract defines it to be (§2.1): durable storage persists, memory does
+// not — so booting a second lifecycle instance over the same real storage
+// IS the fault injection.
+
+import { describe, it, expect } from '../../framework.js';
+import {
+  makeLifecycleBoot, makeDispatchTracker, retryClassForTool,
+  registerTool, clearTools, dispatchToolCall,
+  OPERATION_STATES,
+} from '/peerd-runtime/index.js';
+
+const S = OPERATION_STATES;
+
+// REAL browser storage. As an extension page this is chrome.storage.local
+// (the SW's actual kv backing); under the CDP harness the runner serves
+// over localhost where chrome.* is absent, so the same contract rides real
+// IndexedDB — still durable browser storage with the §2.1 survival
+// property (persists across the simulated eviction), still the async IO
+// path the bun suite cannot exercise. Namespaced/isolated either way.
+const PREFIX = 'test.lifecycle.';
+const IDB_NAME = 'peerd-test-lifecycle';
+const hasChromeStorage = typeof chrome !== 'undefined' && !!chrome?.storage?.local;
+
+const openTestDb = () => new Promise((resolve, reject) => {
+  const req = indexedDB.open(IDB_NAME, 1);
+  req.onupgradeneeded = () => req.result.createObjectStore('kv');
+  req.onsuccess = () => resolve(req.result);
+  req.onerror = () => reject(req.error);
+});
+/** @param {'readonly'|'readwrite'} mode @param {(store: IDBObjectStore) => IDBRequest} fn */
+const idbOp = async (mode, fn) => {
+  const db = /** @type {IDBDatabase} */ (await openTestDb());
+  try {
+    return await new Promise((resolve, reject) => {
+      const request = fn(db.transaction('kv', mode).objectStore('kv'));
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  } finally { db.close(); }
+};
+
+const realStorage = () => (hasChromeStorage
+  ? {
+    /** @param {string} key */
+    get: async (key) => (await chrome.storage.local.get(PREFIX + key))[PREFIX + key],
+    /** @param {string} key @param {any} value */
+    set: async (key, value) => chrome.storage.local.set({ [PREFIX + key]: value }),
+  }
+  : {
+    /** @param {string} key */
+    get: (key) => idbOp('readonly', (s) => s.get(PREFIX + key)),
+    /** @param {string} key @param {any} value */
+    set: async (key, value) => { await idbOp('readwrite', (s) => s.put(value, PREFIX + key)); },
+  });
+
+const cleanup = async () => {
+  if (hasChromeStorage) {
+    const all = await chrome.storage.local.get(null);
+    const keys = Object.keys(all).filter((k) => k.startsWith(PREFIX));
+    if (keys.length) await chrome.storage.local.remove(keys);
+    return;
+  }
+  await idbOp('readwrite', (s) => s.clear());
+};
+
+let nonceCounter = 0;
+const boot = (extra = {}) => makeLifecycleBoot({
+  storage: realStorage(),
+  nonce: () => `nonce-${Date.now()}-${nonceCounter += 1}`,
+  ...extra,
+});
+
+describe('lifecycle recovery over real chrome.storage', () => {
+  it('a rebooted generation settles each retry class to its contract state', async () => {
+    await cleanup();
+    try {
+      const gen1 = boot();
+      const { generation } = await gen1.init();
+      const log = gen1.operationLog;
+      /** @param {string} id @param {string} retryClass */
+      const begin = (id, retryClass) => log.begin({
+        operationId: id, sessionId: 'sess-real', toolName: `tool-${retryClass}`,
+        retryClass, generationId: generation.id,
+      });
+
+      await begin('real-b', 'B');
+      await log.transition('real-b', S.RUNNING);
+      await log.markDispatched('real-b');
+      await begin('real-e', 'E');
+      await log.transition('real-e', S.RUNNING);
+      await log.markDispatched('real-e');
+      await begin('real-e2', 'E');
+      await log.transition('real-e2', S.RUNNING);
+      await log.transition('real-e2', S.AWAITING_USER);
+
+      // The eviction: a fresh boot over the same real storage.
+      const gen2 = boot();
+      const { plan } = await gen2.init();
+      expect(plan.transitions.length).toBe(3);
+      expect((await gen2.operationLog.get('real-b'))?.state).toBe(S.INTERRUPTED);
+      expect((await gen2.operationLog.get('real-e'))?.state).toBe(S.OUTCOME_UNKNOWN);
+      expect((await gen2.operationLog.get('real-e2'))?.state).toBe(S.INTERRUPTED);
+
+      // The agent-facing notice drains once, then never again.
+      const block = await gen2.drainNoticesFor('sess-real');
+      expect(block.includes('outcome_unknown')).toBe(true);
+      expect(await gen2.drainNoticesFor('sess-real')).toBe('');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('generation seq survives the reboot monotonically in real storage', async () => {
+    await cleanup();
+    try {
+      const first = await boot().init();
+      const second = await boot().init();
+      expect(second.generation.seq).toBe(first.generation.seq + 1);
+      expect(second.generation.id === first.generation.id).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('the wired dispatcher refuses a cross-generation Class E replay end-to-end', async () => {
+    await cleanup();
+    clearTools();
+    try {
+      let executions = 0;
+      registerTool(/** @type {any} */ ({
+        name: 'test_submit', description: 'x', schema: {},
+        primitive: 'web', sideEffect: 'mutate_external',
+        origins: () => [],
+        execute: async () => { executions += 1; throw new Error('request timed out'); },
+      }));
+      const ctx = (/** @type {any} */ tracker) => /** @type {any} */ ({
+        audit: async () => {}, hooks: [],
+        session: { sessionId: 'sess-real' },
+        permission: { mode: 'act', confirmActions: false },
+        lifecycle: tracker,
+      });
+
+      // Generation 1 dispatches; the timeout settles it outcome_unknown.
+      const gen1 = boot();
+      const g1 = await gen1.init();
+      const tracker1 = makeDispatchTracker({
+        operationLog: gen1.operationLog,
+        generationId: () => g1.generation.id,
+        retryClassFor: retryClassForTool,
+      });
+      const first = await dispatchToolCall(
+        { id: 'real-tu-1', name: 'test_submit', args: {} }, ctx(tracker1));
+      expect(first.ok).toBe(false);
+      expect(String(/** @type {any} */ (first).error).startsWith('outcome_unknown:')).toBe(true);
+
+      // Generation 2 (post-eviction) re-drives the same tool_use id: the
+      // replay guard must answer without re-executing the tool.
+      const gen2 = boot();
+      const g2 = await gen2.init();
+      const tracker2 = makeDispatchTracker({
+        operationLog: gen2.operationLog,
+        generationId: () => g2.generation.id,
+        retryClassFor: retryClassForTool,
+      });
+      const replay = await dispatchToolCall(
+        { id: 'real-tu-1', name: 'test_submit', args: {} }, ctx(tracker2));
+      expect(executions).toBe(1);
+      expect(replay.ok).toBe(false);
+      expect(String(/** @type {any} */ (replay).error).startsWith('outcome_unknown:')).toBe(true);
+    } finally {
+      clearTools();
+      await cleanup();
+    }
+  });
+});

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -121,7 +121,7 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // the merged count at 579 (computed on the merged tree, not summed).
 // peerd-runtime/doc + its offscreen/SW/tool wiring (the read_doc document
 // reader) all landed // @ts-check-clean, so the floor moves up to lock them in.
-const COVERED_FLOOR = 599;
+const COVERED_FLOOR = 608;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -121,7 +121,7 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // the merged count at 579 (computed on the merged tree, not summed).
 // peerd-runtime/doc + its offscreen/SW/tool wiring (the read_doc document
 // reader) all landed // @ts-check-clean, so the floor moves up to lock them in.
-const COVERED_FLOOR = 608;
+const COVERED_FLOOR = 614;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -124,7 +124,10 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // Merge with main (#309 dpop nonces): this branch's lifecycle files put the
 // floor at 614; main adds peerd-egress/dpop/nonce.js. Computed on the MERGED
 // tree, not summed — the same shape as the 579 merge above.
-const COVERED_FLOOR = 615;
+// 615 → 618: the lifecycle hardening batch — failure-taxonomy.js (typed
+// outcomes), write-guard.js (§11.5 enforcement), engine-liveness.js (§9
+// ledger); all carry // @ts-check.
+const COVERED_FLOOR = 618;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/scripts/cdp/e2e-harness.mjs
+++ b/scripts/cdp/e2e-harness.mjs
@@ -54,9 +54,14 @@ export const sseText = (text) => [
 
 // A turn that calls ONE tool: role(+optional text) → a tool_calls delta →
 // finish 'tool_calls' + usage → [DONE]. Drives the dispatcher for real.
+// why unique ids: real providers mint a fresh id per tool call, and the
+// lifecycle replay guard keys on (session, id) — a fixed id would make two
+// UNRELATED scripted calls in one session read as a replay of each other,
+// which no real wire ever produces.
+let sseToolCallSeq = 0;
 export const sseToolCall = (name, args, { text = '' } = {}) => [
   `data: ${JSON.stringify({ choices: [{ delta: { role: 'assistant', content: text } }] })}`,
-  `data: ${JSON.stringify({ choices: [{ delta: { tool_calls: [{ index: 0, id: 'call_e2e_1', type: 'function', function: { name, arguments: JSON.stringify(args) } }] } }] })}`,
+  `data: ${JSON.stringify({ choices: [{ delta: { tool_calls: [{ index: 0, id: `call_e2e_${sseToolCallSeq += 1}`, type: 'function', function: { name, arguments: JSON.stringify(args) } }] } }] })}`,
   `data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: 'tool_calls' }], usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 } })}`,
   'data: [DONE]', '',
 ].join('\n\n') + '\n\n';

--- a/scripts/cdp/e2e-harness.mjs
+++ b/scripts/cdp/e2e-harness.mjs
@@ -59,12 +59,16 @@ export const sseText = (text) => [
 // UNRELATED scripted calls in one session read as a replay of each other,
 // which no real wire ever produces.
 let sseToolCallSeq = 0;
-export const sseToolCall = (name, args, { text = '' } = {}) => [
-  `data: ${JSON.stringify({ choices: [{ delta: { role: 'assistant', content: text } }] })}`,
-  `data: ${JSON.stringify({ choices: [{ delta: { tool_calls: [{ index: 0, id: `call_e2e_${sseToolCallSeq += 1}`, type: 'function', function: { name, arguments: JSON.stringify(args) } }] } }] })}`,
-  `data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: 'tool_calls' }], usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 } })}`,
-  'data: [DONE]', '',
-].join('\n\n') + '\n\n';
+export const sseToolCall = (name, args, { text = '' } = {}) => {
+  sseToolCallSeq += 1;
+  const id = `call_e2e_${sseToolCallSeq}`;
+  return [
+    `data: ${JSON.stringify({ choices: [{ delta: { role: 'assistant', content: text } }] })}`,
+    `data: ${JSON.stringify({ choices: [{ delta: { tool_calls: [{ index: 0, id, type: 'function', function: { name, arguments: JSON.stringify(args) } }] } }] })}`,
+    `data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: 'tool_calls' }], usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 } })}`,
+    'data: [DONE]', '',
+  ].join('\n\n') + '\n\n';
+};
 
 // ---- Chrome binary resolution (mirrors run-inbrowser-tests.mjs) -------------
 export function resolveChrome() {

--- a/scripts/cdp/e2e-harness.mjs
+++ b/scripts/cdp/e2e-harness.mjs
@@ -61,11 +61,23 @@ export const sseText = (text) => [
 let sseToolCallSeq = 0;
 export const sseToolCall = (name, args, { text = '' } = {}) => {
   sseToolCallSeq += 1;
-  const id = `call_e2e_${sseToolCallSeq}`;
+  // Built as plain statements (no keyword-named keys inside template
+  // expressions) — the CodeQL extractor rejected the denser one-liner shape
+  // twice; runtime behavior is identical.
+  const toolCall = {
+    index: 0,
+    id: `call_e2e_${sseToolCallSeq}`,
+    type: 'function',
+    'function': { name, 'arguments': JSON.stringify(args) },
+  };
+  const openDelta = JSON.stringify({ choices: [{ delta: { role: 'assistant', content: text } }] });
+  const callDelta = JSON.stringify({ choices: [{ delta: { tool_calls: [toolCall] } }] });
+  const finishDelta = JSON.stringify({
+    choices: [{ delta: {}, finish_reason: 'tool_calls' }],
+    usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+  });
   return [
-    `data: ${JSON.stringify({ choices: [{ delta: { role: 'assistant', content: text } }] })}`,
-    `data: ${JSON.stringify({ choices: [{ delta: { tool_calls: [{ index: 0, id, type: 'function', function: { name, arguments: JSON.stringify(args) } }] } }] })}`,
-    `data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: 'tool_calls' }], usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 } })}`,
+    `data: ${openDelta}`, `data: ${callDelta}`, `data: ${finishDelta}`,
     'data: [DONE]', '',
   ].join('\n\n') + '\n\n';
 };

--- a/tests/peerd-egress/dpop.test.ts
+++ b/tests/peerd-egress/dpop.test.ts
@@ -238,8 +238,11 @@ describe('signDpopProof — real ES256, real verification', () => {
       jti: 'jti-raw', iatSeconds: 1700000000,
     }))!;
     const sig = Buffer.from(proof.split('.')[2], 'base64url');
+    // Length alone distinguishes the forms: raw r||s for P-256 is exactly 64
+    // bytes; a DER ECDSA-Sig-Value is 70–72. (A first-byte 0x30 check was
+    // removed — r's leading byte is effectively uniform, so it IS 0x30 in
+    // ~1/256 runs, a real CI flake.)
     expect(sig.length).toBe(64);
-    expect(sig[0]).not.toBe(0x30);   // a DER SEQUENCE tag would mean we re-encoded
   });
 
   test('two proofs for the SAME request differ (fresh jti) and both verify', async () => {

--- a/tests/peerd-runtime/lifecycle/audit-recovery.test.ts
+++ b/tests/peerd-runtime/lifecycle/audit-recovery.test.ts
@@ -32,6 +32,24 @@ describe('audit sanitization', () => {
     expect(detail.nested.ok).toBe('kept');
   });
 
+  test('__proto__/constructor/prototype keys are dropped, not assigned — no prototype pollution', () => {
+    const detail = sanitizeDetail(JSON.parse('{"__proto__":{"polluted":true},"constructor":1,"ok":2}')) as Record<string, unknown>;
+    expect(Object.hasOwn(detail, '__proto__')).toBe(false);
+    expect(Object.hasOwn(detail, 'constructor')).toBe(false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(Object.getPrototypeOf(detail)).toBe(Object.prototype);
+    expect(detail.ok).toBe(2);
+  });
+
+  test('Errors keep name+message; Dates become ISO strings', () => {
+    const detail = sanitizeDetail({
+      error: new RangeError('too big'),
+      when: new Date('2026-08-05T00:00:00Z'),
+    }) as Record<string, any>;
+    expect(detail.error).toEqual({ name: 'RangeError', message: 'too big' });
+    expect(detail.when).toBe('2026-08-05T00:00:00.000Z');
+  });
+
   test('strings are truncated and depth is bounded', () => {
     const long = 'x'.repeat(2000);
     expect((sanitizeDetail(long) as string).length).toBeLessThan(600);
@@ -67,6 +85,12 @@ describe('recovery reports — §14 categories', () => {
   test('Class B → retry requires budget confirmation', () => {
     const verdict = decideRecovery({ retryClass: 'B', dispatched: false });
     expect(categorizeRecovery(verdict, { retryClass: 'B' }))
+      .toBe(RECOVERY_CATEGORIES.RETRY_REQUIRES_BUDGET);
+  });
+
+  test('a budget-exhausted verdict is the budget case even without class context', () => {
+    const verdict = decideRecovery({ retryClass: 'B', dispatched: false, budgetRemaining: false });
+    expect(categorizeRecovery(verdict, {}))
       .toBe(RECOVERY_CATEGORIES.RETRY_REQUIRES_BUDGET);
   });
 

--- a/tests/peerd-runtime/lifecycle/audit-recovery.test.ts
+++ b/tests/peerd-runtime/lifecycle/audit-recovery.test.ts
@@ -94,6 +94,16 @@ describe('recovery reports — §14 categories', () => {
     expect(report.user).toContain('saved files remain');
   });
 
+  test('settled verdicts are refused — a completed Class E action must never be labelled "safe to retry"', () => {
+    const completedVerdict = decideRecovery({
+      retryClass: 'E', dispatched: true, evidence: { kind: 'success-response' },
+    });
+    expect(() => categorizeRecovery(completedVerdict, { retryClass: 'E' }))
+      .toThrow(TypeError);
+    expect(() => describeRecovery(completedVerdict, { retryClass: 'E' }))
+      .toThrow(TypeError);
+  });
+
   test('the two explicit builders: security degradation and migration blocked', () => {
     const security = securityDegradationReport({ detail: 'offscreen doc refused' });
     expect(security.category).toBe(RECOVERY_CATEGORIES.SECURITY_DEGRADATION);

--- a/tests/peerd-runtime/lifecycle/audit-recovery.test.ts
+++ b/tests/peerd-runtime/lifecycle/audit-recovery.test.ts
@@ -1,0 +1,108 @@
+// Lifecycle audit sanitization (§13) + the paired user/agent recovery
+// reports (§14): same semantic distinction on both sides, secrets
+// structurally excluded from audit detail.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  LIFECYCLE_EVENTS, lifecycleAuditEntry, sanitizeDetail,
+} from '../../../extension/peerd-runtime/lifecycle/audit-events.js';
+import {
+  RECOVERY_CATEGORIES, categorizeRecovery, describeRecovery,
+  securityDegradationReport, migrationBlockedReport,
+} from '../../../extension/peerd-runtime/lifecycle/recovery-report.js';
+import { decideRecovery } from '../../../extension/peerd-runtime/lifecycle/retry-class.js';
+import { OPERATION_STATES } from '../../../extension/peerd-runtime/lifecycle/operation-state.js';
+
+describe('audit sanitization', () => {
+  test('forbidden keys are dropped at any depth', () => {
+    const detail = sanitizeDetail({
+      toolName: 'fetch_url',
+      authorization: 'Bearer xyz',
+      nested: {
+        setCookie: 'sid=1', dpopProof: 'jwt', requestBody: 'payload',
+        apiKey: 'sk-123', ok: 'kept',
+      },
+    }) as Record<string, any>;
+    expect(detail.toolName).toBe('fetch_url');
+    expect(detail.authorization).toBeUndefined();
+    expect(detail.nested.setCookie).toBeUndefined();
+    expect(detail.nested.dpopProof).toBeUndefined();
+    expect(detail.nested.requestBody).toBeUndefined();
+    expect(detail.nested.apiKey).toBeUndefined();
+    expect(detail.nested.ok).toBe('kept');
+  });
+
+  test('strings are truncated and depth is bounded', () => {
+    const long = 'x'.repeat(2000);
+    expect((sanitizeDetail(long) as string).length).toBeLessThan(600);
+    const deep = { a: { b: { c: { d: { e: { f: 1 } } } } } };
+    expect(JSON.stringify(sanitizeDetail(deep))).toContain('depth-capped');
+  });
+
+  test('entries carry the correlation chain and refuse unknown events', () => {
+    const entry = lifecycleAuditEntry({
+      event: LIFECYCLE_EVENTS.RETRY_REFUSED,
+      sessionId: 's', actorId: 'a', operationId: 'o', attempt: 2,
+      result: 'outcome_unknown', generationId: 'gen-1-x',
+      detail: { password: 'nope', why: 'class E' },
+    });
+    expect(entry).toMatchObject({
+      event: 'lifecycle.retry.refused', sessionId: 's', actorId: 'a',
+      operationId: 'o', attempt: 2, result: 'outcome_unknown',
+    });
+    expect((entry.detail as Record<string, unknown>).password).toBeUndefined();
+    expect(() => lifecycleAuditEntry({ event: 'made.up' })).toThrow(TypeError);
+  });
+});
+
+describe('recovery reports — §14 categories', () => {
+  test('interrupted Class A/C/E-undispatched → safe to retry', () => {
+    for (const retryClass of ['A', 'C', 'E']) {
+      const verdict = decideRecovery({ retryClass, dispatched: false });
+      expect(categorizeRecovery(verdict, { retryClass }))
+        .toBe(RECOVERY_CATEGORIES.SAFE_TO_RETRY);
+    }
+  });
+
+  test('Class B → retry requires budget confirmation', () => {
+    const verdict = decideRecovery({ retryClass: 'B', dispatched: false });
+    expect(categorizeRecovery(verdict, { retryClass: 'B' }))
+      .toBe(RECOVERY_CATEGORIES.RETRY_REQUIRES_BUDGET);
+  });
+
+  test('outcome_unknown → verify before retry, and user/agent agree', () => {
+    const verdict = decideRecovery({ retryClass: 'E', dispatched: true });
+    const report = describeRecovery(verdict, {
+      retryClass: 'E', operationId: 'op-1', toolName: 'submit_form',
+    });
+    expect(report.category).toBe(RECOVERY_CATEGORIES.VERIFY_BEFORE_RETRY);
+    expect(report.user).toContain('Check the target before repeating it');
+    expect(report.agent).toMatchObject({
+      category: RECOVERY_CATEGORIES.VERIFY_BEFORE_RETRY,
+      state: OPERATION_STATES.OUTCOME_UNKNOWN,
+      autoRetry: false,
+      verificationRequired: true,
+      operationId: 'op-1',
+      toolName: 'submit_form',
+    });
+  });
+
+  test('Class F → resource lost, files remain', () => {
+    const verdict = decideRecovery({ retryClass: 'F', dispatched: false });
+    const report = describeRecovery(verdict, { retryClass: 'F' });
+    expect(report.category).toBe(RECOVERY_CATEGORIES.RESOURCE_LOST);
+    expect(report.user).toContain('saved files remain');
+  });
+
+  test('the two explicit builders: security degradation and migration blocked', () => {
+    const security = securityDegradationReport({ detail: 'offscreen doc refused' });
+    expect(security.category).toBe(RECOVERY_CATEGORIES.SECURITY_DEGRADATION);
+    expect(security.user).toContain('was not run');
+    expect(security.agent.autoRetry).toBe(false);
+
+    const migration = migrationBlockedReport({ diagnosticId: 'store-sessions-newer-v9' });
+    expect(migration.category).toBe(RECOVERY_CATEGORIES.MIGRATION_BLOCKED);
+    expect(migration.user).toContain('No data was changed');
+    expect(migration.agent.diagnosticId).toBe('store-sessions-newer-v9');
+  });
+});

--- a/tests/peerd-runtime/lifecycle/boot.test.ts
+++ b/tests/peerd-runtime/lifecycle/boot.test.ts
@@ -1,0 +1,143 @@
+// Lifecycle boot — the SW-eviction sequence over storage that survives it.
+// Simulates eviction the way the contract defines it (§2.1): durable
+// storage persists, memory does not — a second boot over the same storage
+// IS the eviction, and must settle what the first generation left behind.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  makeLifecycleBoot, GENERATION_KEY,
+} from '../../../extension/peerd-runtime/lifecycle/boot.js';
+import { OPERATION_STATES } from '../../../extension/peerd-runtime/lifecycle/operation-state.js';
+
+const S = OPERATION_STATES;
+
+const makeStorage = () => {
+  const map = new Map<string, unknown>();
+  return {
+    get: async (k: string) => structuredClone(map.get(k)),
+    set: async (k: string, v: unknown) => { map.set(k, structuredClone(v)); },
+  };
+};
+
+const boot = (storage = makeStorage(), extra: Record<string, unknown> = {}) => {
+  let n = 0;
+  return makeLifecycleBoot({
+    storage,
+    nonce: () => `nonce-${n += 1}-xxxx`,
+    now: () => 1000 + n,
+    ...extra,
+  });
+};
+
+describe('generation continuity', () => {
+  test('each boot mints a monotonically newer generation, persisted before reconcile', async () => {
+    const storage = makeStorage();
+    const first = await boot(storage).init();
+    const second = await boot(storage).init();
+    expect(first.generation.seq).toBe(1);
+    expect(second.generation.seq).toBe(2);
+    expect(second.generation.id).not.toBe(first.generation.id);
+    expect(((await storage.get(GENERATION_KEY)) as { seq: number }).seq).toBe(2);
+  });
+});
+
+describe('the eviction matrix over durable storage', () => {
+  // One tool from every retry class, killed at a characteristic phase
+  // (§16.3): the first generation records the phase, the second boot must
+  // settle each to the contract's terminal state.
+  test('a second boot settles every orphan to its class-correct terminal state', async () => {
+    const storage = makeStorage();
+    const gen1 = boot(storage);
+    const { generation } = await gen1.init();
+    const log = gen1.operationLog;
+
+    const begin = (operationId: string, retryClass: string) => log.begin({
+      operationId, sessionId: 'sess-1', toolName: `tool-${retryClass}`,
+      retryClass, generationId: generation.id,
+    });
+
+    // Class B read: killed after dispatch.
+    await begin('op-b', 'B');
+    await log.transition('op-b', S.RUNNING);
+    await log.markDispatched('op-b');
+    // Class C write: killed before dispatch.
+    await begin('op-c', 'C');
+    await log.transition('op-c', S.RUNNING);
+    // Class D: killed after dispatch, no ack.
+    await begin('op-d', 'D');
+    await log.transition('op-d', S.RUNNING);
+    await log.markDispatched('op-d');
+    // Class E: killed after dispatch — THE case.
+    await begin('op-e', 'E');
+    await log.transition('op-e', S.RUNNING);
+    await log.markDispatched('op-e');
+    // Class E: killed during the approval prompt.
+    await begin('op-e2', 'E');
+    await log.transition('op-e2', S.RUNNING);
+    await log.transition('op-e2', S.AWAITING_USER);
+    // Class F resource: killed mid-registration.
+    await begin('op-f', 'F');
+    await log.transition('op-f', S.RUNNING);
+
+    // ---- the eviction: same storage, fresh boot ----
+    const gen2 = boot(storage);
+    const { plan } = await gen2.init();
+    expect(plan.transitions.length).toBe(6);
+
+    const state = async (id: string) => (await gen2.operationLog.get(id))!.state;
+    expect(await state('op-b')).toBe(S.INTERRUPTED);      // retryable read
+    expect(await state('op-c')).toBe(S.INTERRUPTED);      // idempotent write
+    expect(await state('op-d')).toBe(S.OUTCOME_UNKNOWN);  // verify first
+    expect(await state('op-e')).toBe(S.OUTCOME_UNKNOWN);  // never auto-retry
+    expect(await state('op-e2')).toBe(S.INTERRUPTED);     // approval died with the generation
+    expect(await state('op-f')).toBe(S.INTERRUPTED);      // recreate, no continuation
+  });
+
+  test('a third boot finds nothing left to settle (reconcile is idempotent)', async () => {
+    const storage = makeStorage();
+    const gen1 = boot(storage);
+    const { generation } = await gen1.init();
+    await gen1.operationLog.begin({
+      operationId: 'op-1', sessionId: 's', toolName: 't',
+      retryClass: 'E', generationId: generation.id,
+    });
+    await boot(storage).init();
+    const { plan } = await boot(storage).init();
+    expect(plan.transitions.length).toBe(0);
+  });
+});
+
+describe('notices — both audiences, delivered once', () => {
+  test('audit entries append, the user notify fires, and the agent drain is read-once', async () => {
+    const storage = makeStorage();
+    const audits: Array<Record<string, unknown>> = [];
+    const notes: string[] = [];
+    const gen1 = boot(storage);
+    const { generation } = await gen1.init();
+    await gen1.operationLog.begin({
+      operationId: 'op-e', sessionId: 'sess-9', toolName: 'submit_form',
+      retryClass: 'E', generationId: generation.id, });
+    await gen1.operationLog.transition('op-e', S.RUNNING);
+    await gen1.operationLog.markDispatched('op-e');
+
+    const gen2 = boot(storage, {
+      appendAudit: async (e: Record<string, unknown>) => { audits.push(e); },
+      notify: (_sid: string, text: string) => { notes.push(text); },
+    });
+    await gen2.init();
+
+    expect(audits.some((e) => e.event === 'lifecycle.generation.sw-changed')).toBe(true);
+    expect(audits.some((e) => e.event === 'lifecycle.operation.outcome_unknown')).toBe(true);
+    expect(notes.length).toBe(1);
+    expect(notes[0]).toContain('Check the target');
+
+    const block = await gen2.drainNoticesFor('sess-9');
+    expect(block).toContain('<interruption-recovery>');
+    expect(block).toContain('outcome_unknown');
+    expect(block).toContain('submit_form');
+    // Read-once: drained notices do not repeat on the next turn.
+    expect(await gen2.drainNoticesFor('sess-9')).toBe('');
+    // Other sessions see nothing.
+    expect(await gen2.drainNoticesFor('sess-other')).toBe('');
+  });
+});

--- a/tests/peerd-runtime/lifecycle/boot.test.ts
+++ b/tests/peerd-runtime/lifecycle/boot.test.ts
@@ -165,6 +165,47 @@ describe('notices — both audiences, delivered once', () => {
     expect(block).toContain('outcome_unknown');
   });
 
+  test('concurrent park and drain never lose or resurrect a notice (the queue)', async () => {
+    const storage = makeStorage();
+    const b = boot(storage);
+    await b.init();
+    // Interleave heavily: parks for T racing drains of S. Every parked
+    // notice must be drained exactly once, no loss, no duplication.
+    await b.parkNotice('S', { recoveryRecord: { operationId: 'op-s' }, user: 'notice S' });
+    const results = await Promise.all([
+      b.parkNotice('T', { recoveryRecord: { operationId: 'op-t1' }, user: 'notice T1' }),
+      b.drainNoticesFor('S'),
+      b.parkNotice('T', { recoveryRecord: { operationId: 'op-t2' }, user: 'notice T2' }),
+      b.drainNoticesFor('S'),
+    ]);
+    const sDrains = [results[1], results[3]].filter((x) => x !== '');
+    expect(sDrains.length).toBe(1); // read-once held under the race
+    const tBlock = await b.drainNoticesFor('T');
+    expect(tBlock).toContain('notice T1'); // neither park was lost
+    expect(tBlock).toContain('notice T2');
+    expect(await b.drainNoticesFor('T')).toBe(''); // and delivered once
+  });
+
+  test('purgeSession: a deleted session\'s notices vanish and its open operations settle cancelled', async () => {
+    const storage = makeStorage();
+    const b = boot(storage);
+    const { generation } = await b.init();
+    await b.operationLog.begin({
+      operationId: 'op-open', sessionId: 'sess-del', toolName: 'submit_form',
+      retryClass: 'E', generationId: generation.id,
+    });
+    await b.operationLog.transition('op-open', S.RUNNING);
+    await b.operationLog.markDispatched('op-open');
+    await b.parkNotice('sess-del', { recoveryRecord: { operationId: 'op-old' }, user: 'stale' });
+
+    await b.purgeSession('sess-del');
+    expect(await b.drainNoticesFor('sess-del')).toBe('');
+    expect((await b.operationLog.get('op-open'))!.state).toBe(S.CANCELLED);
+    // A fresh boot has nothing to resurrect for the deleted session.
+    const { plan } = await boot(storage).init();
+    expect(plan.transitions.length).toBe(0);
+  });
+
   test('a throwing resolver falls back to the operation\'s own session', async () => {
     const storage = makeStorage();
     const gen1 = boot(storage);

--- a/tests/peerd-runtime/lifecycle/boot.test.ts
+++ b/tests/peerd-runtime/lifecycle/boot.test.ts
@@ -140,4 +140,45 @@ describe('notices — both audiences, delivered once', () => {
     // Other sessions see nothing.
     expect(await gen2.drainNoticesFor('sess-other')).toBe('');
   });
+
+  test('an actor session\'s notice routes to the parent chat via resolveNoticeSession', async () => {
+    const storage = makeStorage();
+    const gen1 = boot(storage);
+    const { generation } = await gen1.init();
+    await gen1.operationLog.begin({
+      operationId: 'op-actor', sessionId: 'actor-child-3', actorId: 'web:9',
+      toolName: 'click', retryClass: 'E', generationId: generation.id,
+    });
+    await gen1.operationLog.transition('op-actor', S.RUNNING);
+    await gen1.operationLog.markDispatched('op-actor');
+
+    const gen2 = boot(storage, {
+      resolveNoticeSession: async (sid: string) =>
+        (sid === 'actor-child-3' ? 'root-chat-1' : sid),
+    });
+    await gen2.init();
+    // The notice landed on the ROOT chat — the session that takes turns —
+    // not the ephemeral actor child.
+    expect(await gen2.drainNoticesFor('actor-child-3')).toBe('');
+    const block = await gen2.drainNoticesFor('root-chat-1');
+    expect(block).toContain('click');
+    expect(block).toContain('outcome_unknown');
+  });
+
+  test('a throwing resolver falls back to the operation\'s own session', async () => {
+    const storage = makeStorage();
+    const gen1 = boot(storage);
+    const { generation } = await gen1.init();
+    await gen1.operationLog.begin({
+      operationId: 'op-1', sessionId: 'sess-1', toolName: 't',
+      retryClass: 'E', generationId: generation.id,
+    });
+    await gen1.operationLog.transition('op-1', S.RUNNING);
+    await gen1.operationLog.markDispatched('op-1');
+    const gen2 = boot(storage, {
+      resolveNoticeSession: async () => { throw new Error('sessions store down'); },
+    });
+    await gen2.init();
+    expect(await gen2.drainNoticesFor('sess-1')).toContain('outcome_unknown');
+  });
 });

--- a/tests/peerd-runtime/lifecycle/confirmation.test.ts
+++ b/tests/peerd-runtime/lifecycle/confirmation.test.ts
@@ -106,3 +106,36 @@ describe('single use', () => {
     expect(() => bindConfirmation({ ...base, generationId: '' })).toThrow(TypeError);
   });
 });
+
+describe('fail-closed bindings — no wildcard approvals', () => {
+  test('a target that does not normalize to a non-empty string refuses to bind', () => {
+    // A URL object where a string was meant is an ordinary call-site
+    // mistake; silently binding target '' would mint a wildcard approval.
+    expect(() => bindConfirmation({ ...base, target: new URL('https://bank.example/pay') as unknown as string }))
+      .toThrow(TypeError);
+    expect(() => bindConfirmation({ ...base, target: undefined })).toThrow(TypeError);
+    expect(() => bindConfirmation({ ...base, target: '   ' })).toThrow(TypeError);
+  });
+
+  test('a crafted/legacy proof with an empty target never matches an empty-normalizing request', () => {
+    const proof = { ...bindConfirmation(base), target: '' };
+    const verdict = confirmationSatisfies(proof, {
+      ...base, target: new URL('https://evil.example/steal') as unknown as string, now: base.now + 1,
+    });
+    expect(verdict.valid).toBe(false);
+    expect(verdict.reason).toContain('target missing');
+  });
+
+  test('a proof with a missing or non-numeric expiresAt fails closed, not eternal', () => {
+    const fresh = bindConfirmation(base);
+    for (const expiresAt of [undefined, Number.NaN, '99999999999999', {}]) {
+      const proof = { ...fresh, expiresAt: expiresAt as unknown as number };
+      const verdict = confirmationSatisfies(proof, { ...base, now: base.now + 1 });
+      expect(verdict.valid).toBe(false);
+    }
+  });
+
+  test('a non-finite clock refuses to bind (a NaN deadline would never expire)', () => {
+    expect(() => bindConfirmation({ ...base, now: Number.NaN })).toThrow(TypeError);
+  });
+});

--- a/tests/peerd-runtime/lifecycle/confirmation.test.ts
+++ b/tests/peerd-runtime/lifecycle/confirmation.test.ts
@@ -1,0 +1,108 @@
+// Confirmation binding (§8.3) — one approval covers one named action against
+// one normalized target for one operation under one capability generation,
+// once, inside a bounded window.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  bindConfirmation, confirmationSatisfies, consumeConfirmation,
+  normalizeConfirmationTarget, CONFIRMATION_TTL_MS,
+} from '../../../extension/peerd-runtime/lifecycle/confirmation.js';
+
+const base = {
+  operationId: 'op-1',
+  action: 'send_message',
+  target: 'https://example.com/api/send',
+  generationId: 'gen-1-aaaa',
+  now: 10_000,
+};
+
+describe('target normalization', () => {
+  test('cosmetic URL differences collapse; the resource selection survives', () => {
+    expect(normalizeConfirmationTarget('HTTPS://Example.COM:443/api/send#frag'))
+      .toBe('https://example.com/api/send');
+    expect(normalizeConfirmationTarget('https://example.com/api?x=1'))
+      .toBe('https://example.com/api?x=1');
+  });
+
+  test('non-URL targets normalize to their trimmed selves', () => {
+    expect(normalizeConfirmationTarget('  vault:openai-key ')).toBe('vault:openai-key');
+    expect(normalizeConfirmationTarget(undefined)).toBe('');
+  });
+});
+
+describe('binding and matching', () => {
+  test('a fresh proof satisfies the exact request it was bound for', () => {
+    const proof = bindConfirmation(base);
+    expect(proof.expiresAt).toBe(base.now + CONFIRMATION_TTL_MS);
+    const verdict = confirmationSatisfies(proof, { ...base, now: base.now + 1000 });
+    expect(verdict.valid).toBe(true);
+  });
+
+  test('every changed binding refuses: operation, action, target, generation', () => {
+    const proof = bindConfirmation(base);
+    const later = base.now + 1000;
+    const cases = [
+      { ...base, now: later, operationId: 'op-2' },
+      { ...base, now: later, action: 'delete_resource' },
+      { ...base, now: later, target: 'https://example.com/api/delete' },
+      { ...base, now: later, generationId: 'gen-2-bbbb' },
+    ];
+    for (const request of cases) {
+      expect(confirmationSatisfies(proof, request).valid).toBe(false);
+    }
+  });
+
+  test('a retry that recreated the operation cannot consume the old approval', () => {
+    const proof = bindConfirmation(base);
+    const verdict = confirmationSatisfies(proof,
+      { ...base, operationId: 'op-1-retry', now: base.now + 1 });
+    expect(verdict.valid).toBe(false);
+    expect(verdict.reason).toContain('different operation');
+  });
+
+  test('a SW restart (new generation) invalidates the approval', () => {
+    const proof = bindConfirmation(base);
+    const verdict = confirmationSatisfies(proof,
+      { ...base, generationId: 'gen-2-cccc', now: base.now + 1 });
+    expect(verdict.valid).toBe(false);
+    expect(verdict.reason).toContain('generation changed');
+  });
+
+  test('the window is bounded and judged by the injected clock', () => {
+    const proof = bindConfirmation(base);
+    expect(confirmationSatisfies(proof,
+      { ...base, now: proof.expiresAt }).valid).toBe(false);
+    expect(confirmationSatisfies(proof,
+      { ...base, now: proof.expiresAt - 1 }).valid).toBe(true);
+  });
+
+  test('a cosmetically different target string still matches after normalization', () => {
+    const proof = bindConfirmation(base);
+    const verdict = confirmationSatisfies(proof, {
+      ...base, target: 'HTTPS://EXAMPLE.com:443/api/send#x', now: base.now + 1,
+    });
+    expect(verdict.valid).toBe(true);
+  });
+});
+
+describe('single use', () => {
+  test('a consumed proof never satisfies again', () => {
+    const proof = bindConfirmation(base);
+    const spent = consumeConfirmation(proof);
+    expect(spent.consumed).toBe(true);
+    expect(proof.consumed).toBe(false); // immutably copied, not mutated
+    const verdict = confirmationSatisfies(spent, { ...base, now: base.now + 1 });
+    expect(verdict.valid).toBe(false);
+    expect(verdict.reason).toContain('consumed');
+  });
+
+  test('missing proof refuses', () => {
+    expect(confirmationSatisfies(null, base).valid).toBe(false);
+    expect(confirmationSatisfies(undefined, base).valid).toBe(false);
+  });
+
+  test('binding without the required identities throws', () => {
+    expect(() => bindConfirmation({ ...base, operationId: '' })).toThrow(TypeError);
+    expect(() => bindConfirmation({ ...base, generationId: '' })).toThrow(TypeError);
+  });
+});

--- a/tests/peerd-runtime/lifecycle/dispatch-boundary-guarantees.test.ts
+++ b/tests/peerd-runtime/lifecycle/dispatch-boundary-guarantees.test.ts
@@ -138,7 +138,7 @@ describe('§8 persist-before-report: the settle write lands before the dispatche
 
 describe('replay identity survives compaction (tombstones)', () => {
   test('a completed Class E call refuses re-execution even after its record was pruned past the cap', async () => {
-    const { storage, log } = makeLog();
+    const { storage } = makeLog();
     let t = 0;
     const agedLog = createOperationLog({ storage, now: () => ++t });
     // The Class E operation completes…

--- a/tests/peerd-runtime/lifecycle/dispatch-boundary-guarantees.test.ts
+++ b/tests/peerd-runtime/lifecycle/dispatch-boundary-guarantees.test.ts
@@ -120,6 +120,109 @@ describe('GUARANTEE 2 + fail-closed: Class D/E never execute when tracking canno
   });
 });
 
+describe('GUARANTEE 2: an UNEXPECTED beginTracking rejection still fails closed for D/E', () => {
+  // The tracker's own failure paths are covered above. This is the harder
+  // question: the dispatcher used to swallow ANY beginTracking rejection
+  // with `.catch(() => null)` and run untracked. These tests force
+  // beginTracking ITSELF to reject — the contract-violating case — and
+  // prove the dispatcher refuses independently of the broken tracker.
+  const rejectingTracker = {
+    beginTracking: async () => { throw new Error('tracker contract violated'); },
+    settleTracking: async () => null,
+  };
+
+  test('Class E: execute() never entered, dispatcher refuses, nothing persisted', async () => {
+    const { storage, log } = makeLog();
+    const calls = spyTool('submit_form', 'mutate_external');
+    const result = await dispatchToolCall(
+      { id: 'tu-1', name: 'submit_form', args: {} },
+      baseCtx(rejectingTracker) as any);
+
+    expect(calls.count).toBe(0);                                  // no side effect
+    expect(result.ok).toBe(false);                                // refusal
+    expect((result as { error: string }).error).toContain('NOT executed');
+    expect((result.meta as any).recovery.category).toBe('security_degradation');
+    // No half-written lifecycle state: the log was never touched, so a
+    // later boot has nothing to reconcile and nothing to misreport.
+    expect(storage.journal).toEqual([]);
+    expect(await log.get('sess-1:tu-1')).toBeUndefined();
+    expect(await log.listNonterminal()).toEqual([]);
+  });
+
+  test('Class D refuses the same way', async () => {
+    const calls = spyTool('dweb_share', 'mutate_external'); // named D override
+    const result = await dispatchToolCall(
+      { id: 'tu-1', name: 'dweb_share', args: {} },
+      baseCtx(rejectingTracker) as any);
+    expect(calls.count).toBe(0);
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).toContain('NOT executed');
+  });
+
+  test('Class A/B/C keep the safe degradation — a broken tracker cannot take reads down', async () => {
+    const a = spyTool('read_page', 'read');
+    const b = spyTool('fetch_url_like', 'read', 'B');
+    const c = spyTool('js_write_file_like', 'write', 'C');
+    for (const [name, calls] of [['read_page', a], ['fetch_url_like', b], ['js_write_file_like', c]] as const) {
+      const result = await dispatchToolCall(
+        { id: `tu-${name}`, name, args: {} }, baseCtx(rejectingTracker) as any);
+      expect(result.ok).toBe(true);
+      expect(calls.count).toBe(1);
+    }
+  });
+
+  test('the real tracker is TOTAL: internals that blow up produce a refusal, never a rejection', async () => {
+    // Each of these breaks a different internal the tracker depends on.
+    const cases = [
+      ['throwing classifier', makeDispatchTracker({
+        operationLog: createOperationLog({ storage: makeStorage() }),
+        generationId: () => 'gen-1-x',
+        retryClassFor: () => { throw new Error('classifier exploded'); },
+      })],
+      ['throwing generationId', makeDispatchTracker({
+        operationLog: createOperationLog({ storage: makeStorage() }),
+        generationId: () => { throw new Error('no generation'); },
+        retryClassFor: retryClassForTool,
+      })],
+      ['unreadable replay identity (tombstone store down)', makeDispatchTracker({
+        operationLog: {
+          ...createOperationLog({ storage: makeStorage() }),
+          getTombstone: async () => { throw new Error('tombstone store unreadable'); },
+        } as any,
+        generationId: () => 'gen-1-x',
+        retryClassFor: retryClassForTool,
+      })],
+    ] as const;
+
+    for (const [label, tracker] of cases) {
+      const begun = await tracker.beginTracking({
+        callId: 'c1', tool: { name: 'submit_form', sideEffect: 'mutate_external' },
+        sessionId: 's',
+      });
+      expect(begun && 'refuse' in begun, label).toBe(true);
+      expect((begun as any).refuse.error, label).toContain('NOT executed');
+    }
+  });
+
+  test('an unreadable replay-identity store never silently proceeds for Class E', async () => {
+    // The question "has this exact call already run?" is unanswered — the
+    // one answer that is NOT allowed is assuming "no".
+    const tracker = makeDispatchTracker({
+      operationLog: {
+        ...createOperationLog({ storage: makeStorage() }),
+        getTombstone: async () => { throw new Error('store unreadable'); },
+      } as any,
+      generationId: () => 'gen-1-x',
+      retryClassFor: retryClassForTool,
+    });
+    const calls = spyTool('submit_form', 'mutate_external');
+    const result = await dispatchToolCall(
+      { id: 'tu-1', name: 'submit_form', args: {} }, baseCtx(tracker) as any);
+    expect(calls.count).toBe(0);
+    expect((result as { error: string }).error).toContain('replay-identity lookup failed');
+  });
+});
+
 describe('§8 persist-before-report: the settle write lands before the dispatcher returns', () => {
   test('the COMPLETED transition is journaled before dispatchToolCall resolves', async () => {
     const { storage, log } = makeLog();
@@ -236,6 +339,47 @@ describe('§8.3 the confirmation forensic chain on the durable record', () => {
       operationId: 'sess-1:tu-1', action: 'submit_form',
       target: 'https://example.com/pay', generationId: 'gen-2-y', now: 50_001,
     }).valid).toBe(false);
+  });
+
+  test('idempotency keys are ORDER-INDEPENDENT and SHA-256 wide', async () => {
+    const { log } = makeLog();
+    const tracker = makeDispatchTracker({
+      operationLog: log, generationId: () => 'gen-1-x', retryClassFor: () => 'D' as any,
+    });
+    const keyFor = async (callId: string, args: Record<string, unknown>) => {
+      await tracker.beginTracking({
+        callId, tool: { name: 'dweb_share' }, sessionId: 's', args,
+      });
+      return (await log.get(`s:${callId}`))!.idempotencyKey!;
+    };
+    // Same content, different property order at two depths — one key.
+    const a = await keyFor('c1', { title: 'post', meta: { x: 1, y: 2 }, body: 'hi' });
+    const b = await keyFor('c2', { body: 'hi', meta: { y: 2, x: 1 }, title: 'post' });
+    expect(a).toBe(b);
+    // Array ORDER is semantic — it must still separate operations.
+    const c = await keyFor('c3', { tags: ['x', 'y'] });
+    const d = await keyFor('c4', { tags: ['y', 'x'] });
+    expect(c).not.toBe(d);
+    // SHA-256 hex, not a 32-bit digest.
+    expect(a).toMatch(/^dweb_share:[0-9a-f]{64}$/);
+  });
+
+  test('canonicalJson: stable across key order, faithful to arrays, depth-bounded', async () => {
+    const { canonicalJson, sha256Hex, idempotencyKeyFor } = await import(
+      '../../../extension/peerd-runtime/lifecycle/dispatch-tracking.js');
+    expect(canonicalJson({ b: 1, a: 2 })).toBe(canonicalJson({ a: 2, b: 1 }));
+    expect(canonicalJson({ a: [1, 2] })).not.toBe(canonicalJson({ a: [2, 1] }));
+    expect(canonicalJson({ a: undefined })).toBe('{"a":null}');
+    // A pathological nest terminates instead of blowing the stack.
+    let deep: Record<string, unknown> = { end: true };
+    for (let i = 0; i < 200; i += 1) deep = { nest: deep };
+    expect(() => canonicalJson(deep)).not.toThrow();
+    expect(canonicalJson(deep)).toContain('depth-capped');
+    // Known-answer check that this really is SHA-256.
+    expect(await sha256Hex('abc')).toBe(
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+    expect(await idempotencyKeyFor('t', { a: 1 }))
+      .toBe(`t:${await sha256Hex('{"a":1}')}`);
   });
 
   test('Class C/D records carry a deterministic idempotency key (same args → same key; retries reuse it)', async () => {

--- a/tests/peerd-runtime/lifecycle/dispatch-boundary-guarantees.test.ts
+++ b/tests/peerd-runtime/lifecycle/dispatch-boundary-guarantees.test.ts
@@ -1,0 +1,288 @@
+// Boundary-guarantee proofs — each test is named for the contract guarantee
+// it defends, and each of the reviewer's mutation probes would fail exactly
+// one of them. All run at the REAL dispatcher boundary (dispatchToolCall +
+// an execution spy), not against the tracker in isolation.
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { makeDispatchTracker, makeFailClosedTracker } from '../../../extension/peerd-runtime/lifecycle/dispatch-tracking.js';
+import { createOperationLog, OPERATION_LOG_MAX_TERMINAL } from '../../../extension/peerd-runtime/lifecycle/operation-log.js';
+import { makeLifecycleBoot } from '../../../extension/peerd-runtime/lifecycle/boot.js';
+import { OPERATION_STATES } from '../../../extension/peerd-runtime/lifecycle/operation-state.js';
+import { confirmationSatisfies } from '../../../extension/peerd-runtime/lifecycle/confirmation.js';
+import { retryClassForTool } from '../../../extension/peerd-runtime/lifecycle/tool-retry-class.js';
+import { registerTool, clearTools } from '../../../extension/peerd-runtime/tools/registry.js';
+import { dispatchToolCall } from '../../../extension/peerd-runtime/tools/dispatcher.js';
+import { fromOpenAiStream } from '../../../extension/peerd-provider/format/from-openai.js';
+
+const S = OPERATION_STATES;
+
+const makeStorage = () => {
+  const map = new Map<string, unknown>();
+  const journal: string[] = [];
+  return {
+    map, journal,
+    get: async (k: string) => structuredClone(map.get(k)),
+    set: async (k: string, v: unknown) => { journal.push(`set:${k}`); map.set(k, structuredClone(v)); },
+  };
+};
+
+const makeLog = (storage = makeStorage()) => ({
+  storage,
+  log: createOperationLog({ storage, now: () => 1 }),
+});
+
+const spyTool = (name: string, sideEffect: string, retryClass?: string) => {
+  const calls = { count: 0 };
+  registerTool({
+    name, description: 'x', schema: {}, primitive: 'web', sideEffect,
+    ...(retryClass ? { retryClass } : {}),
+    origins: () => ['https://example.com'],
+    execute: async () => { calls.count += 1; return { ok: true, content: 'done' }; },
+  } as any);
+  return calls;
+};
+
+const baseCtx = (lifecycle: unknown, extra: Record<string, unknown> = {}) => ({
+  audit: async () => {},
+  session: { sessionId: 'sess-1' },
+  permission: { mode: 'act', confirmActions: false },
+  hooks: [],
+  lifecycle,
+  ...extra,
+});
+
+beforeEach(() => clearTools());
+
+describe('GUARANTEE 2 + fail-closed: Class D/E never execute when tracking cannot start', () => {
+  test('operationLog.begin throws + Class E → refusal at the dispatcher, execute() never entered', async () => {
+    const tracker = makeDispatchTracker({
+      operationLog: createOperationLog({
+        storage: { get: async () => { throw new Error('storage dead'); },
+          set: async () => { throw new Error('storage dead'); } },
+      }),
+      generationId: () => 'gen-1-x',
+      retryClassFor: retryClassForTool,
+    });
+    const calls = spyTool('submit_form', 'mutate_external'); // → Class E by taxonomy
+    const result = await dispatchToolCall(
+      { id: 'tu-1', name: 'submit_form', args: {} }, baseCtx(tracker) as any);
+    expect(calls.count).toBe(0);
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).toContain('NOT executed');
+  });
+
+  test('boot failed (fail-closed tracker) → Class D and E refused, execute() never entered; A/B/C still run', async () => {
+    const tracker = makeFailClosedTracker({
+      reason: 'lifecycle boot failed', retryClassFor: retryClassForTool,
+    });
+    const e = spyTool('submit_form', 'mutate_external');
+    const d = spyTool('dweb_share', 'mutate_external');       // named D override
+    const b = spyTool('fetch_url_like', 'read', 'B');
+    const a = spyTool('read_page', 'read');
+
+    for (const [name, calls, shouldRun] of [
+      ['submit_form', e, false], ['dweb_share', d, false],
+      ['fetch_url_like', b, true], ['read_page', a, true],
+    ] as const) {
+      const result = await dispatchToolCall(
+        { id: `tu-${name}`, name, args: {} }, baseCtx(tracker) as any);
+      expect(calls.count).toBe(shouldRun ? 1 : 0);
+      if (!shouldRun) expect(result.ok).toBe(false);
+    }
+  });
+
+  test('no Class E dispatch proceeds while lifecycle arming is unresolved (the boot-window pattern)', async () => {
+    // The SW's buildToolContext awaits the boot before handing out any ctx;
+    // this pins that pattern: ctx construction blocks, so execute cannot be
+    // reached until the tracker is armed — and the armed result then
+    // governs the dispatch.
+    const { log } = makeLog();
+    let armTracker: (t: unknown) => void = () => {};
+    const armed: Promise<unknown> = new Promise((resolve) => { armTracker = resolve; });
+    const buildCtx = async () => baseCtx(await armed);
+    const calls = spyTool('submit_form', 'mutate_external');
+
+    let settled = false;
+    const inFlight = buildCtx().then((ctx) =>
+      dispatchToolCall({ id: 'tu-1', name: 'submit_form', args: {} }, ctx as any))
+      .then((r) => { settled = true; return r; });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(calls.count).toBe(0); // nothing executed while unarmed
+    expect(settled).toBe(false);
+
+    armTracker(makeDispatchTracker({
+      operationLog: log, generationId: () => 'gen-1-x', retryClassFor: retryClassForTool,
+    }));
+    const result = await inFlight;
+    expect(result.ok).toBe(true);
+    expect(calls.count).toBe(1); // ran exactly once, tracked, after arming
+    expect((await log.get('sess-1:tu-1'))!.state).toBe(S.COMPLETED);
+  });
+});
+
+describe('§8 persist-before-report: the settle write lands before the dispatcher returns', () => {
+  test('the COMPLETED transition is journaled before dispatchToolCall resolves', async () => {
+    const { storage, log } = makeLog();
+    const tracker = makeDispatchTracker({
+      operationLog: log, generationId: () => 'gen-1-x', retryClassFor: retryClassForTool,
+    });
+    spyTool('submit_form', 'mutate_external');
+    const writesAtResolve = await dispatchToolCall(
+      { id: 'tu-1', name: 'submit_form', args: {} }, baseCtx(tracker) as any)
+      .then(() => storage.journal.length);
+    // …and the record IS completed at that instant (not settled later).
+    expect(writesAtResolve).toBe(storage.journal.length);
+    expect((await log.get('sess-1:tu-1'))!.state).toBe(S.COMPLETED);
+  });
+});
+
+describe('replay identity survives compaction (tombstones)', () => {
+  test('a completed Class E call refuses re-execution even after its record was pruned past the cap', async () => {
+    const { storage, log } = makeLog();
+    let t = 0;
+    const agedLog = createOperationLog({ storage, now: () => ++t });
+    // The Class E operation completes…
+    await agedLog.begin({
+      operationId: 'sess-1:tu-pay', sessionId: 'sess-1', toolName: 'submit_form',
+      retryClass: 'E', generationId: 'gen-1-x',
+    });
+    await agedLog.transition('sess-1:tu-pay', S.RUNNING);
+    await agedLog.transition('sess-1:tu-pay', S.COMPLETED,
+      { evidence: { kind: 'success-response' } });
+    // …then 500+ later operations age its full record out.
+    for (let i = 0; i < OPERATION_LOG_MAX_TERMINAL + 2; i += 1) {
+      const id = `op-${i}`;
+      await agedLog.begin({
+        operationId: id, sessionId: 's2', toolName: 't', retryClass: 'E',
+        generationId: 'gen-1-x',
+      });
+      await agedLog.transition(id, S.RUNNING);
+      await agedLog.transition(id, S.COMPLETED, { evidence: { kind: 'success-response' } });
+    }
+    expect(await agedLog.get('sess-1:tu-pay')).toBeUndefined(); // full record gone
+
+    const tracker = makeDispatchTracker({
+      operationLog: agedLog, generationId: () => 'gen-2-y', retryClassFor: retryClassForTool,
+    });
+    const calls = spyTool('submit_form', 'mutate_external');
+    const replay = await dispatchToolCall(
+      { id: 'tu-pay', name: 'submit_form', args: {} }, baseCtx(tracker) as any);
+    expect(calls.count).toBe(0); // the tombstone refused it
+    expect((replay as { error: string }).error).toStartWith('completed:');
+  });
+});
+
+describe('uncertainty is never silently discarded (overflow evidence)', () => {
+  test('compacting unknowns past the cap leaves a drained overflow record and a boot notice', async () => {
+    const storage = makeStorage();
+    let n = 0;
+    const boot = makeLifecycleBoot({
+      storage, nonce: () => `nonce-${n += 1}-xxxx`, now: () => 1000 + n,
+    });
+    const { generation } = await boot.init();
+    let t = 0;
+    const log = createOperationLog({ storage, now: () => ++t });
+    for (let i = 0; i < 202; i += 1) {
+      const id = `unk-${i}`;
+      await log.begin({
+        operationId: id, sessionId: 'sess-9', toolName: 'submit_form',
+        retryClass: 'E', generationId: generation.id,
+      });
+      await log.transition(id, S.RUNNING);
+      await log.transition(id, S.OUTCOME_UNKNOWN, { dispatched: true });
+    }
+    // The next boot surfaces the compaction as evidence + a notice.
+    const boot2 = makeLifecycleBoot({
+      storage, nonce: () => `nonce-${n += 1}-xxxx`, now: () => 2000 + n,
+    });
+    await boot2.init();
+    const block = await boot2.drainNoticesFor('sess-9');
+    expect(block).toContain('compacted');
+    expect(block).toContain('Verify');
+  });
+});
+
+describe('§8.3 the confirmation forensic chain on the durable record', () => {
+  test('an approved dispatch persists a consumed, generation-bound proof that a restart invalidates', async () => {
+    const { log } = makeLog();
+    const tracker = makeDispatchTracker({
+      operationLog: log, generationId: () => 'gen-1-x',
+      retryClassFor: retryClassForTool, now: () => 50_000,
+    });
+    const begun = await tracker.beginTracking({
+      callId: 'tu-1', tool: { name: 'submit_form', sideEffect: 'mutate_external' },
+      sessionId: 'sess-1', target: 'https://example.com/pay',
+      confirmed: true, args: { amount: 5 },
+    });
+    expect(begun && 'handle' in begun).toBe(true);
+    const record = (await log.get('sess-1:tu-1'))!;
+    const proof = record.confirmationProof as any;
+    expect(record.confirmationRef).toBe('sess-1:tu-1:confirm');
+    expect(proof).toMatchObject({
+      operationId: 'sess-1:tu-1', action: 'submit_form',
+      target: 'https://example.com/pay', generationId: 'gen-1-x',
+      consumed: true, // one approval covers exactly one dispatch
+    });
+    expect(proof.expiresAt).toBeGreaterThan(proof.grantedAt);
+
+    // Consumed: never satisfies again, even for the identical request.
+    expect(confirmationSatisfies(proof, {
+      operationId: 'sess-1:tu-1', action: 'submit_form',
+      target: 'https://example.com/pay', generationId: 'gen-1-x', now: 50_001,
+    }).valid).toBe(false);
+    // Stale after a restart: the new generation refuses it outright.
+    const fresh = { ...proof, consumed: false };
+    expect(confirmationSatisfies(fresh, {
+      operationId: 'sess-1:tu-1', action: 'submit_form',
+      target: 'https://example.com/pay', generationId: 'gen-2-y', now: 50_001,
+    }).valid).toBe(false);
+  });
+
+  test('Class C/D records carry a deterministic idempotency key (same args → same key; retries reuse it)', async () => {
+    const { log } = makeLog();
+    const tracker = makeDispatchTracker({
+      operationLog: log, generationId: () => 'gen-1-x',
+      retryClassFor: () => 'D' as any,
+    });
+    await tracker.beginTracking({
+      callId: 'c1', tool: { name: 'dweb_share' }, sessionId: 's',
+      args: { content: 'hello', title: 'post' },
+    });
+    const key1 = (await log.get('s:c1'))!.idempotencyKey;
+    await tracker.beginTracking({
+      callId: 'c2', tool: { name: 'dweb_share' }, sessionId: 's',
+      args: { content: 'hello', title: 'post' },
+    });
+    const key2 = (await log.get('s:c2'))!.idempotencyKey;
+    await tracker.beginTracking({
+      callId: 'c3', tool: { name: 'dweb_share' }, sessionId: 's',
+      args: { content: 'DIFFERENT' },
+    });
+    const key3 = (await log.get('s:c3'))!.idempotencyKey;
+    expect(key1).toBeDefined();
+    expect(key1).toBe(key2!);      // deterministic across identical calls
+    expect(key1).not.toBe(key3!);  // args select the operation
+  });
+});
+
+describe('operation identity assumptions hold at the formatter seam', () => {
+  test('fromOpenAiStream preserves provider tool-call ids verbatim (no regeneration)', async () => {
+    const sse = [
+      `data: ${JSON.stringify({ choices: [{ delta: { role: 'assistant' } }] })}`,
+      `data: ${JSON.stringify({ choices: [{ delta: { tool_calls: [{ index: 0, id: 'call_VERBATIM_9x', type: 'function', function: { name: 'submit_form', arguments: '{}' } }] } }] })}`,
+      `data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: 'tool_calls' }] })}`,
+      'data: [DONE]', '',
+    ].join('\n\n');
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(sse));
+        controller.close();
+      },
+    });
+    const ids: string[] = [];
+    for await (const ev of fromOpenAiStream(body as any)) {
+      if ((ev as any).type === 'tool-use-start') ids.push((ev as any).id);
+    }
+    expect(ids).toEqual(['call_VERBATIM_9x']);
+  });
+});

--- a/tests/peerd-runtime/lifecycle/dispatch-tracking.test.ts
+++ b/tests/peerd-runtime/lifecycle/dispatch-tracking.test.ts
@@ -143,6 +143,112 @@ describe('settleTracking — §16.2 semantic failures', () => {
   });
 });
 
+describe('fail closed when tracking cannot start', () => {
+  const brokenStorage = () => createOperationLog({
+    storage: {
+      get: async () => { throw new Error('quota exceeded'); },
+      set: async () => { throw new Error('quota exceeded'); },
+    },
+    now: () => 1,
+  });
+
+  test('Class E and D are REFUSED, not executed untracked, when the log is down', async () => {
+    for (const retryClass of ['E', 'D']) {
+      const tracker = makeDispatchTracker({
+        operationLog: brokenStorage(),
+        generationId: () => 'gen-1-x',
+        retryClassFor: (tool) => (tool as { retryClass?: string }).retryClass as any,
+      });
+      const begun = await tracker.beginTracking({
+        callId: 'c1', tool: { name: 'submit_form', retryClass }, sessionId: 's',
+      });
+      expect(begun && 'refuse' in begun).toBe(true);
+      const refusal = (begun as { refuse: { error: string, recovery: any } }).refuse;
+      expect(refusal.error).toContain('NOT executed');
+      expect(refusal.recovery.category).toBe('security_degradation');
+    }
+  });
+
+  test('Class B degrades to untracked — a broken log must not brick reads', async () => {
+    const tracker = makeDispatchTracker({
+      operationLog: brokenStorage(),
+      generationId: () => 'gen-1-x',
+      retryClassFor: () => 'B' as any,
+    });
+    const begun = await tracker.beginTracking({
+      callId: 'c1', tool: { name: 'fetch_url', retryClass: 'B' }, sessionId: 's',
+    });
+    expect(begun).toBeNull();
+  });
+
+  test('a death MID-SEQUENCE (begin ok, markDispatched fails) also refuses D/E', async () => {
+    let writes = 0;
+    const log = createOperationLog({
+      storage: {
+        get: async () => undefined,
+        set: async () => { writes += 1; if (writes > 1) throw new Error('storage died'); },
+      },
+      now: () => 1,
+    });
+    const tracker = makeDispatchTracker({
+      operationLog: log, generationId: () => 'gen-1-x',
+      retryClassFor: () => 'E' as any,
+    });
+    const begun = await tracker.beginTracking({
+      callId: 'c1', tool: { name: 'submit_form', retryClass: 'E' }, sessionId: 's',
+    });
+    expect(begun && 'refuse' in begun).toBe(true);
+  });
+
+  test('makeFailClosedTracker: the boot-failure tracker refuses D/E and passes A/B/C', async () => {
+    const { makeFailClosedTracker } = await import(
+      '../../../extension/peerd-runtime/lifecycle/dispatch-tracking.js');
+    const tracker = makeFailClosedTracker({
+      reason: 'lifecycle boot failed',
+      retryClassFor: (tool) => (tool as { retryClass?: string }).retryClass as any,
+    });
+    const refused = await tracker.beginTracking({ tool: { name: 'submit_form', retryClass: 'E' } });
+    expect(refused && 'refuse' in refused).toBe(true);
+    expect((refused as any).refuse.error).toContain('boot failed');
+    expect(await tracker.beginTracking({ tool: { name: 'read_page', retryClass: 'A' } })).toBeNull();
+    expect(await tracker.beginTracking({ tool: { name: 'fetch_url', retryClass: 'B' } })).toBeNull();
+    expect(await tracker.settleTracking()).toBeNull();
+  });
+});
+
+describe('typed failure outcomes outrank string heuristics', () => {
+  const settleTyped = async (retryClass: string, error: string, outcomeKind?: string) => {
+    const { tracker, log } = makeTracker();
+    const begun = await tracker.beginTracking({
+      callId: 'c1', tool: { name: 't', retryClass }, sessionId: 's',
+    });
+    const rewrite = await tracker.settleTracking(
+      (begun as { handle: any }).handle,
+      { ok: false, error, outcomeKind: outcomeKind as any });
+    return { rewrite, record: await log.get('s:c1') };
+  };
+
+  test('pre-effect-failure settles failed even when the message LOOKS like a timeout', async () => {
+    const { record } = await settleTyped('E', 'gateway timed out validating the payload', 'pre-effect-failure');
+    expect(record!.state).toBe(S.FAILED);
+  });
+
+  test('transport-lost settles ambiguous even when the message looks definitive', async () => {
+    const { record } = await settleTyped('E', 'element not found: #missing', 'transport-lost');
+    expect(record!.state).toBe(S.OUTCOME_UNKNOWN);
+  });
+
+  test('host-lost is ambiguous for E, interrupted for B', async () => {
+    expect((await settleTyped('E', 'x', 'host-lost')).record!.state).toBe(S.OUTCOME_UNKNOWN);
+    expect((await settleTyped('B', 'x', 'host-lost')).record!.state).toBe(S.INTERRUPTED);
+  });
+
+  test('an unstamped failure still takes the heuristic path', async () => {
+    const { record } = await settleTyped('E', 'request timed out');
+    expect(record!.state).toBe(S.OUTCOME_UNKNOWN);
+  });
+});
+
 describe('the replay guard — guarantee 2', () => {
   test('re-dispatching an unproven Class E call is REFUSED with outcome_unknown', async () => {
     const { tracker, log } = makeTracker();

--- a/tests/peerd-runtime/lifecycle/dispatch-tracking.test.ts
+++ b/tests/peerd-runtime/lifecycle/dispatch-tracking.test.ts
@@ -250,20 +250,75 @@ describe('typed failure outcomes outrank string heuristics', () => {
 });
 
 describe('the replay guard — guarantee 2', () => {
-  test('re-dispatching an unproven Class E call is REFUSED with outcome_unknown', async () => {
+  test('a CURRENT-generation duplicate is refused WITHOUT mutating the live record', async () => {
+    // The first dispatch is still executing in this very SW — its outcome
+    // is pending, not lost. The duplicate must be refused, but force-
+    // settling the record would discard the evidence about to arrive.
     const { tracker, log } = makeTracker();
     await tracker.beginTracking({
       callId: 'c1', tool: { name: 'submit_form', retryClass: 'E' }, sessionId: 's',
     });
-    // SW dies here: dispatched, no settle. New generation re-drives the
-    // same tool_use id.
     const begun = await tracker.beginTracking({
       callId: 'c1', tool: { name: 'submit_form', retryClass: 'E' }, sessionId: 's',
     });
     expect(begun && 'refuse' in begun).toBe(true);
     const refusal = (begun as { refuse: { error: string } }).refuse;
     expect(refusal.error).toStartWith('outcome_unknown:');
+    expect(refusal.error).toContain('still pending');
+    expect((await log.get('s:c1'))!.state).toBe(S.AWAITING_REMOTE); // NOT mutated
+  });
+
+  test('a DEAD-generation unproven Class E record IS force-settled outcome_unknown on replay', async () => {
+    const { tracker, log } = makeTracker();
+    // The record as a dead SW left it: dispatched under gen-0, unsettled.
+    await log.begin({
+      operationId: 's:c1', sessionId: 's', toolName: 'submit_form',
+      retryClass: 'E', generationId: 'gen-0-dead',
+    });
+    await log.transition('s:c1', S.RUNNING);
+    await log.markDispatched('s:c1');
+    const begun = await tracker.beginTracking({
+      callId: 'c1', tool: { name: 'submit_form', retryClass: 'E' }, sessionId: 's',
+    });
+    expect((begun as { refuse: { error: string } }).refuse.error).toStartWith('outcome_unknown:');
     expect((await log.get('s:c1'))!.state).toBe(S.OUTCOME_UNKNOWN);
+  });
+
+  test('late positive evidence resolves a force-parked outcome_unknown record', async () => {
+    const { tracker, log } = makeTracker();
+    const begun = await tracker.beginTracking({
+      callId: 'c1', tool: { name: 'submit_form', retryClass: 'E' }, sessionId: 's',
+    });
+    // Simulate the mid-execute force-park (as a dead-generation replay
+    // would have done it) …
+    await log.settle('s:c1', {
+      state: S.OUTCOME_UNKNOWN, autoRetry: false, retryRequires: [],
+      keepIdempotencyKey: false, verificationRequired: true,
+      recreateResource: false, reason: 'force-parked',
+    });
+    // … then the ORIGINAL dispatch resolves with proof. resolveUnknown is
+    // the sanctioned evidence-gated exit; the evidence must not be dropped.
+    await tracker.settleTracking((begun as { handle: any }).handle, { ok: true });
+    expect((await log.get('s:c1'))!.state).toBe(S.COMPLETED);
+  });
+
+  test('a class-confusion replay (recorded E, presented D) is REFUSED, never run untracked', async () => {
+    const { tracker, log } = makeTracker();
+    await log.begin({
+      operationId: 's:c1', sessionId: 's', toolName: 'submit_form',
+      retryClass: 'E', generationId: 'gen-0-dead',
+    });
+    await log.settle('s:c1', {
+      state: S.INTERRUPTED, autoRetry: false, retryRequires: ['user-instruction'],
+      keepIdempotencyKey: false, verificationRequired: false,
+      recreateResource: false, reason: 'pre-dispatch death',
+    });
+    const begun = await tracker.beginTracking({
+      callId: 'c1', tool: { name: 'submit_form', retryClass: 'D' }, sessionId: 's',
+    });
+    // Previously this path REJECTED (newAttempt's class check), and the
+    // dispatcher's fail-open catch executed the replay untracked.
+    expect(begun && 'refuse' in begun).toBe(true);
   });
 
   test('a completed call refuses re-execution — duplicates are named, not run', async () => {

--- a/tests/peerd-runtime/lifecycle/dispatch-tracking.test.ts
+++ b/tests/peerd-runtime/lifecycle/dispatch-tracking.test.ts
@@ -1,0 +1,270 @@
+// Dispatch tracking — the contract wired into the dispatcher choke point.
+// Covers: per-class settle semantics (§16.2 no generic timeouts), the
+// replay guard (guarantee 2: an automatic re-dispatch of an unproven
+// Class E call is refused, never executed), and the full dispatchToolCall
+// path against a real in-memory operation log.
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { makeDispatchTracker } from '../../../extension/peerd-runtime/lifecycle/dispatch-tracking.js';
+import { createOperationLog } from '../../../extension/peerd-runtime/lifecycle/operation-log.js';
+import { OPERATION_STATES } from '../../../extension/peerd-runtime/lifecycle/operation-state.js';
+import { classifyFailure } from '../../../extension/peerd-runtime/observability/failure-classify.js';
+import { registerTool, clearTools } from '../../../extension/peerd-runtime/tools/registry.js';
+import { dispatchToolCall } from '../../../extension/peerd-runtime/tools/dispatcher.js';
+
+const S = OPERATION_STATES;
+
+const makeLog = () => {
+  const map = new Map<string, unknown>();
+  return createOperationLog({
+    storage: {
+      get: async (k: string) => map.get(k),
+      set: async (k: string, v: unknown) => { map.set(k, structuredClone(v)); },
+    },
+    now: () => 1,
+  });
+};
+
+const makeTracker = (log = makeLog()) => ({
+  log,
+  tracker: makeDispatchTracker({
+    operationLog: log,
+    generationId: () => 'gen-1-nonce',
+    retryClassFor: (tool) => (tool as { retryClass?: string }).retryClass as any ?? 'E',
+    classifyFailure,
+  }),
+});
+
+describe('beginTracking', () => {
+  test('Class A reads are untracked — no storage write per read', async () => {
+    const { tracker } = makeTracker();
+    const begun = await tracker.beginTracking({
+      callId: 'c1', tool: { name: 'read_page', retryClass: 'A' }, sessionId: 's',
+    });
+    expect(begun).toBeNull();
+  });
+
+  test('a tracked call is recorded dispatched BEFORE execute', async () => {
+    const { tracker, log } = makeTracker();
+    const begun = await tracker.beginTracking({
+      callId: 'c1', tool: { name: 'submit_form', retryClass: 'E' },
+      sessionId: 's', target: 'https://example.com',
+    });
+    expect(begun && 'handle' in begun).toBe(true);
+    const record = await log.get('s:c1');
+    expect(record!.state).toBe(S.AWAITING_REMOTE);
+    expect(record!.dispatched).toBe(true);
+  });
+});
+
+describe('settleTracking — §16.2 semantic failures', () => {
+  const settle = async (retryClass: string, error: string) => {
+    const { tracker, log } = makeTracker();
+    const begun = await tracker.beginTracking({
+      callId: 'c1', tool: { name: 't', retryClass }, sessionId: 's',
+    });
+    const rewrite = await tracker.settleTracking(
+      (begun as { handle: any }).handle, { ok: false, error });
+    return { rewrite, record: await log.get('s:c1') };
+  };
+
+  test('success settles completed with evidence', async () => {
+    const { tracker, log } = makeTracker();
+    const begun = await tracker.beginTracking({
+      callId: 'c1', tool: { name: 't', retryClass: 'E' }, sessionId: 's',
+    });
+    const rewrite = await tracker.settleTracking(
+      (begun as { handle: any }).handle, { ok: true });
+    expect(rewrite).toBeNull();
+    expect((await log.get('s:c1'))!.state).toBe(S.COMPLETED);
+  });
+
+  test('a definitive error settles failed, no rewrite', async () => {
+    const { rewrite, record } = await settle('E', 'element not found: #missing');
+    expect(rewrite).toBeNull();
+    expect(record!.state).toBe(S.FAILED);
+  });
+
+  test('a timeout on a Class E dispatch settles outcome_unknown and rewrites the error', async () => {
+    const { rewrite, record } = await settle('E', 'request timed out after 30000ms');
+    expect(record!.state).toBe(S.OUTCOME_UNKNOWN);
+    expect(rewrite!.error).toStartWith('outcome_unknown:');
+    expect(rewrite!.error).toContain('Check the target before repeating it');
+    expect(rewrite!.recovery).toMatchObject({
+      category: 'verify_before_retry', autoRetry: false, verificationRequired: true,
+    });
+  });
+
+  test('an HTTP 5xx on a Class E dispatch is ambiguous too — the server got the request', async () => {
+    const { record } = await settle('E', 'HTTP 502 Bad Gateway');
+    expect(record!.state).toBe(S.OUTCOME_UNKNOWN);
+  });
+
+  test('a timeout on a Class B read settles interrupted — retryable, budget-worded', async () => {
+    const { rewrite, record } = await settle('B', 'fetch failed: connection reset');
+    expect(record!.state).toBe(S.INTERRUPTED);
+    expect(rewrite!.error).toStartWith('interrupted:');
+  });
+
+  test('an abort on a Class E dispatch is outcome_unknown, not a false cancelled', async () => {
+    const { tracker, log } = makeTracker();
+    const begun = await tracker.beginTracking({
+      callId: 'c1', tool: { name: 't', retryClass: 'E' }, sessionId: 's',
+    });
+    await tracker.settleTracking((begun as { handle: any }).handle,
+      { ok: false, error: 'x', aborted: true });
+    expect((await log.get('s:c1'))!.state).toBe(S.OUTCOME_UNKNOWN);
+  });
+
+  test('an abort on a Class C write settles cancelled cleanly', async () => {
+    const { tracker, log } = makeTracker();
+    const begun = await tracker.beginTracking({
+      callId: 'c1', tool: { name: 't', retryClass: 'C' }, sessionId: 's',
+    });
+    const rewrite = await tracker.settleTracking((begun as { handle: any }).handle,
+      { ok: false, error: 'stopped', aborted: true });
+    expect((await log.get('s:c1'))!.state).toBe(S.CANCELLED);
+    expect(rewrite!.error).toStartWith('cancelled:');
+  });
+});
+
+describe('the replay guard — guarantee 2', () => {
+  test('re-dispatching an unproven Class E call is REFUSED with outcome_unknown', async () => {
+    const { tracker, log } = makeTracker();
+    await tracker.beginTracking({
+      callId: 'c1', tool: { name: 'submit_form', retryClass: 'E' }, sessionId: 's',
+    });
+    // SW dies here: dispatched, no settle. New generation re-drives the
+    // same tool_use id.
+    const begun = await tracker.beginTracking({
+      callId: 'c1', tool: { name: 'submit_form', retryClass: 'E' }, sessionId: 's',
+    });
+    expect(begun && 'refuse' in begun).toBe(true);
+    const refusal = (begun as { refuse: { error: string } }).refuse;
+    expect(refusal.error).toStartWith('outcome_unknown:');
+    expect((await log.get('s:c1'))!.state).toBe(S.OUTCOME_UNKNOWN);
+  });
+
+  test('a completed call refuses re-execution — duplicates are named, not run', async () => {
+    const { tracker } = makeTracker();
+    const begun = await tracker.beginTracking({
+      callId: 'c1', tool: { name: 'submit_form', retryClass: 'E' }, sessionId: 's',
+    });
+    await tracker.settleTracking((begun as { handle: any }).handle, { ok: true });
+    const again = await tracker.beginTracking({
+      callId: 'c1', tool: { name: 'submit_form', retryClass: 'E' }, sessionId: 's',
+    });
+    expect((again as { refuse: { error: string } }).refuse.error).toStartWith('completed:');
+  });
+
+  test('an interrupted Class B call re-drives as a fresh attempt', async () => {
+    const { tracker, log } = makeTracker();
+    await tracker.beginTracking({
+      callId: 'c1', tool: { name: 'fetch_url', retryClass: 'B' }, sessionId: 's',
+    });
+    await log.settle('s:c1', {
+      state: S.INTERRUPTED, autoRetry: true, retryRequires: [],
+      keepIdempotencyKey: false, verificationRequired: false,
+      recreateResource: false, reason: 'sw died',
+    });
+    const begun = await tracker.beginTracking({
+      callId: 'c1', tool: { name: 'fetch_url', retryClass: 'B' }, sessionId: 's',
+    });
+    expect(begun && 'handle' in begun).toBe(true);
+    expect((await log.get('s:c1'))!.attempt).toBe(2);
+  });
+
+  test('an interrupted-before-dispatch Class E call refuses the automatic replay even though it is safe', async () => {
+    const { tracker, log } = makeTracker();
+    // The record as a real pre-dispatch eviction leaves it: begun and
+    // running, never dispatched, settled interrupted by the reconciler.
+    await log.begin({
+      operationId: 's:c1', sessionId: 's', toolName: 'submit_form',
+      retryClass: 'E', generationId: 'gen-0-old',
+    });
+    await log.transition('s:c1', S.RUNNING);
+    await log.settle('s:c1', {
+      state: S.INTERRUPTED, autoRetry: false, retryRequires: ['user-instruction'],
+      keepIdempotencyKey: false, verificationRequired: false,
+      recreateResource: false, reason: 'sw died pre-dispatch',
+    });
+    const begun = await tracker.beginTracking({
+      callId: 'c1', tool: { name: 'submit_form', retryClass: 'E' }, sessionId: 's',
+    });
+    expect((begun as { refuse: { error: string } }).refuse.error).toStartWith('interrupted:');
+  });
+
+  test('a dispatched-then-interrupted Class E record still refuses as outcome_unknown — dispatch outranks the label', async () => {
+    const { tracker, log } = makeTracker();
+    await tracker.beginTracking({
+      callId: 'c1', tool: { name: 'submit_form', retryClass: 'E' }, sessionId: 's',
+    });
+    await log.settle('s:c1', {
+      state: S.INTERRUPTED, autoRetry: false, retryRequires: [],
+      keepIdempotencyKey: false, verificationRequired: false,
+      recreateResource: false, reason: 'mislabelled',
+    });
+    const begun = await tracker.beginTracking({
+      callId: 'c1', tool: { name: 'submit_form', retryClass: 'E' }, sessionId: 's',
+    });
+    expect((begun as { refuse: { error: string } }).refuse.error).toStartWith('outcome_unknown:');
+  });
+});
+
+describe('the full dispatcher path', () => {
+  const baseCtx = () => ({
+    audit: async () => {},
+    session: { sessionId: 'sess-1' },
+    permission: { mode: 'act', confirmActions: false },
+    hooks: [],
+  });
+
+  beforeEach(() => clearTools());
+
+  test('a tracked tool that times out returns the semantic error and recovery meta', async () => {
+    const { tracker, log } = makeTracker();
+    registerTool({
+      name: 'flaky_submit', description: 'x', schema: {},
+      primitive: 'web', sideEffect: 'mutate_external', retryClass: 'E',
+      origins: () => ['https://example.com'],
+      execute: async () => { throw new Error('request timed out'); },
+    } as any);
+    const result = await dispatchToolCall(
+      { id: 'tu-1', name: 'flaky_submit', args: {} },
+      { ...baseCtx(), lifecycle: tracker } as any,
+    );
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).toStartWith('outcome_unknown:');
+    expect((result.meta as any).recovery.category).toBe('verify_before_retry');
+    expect((await log.get('sess-1:tu-1'))!.state).toBe(S.OUTCOME_UNKNOWN);
+  });
+
+  test('re-dispatching the same tool_use id does NOT re-execute the tool', async () => {
+    const { tracker } = makeTracker();
+    let executions = 0;
+    registerTool({
+      name: 'pay_once', description: 'x', schema: {},
+      primitive: 'web', sideEffect: 'mutate_external', retryClass: 'E',
+      origins: () => [],
+      execute: async () => { executions += 1; throw new Error('connection reset'); },
+    } as any);
+    const ctx = { ...baseCtx(), lifecycle: tracker } as any;
+    await dispatchToolCall({ id: 'tu-1', name: 'pay_once', args: {} }, ctx);
+    const replay = await dispatchToolCall({ id: 'tu-1', name: 'pay_once', args: {} }, ctx);
+    expect(executions).toBe(1); // the replay never reached execute()
+    expect(replay.ok).toBe(false);
+    expect((replay as { error: string }).error).toStartWith('outcome_unknown:');
+  });
+
+  test('without ctx.lifecycle the dispatch is unchanged (no tracking, no rewrite)', async () => {
+    registerTool({
+      name: 'plain', description: 'x', schema: {},
+      primitive: 'web', sideEffect: 'mutate_external',
+      origins: () => [],
+      execute: async () => { throw new Error('request timed out'); },
+    } as any);
+    const result = await dispatchToolCall(
+      { id: 'tu-1', name: 'plain', args: {} }, baseCtx() as any);
+    expect((result as { error: string }).error).toBe('request timed out');
+  });
+});

--- a/tests/peerd-runtime/lifecycle/dispatch-tracking.test.ts
+++ b/tests/peerd-runtime/lifecycle/dispatch-tracking.test.ts
@@ -100,6 +100,21 @@ describe('settleTracking — §16.2 semantic failures', () => {
     expect(record!.state).toBe(S.OUTCOME_UNKNOWN);
   });
 
+  test('execution-host deaths are ambiguous, not tool-attested failures', async () => {
+    for (const error of [
+      'script_failed: Error: The message port closed before a response was received.',
+      'Could not establish connection. Receiving end does not exist.',
+      'VMTabClosed: the VM tab was closed mid-command',
+      'worker terminated before the job settled',
+    ]) {
+      const { record } = await settle('E', error);
+      expect(record!.state).toBe(S.OUTCOME_UNKNOWN);
+    }
+    // …while a genuine pre-effect refusal from the tool itself stays failed.
+    const { record } = await settle('E', 'element not found: #missing');
+    expect(record!.state).toBe(S.FAILED);
+  });
+
   test('a timeout on a Class B read settles interrupted — retryable, budget-worded', async () => {
     const { rewrite, record } = await settle('B', 'fetch failed: connection reset');
     expect(record!.state).toBe(S.INTERRUPTED);
@@ -171,7 +186,37 @@ describe('the replay guard — guarantee 2', () => {
       callId: 'c1', tool: { name: 'fetch_url', retryClass: 'B' }, sessionId: 's',
     });
     expect(begun && 'handle' in begun).toBe(true);
-    expect((await log.get('s:c1'))!.attempt).toBe(2);
+    const record = (await log.get('s:c1'))!;
+    expect(record.attempt).toBe(2);
+    // The retry mirrors the fresh path: dispatched marked before execute
+    // and the LIVE generation stamped — a second eviction must reconcile
+    // this as a dispatched attempt of the current generation, never as
+    // "never attempted" under a dead one.
+    expect(record.state).toBe(S.AWAITING_REMOTE);
+    expect(record.dispatched).toBe(true);
+    expect(record.generationId).toBe('gen-1-nonce');
+  });
+
+  test('a retried Class D killed mid-flight reconciles as outcome_unknown, not safe-to-retry', async () => {
+    const { tracker, log } = makeTracker();
+    await log.begin({
+      operationId: 's:c1', sessionId: 's', toolName: 'dweb_share',
+      retryClass: 'D', generationId: 'gen-0-old',
+    });
+    await log.settle('s:c1', {
+      state: S.INTERRUPTED, autoRetry: true, retryRequires: [],
+      keepIdempotencyKey: true, verificationRequired: false,
+      recreateResource: false, reason: 'first eviction, pre-dispatch',
+    });
+    // The sanctioned re-drive… then the SW dies mid-execute.
+    const begun = await tracker.beginTracking({
+      callId: 'c1', tool: { name: 'dweb_share', retryClass: 'D' }, sessionId: 's',
+    });
+    expect(begun && 'handle' in begun).toBe(true);
+    const record = (await log.get('s:c1'))!;
+    // The durable evidence a reconciler needs: dispatched, current gen.
+    expect(record.dispatched).toBe(true);
+    expect(record.generationId).toBe('gen-1-nonce');
   });
 
   test('an interrupted-before-dispatch Class E call refuses the automatic replay even though it is safe', async () => {

--- a/tests/peerd-runtime/lifecycle/dispatch-tracking.test.ts
+++ b/tests/peerd-runtime/lifecycle/dispatch-tracking.test.ts
@@ -79,8 +79,17 @@ describe('settleTracking — §16.2 semantic failures', () => {
     expect((await log.get('s:c1'))!.state).toBe(S.COMPLETED);
   });
 
-  test('a definitive error settles failed, no rewrite', async () => {
+  test('an UNTYPED error on a dispatched Class E defaults to outcome_unknown — burden of proof inverted', async () => {
+    // 'element not found' READS definitive, but an unstamped string proves
+    // nothing about whether the effect landed. Only a typed
+    // pre-effect-failure carries the "did not occur" claim for D/E.
     const { rewrite, record } = await settle('E', 'element not found: #missing');
+    expect(record!.state).toBe(S.OUTCOME_UNKNOWN);
+    expect(rewrite!.error).toStartWith('outcome_unknown:');
+  });
+
+  test('an untyped definitive error on a Class B read still settles failed (heuristics decide for A/B/C)', async () => {
+    const { rewrite, record } = await settle('B', 'element not found: #missing');
     expect(rewrite).toBeNull();
     expect(record!.state).toBe(S.FAILED);
   });
@@ -110,9 +119,10 @@ describe('settleTracking — §16.2 semantic failures', () => {
       const { record } = await settle('E', error);
       expect(record!.state).toBe(S.OUTCOME_UNKNOWN);
     }
-    // …while a genuine pre-effect refusal from the tool itself stays failed.
+    // …and an untyped tool string ALSO lands unknown (inverted burden);
+    // only the typed pre-effect stamp settles failed for a dispatched E.
     const { record } = await settle('E', 'element not found: #missing');
-    expect(record!.state).toBe(S.FAILED);
+    expect(record!.state).toBe(S.OUTCOME_UNKNOWN);
   });
 
   test('a timeout on a Class B read settles interrupted — retryable, budget-worded', async () => {

--- a/tests/peerd-runtime/lifecycle/engine-liveness.test.ts
+++ b/tests/peerd-runtime/lifecycle/engine-liveness.test.ts
@@ -1,0 +1,61 @@
+// The §9 engine-liveness ledger — the durable fact ("this instance was
+// HOSTED when the lights went out") that lets a boot tell dormant catalog
+// entries from freshly-orphaned processes.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  makeEngineLiveness, ENGINE_LIVENESS_KEY,
+} from '../../../extension/peerd-runtime/lifecycle/engine-liveness.js';
+
+const makeStorage = () => {
+  const map = new Map<string, unknown>();
+  return {
+    map,
+    get: async (k: string) => structuredClone(map.get(k)),
+    set: async (k: string, v: unknown) => { map.set(k, structuredClone(v)); },
+  };
+};
+
+describe('adopt / drop / sweep', () => {
+  test('the eviction story: hosted instances without surviving tabs are the lost set', async () => {
+    const storage = makeStorage();
+    const before = makeEngineLiveness({ storage, now: () => 1 });
+    await before.adopt('vm', 'vm-1', 11);
+    await before.adopt('notebook', 'nb-1', 12);
+    await before.adopt('app', 'app-1', 13);
+    await before.drop('app', 'app-1'); // clean close before the eviction
+
+    // The eviction: fresh instance over the same storage; only the VM's
+    // tab survived (the tracker re-adopted it at bootstrap).
+    const after = makeEngineLiveness({ storage, now: () => 2 });
+    const lost = await after.sweep({ surviving: ['vm:vm-1'] });
+    expect(lost.map((l) => `${l.kind}:${l.id}`)).toEqual(['notebook:nb-1']);
+
+    // The ledger now holds exactly the survivors — a second sweep is clean.
+    expect(await after.sweep({ surviving: ['vm:vm-1'] })).toEqual([]);
+  });
+
+  test('adopt is idempotent and the ledger heals from corruption', async () => {
+    const storage = makeStorage();
+    storage.map.set(ENGINE_LIVENESS_KEY, 'torn-write-garbage');
+    const liveness = makeEngineLiveness({ storage, now: () => 1 });
+    await liveness.adopt('vm', 'vm-1', 11);
+    await liveness.adopt('vm', 'vm-1', 11);
+    const lost = await liveness.sweep({ surviving: [] });
+    expect(lost.length).toBe(1);
+    expect(typeof storage.map.get(ENGINE_LIVENESS_KEY)).toBe('object');
+  });
+
+  test('a failing storage layer never throws into the tracker hooks', async () => {
+    const liveness = makeEngineLiveness({
+      storage: {
+        get: async () => { throw new Error('down'); },
+        set: async () => { throw new Error('down'); },
+      },
+    });
+    await liveness.adopt('vm', 'vm-1', 11); // must not reject
+    await liveness.drop('vm', 'vm-1');
+    // sweep still resolves (empty — nothing readable).
+    expect(await liveness.sweep({ surviving: [] })).toEqual([]);
+  });
+});

--- a/tests/peerd-runtime/lifecycle/fault-injection.test.ts
+++ b/tests/peerd-runtime/lifecycle/fault-injection.test.ts
@@ -1,0 +1,691 @@
+// Fault injection at the hardest kill points (contract §15 / §16.3).
+//
+// The other lifecycle suites kill the process BETWEEN calls — a second boot
+// over surviving storage IS the eviction. This one kills it INSIDE the
+// calls: the nth durable write rejects, or persists and then takes the
+// whole storage layer down with it, or lands a truncated value before
+// rejecting. Storage is the only thing that survives an eviction, so a
+// write that half-happened is the one failure the contract cannot reason
+// its way out of after the fact.
+//
+// What is asserted, and why it is never an internal error: the operation
+// log serializes mutations through an internal queue, and both boot() and
+// the dispatch tracker swallow storage errors BY DESIGN (per-record
+// isolation on the reconcile sweep; "settling must never mask the tool's
+// own outcome"). So the observable contract lives in the DURABLE OUTCOME —
+// what a fresh boot over the surviving bytes reports — not in which promise
+// rejected. Every test below ends at a fresh boot.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  makeLifecycleBoot, GENERATION_KEY, PENDING_NOTICES_KEY,
+} from '../../../extension/peerd-runtime/lifecycle/boot.js';
+import {
+  createOperationLog, OPERATION_LOG_KEY,
+} from '../../../extension/peerd-runtime/lifecycle/operation-log.js';
+import { makeDispatchTracker } from '../../../extension/peerd-runtime/lifecycle/dispatch-tracking.js';
+import { OPERATION_STATES } from '../../../extension/peerd-runtime/lifecycle/operation-state.js';
+import { retryClassForTool } from '../../../extension/peerd-runtime/lifecycle/tool-retry-class.js';
+import {
+  classifyStoreVersion, guardStore, runMigration,
+} from '../../../extension/peerd-runtime/lifecycle/store-version.js';
+
+const S = OPERATION_STATES;
+
+// --- the fault-injecting storage adapter ------------------------------------
+//
+// Wraps an in-memory map with programmable faults and a journal of every op.
+// Named error subclasses (house style) so a swallowed rejection is still
+// identifiable in the journal.
+
+class StorageWriteError extends Error {
+  constructor(key: string) {
+    super(`injected write failure on ${key}`);
+    this.name = 'StorageWriteError';
+  }
+}
+
+class StorageDeadError extends Error {
+  constructor(key: string) {
+    super(`storage layer is gone (op on ${key} after the injected death)`);
+    this.name = 'StorageDeadError';
+  }
+}
+
+class TornWriteError extends Error {
+  constructor(key: string) {
+    super(`torn write on ${key}: a truncated value landed, the write rejected`);
+    this.name = 'TornWriteError';
+  }
+}
+
+type JournalEntry = {
+  op: 'get' | 'set';
+  key: string;
+  outcome: 'ok' | 'write-failed' | 'torn' | 'dead';
+};
+
+/**
+ * Fault counts are 1-based and start over each time a fault is armed, so a
+ * test says "the 2nd write from HERE" without counting the setup's writes.
+ */
+const makeFaultyStorage = () => {
+  const map = new Map<string, unknown>();
+  const journal: JournalEntry[] = [];
+  const torn = new Map<string, unknown>();
+  let writes = 0;
+  let failAt: number | null = null;
+  let dieAfter: number | null = null;
+  let dead = false;
+
+  const note = (op: JournalEntry['op'], key: string, outcome: JournalEntry['outcome']) => {
+    journal.push({ op, key, outcome });
+  };
+
+  return {
+    // ---- the adapter the lifecycle modules see (get/set only) ----
+    get: async (key: string): Promise<unknown> => {
+      if (dead) { note('get', key, 'dead'); throw new StorageDeadError(key); }
+      note('get', key, 'ok');
+      return structuredClone(map.get(key));
+    },
+    set: async (key: string, value: unknown): Promise<void> => {
+      writes += 1;
+      if (dead) { note('set', key, 'dead'); throw new StorageDeadError(key); }
+      if (torn.has(key)) {
+        // A torn write: the truncated bytes ARE durable, the write still
+        // reports failure. Nobody gets to "roll back" what already landed.
+        map.set(key, torn.get(key));
+        torn.delete(key);
+        note('set', key, 'torn');
+        throw new TornWriteError(key);
+      }
+      if (failAt === writes) { note('set', key, 'write-failed'); throw new StorageWriteError(key); }
+      map.set(key, structuredClone(value));
+      note('set', key, 'ok');
+      // Persisted, THEN died — the mid-sequence death the contract's
+      // "created before dispatch, dispatched before the effect" ordering
+      // exists to survive.
+      if (dieAfter === writes) dead = true;
+    },
+
+    // ---- fault programming ----
+    /** The nth set() from now rejects; nothing is persisted for it. */
+    failWriteAt: (nth: number) => { writes = 0; failAt = nth; dieAfter = null; },
+    /** The nth set() from now persists; every op after it rejects. */
+    dieAfterWrites: (nth: number) => { writes = 0; dieAfter = nth; failAt = null; },
+    /** The next set() of `key` persists `corrupted`, then rejects. */
+    tornWrite: (key: string, corrupted: unknown) => { torn.set(key, corrupted); },
+
+    // ---- test-side inspection of what SURVIVED ----
+    /** Clear the faults, keep the bytes — this is the next browser start. */
+    heal: () => { dead = false; failAt = null; dieAfter = null; torn.clear(); writes = 0; },
+    journal,
+    peek: (key: string): unknown => map.get(key),
+    poke: (key: string, value: unknown) => { map.set(key, value); },
+    wipe: (keys: string[]) => { for (const key of keys) map.delete(key); },
+  };
+};
+
+type FaultyStorage = ReturnType<typeof makeFaultyStorage>;
+
+// --- shared harness ---------------------------------------------------------
+
+let clock = 1_700_000_000_000;
+const tick = () => (clock += 1);
+let mints = 0;
+const nonces: string[] = [];
+const nextNonce = () => {
+  mints += 1;
+  const nonce = `nonce-${mints}-b0a7c9de`;
+  nonces.push(nonce);
+  return nonce;
+};
+
+const bootOver = (storage: FaultyStorage, extra: Record<string, unknown> = {}) =>
+  makeLifecycleBoot({ storage, nonce: nextNonce, now: tick, ...extra });
+
+const logOver = (storage: FaultyStorage) =>
+  createOperationLog({ storage, now: tick });
+
+// Real descriptors, classified by the LIVE classifier — the kill-point
+// matrix must ride the same class the dispatcher would compute.
+const TOOLS = {
+  B: { name: 'fetch_url', sideEffect: 'read', primitive: 'web' },
+  C: { name: 'notebook_write', sideEffect: 'write', primitive: 'notebook' },
+  D: { name: 'dweb_share', sideEffect: 'write', primitive: 'dweb' },
+  E: { name: 'submit_form', sideEffect: 'mutate_external', primitive: 'tab' },
+} as const;
+
+type ClassKey = keyof typeof TOOLS;
+
+const swallow = (promise: Promise<unknown>) => promise.then(() => {}, () => {});
+
+/**
+ * Drive one operation to a kill point and leave the storage healed (the
+ * bytes that survived the death). `writesBeforeDeath` picks the moment:
+ *   1 → died right after begin()            (created, dispatched:false)
+ *   2 → died after the running transition   (running, dispatched:false)
+ *   3 → died right after markDispatched()   (awaiting_remote, dispatched:true)
+ * Every rejection after the death IS the death — the caller never sees it,
+ * exactly as a killed service worker never sees anything.
+ */
+const killDuringDispatch = async (storage: FaultyStorage, input: {
+  operationId: string, sessionId: string, tool: { name: string },
+  generationId: string, writesBeforeDeath: number,
+}) => {
+  const log = logOver(storage);
+  storage.dieAfterWrites(input.writesBeforeDeath);
+  await swallow(log.begin({
+    operationId: input.operationId,
+    sessionId: input.sessionId,
+    toolName: input.tool.name,
+    retryClass: retryClassForTool(input.tool),
+    generationId: input.generationId,
+  }));
+  await swallow(log.transition(input.operationId, S.RUNNING));
+  await swallow(log.markDispatched(input.operationId));
+  storage.heal();
+};
+
+const trackerOn = (storage: FaultyStorage, generationId: string) =>
+  makeDispatchTracker({
+    operationLog: logOver(storage),
+    generationId: () => generationId,
+    retryClassFor: retryClassForTool,
+  });
+
+// --- 1. death BETWEEN begin() and markDispatched() --------------------------
+
+describe('kill point: between begin() and markDispatched()', () => {
+  test('the descriptors under test classify as B/C/D/E on the live classifier', () => {
+    for (const key of Object.keys(TOOLS) as ClassKey[]) {
+      expect(retryClassForTool(TOOLS[key])).toBe(key);
+    }
+  });
+
+  test('B/C/D/E all survive as undispatched and a fresh boot settles every one interrupted', async () => {
+    const storage = makeFaultyStorage();
+    const first = await bootOver(storage).init();
+
+    // Two parking spots, both strictly before the dispatch stamp: the log
+    // write landed and the process died (created), and the running
+    // transition landed and the process died (running).
+    const killPoints: Array<[ClassKey, number]> = [['B', 2], ['C', 1], ['D', 2], ['E', 1]];
+    for (const [key, writesBeforeDeath] of killPoints) {
+      await killDuringDispatch(storage, {
+        operationId: `op-${key}`, sessionId: 'sess-1', tool: TOOLS[key],
+        generationId: first.generation.id, writesBeforeDeath,
+      });
+    }
+
+    // What survived: a record that never claims the effect left peerd.
+    const survivors = storage.peek(OPERATION_LOG_KEY) as Record<string, {
+      state: string, dispatched?: boolean }>;
+    for (const key of Object.keys(TOOLS) as ClassKey[]) {
+      const record = survivors[`op-${key}`];
+      expect([S.CREATED, S.RUNNING] as string[]).toContain(record.state);
+      expect(record.dispatched).not.toBe(true);
+    }
+
+    const second = bootOver(storage);
+    const { plan } = await second.init();
+    expect(plan.transitions.length).toBe(4);
+
+    for (const key of Object.keys(TOOLS) as ClassKey[]) {
+      // Nothing was dispatched, so nothing is uncertain — even Class E.
+      expect((await second.operationLog.get(`op-${key}`)).state).toBe(S.INTERRUPTED);
+    }
+    const verdictFor = (id: string) =>
+      plan.transitions.find((t) => t.operationId === id)!.verdict;
+    // Class E interrupted pre-dispatch is SAFE but still not automatic.
+    expect(verdictFor('op-E').autoRetry).toBe(false);
+    expect(verdictFor('op-E').retryRequires).toContain('user-instruction');
+    // Class C/D keep the original idempotency key on the retry.
+    expect(verdictFor('op-C').keepIdempotencyKey).toBe(true);
+    expect(verdictFor('op-D').keepIdempotencyKey).toBe(true);
+    expect(verdictFor('op-B').autoRetry).toBe(true);
+  });
+
+  test('Class D — the sanctioned re-drive works over the reconciled record', async () => {
+    const storage = makeFaultyStorage();
+    const first = await bootOver(storage).init();
+    await killDuringDispatch(storage, {
+      operationId: 'sess-1:call-1', sessionId: 'sess-1', tool: TOOLS.D,
+      generationId: first.generation.id, writesBeforeDeath: 2,
+    });
+
+    const second = bootOver(storage);
+    const { generation } = await second.init();
+    expect((await second.operationLog.get('sess-1:call-1')).state).toBe(S.INTERRUPTED);
+
+    const begun = await trackerOn(storage, generation.id).beginTracking({
+      callId: 'call-1', tool: TOOLS.D, sessionId: 'sess-1',
+    });
+    expect(begun && 'handle' in begun).toBe(true);
+    const record = await second.operationLog.get('sess-1:call-1');
+    expect(record.attempt).toBe(2);
+    // The re-drive mirrors a fresh dispatch: live generation stamped and
+    // dispatched marked BEFORE the effect can leave, so a second death
+    // reconciles it as dispatched-unproven, never as "never attempted".
+    expect(record.state).toBe(S.AWAITING_REMOTE);
+    expect(record.dispatched).toBe(true);
+    expect(record.generationId).toBe(generation.id);
+  });
+});
+
+// --- 2. death IMMEDIATELY AFTER markDispatched() ----------------------------
+
+describe('kill point: immediately after markDispatched()', () => {
+  for (const key of ['D', 'E'] as ClassKey[]) {
+    test(`Class ${key} lands outcome_unknown and the tracker refuses the same-id re-dispatch`, async () => {
+      const storage = makeFaultyStorage();
+      const first = await bootOver(storage).init();
+      await killDuringDispatch(storage, {
+        operationId: 'sess-1:call-1', sessionId: 'sess-1', tool: TOOLS[key],
+        generationId: first.generation.id, writesBeforeDeath: 3,
+      });
+
+      // The evidence the reconciler rides: the effect may already have left.
+      const survivor = (storage.peek(OPERATION_LOG_KEY) as Record<string, {
+        state: string, dispatched?: boolean }>)['sess-1:call-1'];
+      expect(survivor.state).toBe(S.AWAITING_REMOTE);
+      expect(survivor.dispatched).toBe(true);
+
+      const second = bootOver(storage);
+      const { generation, plan } = await second.init();
+      expect((await second.operationLog.get('sess-1:call-1')).state).toBe(S.OUTCOME_UNKNOWN);
+      expect(plan.transitions[0].verdict.verificationRequired).toBe(true);
+      expect(plan.notifications[0].recoveryRecord.sideEffectStatus).toBe('outcome_unknown');
+
+      // …and the replay guard refuses the automatic re-dispatch outright.
+      const begun = await trackerOn(storage, generation.id).beginTracking({
+        callId: 'call-1', tool: TOOLS[key], sessionId: 'sess-1',
+      });
+      expect(begun && 'refuse' in begun).toBe(true);
+      expect((begun as { refuse: { error: string } }).refuse.error).toStartWith('outcome_unknown:');
+      expect((await second.operationLog.get('sess-1:call-1')).attempt).toBe(1); // no re-drive
+    });
+  }
+});
+
+// --- 3. death DURING settle persistence -------------------------------------
+
+describe("kill point: inside settleTracking's own persistence", () => {
+  const dispatchThenLoseTheSettle = async (
+    outcome: { ok: boolean, error?: string, resultDigest?: string },
+  ) => {
+    const storage = makeFaultyStorage();
+    const tracker = trackerOn(storage, 'gen-1-b0a7c9de');
+    const begun = await tracker.beginTracking({
+      callId: 'call-1', tool: TOOLS.E, sessionId: 'sess-1',
+    });
+    const handle = (begun as { handle: { operationId: string, retryClass: 'E', toolName: string } }).handle;
+    // The settle's transition write is the one that dies.
+    storage.failWriteAt(1);
+    const rewrite = await tracker.settleTracking(handle, outcome);
+    storage.heal();
+    return { storage, rewrite };
+  };
+
+  test('a Class E SUCCESS whose settle write is lost never becomes completed-without-evidence', async () => {
+    const { storage, rewrite } = await dispatchThenLoseTheSettle({
+      ok: true, resultDigest: 'sha256:abc',
+    });
+
+    const survivor = (storage.peek(OPERATION_LOG_KEY) as Record<string, {
+      state: string, dispatched?: boolean, evidence?: unknown }>)['sess-1:call-1'];
+    expect(survivor.state).toBe(S.AWAITING_REMOTE); // the completion never landed
+    expect(survivor.evidence).toBeUndefined();
+
+    const boot = bootOver(storage);
+    await boot.init();
+    // The safe direction: peerd forgot a success rather than inventing one.
+    expect((await boot.operationLog.get('sess-1:call-1')).state).toBe(S.OUTCOME_UNKNOWN);
+
+    // gap (safe direction, so not a FIXME): settleTracking swallows the
+    // persistence failure and returns null, so the DISPATCHER still reports
+    // the tool's success to the agent while the durable log says nothing
+    // landed — §8's persist-before-report ordering is inverted here. The
+    // consequence is a false UNCERTAINTY on the next boot (the agent is told
+    // to verify an operation that actually completed), never a false claim.
+    expect(rewrite).toBeNull();
+  });
+
+  test('a Class E AMBIGUOUS failure whose settle write is lost never becomes failed-without-evidence', async () => {
+    const { storage, rewrite } = await dispatchThenLoseTheSettle({
+      ok: false, error: 'request timed out after 30000ms',
+    });
+
+    const survivor = (storage.peek(OPERATION_LOG_KEY) as Record<string, {
+      state: string }>)['sess-1:call-1'];
+    expect(survivor.state).toBe(S.AWAITING_REMOTE); // NOT failed
+
+    const boot = bootOver(storage);
+    await boot.init();
+    expect((await boot.operationLog.get('sess-1:call-1')).state).toBe(S.OUTCOME_UNKNOWN);
+
+    // FIXED (was FIXME §16.2): the semantic report no longer depends on the
+    // settle write landing — a persist failure defers the durable copy to
+    // the next boot's reconcile, but the agent STILL hears outcome_unknown
+    // now, so it cannot read a generic timeout as a definite failure and
+    // re-issue the Class E action under a fresh call id.
+    expect(rewrite).not.toBeNull();
+    expect(rewrite!.error).toStartWith('outcome_unknown:');
+    expect((rewrite!.recovery as { category: string }).category).toBe('verify_before_retry');
+  });
+});
+
+// --- 4. death DURING boot's own reconcile -----------------------------------
+
+describe("kill point: inside boot's own reconcile sweep", () => {
+  test('a second boot settles what the dying sweep never applied (idempotence under partial application)', async () => {
+    const storage = makeFaultyStorage();
+    const first = await bootOver(storage).init();
+    for (const id of ['op-1', 'op-2', 'op-3']) {
+      await killDuringDispatch(storage, {
+        operationId: id, sessionId: 'sess-1', tool: TOOLS.E,
+        generationId: first.generation.id, writesBeforeDeath: 3,
+      });
+    }
+
+    // Writes in init(): 1 = the generation, 2 = the first settle, then the
+    // storage is gone — the remaining settles, the audit and the notice
+    // parking all reject into their per-record isolation catches.
+    const lostNotices: string[] = [];
+    storage.dieAfterWrites(2);
+    const second = bootOver(storage, {
+      notify: (_sessionId: string, text: string) => { lostNotices.push(text); },
+    });
+    const { plan } = await second.init();
+    expect(plan.transitions.length).toBe(3); // the PLAN was complete…
+    storage.heal();
+
+    const applied = storage.peek(OPERATION_LOG_KEY) as Record<string, { state: string }>;
+    expect(applied['op-1'].state).toBe(S.OUTCOME_UNKNOWN); // …its application was not
+    expect(applied['op-2'].state).toBe(S.AWAITING_REMOTE);
+    expect(applied['op-3'].state).toBe(S.AWAITING_REMOTE);
+    // The user-facing notify still fired for all three (best effort, memory
+    // only); the DURABLE agent-facing copy died with the storage.
+    expect(lostNotices.length).toBe(3);
+    expect(await second.drainNoticesFor('sess-1')).toBe('');
+
+    const third = bootOver(storage);
+    const { plan: replan } = await third.init();
+    expect(replan.transitions.length).toBe(2); // only the unapplied two
+    for (const id of ['op-1', 'op-2', 'op-3']) {
+      expect((await third.operationLog.get(id)).state).toBe(S.OUTCOME_UNKNOWN);
+    }
+    // Re-settling is not re-notifying: op-1 was already terminal, so the
+    // agent hears about the two the dead sweep dropped, once.
+    const block = await third.drainNoticesFor('sess-1');
+    expect(block).toContain('<interruption-recovery>');
+    expect(block.match(/outcome_unknown/g)!.length).toBeGreaterThanOrEqual(2);
+    expect(await third.drainNoticesFor('sess-1')).toBe('');
+
+    const fourth = bootOver(storage);
+    expect((await fourth.init()).plan.transitions.length).toBe(0); // fixpoint
+  });
+});
+
+// --- 5. death DURING generation persistence ---------------------------------
+
+describe('kill point: the generation write itself', () => {
+  test('the next boot still mints a strictly newer generation (the nonce disambiguates) and reconciles', async () => {
+    const storage = makeFaultyStorage();
+    const first = await bootOver(storage).init();
+    expect(first.generation.seq).toBe(1);
+    await killDuringDispatch(storage, {
+      operationId: 'op-e', sessionId: 'sess-1', tool: TOOLS.E,
+      generationId: first.generation.id, writesBeforeDeath: 3,
+    });
+
+    // The generation is persisted BEFORE reconciling, on purpose — so this
+    // failure takes the whole boot down rather than reconciling under an id
+    // no later boot could recognize.
+    storage.failWriteAt(1);
+    const doomed = bootOver(storage);
+    await expect(doomed.init()).rejects.toThrow(StorageWriteError);
+    const doomedNonce = nonces[nonces.length - 1];
+    storage.heal();
+
+    // Nothing of the dead generation is durable: the seq is untouched and
+    // its orphan is still nonterminal.
+    expect((storage.peek(GENERATION_KEY) as { seq: number, id: string }).seq).toBe(1);
+    expect((storage.peek(GENERATION_KEY) as { id: string }).id).toBe(first.generation.id);
+    expect((storage.peek(OPERATION_LOG_KEY) as Record<string, { state: string }>)['op-e'].state)
+      .toBe(S.AWAITING_REMOTE);
+
+    const next = bootOver(storage);
+    const { generation, plan } = await next.init();
+    // Strictly newer than the last DURABLE generation…
+    expect(generation.seq).toBeGreaterThan(1);
+    expect(generation.id).not.toBe(first.generation.id);
+    // …and distinct from the id the dead boot handed out at the same seq —
+    // the seq alone repeats when its write is lost; the nonce cannot.
+    expect(generation.id).not.toBe(`gen-${generation.seq}-${doomedNonce}`);
+    expect(doomedNonce).not.toBe(nonces[nonces.length - 1]);
+    // The reconcile the dead boot never reached happens here.
+    expect(plan.transitions.length).toBe(1);
+    expect((await next.operationLog.get('op-e')).state).toBe(S.OUTCOME_UNKNOWN);
+  });
+});
+
+// --- 6. migration kill points -----------------------------------------------
+
+describe('kill point: mid-migration (checkpointed, write-through)', () => {
+  const STORE = 'sessions';
+  const DATA_KEY = 'peerd.test.sessions.data';
+  const CHECKPOINT_KEY = 'peerd.test.sessions.checkpoint';
+
+  const steps = [
+    {
+      from: 1, to: 2, drops: ['old'],
+      migrate: (d: Record<string, unknown>) => {
+        const { old, ...rest } = d;
+        return { ...rest, renamed: old };
+      },
+    },
+    {
+      from: 2, to: 3, drops: ['legacy'],
+      migrate: (d: Record<string, unknown>) => {
+        const { legacy, ...rest } = d;
+        return { ...rest, count: 0 };
+      },
+    },
+  ];
+
+  // runMigration is PURE — the write-through checkpoint is the shell's job.
+  // This is that shell: one step, persist the migrated data, persist the
+  // cursor, repeat. A death anywhere in it leaves exactly what had landed.
+  const migrateWithCheckpoint = async (storage: FaultyStorage, input: {
+    data: unknown, fromVersion: number, toVersion: number, checkpointVersion?: number,
+  }) => {
+    let current: unknown = input.data;
+    let version = input.checkpointVersion ?? input.fromVersion;
+    for (const step of steps.filter((s) => s.to > version)) {
+      const result = runMigration({
+        store: STORE, data: current, fromVersion: version, toVersion: step.to, steps: [step],
+      });
+      if (!result.ok) return result;
+      current = result.data;
+      version = result.version;
+      await storage.set(DATA_KEY, current);
+      await storage.set(CHECKPOINT_KEY, version);
+    }
+    return { ok: true as const, data: current, version };
+  };
+
+  test('killed after the step-1 checkpoint, the resume completes idempotently', async () => {
+    const storage = makeFaultyStorage();
+    storage.poke(DATA_KEY, { old: 'x', legacy: true, mystery: 'keep-me' });
+
+    // Writes: 1 = the v2 data, 2 = the v2 cursor, then the process dies —
+    // the v1→v2 step is durable, the v2→v3 step never gets to write.
+    storage.dieAfterWrites(2);
+    await expect(migrateWithCheckpoint(storage, {
+      data: storage.peek(DATA_KEY), fromVersion: 1, toVersion: 3,
+    })).rejects.toThrow(StorageDeadError);
+    storage.heal();
+
+    expect(storage.peek(CHECKPOINT_KEY)).toBe(2);
+    expect(storage.peek(DATA_KEY)).toEqual({ renamed: 'x', legacy: true, mystery: 'keep-me' });
+
+    // The resume: steps at or below the durable cursor are skipped, so the
+    // already-migrated data is never re-migrated.
+    const resumed = runMigration({
+      store: STORE, data: storage.peek(DATA_KEY), fromVersion: 1, toVersion: 3, steps,
+      checkpointVersion: storage.peek(CHECKPOINT_KEY) as number,
+    });
+    if (!resumed.ok) throw new Error(resumed.reason);
+    expect(resumed.completedSteps).toEqual([3]);
+    expect(resumed.data).toEqual({ renamed: 'x', mystery: 'keep-me', count: 0 });
+
+    // Idempotent on rerun: the same resume twice, and a full rerun over the
+    // FINISHED data at the finished cursor, are both no-op successes.
+    const again = runMigration({
+      store: STORE, data: storage.peek(DATA_KEY), fromVersion: 1, toVersion: 3, steps,
+      checkpointVersion: 2,
+    });
+    expect(again).toEqual(resumed);
+    const afterCompletion = runMigration({
+      store: STORE, data: resumed.data, fromVersion: 1, toVersion: 3, steps,
+      checkpointVersion: 3,
+    });
+    if (!afterCompletion.ok) throw new Error(afterCompletion.reason);
+    expect(afterCompletion.data).toEqual(resumed.data);
+    expect(afterCompletion.completedSteps).toEqual([]);
+  });
+
+  test('a TORN data write at the kill point fails closed — original retained, cursor unmoved', async () => {
+    const storage = makeFaultyStorage();
+    const original = { old: 'x', legacy: true, mystery: 'keep-me' };
+    storage.poke(DATA_KEY, original);
+
+    // The migrated v2 payload lands truncated and the write reports failure:
+    // the durable store now holds bytes that are not a record at all.
+    const truncated = '{"renamed":"x","legacy":tr';
+    storage.tornWrite(DATA_KEY, truncated);
+    await expect(migrateWithCheckpoint(storage, {
+      data: storage.peek(DATA_KEY), fromVersion: 1, toVersion: 3,
+    })).rejects.toThrow(TornWriteError);
+
+    // The cursor never advanced past the torn write…
+    expect(storage.peek(CHECKPOINT_KEY)).toBeUndefined();
+    expect(storage.peek(DATA_KEY)).toBe(truncated);
+
+    // …so the resume classifies the survivor, and both the guard and the
+    // migration driver fail closed with a deterministic diagnostic and the
+    // stored bytes handed back untouched — never an empty replacement.
+    expect(classifyStoreVersion({ found: undefined, supported: 3 })).toBe('malformed');
+    const guard = guardStore({ store: STORE, found: undefined, supported: 3 });
+    expect(guard.mode).toBe('read-only');
+    expect(guard.diagnosticId).toBe('store-sessions-malformed-version');
+
+    const resumed = runMigration({
+      store: STORE, data: storage.peek(DATA_KEY), fromVersion: 1, toVersion: 3, steps,
+    });
+    expect(resumed.ok).toBe(false);
+    if (resumed.ok) return;
+    expect(resumed.diagnosticId).toBe('migrate-sessions-malformed-data');
+    expect(resumed.data).toBe(truncated); // the corrupt original, for diagnosis
+    expect(resumed.resumeFrom).toBe(1);
+  });
+});
+
+// --- 7. browser restart: the session tier is wiped, the profile tier is not --
+
+describe('kill point: a browser restart (session tier cleared, profile tier kept)', () => {
+  test('the generation and the operation log survive, and reconcile still settles the orphans', async () => {
+    const storage = makeFaultyStorage();
+    const first = await bootOver(storage).init();
+    await killDuringDispatch(storage, {
+      operationId: 'op-e', sessionId: 'sess-1', tool: TOOLS.E,
+      generationId: first.generation.id, writesBeforeDeath: 3,
+    });
+
+    // The session tier, by name, from the mirror contract in
+    // peerd-egress/storage/session-cache.js (chrome.storage.session: RAM
+    // only, cleared on browser restart). Named here rather than imported —
+    // this suite must not pull the vault into a pure-logic test.
+    const SESSION_TIER = ['currentSessionId', 'vault.unlockedAt', 'vault.unlocked.v1'];
+    for (const key of SESSION_TIER) storage.poke(key, { mirrored: true });
+
+    // The restart.
+    storage.wipe(SESSION_TIER);
+
+    for (const key of SESSION_TIER) expect(storage.peek(key)).toBeUndefined();
+    expect(storage.peek(GENERATION_KEY)).toBeDefined();
+    expect(storage.peek(OPERATION_LOG_KEY)).toBeDefined();
+
+    const next = bootOver(storage);
+    const { generation, plan } = await next.init();
+    // Profile tier: the seq kept counting across the restart, so authority
+    // stamped by the pre-restart generation can still be recognized as stale.
+    expect(generation.seq).toBe(first.generation.seq + 1);
+    expect(plan.transitions.length).toBe(1);
+    expect((await next.operationLog.get('op-e')).state).toBe(S.OUTCOME_UNKNOWN);
+    expect(await next.drainNoticesFor('sess-1')).toContain('outcome_unknown');
+  });
+});
+
+// --- 8. torn pending-notices write ------------------------------------------
+
+describe('kill point: a torn pending-notices write', () => {
+  test('the drain never throws into a turn — but a later boot that must park notices does', async () => {
+    const storage = makeFaultyStorage();
+    const first = await bootOver(storage).init();
+    await killDuringDispatch(storage, {
+      operationId: 'op-1', sessionId: 'sess-1', tool: TOOLS.E,
+      generationId: first.generation.id, writesBeforeDeath: 3,
+    });
+
+    // Boot 2 settles the orphan and parks its notice — and THAT write tears.
+    const truncated = '{"sess-1":[{"user":"submit_form was dispatch';
+    storage.tornWrite(PENDING_NOTICES_KEY, truncated);
+    const second = bootOver(storage);
+    const { generation } = await second.init(); // the parked write is best-effort
+    expect(storage.peek(PENDING_NOTICES_KEY)).toBe(truncated);
+    expect((await second.operationLog.get('op-1')).state).toBe(S.OUTCOME_UNKNOWN);
+
+    // The turn driver's read path holds: garbage in, empty string out, no
+    // throw into the agent's turn (the notice itself is lost with the write).
+    expect(await second.drainNoticesFor('sess-1')).toBe('');
+    expect(await second.drainNoticesFor('sess-other')).toBe('');
+
+    // A LATER interruption, with the corrupted value still on disk.
+    await killDuringDispatch(storage, {
+      operationId: 'op-2', sessionId: 'sess-1', tool: TOOLS.E,
+      generationId: generation.id, writesBeforeDeath: 3,
+    });
+    const third = bootOver(storage);
+
+    // FIXED (was FIXME §14): a primitive left by a torn write is treated as
+    // an empty notices store and REPAIRED by overwrite — init() completes,
+    // the settles apply, the new notice parks, and the fail-closed tracker
+    // is never armed off one bad kv value.
+    await third.init();
+    expect((await third.operationLog.get('op-2')).state).toBe(S.OUTCOME_UNKNOWN);
+    const repaired = storage.peek(PENDING_NOTICES_KEY);
+    expect(typeof repaired).toBe('object');
+    expect(await third.drainNoticesFor('sess-1')).toContain('outcome_unknown');
+  });
+
+  test('an OBJECT-shaped corruption is survivable — a boot repairs it by overwriting', async () => {
+    const storage = makeFaultyStorage();
+    const first = await bootOver(storage).init();
+    await killDuringDispatch(storage, {
+      operationId: 'op-1', sessionId: 'sess-1', tool: TOOLS.E,
+      generationId: first.generation.id, writesBeforeDeath: 3,
+    });
+    // Right shape, wrong contents: the per-session value is not a list.
+    storage.poke(PENDING_NOTICES_KEY, { 'sess-1': 'not-a-list', 'sess-2': 42 });
+
+    const second = bootOver(storage);
+    expect(await second.drainNoticesFor('sess-1')).toBe('');
+    await second.init();
+    const block = await second.drainNoticesFor('sess-1');
+    expect(block).toContain('<interruption-recovery>');
+    expect(block).toContain('outcome_unknown');
+  });
+});

--- a/tests/peerd-runtime/lifecycle/fixtures/profile-maximal-historical.json
+++ b/tests/peerd-runtime/lifecycle/fixtures/profile-maximal-historical.json
@@ -1,0 +1,6493 @@
+{
+  "_provenance": {
+    "peerdVersion": "composite (0.1.0 → 0.4.0)",
+    "shapeCommit": "n/a — COMPOSITE, not a release snapshot",
+    "shapeDate": "2026-08-05",
+    "notes": [
+      "COMPOSITE TORTURE FIXTURE — deliberately NOT a real release snapshot. The other four fixtures each pin ONE release's shapes; this one mixes eras inside a SINGLE profile, because that is what a long-lived install actually looks like: records written by 0.1.0 sitting next to records written by 0.4.0, never rewritten (peerd has no rewrite pass — every shape change defaults at read time).",
+      "Do NOT cite this file as evidence of what any version wrote. Its per-record shapes are all real (see the sibling fixtures for their provenance); their CO-EXISTENCE is the fabrication, and it is the point.",
+      "MIXED ERAS: two pre-per-message-store v1 records (inline `messages`, no messagesV2/msgIndex) carrying the pre-collapse Codex-style `actTier` — one 'auto-edit', one 'full-auto' — sit next to v2 records (msgIndex + messagesV2:true). Reading the v1 pair migrates ONLY them; the v2 neighbours are not touched.",
+      "actTier per bd7a135:docs/DECISIONS.md §18 (deleted in 5b386dd, restored in behavior): suggest AND auto-edit → confirm ON, only full-auto → OFF, unknown tiers fail safe to ON — \"a migration must never widen authority\".",
+      "MODERN ACTORS: a tab-backed web actor with originState (actor/origin-lock.js ActorOriginState — mode/ownedOrigin/provisional/excursion/excursionsUsed, persisted through actor/origin-state-store.js), a DESIGN-18 API actor (backing:'api', instanceId = the owned ORIGIN, no tab), the dweb daemon actor (actorType:'dweb'), and a #160 review child (review:true).",
+      "PARTIALLY STAMPED: storeVersions carries SOME surfaces at 1 and omits the rest — the state a profile is in when a stamping run was interrupted (or when the registry grew a surface after the last stamp). The stamped ones must classify from their stamp; the absent ones must read as firstRun, never as a skew.",
+      "hooks is the ARRAY stored under HOOKS_STORAGE_KEY (tools/hooks/registry.js, `hooks.user.v1`); hooksStorageKey below pins that name so a rename shows up here.",
+      "dpop-keys appears ONLY as an EXPORT-side omission: rung 2 of the credential ladder is a non-extractable keypair HANDLE, so there is nothing to put in a fixture — the honest representation is durability.omittedDeviceBound naming it (§12: \"the export format must identify omitted device-bound state\").",
+      "BULK: ~40 sessions, a few with long message arrays, so the store path is exercised at a size a real profile reaches rather than at three records. Generated compactly; the whole file stays well under 300 KB.",
+      "Planted unknown*FromANewerBuild / future* fields throughout (settings, records at every era, message bodies, hooks, memory docs, the export envelope) — forward-compat data a later build wrote that today's build must carry through untouched."
+    ]
+  },
+  "storeVersions": {
+    "sessions": 1,
+    "memory": 1,
+    "hooks": 1
+  },
+  "settings": {
+    "backgroundTabsEnabled": false,
+    "voiceVariant": "small",
+    "providerName": "anthropic",
+    "providerModel": "claude-opus-4-1",
+    "advancedAutomationEnabled": false,
+    "watchAgentTab": true,
+    "webActorActionSurface": "code",
+    "prewalkEnabled": true,
+    "enginePrewalkEnabled": true,
+    "prewalkExecutorModel": "claude-haiku-4-5",
+    "confirmWebWrites": false,
+    "autoMemoryEnabled": false,
+    "spendLimitUsd": 250,
+    "vaultAutoLockMs": 60000,
+    "auditLogMaxEntries": 100000,
+    "providerFallbacks": [
+      "openrouter"
+    ],
+    "dwebEnabled": true,
+    "dwebAgentEnabled": true,
+    "unknownSettingFromANewerBuild": {
+      "shape": "forward-compat",
+      "keep": true
+    }
+  },
+  "hooksStorageKey": "hooks.user.v1",
+  "sessions": [
+    {
+      "sessionId": "0197c4a1-9000-7000-8000-0000000090a1",
+      "createdAt": 1750464900000,
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-5",
+      "title": "tidy the release notes",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "actTier": "auto-edit",
+      "messages": [
+        {
+          "role": "user",
+          "content": "tidy the release notes",
+          "id": "0197c4a1-9001-7000-8000-0000000090b1",
+          "when": 1750464900100
+        },
+        {
+          "role": "assistant",
+          "content": "Reading the current notes first.",
+          "id": "0197c4a1-9002-7000-8000-0000000090b2",
+          "when": 1750464901000,
+          "model": "claude-sonnet-4-5",
+          "provider": "anthropic",
+          "stopReason": "tool_use",
+          "toolUses": [
+            {
+              "id": "toolu_legacy_9",
+              "name": "get",
+              "input": {
+                "url": "https://example.test/notes"
+              }
+            }
+          ],
+          "unknownMessageFieldFromANewerBuild": "keep-me"
+        }
+      ],
+      "cost": {
+        "inputTokens": 2400,
+        "outputTokens": 380,
+        "cacheReadTokens": 0,
+        "cacheWriteTokens": 0,
+        "cost": 0.0163,
+        "turns": 1
+      },
+      "unknownRecordFieldFromANewerBuild": {
+        "why": "forward-compat: must survive every read path"
+      }
+    },
+    {
+      "sessionId": "0197c4a1-9100-7000-8000-0000000090a2",
+      "createdAt": 1750464950000,
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-5",
+      "title": "diff the two note drafts",
+      "kind": "subagent",
+      "parentSessionId": "0197c4a1-9000-7000-8000-0000000090a1",
+      "task": "diff the two note drafts and list what changed",
+      "depth": 1,
+      "actTier": "full-auto",
+      "messages": [
+        {
+          "role": "user",
+          "content": "diff the two note drafts and list what changed",
+          "id": "0197c4a1-9101-7000-8000-0000000090b3",
+          "when": 1750464950100
+        }
+      ],
+      "futureSubagentField": [
+        "planted",
+        "unknown"
+      ]
+    },
+    {
+      "sessionId": "01990b00-1000-7000-8000-000000020001",
+      "createdAt": 1754400000000,
+      "provider": "anthropic",
+      "model": "claude-opus-4-1",
+      "title": "file the quarterly VAT return",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "customSystemPrompt": "Show the arithmetic for every total.",
+      "toolManifest": {
+        "preset": "research",
+        "allow": [
+          "fetch_url",
+          "read_web_cache",
+          "message_actor",
+          "inspect"
+        ]
+      },
+      "todos": [
+        {
+          "id": 1,
+          "text": "collect the quarter's invoices",
+          "status": "done"
+        },
+        {
+          "id": 2,
+          "text": "total the reclaimable VAT",
+          "status": "pending",
+          "validation": "the total matches the ledger sum to the penny"
+        }
+      ],
+      "prewalk": {
+        "phase": "executing",
+        "plannerProvider": "anthropic",
+        "plannerModel": "claude-opus-4-1",
+        "executorProvider": "anthropic",
+        "executorModel": "claude-haiku-4-5",
+        "armedAt": 1754400001000,
+        "swappedAt": 1754400090000
+      },
+      "cost": {
+        "inputTokens": 210400,
+        "outputTokens": 14300,
+        "cacheReadTokens": 180000,
+        "cacheWriteTokens": 21000,
+        "cost": 2.4419,
+        "turns": 21
+      },
+      "unknownRecordFieldFromANewerBuild": {
+        "why": "forward-compat: must survive every read path"
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990b00-1001-7000-8000-000000021001",
+        "01990b00-1002-7000-8000-000000021002"
+      ]
+    },
+    {
+      "sessionId": "01990b00-2000-7000-8000-000000020002",
+      "createdAt": 1754400060000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "kind": "actor",
+      "parentSessionId": "01990b00-1000-7000-8000-000000020001",
+      "depth": 1,
+      "instanceId": "2211",
+      "actorType": "web",
+      "backing": "tab",
+      "spawnedTrusted": true,
+      "grantedTools": [
+        "snapshot",
+        "read_page",
+        "click",
+        "type",
+        "navigate",
+        "fetch_url",
+        "read_web_cache",
+        "site_capture"
+      ],
+      "originState": {
+        "mode": "bound",
+        "ownedOrigin": "https://vat.example.test",
+        "provisional": false,
+        "excursion": {
+          "returnTo": "https://vat.example.test/returns/q3",
+          "openedAt": 1754400120000,
+          "lastLanding": "https://help.example.test/vat-codes",
+          "budget": 3,
+          "deadline": 1754400420000
+        },
+        "excursionsUsed": 2
+      },
+      "unknownActorFieldFromANewerBuild": {
+        "boundSince": 1754400061000
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990b00-2001-7000-8000-000000021003"
+      ]
+    },
+    {
+      "sessionId": "01990b00-3000-7000-8000-000000020003",
+      "createdAt": 1754400200000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "kind": "actor",
+      "parentSessionId": "01990b00-1000-7000-8000-000000020001",
+      "depth": 1,
+      "instanceId": "https://api.ledger.example.test",
+      "actorType": "web",
+      "backing": "api",
+      "spawnedTrusted": true,
+      "grantedTools": [
+        "fetch_url",
+        "read_web_cache",
+        "site_client_run",
+        "site_client_read",
+        "site_client_write"
+      ],
+      "futureApiActorField": {
+        "derivedClient": "ledger.v3"
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990b00-3001-7000-8000-000000021004"
+      ]
+    },
+    {
+      "sessionId": "01990b00-4000-7000-8000-000000020004",
+      "createdAt": 1754400300000,
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "kind": "actor",
+      "depth": 0,
+      "instanceId": "dweb",
+      "actorType": "dweb",
+      "grantedTools": [
+        "dweb_share",
+        "dweb_discover",
+        "dweb_install",
+        "dweb_peers",
+        "dweb_block",
+        "a2a_run"
+      ],
+      "unknownDwebActorFieldFromANewerBuild": {
+        "inboundSeen": 4
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990b00-4001-7000-8000-000000021005"
+      ]
+    },
+    {
+      "sessionId": "01990b00-5000-7000-8000-000000020005",
+      "createdAt": 1754400400000,
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "kind": "spawned",
+      "parentSessionId": "01990b00-1000-7000-8000-000000020001",
+      "task": "review the VAT totals notebook",
+      "depth": 1,
+      "spawnedTrusted": true,
+      "review": true,
+      "grantedTools": [
+        "js_read_file",
+        "app_read_file",
+        "read_doc"
+      ],
+      "futureReviewFieldFromANewerBuild": "keep-me",
+      "messagesV2": true,
+      "msgIndex": [
+        "01990b00-5001-7000-8000-000000021006"
+      ]
+    },
+    {
+      "sessionId": "01990b00-6000-7000-8000-000000020006",
+      "createdAt": 1754300000000,
+      "archivedAt": 1754350000000,
+      "provider": "openrouter",
+      "model": "anthropic/claude-3.7-sonnet",
+      "title": "old: chase the missing receipt",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": true,
+      "futureArchiveField": {
+        "reason": "auto-archived on switch-away"
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990b00-6001-7000-8000-000000021007"
+      ]
+    },
+    {
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "createdAt": 1754410000000,
+      "provider": "anthropic",
+      "model": "claude-opus-4-1",
+      "title": "bulk 0: the supplier onboarding form",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": true,
+      "cost": {
+        "inputTokens": 4000,
+        "outputTokens": 400,
+        "cacheReadTokens": 2000,
+        "cacheWriteTokens": 300,
+        "cost": 0.01,
+        "turns": 20
+      },
+      "unknownBulkFieldFromANewerBuild": {
+        "i": 0,
+        "keep": true
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c00-2000-7000-8000-000000000000",
+        "01990c00-2000-7000-8000-000000000001",
+        "01990c00-2000-7000-8000-000000000002",
+        "01990c00-2000-7000-8000-000000000003",
+        "01990c00-2000-7000-8000-000000000004",
+        "01990c00-2000-7000-8000-000000000005",
+        "01990c00-2000-7000-8000-000000000006",
+        "01990c00-2000-7000-8000-000000000007",
+        "01990c00-2000-7000-8000-000000000008",
+        "01990c00-2000-7000-8000-000000000009",
+        "01990c00-2000-7000-8000-000000000010",
+        "01990c00-2000-7000-8000-000000000011",
+        "01990c00-2000-7000-8000-000000000012",
+        "01990c00-2000-7000-8000-000000000013",
+        "01990c00-2000-7000-8000-000000000014",
+        "01990c00-2000-7000-8000-000000000015",
+        "01990c00-2000-7000-8000-000000000016",
+        "01990c00-2000-7000-8000-000000000017",
+        "01990c00-2000-7000-8000-000000000018",
+        "01990c00-2000-7000-8000-000000000019",
+        "01990c00-2000-7000-8000-000000000020",
+        "01990c00-2000-7000-8000-000000000021",
+        "01990c00-2000-7000-8000-000000000022",
+        "01990c00-2000-7000-8000-000000000023",
+        "01990c00-2000-7000-8000-000000000024",
+        "01990c00-2000-7000-8000-000000000025",
+        "01990c00-2000-7000-8000-000000000026",
+        "01990c00-2000-7000-8000-000000000027",
+        "01990c00-2000-7000-8000-000000000028",
+        "01990c00-2000-7000-8000-000000000029",
+        "01990c00-2000-7000-8000-000000000030",
+        "01990c00-2000-7000-8000-000000000031",
+        "01990c00-2000-7000-8000-000000000032",
+        "01990c00-2000-7000-8000-000000000033",
+        "01990c00-2000-7000-8000-000000000034",
+        "01990c00-2000-7000-8000-000000000035",
+        "01990c00-2000-7000-8000-000000000036",
+        "01990c00-2000-7000-8000-000000000037",
+        "01990c00-2000-7000-8000-000000000038",
+        "01990c00-2000-7000-8000-000000000039"
+      ]
+    },
+    {
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "createdAt": 1754410100000,
+      "provider": "anthropic",
+      "model": "claude-opus-4-1",
+      "title": "bulk 1: the payroll export",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "cost": {
+        "inputTokens": 4137,
+        "outputTokens": 411,
+        "cacheReadTokens": 2061,
+        "cacheWriteTokens": 307,
+        "cost": 0.0131,
+        "turns": 20
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c01-2000-7000-8000-000100000000",
+        "01990c01-2000-7000-8000-000100000001",
+        "01990c01-2000-7000-8000-000100000002",
+        "01990c01-2000-7000-8000-000100000003",
+        "01990c01-2000-7000-8000-000100000004",
+        "01990c01-2000-7000-8000-000100000005",
+        "01990c01-2000-7000-8000-000100000006",
+        "01990c01-2000-7000-8000-000100000007",
+        "01990c01-2000-7000-8000-000100000008",
+        "01990c01-2000-7000-8000-000100000009",
+        "01990c01-2000-7000-8000-000100000010",
+        "01990c01-2000-7000-8000-000100000011",
+        "01990c01-2000-7000-8000-000100000012",
+        "01990c01-2000-7000-8000-000100000013",
+        "01990c01-2000-7000-8000-000100000014",
+        "01990c01-2000-7000-8000-000100000015",
+        "01990c01-2000-7000-8000-000100000016",
+        "01990c01-2000-7000-8000-000100000017",
+        "01990c01-2000-7000-8000-000100000018",
+        "01990c01-2000-7000-8000-000100000019",
+        "01990c01-2000-7000-8000-000100000020",
+        "01990c01-2000-7000-8000-000100000021",
+        "01990c01-2000-7000-8000-000100000022",
+        "01990c01-2000-7000-8000-000100000023",
+        "01990c01-2000-7000-8000-000100000024",
+        "01990c01-2000-7000-8000-000100000025",
+        "01990c01-2000-7000-8000-000100000026",
+        "01990c01-2000-7000-8000-000100000027",
+        "01990c01-2000-7000-8000-000100000028",
+        "01990c01-2000-7000-8000-000100000029",
+        "01990c01-2000-7000-8000-000100000030",
+        "01990c01-2000-7000-8000-000100000031",
+        "01990c01-2000-7000-8000-000100000032",
+        "01990c01-2000-7000-8000-000100000033",
+        "01990c01-2000-7000-8000-000100000034",
+        "01990c01-2000-7000-8000-000100000035",
+        "01990c01-2000-7000-8000-000100000036",
+        "01990c01-2000-7000-8000-000100000037",
+        "01990c01-2000-7000-8000-000100000038",
+        "01990c01-2000-7000-8000-000100000039"
+      ]
+    },
+    {
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "createdAt": 1754410200000,
+      "provider": "anthropic",
+      "model": "claude-opus-4-1",
+      "title": "bulk 2: the expense policy page",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "cost": {
+        "inputTokens": 4274,
+        "outputTokens": 422,
+        "cacheReadTokens": 2122,
+        "cacheWriteTokens": 314,
+        "cost": 0.0162,
+        "turns": 20
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c02-2000-7000-8000-000200000000",
+        "01990c02-2000-7000-8000-000200000001",
+        "01990c02-2000-7000-8000-000200000002",
+        "01990c02-2000-7000-8000-000200000003",
+        "01990c02-2000-7000-8000-000200000004",
+        "01990c02-2000-7000-8000-000200000005",
+        "01990c02-2000-7000-8000-000200000006",
+        "01990c02-2000-7000-8000-000200000007",
+        "01990c02-2000-7000-8000-000200000008",
+        "01990c02-2000-7000-8000-000200000009",
+        "01990c02-2000-7000-8000-000200000010",
+        "01990c02-2000-7000-8000-000200000011",
+        "01990c02-2000-7000-8000-000200000012",
+        "01990c02-2000-7000-8000-000200000013",
+        "01990c02-2000-7000-8000-000200000014",
+        "01990c02-2000-7000-8000-000200000015",
+        "01990c02-2000-7000-8000-000200000016",
+        "01990c02-2000-7000-8000-000200000017",
+        "01990c02-2000-7000-8000-000200000018",
+        "01990c02-2000-7000-8000-000200000019",
+        "01990c02-2000-7000-8000-000200000020",
+        "01990c02-2000-7000-8000-000200000021",
+        "01990c02-2000-7000-8000-000200000022",
+        "01990c02-2000-7000-8000-000200000023",
+        "01990c02-2000-7000-8000-000200000024",
+        "01990c02-2000-7000-8000-000200000025",
+        "01990c02-2000-7000-8000-000200000026",
+        "01990c02-2000-7000-8000-000200000027",
+        "01990c02-2000-7000-8000-000200000028",
+        "01990c02-2000-7000-8000-000200000029",
+        "01990c02-2000-7000-8000-000200000030",
+        "01990c02-2000-7000-8000-000200000031",
+        "01990c02-2000-7000-8000-000200000032",
+        "01990c02-2000-7000-8000-000200000033",
+        "01990c02-2000-7000-8000-000200000034",
+        "01990c02-2000-7000-8000-000200000035",
+        "01990c02-2000-7000-8000-000200000036",
+        "01990c02-2000-7000-8000-000200000037",
+        "01990c02-2000-7000-8000-000200000038",
+        "01990c02-2000-7000-8000-000200000039"
+      ]
+    },
+    {
+      "sessionId": "01990c03-1000-7000-8000-000000030003",
+      "createdAt": 1754410300000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 3: the FX rate table",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": true,
+      "cost": {
+        "inputTokens": 4411,
+        "outputTokens": 433,
+        "cacheReadTokens": 2183,
+        "cacheWriteTokens": 321,
+        "cost": 0.0193,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c03-2000-7000-8000-000300000000",
+        "01990c03-2000-7000-8000-000300000001",
+        "01990c03-2000-7000-8000-000300000002",
+        "01990c03-2000-7000-8000-000300000003",
+        "01990c03-2000-7000-8000-000300000004",
+        "01990c03-2000-7000-8000-000300000005"
+      ]
+    },
+    {
+      "sessionId": "01990c04-1000-7000-8000-000000030004",
+      "createdAt": 1754410400000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 4: the audit checklist",
+      "kind": "spawned",
+      "depth": 1,
+      "parentSessionId": "01990b00-1000-7000-8000-000000020001",
+      "spawnedTrusted": true,
+      "task": "look at the audit checklist",
+      "cost": {
+        "inputTokens": 4548,
+        "outputTokens": 444,
+        "cacheReadTokens": 2244,
+        "cacheWriteTokens": 328,
+        "cost": 0.0224,
+        "turns": 3
+      },
+      "unknownBulkFieldFromANewerBuild": {
+        "i": 4,
+        "keep": true
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c04-2000-7000-8000-000400000000",
+        "01990c04-2000-7000-8000-000400000001",
+        "01990c04-2000-7000-8000-000400000002",
+        "01990c04-2000-7000-8000-000400000003",
+        "01990c04-2000-7000-8000-000400000004",
+        "01990c04-2000-7000-8000-000400000005"
+      ]
+    },
+    {
+      "sessionId": "01990c05-1000-7000-8000-000000030005",
+      "createdAt": 1754410500000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 5: the vendor contract diff",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "cost": {
+        "inputTokens": 4685,
+        "outputTokens": 455,
+        "cacheReadTokens": 2305,
+        "cacheWriteTokens": 335,
+        "cost": 0.0255,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c05-2000-7000-8000-000500000000",
+        "01990c05-2000-7000-8000-000500000001",
+        "01990c05-2000-7000-8000-000500000002",
+        "01990c05-2000-7000-8000-000500000003",
+        "01990c05-2000-7000-8000-000500000004",
+        "01990c05-2000-7000-8000-000500000005"
+      ]
+    },
+    {
+      "sessionId": "01990c06-1000-7000-8000-000000030006",
+      "createdAt": 1754410600000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 6: the supplier onboarding form",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": true,
+      "cost": {
+        "inputTokens": 4822,
+        "outputTokens": 466,
+        "cacheReadTokens": 2366,
+        "cacheWriteTokens": 342,
+        "cost": 0.0286,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c06-2000-7000-8000-000600000000",
+        "01990c06-2000-7000-8000-000600000001",
+        "01990c06-2000-7000-8000-000600000002",
+        "01990c06-2000-7000-8000-000600000003",
+        "01990c06-2000-7000-8000-000600000004",
+        "01990c06-2000-7000-8000-000600000005"
+      ]
+    },
+    {
+      "sessionId": "01990c07-1000-7000-8000-000000030007",
+      "createdAt": 1754410700000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 7: the payroll export",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "cost": {
+        "inputTokens": 4959,
+        "outputTokens": 477,
+        "cacheReadTokens": 2427,
+        "cacheWriteTokens": 349,
+        "cost": 0.0317,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c07-2000-7000-8000-000700000000",
+        "01990c07-2000-7000-8000-000700000001",
+        "01990c07-2000-7000-8000-000700000002",
+        "01990c07-2000-7000-8000-000700000003",
+        "01990c07-2000-7000-8000-000700000004",
+        "01990c07-2000-7000-8000-000700000005"
+      ]
+    },
+    {
+      "sessionId": "01990c08-1000-7000-8000-000000030008",
+      "createdAt": 1754410800000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 8: the expense policy page",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "cost": {
+        "inputTokens": 5096,
+        "outputTokens": 488,
+        "cacheReadTokens": 2488,
+        "cacheWriteTokens": 356,
+        "cost": 0.0348,
+        "turns": 3
+      },
+      "unknownBulkFieldFromANewerBuild": {
+        "i": 8,
+        "keep": true
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c08-2000-7000-8000-000800000000",
+        "01990c08-2000-7000-8000-000800000001",
+        "01990c08-2000-7000-8000-000800000002",
+        "01990c08-2000-7000-8000-000800000003",
+        "01990c08-2000-7000-8000-000800000004",
+        "01990c08-2000-7000-8000-000800000005"
+      ]
+    },
+    {
+      "sessionId": "01990c09-1000-7000-8000-000000030009",
+      "createdAt": 1754410900000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 9: the FX rate table",
+      "kind": "spawned",
+      "depth": 1,
+      "parentSessionId": "01990b00-1000-7000-8000-000000020001",
+      "spawnedTrusted": false,
+      "task": "look at the FX rate table",
+      "cost": {
+        "inputTokens": 5233,
+        "outputTokens": 499,
+        "cacheReadTokens": 2549,
+        "cacheWriteTokens": 363,
+        "cost": 0.0379,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c09-2000-7000-8000-000900000000",
+        "01990c09-2000-7000-8000-000900000001",
+        "01990c09-2000-7000-8000-000900000002",
+        "01990c09-2000-7000-8000-000900000003",
+        "01990c09-2000-7000-8000-000900000004",
+        "01990c09-2000-7000-8000-000900000005"
+      ]
+    },
+    {
+      "sessionId": "01990c10-1000-7000-8000-000000030010",
+      "createdAt": 1754411000000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 10: the audit checklist",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "cost": {
+        "inputTokens": 5370,
+        "outputTokens": 510,
+        "cacheReadTokens": 2610,
+        "cacheWriteTokens": 370,
+        "cost": 0.041,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c10-2000-7000-8000-001000000000",
+        "01990c10-2000-7000-8000-001000000001",
+        "01990c10-2000-7000-8000-001000000002",
+        "01990c10-2000-7000-8000-001000000003",
+        "01990c10-2000-7000-8000-001000000004",
+        "01990c10-2000-7000-8000-001000000005"
+      ]
+    },
+    {
+      "sessionId": "01990c11-1000-7000-8000-000000030011",
+      "createdAt": 1754411100000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 11: the vendor contract diff",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "cost": {
+        "inputTokens": 5507,
+        "outputTokens": 521,
+        "cacheReadTokens": 2671,
+        "cacheWriteTokens": 377,
+        "cost": 0.0441,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c11-2000-7000-8000-001100000000",
+        "01990c11-2000-7000-8000-001100000001",
+        "01990c11-2000-7000-8000-001100000002",
+        "01990c11-2000-7000-8000-001100000003",
+        "01990c11-2000-7000-8000-001100000004",
+        "01990c11-2000-7000-8000-001100000005"
+      ]
+    },
+    {
+      "sessionId": "01990c12-1000-7000-8000-000000030012",
+      "createdAt": 1754411200000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 12: the supplier onboarding form",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": true,
+      "cost": {
+        "inputTokens": 5644,
+        "outputTokens": 532,
+        "cacheReadTokens": 2732,
+        "cacheWriteTokens": 384,
+        "cost": 0.0472,
+        "turns": 3
+      },
+      "unknownBulkFieldFromANewerBuild": {
+        "i": 12,
+        "keep": true
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c12-2000-7000-8000-001200000000",
+        "01990c12-2000-7000-8000-001200000001",
+        "01990c12-2000-7000-8000-001200000002",
+        "01990c12-2000-7000-8000-001200000003",
+        "01990c12-2000-7000-8000-001200000004",
+        "01990c12-2000-7000-8000-001200000005"
+      ]
+    },
+    {
+      "sessionId": "01990c13-1000-7000-8000-000000030013",
+      "createdAt": 1754411300000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 13: the payroll export",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "cost": {
+        "inputTokens": 5781,
+        "outputTokens": 543,
+        "cacheReadTokens": 2793,
+        "cacheWriteTokens": 391,
+        "cost": 0.0503,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c13-2000-7000-8000-001300000000",
+        "01990c13-2000-7000-8000-001300000001",
+        "01990c13-2000-7000-8000-001300000002",
+        "01990c13-2000-7000-8000-001300000003",
+        "01990c13-2000-7000-8000-001300000004",
+        "01990c13-2000-7000-8000-001300000005"
+      ]
+    },
+    {
+      "sessionId": "01990c14-1000-7000-8000-000000030014",
+      "createdAt": 1754411400000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 14: the expense policy page",
+      "kind": "spawned",
+      "depth": 1,
+      "parentSessionId": "01990b00-1000-7000-8000-000000020001",
+      "spawnedTrusted": true,
+      "task": "look at the expense policy page",
+      "cost": {
+        "inputTokens": 5918,
+        "outputTokens": 554,
+        "cacheReadTokens": 2854,
+        "cacheWriteTokens": 398,
+        "cost": 0.0534,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c14-2000-7000-8000-001400000000",
+        "01990c14-2000-7000-8000-001400000001",
+        "01990c14-2000-7000-8000-001400000002",
+        "01990c14-2000-7000-8000-001400000003",
+        "01990c14-2000-7000-8000-001400000004",
+        "01990c14-2000-7000-8000-001400000005"
+      ]
+    },
+    {
+      "sessionId": "01990c15-1000-7000-8000-000000030015",
+      "createdAt": 1754411500000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 15: the FX rate table",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": true,
+      "cost": {
+        "inputTokens": 6055,
+        "outputTokens": 565,
+        "cacheReadTokens": 2915,
+        "cacheWriteTokens": 405,
+        "cost": 0.0565,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c15-2000-7000-8000-001500000000",
+        "01990c15-2000-7000-8000-001500000001",
+        "01990c15-2000-7000-8000-001500000002",
+        "01990c15-2000-7000-8000-001500000003",
+        "01990c15-2000-7000-8000-001500000004",
+        "01990c15-2000-7000-8000-001500000005"
+      ]
+    },
+    {
+      "sessionId": "01990c16-1000-7000-8000-000000030016",
+      "createdAt": 1754411600000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 16: the audit checklist",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "cost": {
+        "inputTokens": 6192,
+        "outputTokens": 576,
+        "cacheReadTokens": 2976,
+        "cacheWriteTokens": 412,
+        "cost": 0.0596,
+        "turns": 3
+      },
+      "unknownBulkFieldFromANewerBuild": {
+        "i": 16,
+        "keep": true
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c16-2000-7000-8000-001600000000",
+        "01990c16-2000-7000-8000-001600000001",
+        "01990c16-2000-7000-8000-001600000002",
+        "01990c16-2000-7000-8000-001600000003",
+        "01990c16-2000-7000-8000-001600000004",
+        "01990c16-2000-7000-8000-001600000005"
+      ]
+    },
+    {
+      "sessionId": "01990c17-1000-7000-8000-000000030017",
+      "createdAt": 1754411700000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 17: the vendor contract diff",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "cost": {
+        "inputTokens": 6329,
+        "outputTokens": 587,
+        "cacheReadTokens": 3037,
+        "cacheWriteTokens": 419,
+        "cost": 0.0627,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c17-2000-7000-8000-001700000000",
+        "01990c17-2000-7000-8000-001700000001",
+        "01990c17-2000-7000-8000-001700000002",
+        "01990c17-2000-7000-8000-001700000003",
+        "01990c17-2000-7000-8000-001700000004",
+        "01990c17-2000-7000-8000-001700000005"
+      ]
+    },
+    {
+      "sessionId": "01990c18-1000-7000-8000-000000030018",
+      "createdAt": 1754411800000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 18: the supplier onboarding form",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": true,
+      "cost": {
+        "inputTokens": 6466,
+        "outputTokens": 598,
+        "cacheReadTokens": 3098,
+        "cacheWriteTokens": 426,
+        "cost": 0.0658,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c18-2000-7000-8000-001800000000",
+        "01990c18-2000-7000-8000-001800000001",
+        "01990c18-2000-7000-8000-001800000002",
+        "01990c18-2000-7000-8000-001800000003",
+        "01990c18-2000-7000-8000-001800000004",
+        "01990c18-2000-7000-8000-001800000005"
+      ]
+    },
+    {
+      "sessionId": "01990c19-1000-7000-8000-000000030019",
+      "createdAt": 1754411900000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 19: the payroll export",
+      "kind": "spawned",
+      "depth": 1,
+      "parentSessionId": "01990b00-1000-7000-8000-000000020001",
+      "spawnedTrusted": false,
+      "task": "look at the payroll export",
+      "cost": {
+        "inputTokens": 6603,
+        "outputTokens": 609,
+        "cacheReadTokens": 3159,
+        "cacheWriteTokens": 433,
+        "cost": 0.0689,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c19-2000-7000-8000-001900000000",
+        "01990c19-2000-7000-8000-001900000001",
+        "01990c19-2000-7000-8000-001900000002",
+        "01990c19-2000-7000-8000-001900000003",
+        "01990c19-2000-7000-8000-001900000004",
+        "01990c19-2000-7000-8000-001900000005"
+      ]
+    },
+    {
+      "sessionId": "01990c20-1000-7000-8000-000000030020",
+      "createdAt": 1754412000000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 20: the expense policy page",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "cost": {
+        "inputTokens": 6740,
+        "outputTokens": 620,
+        "cacheReadTokens": 3220,
+        "cacheWriteTokens": 440,
+        "cost": 0.072,
+        "turns": 3
+      },
+      "unknownBulkFieldFromANewerBuild": {
+        "i": 20,
+        "keep": true
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c20-2000-7000-8000-002000000000",
+        "01990c20-2000-7000-8000-002000000001",
+        "01990c20-2000-7000-8000-002000000002",
+        "01990c20-2000-7000-8000-002000000003",
+        "01990c20-2000-7000-8000-002000000004",
+        "01990c20-2000-7000-8000-002000000005"
+      ]
+    },
+    {
+      "sessionId": "01990c21-1000-7000-8000-000000030021",
+      "createdAt": 1754412100000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 21: the FX rate table",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": true,
+      "cost": {
+        "inputTokens": 6877,
+        "outputTokens": 631,
+        "cacheReadTokens": 3281,
+        "cacheWriteTokens": 447,
+        "cost": 0.0751,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c21-2000-7000-8000-002100000000",
+        "01990c21-2000-7000-8000-002100000001",
+        "01990c21-2000-7000-8000-002100000002",
+        "01990c21-2000-7000-8000-002100000003",
+        "01990c21-2000-7000-8000-002100000004",
+        "01990c21-2000-7000-8000-002100000005"
+      ]
+    },
+    {
+      "sessionId": "01990c22-1000-7000-8000-000000030022",
+      "createdAt": 1754412200000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 22: the audit checklist",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "cost": {
+        "inputTokens": 7014,
+        "outputTokens": 642,
+        "cacheReadTokens": 3342,
+        "cacheWriteTokens": 454,
+        "cost": 0.0782,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c22-2000-7000-8000-002200000000",
+        "01990c22-2000-7000-8000-002200000001",
+        "01990c22-2000-7000-8000-002200000002",
+        "01990c22-2000-7000-8000-002200000003",
+        "01990c22-2000-7000-8000-002200000004",
+        "01990c22-2000-7000-8000-002200000005"
+      ]
+    },
+    {
+      "sessionId": "01990c23-1000-7000-8000-000000030023",
+      "createdAt": 1754412300000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 23: the vendor contract diff",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "cost": {
+        "inputTokens": 7151,
+        "outputTokens": 653,
+        "cacheReadTokens": 3403,
+        "cacheWriteTokens": 461,
+        "cost": 0.0813,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c23-2000-7000-8000-002300000000",
+        "01990c23-2000-7000-8000-002300000001",
+        "01990c23-2000-7000-8000-002300000002",
+        "01990c23-2000-7000-8000-002300000003",
+        "01990c23-2000-7000-8000-002300000004",
+        "01990c23-2000-7000-8000-002300000005"
+      ]
+    },
+    {
+      "sessionId": "01990c24-1000-7000-8000-000000030024",
+      "createdAt": 1754412400000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 24: the supplier onboarding form",
+      "kind": "spawned",
+      "depth": 1,
+      "parentSessionId": "01990b00-1000-7000-8000-000000020001",
+      "spawnedTrusted": true,
+      "task": "look at the supplier onboarding form",
+      "cost": {
+        "inputTokens": 7288,
+        "outputTokens": 664,
+        "cacheReadTokens": 3464,
+        "cacheWriteTokens": 468,
+        "cost": 0.0844,
+        "turns": 3
+      },
+      "unknownBulkFieldFromANewerBuild": {
+        "i": 24,
+        "keep": true
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c24-2000-7000-8000-002400000000",
+        "01990c24-2000-7000-8000-002400000001",
+        "01990c24-2000-7000-8000-002400000002",
+        "01990c24-2000-7000-8000-002400000003",
+        "01990c24-2000-7000-8000-002400000004",
+        "01990c24-2000-7000-8000-002400000005"
+      ]
+    },
+    {
+      "sessionId": "01990c25-1000-7000-8000-000000030025",
+      "createdAt": 1754412500000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 25: the payroll export",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "cost": {
+        "inputTokens": 7425,
+        "outputTokens": 675,
+        "cacheReadTokens": 3525,
+        "cacheWriteTokens": 475,
+        "cost": 0.0875,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c25-2000-7000-8000-002500000000",
+        "01990c25-2000-7000-8000-002500000001",
+        "01990c25-2000-7000-8000-002500000002",
+        "01990c25-2000-7000-8000-002500000003",
+        "01990c25-2000-7000-8000-002500000004",
+        "01990c25-2000-7000-8000-002500000005"
+      ]
+    },
+    {
+      "sessionId": "01990c26-1000-7000-8000-000000030026",
+      "createdAt": 1754412600000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 26: the expense policy page",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "cost": {
+        "inputTokens": 7562,
+        "outputTokens": 686,
+        "cacheReadTokens": 3586,
+        "cacheWriteTokens": 482,
+        "cost": 0.0906,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c26-2000-7000-8000-002600000000",
+        "01990c26-2000-7000-8000-002600000001",
+        "01990c26-2000-7000-8000-002600000002",
+        "01990c26-2000-7000-8000-002600000003",
+        "01990c26-2000-7000-8000-002600000004",
+        "01990c26-2000-7000-8000-002600000005"
+      ]
+    },
+    {
+      "sessionId": "01990c27-1000-7000-8000-000000030027",
+      "createdAt": 1754412700000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 27: the FX rate table",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": true,
+      "cost": {
+        "inputTokens": 7699,
+        "outputTokens": 697,
+        "cacheReadTokens": 3647,
+        "cacheWriteTokens": 489,
+        "cost": 0.0937,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c27-2000-7000-8000-002700000000",
+        "01990c27-2000-7000-8000-002700000001",
+        "01990c27-2000-7000-8000-002700000002",
+        "01990c27-2000-7000-8000-002700000003",
+        "01990c27-2000-7000-8000-002700000004",
+        "01990c27-2000-7000-8000-002700000005"
+      ]
+    },
+    {
+      "sessionId": "01990c28-1000-7000-8000-000000030028",
+      "createdAt": 1754412800000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 28: the audit checklist",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "cost": {
+        "inputTokens": 7836,
+        "outputTokens": 708,
+        "cacheReadTokens": 3708,
+        "cacheWriteTokens": 496,
+        "cost": 0.0968,
+        "turns": 3
+      },
+      "unknownBulkFieldFromANewerBuild": {
+        "i": 28,
+        "keep": true
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c28-2000-7000-8000-002800000000",
+        "01990c28-2000-7000-8000-002800000001",
+        "01990c28-2000-7000-8000-002800000002",
+        "01990c28-2000-7000-8000-002800000003",
+        "01990c28-2000-7000-8000-002800000004",
+        "01990c28-2000-7000-8000-002800000005"
+      ]
+    },
+    {
+      "sessionId": "01990c29-1000-7000-8000-000000030029",
+      "createdAt": 1754412900000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 29: the vendor contract diff",
+      "kind": "spawned",
+      "depth": 1,
+      "parentSessionId": "01990b00-1000-7000-8000-000000020001",
+      "spawnedTrusted": false,
+      "task": "look at the vendor contract diff",
+      "cost": {
+        "inputTokens": 7973,
+        "outputTokens": 719,
+        "cacheReadTokens": 3769,
+        "cacheWriteTokens": 503,
+        "cost": 0.0999,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c29-2000-7000-8000-002900000000",
+        "01990c29-2000-7000-8000-002900000001",
+        "01990c29-2000-7000-8000-002900000002",
+        "01990c29-2000-7000-8000-002900000003",
+        "01990c29-2000-7000-8000-002900000004",
+        "01990c29-2000-7000-8000-002900000005"
+      ]
+    },
+    {
+      "sessionId": "01990c30-1000-7000-8000-000000030030",
+      "createdAt": 1754413000000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 30: the supplier onboarding form",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": true,
+      "cost": {
+        "inputTokens": 8110,
+        "outputTokens": 730,
+        "cacheReadTokens": 3830,
+        "cacheWriteTokens": 510,
+        "cost": 0.103,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c30-2000-7000-8000-003000000000",
+        "01990c30-2000-7000-8000-003000000001",
+        "01990c30-2000-7000-8000-003000000002",
+        "01990c30-2000-7000-8000-003000000003",
+        "01990c30-2000-7000-8000-003000000004",
+        "01990c30-2000-7000-8000-003000000005"
+      ]
+    },
+    {
+      "sessionId": "01990c31-1000-7000-8000-000000030031",
+      "createdAt": 1754413100000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 31: the payroll export",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "cost": {
+        "inputTokens": 8247,
+        "outputTokens": 741,
+        "cacheReadTokens": 3891,
+        "cacheWriteTokens": 517,
+        "cost": 0.1061,
+        "turns": 3
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c31-2000-7000-8000-003100000000",
+        "01990c31-2000-7000-8000-003100000001",
+        "01990c31-2000-7000-8000-003100000002",
+        "01990c31-2000-7000-8000-003100000003",
+        "01990c31-2000-7000-8000-003100000004",
+        "01990c31-2000-7000-8000-003100000005"
+      ]
+    },
+    {
+      "sessionId": "01990c32-1000-7000-8000-000000030032",
+      "createdAt": 1754413200000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "title": "bulk 32: the expense policy page",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "cost": {
+        "inputTokens": 8384,
+        "outputTokens": 752,
+        "cacheReadTokens": 3952,
+        "cacheWriteTokens": 524,
+        "cost": 0.1092,
+        "turns": 3
+      },
+      "unknownBulkFieldFromANewerBuild": {
+        "i": 32,
+        "keep": true
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990c32-2000-7000-8000-003200000000",
+        "01990c32-2000-7000-8000-003200000001",
+        "01990c32-2000-7000-8000-003200000002",
+        "01990c32-2000-7000-8000-003200000003",
+        "01990c32-2000-7000-8000-003200000004",
+        "01990c32-2000-7000-8000-003200000005"
+      ]
+    }
+  ],
+  "sessionMessages": [
+    {
+      "id": "01990b00-1001-7000-8000-000000021001",
+      "sessionId": "01990b00-1000-7000-8000-000000020001",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "file the quarterly VAT return",
+        "id": "01990b00-1001-7000-8000-000000021001",
+        "when": 1754400000100
+      }
+    },
+    {
+      "id": "01990b00-1002-7000-8000-000000021002",
+      "sessionId": "01990b00-1000-7000-8000-000000020001",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Collecting the quarter's invoices first.",
+        "id": "01990b00-1002-7000-8000-000000021002",
+        "when": 1754400001500,
+        "model": "claude-opus-4-1",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "thinkingBlocks": [
+          {
+            "type": "thinking",
+            "thinking": "totals before forms",
+            "signature": "sig_opaque_01990b00"
+          }
+        ],
+        "toolUses": [
+          {
+            "id": "toolu_m01",
+            "name": "message_actor",
+            "input": {
+              "handle": "web:2211",
+              "message": "open the invoice list for Q3"
+            }
+          }
+        ],
+        "unknownMessageFieldFromANewerBuild": "keep-me"
+      }
+    },
+    {
+      "id": "01990b00-2001-7000-8000-000000021003",
+      "sessionId": "01990b00-2000-7000-8000-000000020002",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "open the invoice list for Q3",
+        "id": "01990b00-2001-7000-8000-000000021003",
+        "when": 1754400060100
+      }
+    },
+    {
+      "id": "01990b00-3001-7000-8000-000000021004",
+      "sessionId": "01990b00-3000-7000-8000-000000020003",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "pull the Q3 postings from the ledger API",
+        "id": "01990b00-3001-7000-8000-000000021004",
+        "when": 1754400200100
+      }
+    },
+    {
+      "id": "01990b00-4001-7000-8000-000000021005",
+      "sessionId": "01990b00-4000-7000-8000-000000020004",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "a peer asked for the VAT-code dwapp",
+        "id": "01990b00-4001-7000-8000-000000021005",
+        "when": 1754400300100,
+        "inbound": true
+      }
+    },
+    {
+      "id": "01990b00-5001-7000-8000-000000021006",
+      "sessionId": "01990b00-5000-7000-8000-000000020005",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "review the VAT totals notebook",
+        "id": "01990b00-5001-7000-8000-000000021006",
+        "when": 1754400400100
+      }
+    },
+    {
+      "id": "01990b00-6001-7000-8000-000000021007",
+      "sessionId": "01990b00-6000-7000-8000-000000020006",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "chase the missing receipt",
+        "id": "01990b00-6001-7000-8000-000000021007",
+        "when": 1754300000100
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000000",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the supplier onboarding form",
+        "id": "01990c00-2000-7000-8000-000000000000",
+        "when": 1754410000000
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000001",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c00-2000-7000-8000-000000000001",
+        "when": 1754410001000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b0_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/0/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000002",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the supplier onboarding form",
+        "id": "01990c00-2000-7000-8000-000000000002",
+        "when": 1754410002000
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000003",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c00-2000-7000-8000-000000000003",
+        "when": 1754410003000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b0_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/0/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000004",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the supplier onboarding form",
+        "id": "01990c00-2000-7000-8000-000000000004",
+        "when": 1754410004000
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000005",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c00-2000-7000-8000-000000000005",
+        "when": 1754410005000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b0_5",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/0/5"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000006",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 6,
+      "message": {
+        "role": "user",
+        "content": "step 4 on the supplier onboarding form",
+        "id": "01990c00-2000-7000-8000-000000000006",
+        "when": 1754410006000
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000007",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 7,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 4 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c00-2000-7000-8000-000000000007",
+        "when": 1754410007000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b0_7",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/0/7"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000008",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 8,
+      "message": {
+        "role": "user",
+        "content": "step 5 on the supplier onboarding form",
+        "id": "01990c00-2000-7000-8000-000000000008",
+        "when": 1754410008000
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000009",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 9,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 5 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c00-2000-7000-8000-000000000009",
+        "when": 1754410009000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b0_9",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/0/9"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000010",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 10,
+      "message": {
+        "role": "user",
+        "content": "step 6 on the supplier onboarding form",
+        "id": "01990c00-2000-7000-8000-000000000010",
+        "when": 1754410010000
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000011",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 11,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 6 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c00-2000-7000-8000-000000000011",
+        "when": 1754410011000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b0_11",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/0/11"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000012",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 12,
+      "message": {
+        "role": "user",
+        "content": "step 7 on the supplier onboarding form",
+        "id": "01990c00-2000-7000-8000-000000000012",
+        "when": 1754410012000
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000013",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 13,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 7 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c00-2000-7000-8000-000000000013",
+        "when": 1754410013000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b0_13",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/0/13"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000014",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 14,
+      "message": {
+        "role": "user",
+        "content": "step 8 on the supplier onboarding form",
+        "id": "01990c00-2000-7000-8000-000000000014",
+        "when": 1754410014000
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000015",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 15,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 8 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c00-2000-7000-8000-000000000015",
+        "when": 1754410015000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b0_15",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/0/15"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000016",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 16,
+      "message": {
+        "role": "user",
+        "content": "step 9 on the supplier onboarding form",
+        "id": "01990c00-2000-7000-8000-000000000016",
+        "when": 1754410016000
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000017",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 17,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 9 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c00-2000-7000-8000-000000000017",
+        "when": 1754410017000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b0_17",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/0/17"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000018",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 18,
+      "message": {
+        "role": "user",
+        "content": "step 10 on the supplier onboarding form",
+        "id": "01990c00-2000-7000-8000-000000000018",
+        "when": 1754410018000
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000019",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 19,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 10 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c00-2000-7000-8000-000000000019",
+        "when": 1754410019000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b0_19",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/0/19"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000020",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 20,
+      "message": {
+        "role": "user",
+        "content": "step 11 on the supplier onboarding form",
+        "id": "01990c00-2000-7000-8000-000000000020",
+        "when": 1754410020000
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000021",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 21,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 11 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c00-2000-7000-8000-000000000021",
+        "when": 1754410021000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b0_21",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/0/21"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000022",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 22,
+      "message": {
+        "role": "user",
+        "content": "step 12 on the supplier onboarding form",
+        "id": "01990c00-2000-7000-8000-000000000022",
+        "when": 1754410022000
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000023",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 23,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 12 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c00-2000-7000-8000-000000000023",
+        "when": 1754410023000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b0_23",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/0/23"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000024",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 24,
+      "message": {
+        "role": "user",
+        "content": "step 13 on the supplier onboarding form",
+        "id": "01990c00-2000-7000-8000-000000000024",
+        "when": 1754410024000
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000025",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 25,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 13 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c00-2000-7000-8000-000000000025",
+        "when": 1754410025000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b0_25",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/0/25"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000026",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 26,
+      "message": {
+        "role": "user",
+        "content": "step 14 on the supplier onboarding form",
+        "id": "01990c00-2000-7000-8000-000000000026",
+        "when": 1754410026000
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000027",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 27,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 14 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c00-2000-7000-8000-000000000027",
+        "when": 1754410027000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b0_27",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/0/27"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000028",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 28,
+      "message": {
+        "role": "user",
+        "content": "step 15 on the supplier onboarding form",
+        "id": "01990c00-2000-7000-8000-000000000028",
+        "when": 1754410028000
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000029",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 29,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 15 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c00-2000-7000-8000-000000000029",
+        "when": 1754410029000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b0_29",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/0/29"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000030",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 30,
+      "message": {
+        "role": "user",
+        "content": "step 16 on the supplier onboarding form",
+        "id": "01990c00-2000-7000-8000-000000000030",
+        "when": 1754410030000
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000031",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 31,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 16 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c00-2000-7000-8000-000000000031",
+        "when": 1754410031000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b0_31",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/0/31"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000032",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 32,
+      "message": {
+        "role": "user",
+        "content": "step 17 on the supplier onboarding form",
+        "id": "01990c00-2000-7000-8000-000000000032",
+        "when": 1754410032000
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000033",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 33,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 17 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c00-2000-7000-8000-000000000033",
+        "when": 1754410033000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b0_33",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/0/33"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000034",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 34,
+      "message": {
+        "role": "user",
+        "content": "step 18 on the supplier onboarding form",
+        "id": "01990c00-2000-7000-8000-000000000034",
+        "when": 1754410034000
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000035",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 35,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 18 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c00-2000-7000-8000-000000000035",
+        "when": 1754410035000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b0_35",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/0/35"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000036",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 36,
+      "message": {
+        "role": "user",
+        "content": "step 19 on the supplier onboarding form",
+        "id": "01990c00-2000-7000-8000-000000000036",
+        "when": 1754410036000
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000037",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 37,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 19 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c00-2000-7000-8000-000000000037",
+        "when": 1754410037000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b0_37",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/0/37"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000038",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 38,
+      "message": {
+        "role": "user",
+        "content": "step 20 on the supplier onboarding form",
+        "id": "01990c00-2000-7000-8000-000000000038",
+        "when": 1754410038000
+      }
+    },
+    {
+      "id": "01990c00-2000-7000-8000-000000000039",
+      "sessionId": "01990c00-1000-7000-8000-000000030000",
+      "seq": 39,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 20 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c00-2000-7000-8000-000000000039",
+        "when": 1754410039000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000000",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the payroll export",
+        "id": "01990c01-2000-7000-8000-000100000000",
+        "when": 1754410100000
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000001",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the payroll export; reading the page and reporting back.",
+        "id": "01990c01-2000-7000-8000-000100000001",
+        "when": 1754410101000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b1_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/1/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000002",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the payroll export",
+        "id": "01990c01-2000-7000-8000-000100000002",
+        "when": 1754410102000
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000003",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the payroll export; reading the page and reporting back.",
+        "id": "01990c01-2000-7000-8000-000100000003",
+        "when": 1754410103000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b1_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/1/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000004",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the payroll export",
+        "id": "01990c01-2000-7000-8000-000100000004",
+        "when": 1754410104000
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000005",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the payroll export; reading the page and reporting back.",
+        "id": "01990c01-2000-7000-8000-000100000005",
+        "when": 1754410105000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b1_5",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/1/5"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000006",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 6,
+      "message": {
+        "role": "user",
+        "content": "step 4 on the payroll export",
+        "id": "01990c01-2000-7000-8000-000100000006",
+        "when": 1754410106000
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000007",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 7,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 4 of the payroll export; reading the page and reporting back.",
+        "id": "01990c01-2000-7000-8000-000100000007",
+        "when": 1754410107000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b1_7",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/1/7"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000008",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 8,
+      "message": {
+        "role": "user",
+        "content": "step 5 on the payroll export",
+        "id": "01990c01-2000-7000-8000-000100000008",
+        "when": 1754410108000
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000009",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 9,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 5 of the payroll export; reading the page and reporting back.",
+        "id": "01990c01-2000-7000-8000-000100000009",
+        "when": 1754410109000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b1_9",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/1/9"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000010",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 10,
+      "message": {
+        "role": "user",
+        "content": "step 6 on the payroll export",
+        "id": "01990c01-2000-7000-8000-000100000010",
+        "when": 1754410110000
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000011",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 11,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 6 of the payroll export; reading the page and reporting back.",
+        "id": "01990c01-2000-7000-8000-000100000011",
+        "when": 1754410111000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b1_11",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/1/11"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000012",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 12,
+      "message": {
+        "role": "user",
+        "content": "step 7 on the payroll export",
+        "id": "01990c01-2000-7000-8000-000100000012",
+        "when": 1754410112000
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000013",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 13,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 7 of the payroll export; reading the page and reporting back.",
+        "id": "01990c01-2000-7000-8000-000100000013",
+        "when": 1754410113000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b1_13",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/1/13"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000014",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 14,
+      "message": {
+        "role": "user",
+        "content": "step 8 on the payroll export",
+        "id": "01990c01-2000-7000-8000-000100000014",
+        "when": 1754410114000
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000015",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 15,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 8 of the payroll export; reading the page and reporting back.",
+        "id": "01990c01-2000-7000-8000-000100000015",
+        "when": 1754410115000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b1_15",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/1/15"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000016",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 16,
+      "message": {
+        "role": "user",
+        "content": "step 9 on the payroll export",
+        "id": "01990c01-2000-7000-8000-000100000016",
+        "when": 1754410116000
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000017",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 17,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 9 of the payroll export; reading the page and reporting back.",
+        "id": "01990c01-2000-7000-8000-000100000017",
+        "when": 1754410117000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b1_17",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/1/17"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000018",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 18,
+      "message": {
+        "role": "user",
+        "content": "step 10 on the payroll export",
+        "id": "01990c01-2000-7000-8000-000100000018",
+        "when": 1754410118000
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000019",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 19,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 10 of the payroll export; reading the page and reporting back.",
+        "id": "01990c01-2000-7000-8000-000100000019",
+        "when": 1754410119000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b1_19",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/1/19"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000020",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 20,
+      "message": {
+        "role": "user",
+        "content": "step 11 on the payroll export",
+        "id": "01990c01-2000-7000-8000-000100000020",
+        "when": 1754410120000
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000021",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 21,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 11 of the payroll export; reading the page and reporting back.",
+        "id": "01990c01-2000-7000-8000-000100000021",
+        "when": 1754410121000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b1_21",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/1/21"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000022",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 22,
+      "message": {
+        "role": "user",
+        "content": "step 12 on the payroll export",
+        "id": "01990c01-2000-7000-8000-000100000022",
+        "when": 1754410122000
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000023",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 23,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 12 of the payroll export; reading the page and reporting back.",
+        "id": "01990c01-2000-7000-8000-000100000023",
+        "when": 1754410123000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b1_23",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/1/23"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000024",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 24,
+      "message": {
+        "role": "user",
+        "content": "step 13 on the payroll export",
+        "id": "01990c01-2000-7000-8000-000100000024",
+        "when": 1754410124000
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000025",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 25,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 13 of the payroll export; reading the page and reporting back.",
+        "id": "01990c01-2000-7000-8000-000100000025",
+        "when": 1754410125000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b1_25",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/1/25"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000026",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 26,
+      "message": {
+        "role": "user",
+        "content": "step 14 on the payroll export",
+        "id": "01990c01-2000-7000-8000-000100000026",
+        "when": 1754410126000
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000027",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 27,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 14 of the payroll export; reading the page and reporting back.",
+        "id": "01990c01-2000-7000-8000-000100000027",
+        "when": 1754410127000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b1_27",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/1/27"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000028",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 28,
+      "message": {
+        "role": "user",
+        "content": "step 15 on the payroll export",
+        "id": "01990c01-2000-7000-8000-000100000028",
+        "when": 1754410128000
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000029",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 29,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 15 of the payroll export; reading the page and reporting back.",
+        "id": "01990c01-2000-7000-8000-000100000029",
+        "when": 1754410129000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b1_29",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/1/29"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000030",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 30,
+      "message": {
+        "role": "user",
+        "content": "step 16 on the payroll export",
+        "id": "01990c01-2000-7000-8000-000100000030",
+        "when": 1754410130000
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000031",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 31,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 16 of the payroll export; reading the page and reporting back.",
+        "id": "01990c01-2000-7000-8000-000100000031",
+        "when": 1754410131000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b1_31",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/1/31"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000032",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 32,
+      "message": {
+        "role": "user",
+        "content": "step 17 on the payroll export",
+        "id": "01990c01-2000-7000-8000-000100000032",
+        "when": 1754410132000
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000033",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 33,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 17 of the payroll export; reading the page and reporting back.",
+        "id": "01990c01-2000-7000-8000-000100000033",
+        "when": 1754410133000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b1_33",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/1/33"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000034",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 34,
+      "message": {
+        "role": "user",
+        "content": "step 18 on the payroll export",
+        "id": "01990c01-2000-7000-8000-000100000034",
+        "when": 1754410134000
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000035",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 35,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 18 of the payroll export; reading the page and reporting back.",
+        "id": "01990c01-2000-7000-8000-000100000035",
+        "when": 1754410135000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b1_35",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/1/35"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000036",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 36,
+      "message": {
+        "role": "user",
+        "content": "step 19 on the payroll export",
+        "id": "01990c01-2000-7000-8000-000100000036",
+        "when": 1754410136000
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000037",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 37,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 19 of the payroll export; reading the page and reporting back.",
+        "id": "01990c01-2000-7000-8000-000100000037",
+        "when": 1754410137000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b1_37",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/1/37"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000038",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 38,
+      "message": {
+        "role": "user",
+        "content": "step 20 on the payroll export",
+        "id": "01990c01-2000-7000-8000-000100000038",
+        "when": 1754410138000
+      }
+    },
+    {
+      "id": "01990c01-2000-7000-8000-000100000039",
+      "sessionId": "01990c01-1000-7000-8000-000000030001",
+      "seq": 39,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 20 of the payroll export; reading the page and reporting back.",
+        "id": "01990c01-2000-7000-8000-000100000039",
+        "when": 1754410139000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000000",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the expense policy page",
+        "id": "01990c02-2000-7000-8000-000200000000",
+        "when": 1754410200000
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000001",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c02-2000-7000-8000-000200000001",
+        "when": 1754410201000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b2_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/2/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000002",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the expense policy page",
+        "id": "01990c02-2000-7000-8000-000200000002",
+        "when": 1754410202000
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000003",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c02-2000-7000-8000-000200000003",
+        "when": 1754410203000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b2_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/2/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000004",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the expense policy page",
+        "id": "01990c02-2000-7000-8000-000200000004",
+        "when": 1754410204000
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000005",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c02-2000-7000-8000-000200000005",
+        "when": 1754410205000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b2_5",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/2/5"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000006",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 6,
+      "message": {
+        "role": "user",
+        "content": "step 4 on the expense policy page",
+        "id": "01990c02-2000-7000-8000-000200000006",
+        "when": 1754410206000
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000007",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 7,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 4 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c02-2000-7000-8000-000200000007",
+        "when": 1754410207000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b2_7",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/2/7"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000008",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 8,
+      "message": {
+        "role": "user",
+        "content": "step 5 on the expense policy page",
+        "id": "01990c02-2000-7000-8000-000200000008",
+        "when": 1754410208000
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000009",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 9,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 5 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c02-2000-7000-8000-000200000009",
+        "when": 1754410209000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b2_9",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/2/9"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000010",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 10,
+      "message": {
+        "role": "user",
+        "content": "step 6 on the expense policy page",
+        "id": "01990c02-2000-7000-8000-000200000010",
+        "when": 1754410210000
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000011",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 11,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 6 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c02-2000-7000-8000-000200000011",
+        "when": 1754410211000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b2_11",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/2/11"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000012",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 12,
+      "message": {
+        "role": "user",
+        "content": "step 7 on the expense policy page",
+        "id": "01990c02-2000-7000-8000-000200000012",
+        "when": 1754410212000
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000013",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 13,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 7 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c02-2000-7000-8000-000200000013",
+        "when": 1754410213000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b2_13",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/2/13"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000014",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 14,
+      "message": {
+        "role": "user",
+        "content": "step 8 on the expense policy page",
+        "id": "01990c02-2000-7000-8000-000200000014",
+        "when": 1754410214000
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000015",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 15,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 8 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c02-2000-7000-8000-000200000015",
+        "when": 1754410215000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b2_15",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/2/15"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000016",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 16,
+      "message": {
+        "role": "user",
+        "content": "step 9 on the expense policy page",
+        "id": "01990c02-2000-7000-8000-000200000016",
+        "when": 1754410216000
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000017",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 17,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 9 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c02-2000-7000-8000-000200000017",
+        "when": 1754410217000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b2_17",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/2/17"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000018",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 18,
+      "message": {
+        "role": "user",
+        "content": "step 10 on the expense policy page",
+        "id": "01990c02-2000-7000-8000-000200000018",
+        "when": 1754410218000
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000019",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 19,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 10 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c02-2000-7000-8000-000200000019",
+        "when": 1754410219000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b2_19",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/2/19"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000020",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 20,
+      "message": {
+        "role": "user",
+        "content": "step 11 on the expense policy page",
+        "id": "01990c02-2000-7000-8000-000200000020",
+        "when": 1754410220000
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000021",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 21,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 11 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c02-2000-7000-8000-000200000021",
+        "when": 1754410221000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b2_21",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/2/21"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000022",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 22,
+      "message": {
+        "role": "user",
+        "content": "step 12 on the expense policy page",
+        "id": "01990c02-2000-7000-8000-000200000022",
+        "when": 1754410222000
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000023",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 23,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 12 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c02-2000-7000-8000-000200000023",
+        "when": 1754410223000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b2_23",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/2/23"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000024",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 24,
+      "message": {
+        "role": "user",
+        "content": "step 13 on the expense policy page",
+        "id": "01990c02-2000-7000-8000-000200000024",
+        "when": 1754410224000
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000025",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 25,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 13 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c02-2000-7000-8000-000200000025",
+        "when": 1754410225000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b2_25",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/2/25"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000026",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 26,
+      "message": {
+        "role": "user",
+        "content": "step 14 on the expense policy page",
+        "id": "01990c02-2000-7000-8000-000200000026",
+        "when": 1754410226000
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000027",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 27,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 14 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c02-2000-7000-8000-000200000027",
+        "when": 1754410227000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b2_27",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/2/27"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000028",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 28,
+      "message": {
+        "role": "user",
+        "content": "step 15 on the expense policy page",
+        "id": "01990c02-2000-7000-8000-000200000028",
+        "when": 1754410228000
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000029",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 29,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 15 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c02-2000-7000-8000-000200000029",
+        "when": 1754410229000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b2_29",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/2/29"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000030",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 30,
+      "message": {
+        "role": "user",
+        "content": "step 16 on the expense policy page",
+        "id": "01990c02-2000-7000-8000-000200000030",
+        "when": 1754410230000
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000031",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 31,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 16 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c02-2000-7000-8000-000200000031",
+        "when": 1754410231000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b2_31",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/2/31"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000032",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 32,
+      "message": {
+        "role": "user",
+        "content": "step 17 on the expense policy page",
+        "id": "01990c02-2000-7000-8000-000200000032",
+        "when": 1754410232000
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000033",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 33,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 17 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c02-2000-7000-8000-000200000033",
+        "when": 1754410233000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b2_33",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/2/33"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000034",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 34,
+      "message": {
+        "role": "user",
+        "content": "step 18 on the expense policy page",
+        "id": "01990c02-2000-7000-8000-000200000034",
+        "when": 1754410234000
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000035",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 35,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 18 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c02-2000-7000-8000-000200000035",
+        "when": 1754410235000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b2_35",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/2/35"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000036",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 36,
+      "message": {
+        "role": "user",
+        "content": "step 19 on the expense policy page",
+        "id": "01990c02-2000-7000-8000-000200000036",
+        "when": 1754410236000
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000037",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 37,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 19 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c02-2000-7000-8000-000200000037",
+        "when": 1754410237000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b2_37",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/2/37"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000038",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 38,
+      "message": {
+        "role": "user",
+        "content": "step 20 on the expense policy page",
+        "id": "01990c02-2000-7000-8000-000200000038",
+        "when": 1754410238000
+      }
+    },
+    {
+      "id": "01990c02-2000-7000-8000-000200000039",
+      "sessionId": "01990c02-1000-7000-8000-000000030002",
+      "seq": 39,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 20 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c02-2000-7000-8000-000200000039",
+        "when": 1754410239000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c03-2000-7000-8000-000300000000",
+      "sessionId": "01990c03-1000-7000-8000-000000030003",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the FX rate table",
+        "id": "01990c03-2000-7000-8000-000300000000",
+        "when": 1754410300000
+      }
+    },
+    {
+      "id": "01990c03-2000-7000-8000-000300000001",
+      "sessionId": "01990c03-1000-7000-8000-000000030003",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the FX rate table; reading the page and reporting back.",
+        "id": "01990c03-2000-7000-8000-000300000001",
+        "when": 1754410301000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b3_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/3/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c03-2000-7000-8000-000300000002",
+      "sessionId": "01990c03-1000-7000-8000-000000030003",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the FX rate table",
+        "id": "01990c03-2000-7000-8000-000300000002",
+        "when": 1754410302000
+      }
+    },
+    {
+      "id": "01990c03-2000-7000-8000-000300000003",
+      "sessionId": "01990c03-1000-7000-8000-000000030003",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the FX rate table; reading the page and reporting back.",
+        "id": "01990c03-2000-7000-8000-000300000003",
+        "when": 1754410303000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b3_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/3/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c03-2000-7000-8000-000300000004",
+      "sessionId": "01990c03-1000-7000-8000-000000030003",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the FX rate table",
+        "id": "01990c03-2000-7000-8000-000300000004",
+        "when": 1754410304000
+      }
+    },
+    {
+      "id": "01990c03-2000-7000-8000-000300000005",
+      "sessionId": "01990c03-1000-7000-8000-000000030003",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the FX rate table; reading the page and reporting back.",
+        "id": "01990c03-2000-7000-8000-000300000005",
+        "when": 1754410305000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c04-2000-7000-8000-000400000000",
+      "sessionId": "01990c04-1000-7000-8000-000000030004",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the audit checklist",
+        "id": "01990c04-2000-7000-8000-000400000000",
+        "when": 1754410400000
+      }
+    },
+    {
+      "id": "01990c04-2000-7000-8000-000400000001",
+      "sessionId": "01990c04-1000-7000-8000-000000030004",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the audit checklist; reading the page and reporting back.",
+        "id": "01990c04-2000-7000-8000-000400000001",
+        "when": 1754410401000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b4_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/4/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c04-2000-7000-8000-000400000002",
+      "sessionId": "01990c04-1000-7000-8000-000000030004",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the audit checklist",
+        "id": "01990c04-2000-7000-8000-000400000002",
+        "when": 1754410402000
+      }
+    },
+    {
+      "id": "01990c04-2000-7000-8000-000400000003",
+      "sessionId": "01990c04-1000-7000-8000-000000030004",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the audit checklist; reading the page and reporting back.",
+        "id": "01990c04-2000-7000-8000-000400000003",
+        "when": 1754410403000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b4_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/4/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c04-2000-7000-8000-000400000004",
+      "sessionId": "01990c04-1000-7000-8000-000000030004",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the audit checklist",
+        "id": "01990c04-2000-7000-8000-000400000004",
+        "when": 1754410404000
+      }
+    },
+    {
+      "id": "01990c04-2000-7000-8000-000400000005",
+      "sessionId": "01990c04-1000-7000-8000-000000030004",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the audit checklist; reading the page and reporting back.",
+        "id": "01990c04-2000-7000-8000-000400000005",
+        "when": 1754410405000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c05-2000-7000-8000-000500000000",
+      "sessionId": "01990c05-1000-7000-8000-000000030005",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the vendor contract diff",
+        "id": "01990c05-2000-7000-8000-000500000000",
+        "when": 1754410500000
+      }
+    },
+    {
+      "id": "01990c05-2000-7000-8000-000500000001",
+      "sessionId": "01990c05-1000-7000-8000-000000030005",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the vendor contract diff; reading the page and reporting back.",
+        "id": "01990c05-2000-7000-8000-000500000001",
+        "when": 1754410501000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b5_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/5/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c05-2000-7000-8000-000500000002",
+      "sessionId": "01990c05-1000-7000-8000-000000030005",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the vendor contract diff",
+        "id": "01990c05-2000-7000-8000-000500000002",
+        "when": 1754410502000
+      }
+    },
+    {
+      "id": "01990c05-2000-7000-8000-000500000003",
+      "sessionId": "01990c05-1000-7000-8000-000000030005",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the vendor contract diff; reading the page and reporting back.",
+        "id": "01990c05-2000-7000-8000-000500000003",
+        "when": 1754410503000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b5_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/5/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c05-2000-7000-8000-000500000004",
+      "sessionId": "01990c05-1000-7000-8000-000000030005",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the vendor contract diff",
+        "id": "01990c05-2000-7000-8000-000500000004",
+        "when": 1754410504000
+      }
+    },
+    {
+      "id": "01990c05-2000-7000-8000-000500000005",
+      "sessionId": "01990c05-1000-7000-8000-000000030005",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the vendor contract diff; reading the page and reporting back.",
+        "id": "01990c05-2000-7000-8000-000500000005",
+        "when": 1754410505000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c06-2000-7000-8000-000600000000",
+      "sessionId": "01990c06-1000-7000-8000-000000030006",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the supplier onboarding form",
+        "id": "01990c06-2000-7000-8000-000600000000",
+        "when": 1754410600000
+      }
+    },
+    {
+      "id": "01990c06-2000-7000-8000-000600000001",
+      "sessionId": "01990c06-1000-7000-8000-000000030006",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c06-2000-7000-8000-000600000001",
+        "when": 1754410601000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b6_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/6/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c06-2000-7000-8000-000600000002",
+      "sessionId": "01990c06-1000-7000-8000-000000030006",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the supplier onboarding form",
+        "id": "01990c06-2000-7000-8000-000600000002",
+        "when": 1754410602000
+      }
+    },
+    {
+      "id": "01990c06-2000-7000-8000-000600000003",
+      "sessionId": "01990c06-1000-7000-8000-000000030006",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c06-2000-7000-8000-000600000003",
+        "when": 1754410603000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b6_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/6/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c06-2000-7000-8000-000600000004",
+      "sessionId": "01990c06-1000-7000-8000-000000030006",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the supplier onboarding form",
+        "id": "01990c06-2000-7000-8000-000600000004",
+        "when": 1754410604000
+      }
+    },
+    {
+      "id": "01990c06-2000-7000-8000-000600000005",
+      "sessionId": "01990c06-1000-7000-8000-000000030006",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c06-2000-7000-8000-000600000005",
+        "when": 1754410605000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c07-2000-7000-8000-000700000000",
+      "sessionId": "01990c07-1000-7000-8000-000000030007",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the payroll export",
+        "id": "01990c07-2000-7000-8000-000700000000",
+        "when": 1754410700000
+      }
+    },
+    {
+      "id": "01990c07-2000-7000-8000-000700000001",
+      "sessionId": "01990c07-1000-7000-8000-000000030007",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the payroll export; reading the page and reporting back.",
+        "id": "01990c07-2000-7000-8000-000700000001",
+        "when": 1754410701000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b7_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/7/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c07-2000-7000-8000-000700000002",
+      "sessionId": "01990c07-1000-7000-8000-000000030007",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the payroll export",
+        "id": "01990c07-2000-7000-8000-000700000002",
+        "when": 1754410702000
+      }
+    },
+    {
+      "id": "01990c07-2000-7000-8000-000700000003",
+      "sessionId": "01990c07-1000-7000-8000-000000030007",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the payroll export; reading the page and reporting back.",
+        "id": "01990c07-2000-7000-8000-000700000003",
+        "when": 1754410703000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b7_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/7/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c07-2000-7000-8000-000700000004",
+      "sessionId": "01990c07-1000-7000-8000-000000030007",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the payroll export",
+        "id": "01990c07-2000-7000-8000-000700000004",
+        "when": 1754410704000
+      }
+    },
+    {
+      "id": "01990c07-2000-7000-8000-000700000005",
+      "sessionId": "01990c07-1000-7000-8000-000000030007",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the payroll export; reading the page and reporting back.",
+        "id": "01990c07-2000-7000-8000-000700000005",
+        "when": 1754410705000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c08-2000-7000-8000-000800000000",
+      "sessionId": "01990c08-1000-7000-8000-000000030008",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the expense policy page",
+        "id": "01990c08-2000-7000-8000-000800000000",
+        "when": 1754410800000
+      }
+    },
+    {
+      "id": "01990c08-2000-7000-8000-000800000001",
+      "sessionId": "01990c08-1000-7000-8000-000000030008",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c08-2000-7000-8000-000800000001",
+        "when": 1754410801000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b8_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/8/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c08-2000-7000-8000-000800000002",
+      "sessionId": "01990c08-1000-7000-8000-000000030008",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the expense policy page",
+        "id": "01990c08-2000-7000-8000-000800000002",
+        "when": 1754410802000
+      }
+    },
+    {
+      "id": "01990c08-2000-7000-8000-000800000003",
+      "sessionId": "01990c08-1000-7000-8000-000000030008",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c08-2000-7000-8000-000800000003",
+        "when": 1754410803000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b8_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/8/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c08-2000-7000-8000-000800000004",
+      "sessionId": "01990c08-1000-7000-8000-000000030008",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the expense policy page",
+        "id": "01990c08-2000-7000-8000-000800000004",
+        "when": 1754410804000
+      }
+    },
+    {
+      "id": "01990c08-2000-7000-8000-000800000005",
+      "sessionId": "01990c08-1000-7000-8000-000000030008",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c08-2000-7000-8000-000800000005",
+        "when": 1754410805000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c09-2000-7000-8000-000900000000",
+      "sessionId": "01990c09-1000-7000-8000-000000030009",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the FX rate table",
+        "id": "01990c09-2000-7000-8000-000900000000",
+        "when": 1754410900000
+      }
+    },
+    {
+      "id": "01990c09-2000-7000-8000-000900000001",
+      "sessionId": "01990c09-1000-7000-8000-000000030009",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the FX rate table; reading the page and reporting back.",
+        "id": "01990c09-2000-7000-8000-000900000001",
+        "when": 1754410901000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b9_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/9/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c09-2000-7000-8000-000900000002",
+      "sessionId": "01990c09-1000-7000-8000-000000030009",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the FX rate table",
+        "id": "01990c09-2000-7000-8000-000900000002",
+        "when": 1754410902000
+      }
+    },
+    {
+      "id": "01990c09-2000-7000-8000-000900000003",
+      "sessionId": "01990c09-1000-7000-8000-000000030009",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the FX rate table; reading the page and reporting back.",
+        "id": "01990c09-2000-7000-8000-000900000003",
+        "when": 1754410903000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b9_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/9/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c09-2000-7000-8000-000900000004",
+      "sessionId": "01990c09-1000-7000-8000-000000030009",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the FX rate table",
+        "id": "01990c09-2000-7000-8000-000900000004",
+        "when": 1754410904000
+      }
+    },
+    {
+      "id": "01990c09-2000-7000-8000-000900000005",
+      "sessionId": "01990c09-1000-7000-8000-000000030009",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the FX rate table; reading the page and reporting back.",
+        "id": "01990c09-2000-7000-8000-000900000005",
+        "when": 1754410905000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c10-2000-7000-8000-001000000000",
+      "sessionId": "01990c10-1000-7000-8000-000000030010",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the audit checklist",
+        "id": "01990c10-2000-7000-8000-001000000000",
+        "when": 1754411000000
+      }
+    },
+    {
+      "id": "01990c10-2000-7000-8000-001000000001",
+      "sessionId": "01990c10-1000-7000-8000-000000030010",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the audit checklist; reading the page and reporting back.",
+        "id": "01990c10-2000-7000-8000-001000000001",
+        "when": 1754411001000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b10_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/10/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c10-2000-7000-8000-001000000002",
+      "sessionId": "01990c10-1000-7000-8000-000000030010",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the audit checklist",
+        "id": "01990c10-2000-7000-8000-001000000002",
+        "when": 1754411002000
+      }
+    },
+    {
+      "id": "01990c10-2000-7000-8000-001000000003",
+      "sessionId": "01990c10-1000-7000-8000-000000030010",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the audit checklist; reading the page and reporting back.",
+        "id": "01990c10-2000-7000-8000-001000000003",
+        "when": 1754411003000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b10_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/10/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c10-2000-7000-8000-001000000004",
+      "sessionId": "01990c10-1000-7000-8000-000000030010",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the audit checklist",
+        "id": "01990c10-2000-7000-8000-001000000004",
+        "when": 1754411004000
+      }
+    },
+    {
+      "id": "01990c10-2000-7000-8000-001000000005",
+      "sessionId": "01990c10-1000-7000-8000-000000030010",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the audit checklist; reading the page and reporting back.",
+        "id": "01990c10-2000-7000-8000-001000000005",
+        "when": 1754411005000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c11-2000-7000-8000-001100000000",
+      "sessionId": "01990c11-1000-7000-8000-000000030011",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the vendor contract diff",
+        "id": "01990c11-2000-7000-8000-001100000000",
+        "when": 1754411100000
+      }
+    },
+    {
+      "id": "01990c11-2000-7000-8000-001100000001",
+      "sessionId": "01990c11-1000-7000-8000-000000030011",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the vendor contract diff; reading the page and reporting back.",
+        "id": "01990c11-2000-7000-8000-001100000001",
+        "when": 1754411101000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b11_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/11/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c11-2000-7000-8000-001100000002",
+      "sessionId": "01990c11-1000-7000-8000-000000030011",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the vendor contract diff",
+        "id": "01990c11-2000-7000-8000-001100000002",
+        "when": 1754411102000
+      }
+    },
+    {
+      "id": "01990c11-2000-7000-8000-001100000003",
+      "sessionId": "01990c11-1000-7000-8000-000000030011",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the vendor contract diff; reading the page and reporting back.",
+        "id": "01990c11-2000-7000-8000-001100000003",
+        "when": 1754411103000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b11_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/11/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c11-2000-7000-8000-001100000004",
+      "sessionId": "01990c11-1000-7000-8000-000000030011",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the vendor contract diff",
+        "id": "01990c11-2000-7000-8000-001100000004",
+        "when": 1754411104000
+      }
+    },
+    {
+      "id": "01990c11-2000-7000-8000-001100000005",
+      "sessionId": "01990c11-1000-7000-8000-000000030011",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the vendor contract diff; reading the page and reporting back.",
+        "id": "01990c11-2000-7000-8000-001100000005",
+        "when": 1754411105000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c12-2000-7000-8000-001200000000",
+      "sessionId": "01990c12-1000-7000-8000-000000030012",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the supplier onboarding form",
+        "id": "01990c12-2000-7000-8000-001200000000",
+        "when": 1754411200000
+      }
+    },
+    {
+      "id": "01990c12-2000-7000-8000-001200000001",
+      "sessionId": "01990c12-1000-7000-8000-000000030012",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c12-2000-7000-8000-001200000001",
+        "when": 1754411201000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b12_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/12/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c12-2000-7000-8000-001200000002",
+      "sessionId": "01990c12-1000-7000-8000-000000030012",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the supplier onboarding form",
+        "id": "01990c12-2000-7000-8000-001200000002",
+        "when": 1754411202000
+      }
+    },
+    {
+      "id": "01990c12-2000-7000-8000-001200000003",
+      "sessionId": "01990c12-1000-7000-8000-000000030012",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c12-2000-7000-8000-001200000003",
+        "when": 1754411203000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b12_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/12/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c12-2000-7000-8000-001200000004",
+      "sessionId": "01990c12-1000-7000-8000-000000030012",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the supplier onboarding form",
+        "id": "01990c12-2000-7000-8000-001200000004",
+        "when": 1754411204000
+      }
+    },
+    {
+      "id": "01990c12-2000-7000-8000-001200000005",
+      "sessionId": "01990c12-1000-7000-8000-000000030012",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c12-2000-7000-8000-001200000005",
+        "when": 1754411205000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c13-2000-7000-8000-001300000000",
+      "sessionId": "01990c13-1000-7000-8000-000000030013",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the payroll export",
+        "id": "01990c13-2000-7000-8000-001300000000",
+        "when": 1754411300000
+      }
+    },
+    {
+      "id": "01990c13-2000-7000-8000-001300000001",
+      "sessionId": "01990c13-1000-7000-8000-000000030013",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the payroll export; reading the page and reporting back.",
+        "id": "01990c13-2000-7000-8000-001300000001",
+        "when": 1754411301000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b13_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/13/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c13-2000-7000-8000-001300000002",
+      "sessionId": "01990c13-1000-7000-8000-000000030013",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the payroll export",
+        "id": "01990c13-2000-7000-8000-001300000002",
+        "when": 1754411302000
+      }
+    },
+    {
+      "id": "01990c13-2000-7000-8000-001300000003",
+      "sessionId": "01990c13-1000-7000-8000-000000030013",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the payroll export; reading the page and reporting back.",
+        "id": "01990c13-2000-7000-8000-001300000003",
+        "when": 1754411303000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b13_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/13/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c13-2000-7000-8000-001300000004",
+      "sessionId": "01990c13-1000-7000-8000-000000030013",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the payroll export",
+        "id": "01990c13-2000-7000-8000-001300000004",
+        "when": 1754411304000
+      }
+    },
+    {
+      "id": "01990c13-2000-7000-8000-001300000005",
+      "sessionId": "01990c13-1000-7000-8000-000000030013",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the payroll export; reading the page and reporting back.",
+        "id": "01990c13-2000-7000-8000-001300000005",
+        "when": 1754411305000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c14-2000-7000-8000-001400000000",
+      "sessionId": "01990c14-1000-7000-8000-000000030014",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the expense policy page",
+        "id": "01990c14-2000-7000-8000-001400000000",
+        "when": 1754411400000
+      }
+    },
+    {
+      "id": "01990c14-2000-7000-8000-001400000001",
+      "sessionId": "01990c14-1000-7000-8000-000000030014",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c14-2000-7000-8000-001400000001",
+        "when": 1754411401000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b14_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/14/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c14-2000-7000-8000-001400000002",
+      "sessionId": "01990c14-1000-7000-8000-000000030014",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the expense policy page",
+        "id": "01990c14-2000-7000-8000-001400000002",
+        "when": 1754411402000
+      }
+    },
+    {
+      "id": "01990c14-2000-7000-8000-001400000003",
+      "sessionId": "01990c14-1000-7000-8000-000000030014",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c14-2000-7000-8000-001400000003",
+        "when": 1754411403000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b14_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/14/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c14-2000-7000-8000-001400000004",
+      "sessionId": "01990c14-1000-7000-8000-000000030014",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the expense policy page",
+        "id": "01990c14-2000-7000-8000-001400000004",
+        "when": 1754411404000
+      }
+    },
+    {
+      "id": "01990c14-2000-7000-8000-001400000005",
+      "sessionId": "01990c14-1000-7000-8000-000000030014",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c14-2000-7000-8000-001400000005",
+        "when": 1754411405000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c15-2000-7000-8000-001500000000",
+      "sessionId": "01990c15-1000-7000-8000-000000030015",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the FX rate table",
+        "id": "01990c15-2000-7000-8000-001500000000",
+        "when": 1754411500000
+      }
+    },
+    {
+      "id": "01990c15-2000-7000-8000-001500000001",
+      "sessionId": "01990c15-1000-7000-8000-000000030015",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the FX rate table; reading the page and reporting back.",
+        "id": "01990c15-2000-7000-8000-001500000001",
+        "when": 1754411501000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b15_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/15/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c15-2000-7000-8000-001500000002",
+      "sessionId": "01990c15-1000-7000-8000-000000030015",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the FX rate table",
+        "id": "01990c15-2000-7000-8000-001500000002",
+        "when": 1754411502000
+      }
+    },
+    {
+      "id": "01990c15-2000-7000-8000-001500000003",
+      "sessionId": "01990c15-1000-7000-8000-000000030015",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the FX rate table; reading the page and reporting back.",
+        "id": "01990c15-2000-7000-8000-001500000003",
+        "when": 1754411503000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b15_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/15/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c15-2000-7000-8000-001500000004",
+      "sessionId": "01990c15-1000-7000-8000-000000030015",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the FX rate table",
+        "id": "01990c15-2000-7000-8000-001500000004",
+        "when": 1754411504000
+      }
+    },
+    {
+      "id": "01990c15-2000-7000-8000-001500000005",
+      "sessionId": "01990c15-1000-7000-8000-000000030015",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the FX rate table; reading the page and reporting back.",
+        "id": "01990c15-2000-7000-8000-001500000005",
+        "when": 1754411505000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c16-2000-7000-8000-001600000000",
+      "sessionId": "01990c16-1000-7000-8000-000000030016",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the audit checklist",
+        "id": "01990c16-2000-7000-8000-001600000000",
+        "when": 1754411600000
+      }
+    },
+    {
+      "id": "01990c16-2000-7000-8000-001600000001",
+      "sessionId": "01990c16-1000-7000-8000-000000030016",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the audit checklist; reading the page and reporting back.",
+        "id": "01990c16-2000-7000-8000-001600000001",
+        "when": 1754411601000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b16_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/16/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c16-2000-7000-8000-001600000002",
+      "sessionId": "01990c16-1000-7000-8000-000000030016",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the audit checklist",
+        "id": "01990c16-2000-7000-8000-001600000002",
+        "when": 1754411602000
+      }
+    },
+    {
+      "id": "01990c16-2000-7000-8000-001600000003",
+      "sessionId": "01990c16-1000-7000-8000-000000030016",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the audit checklist; reading the page and reporting back.",
+        "id": "01990c16-2000-7000-8000-001600000003",
+        "when": 1754411603000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b16_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/16/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c16-2000-7000-8000-001600000004",
+      "sessionId": "01990c16-1000-7000-8000-000000030016",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the audit checklist",
+        "id": "01990c16-2000-7000-8000-001600000004",
+        "when": 1754411604000
+      }
+    },
+    {
+      "id": "01990c16-2000-7000-8000-001600000005",
+      "sessionId": "01990c16-1000-7000-8000-000000030016",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the audit checklist; reading the page and reporting back.",
+        "id": "01990c16-2000-7000-8000-001600000005",
+        "when": 1754411605000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c17-2000-7000-8000-001700000000",
+      "sessionId": "01990c17-1000-7000-8000-000000030017",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the vendor contract diff",
+        "id": "01990c17-2000-7000-8000-001700000000",
+        "when": 1754411700000
+      }
+    },
+    {
+      "id": "01990c17-2000-7000-8000-001700000001",
+      "sessionId": "01990c17-1000-7000-8000-000000030017",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the vendor contract diff; reading the page and reporting back.",
+        "id": "01990c17-2000-7000-8000-001700000001",
+        "when": 1754411701000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b17_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/17/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c17-2000-7000-8000-001700000002",
+      "sessionId": "01990c17-1000-7000-8000-000000030017",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the vendor contract diff",
+        "id": "01990c17-2000-7000-8000-001700000002",
+        "when": 1754411702000
+      }
+    },
+    {
+      "id": "01990c17-2000-7000-8000-001700000003",
+      "sessionId": "01990c17-1000-7000-8000-000000030017",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the vendor contract diff; reading the page and reporting back.",
+        "id": "01990c17-2000-7000-8000-001700000003",
+        "when": 1754411703000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b17_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/17/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c17-2000-7000-8000-001700000004",
+      "sessionId": "01990c17-1000-7000-8000-000000030017",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the vendor contract diff",
+        "id": "01990c17-2000-7000-8000-001700000004",
+        "when": 1754411704000
+      }
+    },
+    {
+      "id": "01990c17-2000-7000-8000-001700000005",
+      "sessionId": "01990c17-1000-7000-8000-000000030017",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the vendor contract diff; reading the page and reporting back.",
+        "id": "01990c17-2000-7000-8000-001700000005",
+        "when": 1754411705000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c18-2000-7000-8000-001800000000",
+      "sessionId": "01990c18-1000-7000-8000-000000030018",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the supplier onboarding form",
+        "id": "01990c18-2000-7000-8000-001800000000",
+        "when": 1754411800000
+      }
+    },
+    {
+      "id": "01990c18-2000-7000-8000-001800000001",
+      "sessionId": "01990c18-1000-7000-8000-000000030018",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c18-2000-7000-8000-001800000001",
+        "when": 1754411801000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b18_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/18/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c18-2000-7000-8000-001800000002",
+      "sessionId": "01990c18-1000-7000-8000-000000030018",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the supplier onboarding form",
+        "id": "01990c18-2000-7000-8000-001800000002",
+        "when": 1754411802000
+      }
+    },
+    {
+      "id": "01990c18-2000-7000-8000-001800000003",
+      "sessionId": "01990c18-1000-7000-8000-000000030018",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c18-2000-7000-8000-001800000003",
+        "when": 1754411803000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b18_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/18/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c18-2000-7000-8000-001800000004",
+      "sessionId": "01990c18-1000-7000-8000-000000030018",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the supplier onboarding form",
+        "id": "01990c18-2000-7000-8000-001800000004",
+        "when": 1754411804000
+      }
+    },
+    {
+      "id": "01990c18-2000-7000-8000-001800000005",
+      "sessionId": "01990c18-1000-7000-8000-000000030018",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c18-2000-7000-8000-001800000005",
+        "when": 1754411805000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c19-2000-7000-8000-001900000000",
+      "sessionId": "01990c19-1000-7000-8000-000000030019",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the payroll export",
+        "id": "01990c19-2000-7000-8000-001900000000",
+        "when": 1754411900000
+      }
+    },
+    {
+      "id": "01990c19-2000-7000-8000-001900000001",
+      "sessionId": "01990c19-1000-7000-8000-000000030019",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the payroll export; reading the page and reporting back.",
+        "id": "01990c19-2000-7000-8000-001900000001",
+        "when": 1754411901000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b19_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/19/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c19-2000-7000-8000-001900000002",
+      "sessionId": "01990c19-1000-7000-8000-000000030019",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the payroll export",
+        "id": "01990c19-2000-7000-8000-001900000002",
+        "when": 1754411902000
+      }
+    },
+    {
+      "id": "01990c19-2000-7000-8000-001900000003",
+      "sessionId": "01990c19-1000-7000-8000-000000030019",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the payroll export; reading the page and reporting back.",
+        "id": "01990c19-2000-7000-8000-001900000003",
+        "when": 1754411903000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b19_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/19/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c19-2000-7000-8000-001900000004",
+      "sessionId": "01990c19-1000-7000-8000-000000030019",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the payroll export",
+        "id": "01990c19-2000-7000-8000-001900000004",
+        "when": 1754411904000
+      }
+    },
+    {
+      "id": "01990c19-2000-7000-8000-001900000005",
+      "sessionId": "01990c19-1000-7000-8000-000000030019",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the payroll export; reading the page and reporting back.",
+        "id": "01990c19-2000-7000-8000-001900000005",
+        "when": 1754411905000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c20-2000-7000-8000-002000000000",
+      "sessionId": "01990c20-1000-7000-8000-000000030020",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the expense policy page",
+        "id": "01990c20-2000-7000-8000-002000000000",
+        "when": 1754412000000
+      }
+    },
+    {
+      "id": "01990c20-2000-7000-8000-002000000001",
+      "sessionId": "01990c20-1000-7000-8000-000000030020",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c20-2000-7000-8000-002000000001",
+        "when": 1754412001000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b20_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/20/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c20-2000-7000-8000-002000000002",
+      "sessionId": "01990c20-1000-7000-8000-000000030020",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the expense policy page",
+        "id": "01990c20-2000-7000-8000-002000000002",
+        "when": 1754412002000
+      }
+    },
+    {
+      "id": "01990c20-2000-7000-8000-002000000003",
+      "sessionId": "01990c20-1000-7000-8000-000000030020",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c20-2000-7000-8000-002000000003",
+        "when": 1754412003000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b20_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/20/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c20-2000-7000-8000-002000000004",
+      "sessionId": "01990c20-1000-7000-8000-000000030020",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the expense policy page",
+        "id": "01990c20-2000-7000-8000-002000000004",
+        "when": 1754412004000
+      }
+    },
+    {
+      "id": "01990c20-2000-7000-8000-002000000005",
+      "sessionId": "01990c20-1000-7000-8000-000000030020",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c20-2000-7000-8000-002000000005",
+        "when": 1754412005000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c21-2000-7000-8000-002100000000",
+      "sessionId": "01990c21-1000-7000-8000-000000030021",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the FX rate table",
+        "id": "01990c21-2000-7000-8000-002100000000",
+        "when": 1754412100000
+      }
+    },
+    {
+      "id": "01990c21-2000-7000-8000-002100000001",
+      "sessionId": "01990c21-1000-7000-8000-000000030021",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the FX rate table; reading the page and reporting back.",
+        "id": "01990c21-2000-7000-8000-002100000001",
+        "when": 1754412101000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b21_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/21/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c21-2000-7000-8000-002100000002",
+      "sessionId": "01990c21-1000-7000-8000-000000030021",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the FX rate table",
+        "id": "01990c21-2000-7000-8000-002100000002",
+        "when": 1754412102000
+      }
+    },
+    {
+      "id": "01990c21-2000-7000-8000-002100000003",
+      "sessionId": "01990c21-1000-7000-8000-000000030021",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the FX rate table; reading the page and reporting back.",
+        "id": "01990c21-2000-7000-8000-002100000003",
+        "when": 1754412103000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b21_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/21/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c21-2000-7000-8000-002100000004",
+      "sessionId": "01990c21-1000-7000-8000-000000030021",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the FX rate table",
+        "id": "01990c21-2000-7000-8000-002100000004",
+        "when": 1754412104000
+      }
+    },
+    {
+      "id": "01990c21-2000-7000-8000-002100000005",
+      "sessionId": "01990c21-1000-7000-8000-000000030021",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the FX rate table; reading the page and reporting back.",
+        "id": "01990c21-2000-7000-8000-002100000005",
+        "when": 1754412105000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c22-2000-7000-8000-002200000000",
+      "sessionId": "01990c22-1000-7000-8000-000000030022",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the audit checklist",
+        "id": "01990c22-2000-7000-8000-002200000000",
+        "when": 1754412200000
+      }
+    },
+    {
+      "id": "01990c22-2000-7000-8000-002200000001",
+      "sessionId": "01990c22-1000-7000-8000-000000030022",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the audit checklist; reading the page and reporting back.",
+        "id": "01990c22-2000-7000-8000-002200000001",
+        "when": 1754412201000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b22_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/22/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c22-2000-7000-8000-002200000002",
+      "sessionId": "01990c22-1000-7000-8000-000000030022",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the audit checklist",
+        "id": "01990c22-2000-7000-8000-002200000002",
+        "when": 1754412202000
+      }
+    },
+    {
+      "id": "01990c22-2000-7000-8000-002200000003",
+      "sessionId": "01990c22-1000-7000-8000-000000030022",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the audit checklist; reading the page and reporting back.",
+        "id": "01990c22-2000-7000-8000-002200000003",
+        "when": 1754412203000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b22_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/22/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c22-2000-7000-8000-002200000004",
+      "sessionId": "01990c22-1000-7000-8000-000000030022",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the audit checklist",
+        "id": "01990c22-2000-7000-8000-002200000004",
+        "when": 1754412204000
+      }
+    },
+    {
+      "id": "01990c22-2000-7000-8000-002200000005",
+      "sessionId": "01990c22-1000-7000-8000-000000030022",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the audit checklist; reading the page and reporting back.",
+        "id": "01990c22-2000-7000-8000-002200000005",
+        "when": 1754412205000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c23-2000-7000-8000-002300000000",
+      "sessionId": "01990c23-1000-7000-8000-000000030023",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the vendor contract diff",
+        "id": "01990c23-2000-7000-8000-002300000000",
+        "when": 1754412300000
+      }
+    },
+    {
+      "id": "01990c23-2000-7000-8000-002300000001",
+      "sessionId": "01990c23-1000-7000-8000-000000030023",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the vendor contract diff; reading the page and reporting back.",
+        "id": "01990c23-2000-7000-8000-002300000001",
+        "when": 1754412301000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b23_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/23/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c23-2000-7000-8000-002300000002",
+      "sessionId": "01990c23-1000-7000-8000-000000030023",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the vendor contract diff",
+        "id": "01990c23-2000-7000-8000-002300000002",
+        "when": 1754412302000
+      }
+    },
+    {
+      "id": "01990c23-2000-7000-8000-002300000003",
+      "sessionId": "01990c23-1000-7000-8000-000000030023",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the vendor contract diff; reading the page and reporting back.",
+        "id": "01990c23-2000-7000-8000-002300000003",
+        "when": 1754412303000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b23_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/23/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c23-2000-7000-8000-002300000004",
+      "sessionId": "01990c23-1000-7000-8000-000000030023",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the vendor contract diff",
+        "id": "01990c23-2000-7000-8000-002300000004",
+        "when": 1754412304000
+      }
+    },
+    {
+      "id": "01990c23-2000-7000-8000-002300000005",
+      "sessionId": "01990c23-1000-7000-8000-000000030023",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the vendor contract diff; reading the page and reporting back.",
+        "id": "01990c23-2000-7000-8000-002300000005",
+        "when": 1754412305000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c24-2000-7000-8000-002400000000",
+      "sessionId": "01990c24-1000-7000-8000-000000030024",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the supplier onboarding form",
+        "id": "01990c24-2000-7000-8000-002400000000",
+        "when": 1754412400000
+      }
+    },
+    {
+      "id": "01990c24-2000-7000-8000-002400000001",
+      "sessionId": "01990c24-1000-7000-8000-000000030024",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c24-2000-7000-8000-002400000001",
+        "when": 1754412401000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b24_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/24/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c24-2000-7000-8000-002400000002",
+      "sessionId": "01990c24-1000-7000-8000-000000030024",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the supplier onboarding form",
+        "id": "01990c24-2000-7000-8000-002400000002",
+        "when": 1754412402000
+      }
+    },
+    {
+      "id": "01990c24-2000-7000-8000-002400000003",
+      "sessionId": "01990c24-1000-7000-8000-000000030024",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c24-2000-7000-8000-002400000003",
+        "when": 1754412403000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b24_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/24/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c24-2000-7000-8000-002400000004",
+      "sessionId": "01990c24-1000-7000-8000-000000030024",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the supplier onboarding form",
+        "id": "01990c24-2000-7000-8000-002400000004",
+        "when": 1754412404000
+      }
+    },
+    {
+      "id": "01990c24-2000-7000-8000-002400000005",
+      "sessionId": "01990c24-1000-7000-8000-000000030024",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c24-2000-7000-8000-002400000005",
+        "when": 1754412405000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c25-2000-7000-8000-002500000000",
+      "sessionId": "01990c25-1000-7000-8000-000000030025",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the payroll export",
+        "id": "01990c25-2000-7000-8000-002500000000",
+        "when": 1754412500000
+      }
+    },
+    {
+      "id": "01990c25-2000-7000-8000-002500000001",
+      "sessionId": "01990c25-1000-7000-8000-000000030025",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the payroll export; reading the page and reporting back.",
+        "id": "01990c25-2000-7000-8000-002500000001",
+        "when": 1754412501000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b25_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/25/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c25-2000-7000-8000-002500000002",
+      "sessionId": "01990c25-1000-7000-8000-000000030025",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the payroll export",
+        "id": "01990c25-2000-7000-8000-002500000002",
+        "when": 1754412502000
+      }
+    },
+    {
+      "id": "01990c25-2000-7000-8000-002500000003",
+      "sessionId": "01990c25-1000-7000-8000-000000030025",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the payroll export; reading the page and reporting back.",
+        "id": "01990c25-2000-7000-8000-002500000003",
+        "when": 1754412503000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b25_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/25/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c25-2000-7000-8000-002500000004",
+      "sessionId": "01990c25-1000-7000-8000-000000030025",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the payroll export",
+        "id": "01990c25-2000-7000-8000-002500000004",
+        "when": 1754412504000
+      }
+    },
+    {
+      "id": "01990c25-2000-7000-8000-002500000005",
+      "sessionId": "01990c25-1000-7000-8000-000000030025",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the payroll export; reading the page and reporting back.",
+        "id": "01990c25-2000-7000-8000-002500000005",
+        "when": 1754412505000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c26-2000-7000-8000-002600000000",
+      "sessionId": "01990c26-1000-7000-8000-000000030026",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the expense policy page",
+        "id": "01990c26-2000-7000-8000-002600000000",
+        "when": 1754412600000
+      }
+    },
+    {
+      "id": "01990c26-2000-7000-8000-002600000001",
+      "sessionId": "01990c26-1000-7000-8000-000000030026",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c26-2000-7000-8000-002600000001",
+        "when": 1754412601000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b26_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/26/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c26-2000-7000-8000-002600000002",
+      "sessionId": "01990c26-1000-7000-8000-000000030026",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the expense policy page",
+        "id": "01990c26-2000-7000-8000-002600000002",
+        "when": 1754412602000
+      }
+    },
+    {
+      "id": "01990c26-2000-7000-8000-002600000003",
+      "sessionId": "01990c26-1000-7000-8000-000000030026",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c26-2000-7000-8000-002600000003",
+        "when": 1754412603000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b26_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/26/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c26-2000-7000-8000-002600000004",
+      "sessionId": "01990c26-1000-7000-8000-000000030026",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the expense policy page",
+        "id": "01990c26-2000-7000-8000-002600000004",
+        "when": 1754412604000
+      }
+    },
+    {
+      "id": "01990c26-2000-7000-8000-002600000005",
+      "sessionId": "01990c26-1000-7000-8000-000000030026",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c26-2000-7000-8000-002600000005",
+        "when": 1754412605000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c27-2000-7000-8000-002700000000",
+      "sessionId": "01990c27-1000-7000-8000-000000030027",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the FX rate table",
+        "id": "01990c27-2000-7000-8000-002700000000",
+        "when": 1754412700000
+      }
+    },
+    {
+      "id": "01990c27-2000-7000-8000-002700000001",
+      "sessionId": "01990c27-1000-7000-8000-000000030027",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the FX rate table; reading the page and reporting back.",
+        "id": "01990c27-2000-7000-8000-002700000001",
+        "when": 1754412701000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b27_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/27/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c27-2000-7000-8000-002700000002",
+      "sessionId": "01990c27-1000-7000-8000-000000030027",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the FX rate table",
+        "id": "01990c27-2000-7000-8000-002700000002",
+        "when": 1754412702000
+      }
+    },
+    {
+      "id": "01990c27-2000-7000-8000-002700000003",
+      "sessionId": "01990c27-1000-7000-8000-000000030027",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the FX rate table; reading the page and reporting back.",
+        "id": "01990c27-2000-7000-8000-002700000003",
+        "when": 1754412703000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b27_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/27/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c27-2000-7000-8000-002700000004",
+      "sessionId": "01990c27-1000-7000-8000-000000030027",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the FX rate table",
+        "id": "01990c27-2000-7000-8000-002700000004",
+        "when": 1754412704000
+      }
+    },
+    {
+      "id": "01990c27-2000-7000-8000-002700000005",
+      "sessionId": "01990c27-1000-7000-8000-000000030027",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the FX rate table; reading the page and reporting back.",
+        "id": "01990c27-2000-7000-8000-002700000005",
+        "when": 1754412705000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c28-2000-7000-8000-002800000000",
+      "sessionId": "01990c28-1000-7000-8000-000000030028",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the audit checklist",
+        "id": "01990c28-2000-7000-8000-002800000000",
+        "when": 1754412800000
+      }
+    },
+    {
+      "id": "01990c28-2000-7000-8000-002800000001",
+      "sessionId": "01990c28-1000-7000-8000-000000030028",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the audit checklist; reading the page and reporting back.",
+        "id": "01990c28-2000-7000-8000-002800000001",
+        "when": 1754412801000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b28_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/28/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c28-2000-7000-8000-002800000002",
+      "sessionId": "01990c28-1000-7000-8000-000000030028",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the audit checklist",
+        "id": "01990c28-2000-7000-8000-002800000002",
+        "when": 1754412802000
+      }
+    },
+    {
+      "id": "01990c28-2000-7000-8000-002800000003",
+      "sessionId": "01990c28-1000-7000-8000-000000030028",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the audit checklist; reading the page and reporting back.",
+        "id": "01990c28-2000-7000-8000-002800000003",
+        "when": 1754412803000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b28_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/28/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c28-2000-7000-8000-002800000004",
+      "sessionId": "01990c28-1000-7000-8000-000000030028",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the audit checklist",
+        "id": "01990c28-2000-7000-8000-002800000004",
+        "when": 1754412804000
+      }
+    },
+    {
+      "id": "01990c28-2000-7000-8000-002800000005",
+      "sessionId": "01990c28-1000-7000-8000-000000030028",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the audit checklist; reading the page and reporting back.",
+        "id": "01990c28-2000-7000-8000-002800000005",
+        "when": 1754412805000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c29-2000-7000-8000-002900000000",
+      "sessionId": "01990c29-1000-7000-8000-000000030029",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the vendor contract diff",
+        "id": "01990c29-2000-7000-8000-002900000000",
+        "when": 1754412900000
+      }
+    },
+    {
+      "id": "01990c29-2000-7000-8000-002900000001",
+      "sessionId": "01990c29-1000-7000-8000-000000030029",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the vendor contract diff; reading the page and reporting back.",
+        "id": "01990c29-2000-7000-8000-002900000001",
+        "when": 1754412901000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b29_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/29/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c29-2000-7000-8000-002900000002",
+      "sessionId": "01990c29-1000-7000-8000-000000030029",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the vendor contract diff",
+        "id": "01990c29-2000-7000-8000-002900000002",
+        "when": 1754412902000
+      }
+    },
+    {
+      "id": "01990c29-2000-7000-8000-002900000003",
+      "sessionId": "01990c29-1000-7000-8000-000000030029",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the vendor contract diff; reading the page and reporting back.",
+        "id": "01990c29-2000-7000-8000-002900000003",
+        "when": 1754412903000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b29_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/29/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c29-2000-7000-8000-002900000004",
+      "sessionId": "01990c29-1000-7000-8000-000000030029",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the vendor contract diff",
+        "id": "01990c29-2000-7000-8000-002900000004",
+        "when": 1754412904000
+      }
+    },
+    {
+      "id": "01990c29-2000-7000-8000-002900000005",
+      "sessionId": "01990c29-1000-7000-8000-000000030029",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the vendor contract diff; reading the page and reporting back.",
+        "id": "01990c29-2000-7000-8000-002900000005",
+        "when": 1754412905000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c30-2000-7000-8000-003000000000",
+      "sessionId": "01990c30-1000-7000-8000-000000030030",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the supplier onboarding form",
+        "id": "01990c30-2000-7000-8000-003000000000",
+        "when": 1754413000000
+      }
+    },
+    {
+      "id": "01990c30-2000-7000-8000-003000000001",
+      "sessionId": "01990c30-1000-7000-8000-000000030030",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c30-2000-7000-8000-003000000001",
+        "when": 1754413001000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b30_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/30/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c30-2000-7000-8000-003000000002",
+      "sessionId": "01990c30-1000-7000-8000-000000030030",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the supplier onboarding form",
+        "id": "01990c30-2000-7000-8000-003000000002",
+        "when": 1754413002000
+      }
+    },
+    {
+      "id": "01990c30-2000-7000-8000-003000000003",
+      "sessionId": "01990c30-1000-7000-8000-000000030030",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c30-2000-7000-8000-003000000003",
+        "when": 1754413003000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b30_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/30/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c30-2000-7000-8000-003000000004",
+      "sessionId": "01990c30-1000-7000-8000-000000030030",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the supplier onboarding form",
+        "id": "01990c30-2000-7000-8000-003000000004",
+        "when": 1754413004000
+      }
+    },
+    {
+      "id": "01990c30-2000-7000-8000-003000000005",
+      "sessionId": "01990c30-1000-7000-8000-000000030030",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the supplier onboarding form; reading the page and reporting back.",
+        "id": "01990c30-2000-7000-8000-003000000005",
+        "when": 1754413005000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c31-2000-7000-8000-003100000000",
+      "sessionId": "01990c31-1000-7000-8000-000000030031",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the payroll export",
+        "id": "01990c31-2000-7000-8000-003100000000",
+        "when": 1754413100000
+      }
+    },
+    {
+      "id": "01990c31-2000-7000-8000-003100000001",
+      "sessionId": "01990c31-1000-7000-8000-000000030031",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the payroll export; reading the page and reporting back.",
+        "id": "01990c31-2000-7000-8000-003100000001",
+        "when": 1754413101000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b31_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/31/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c31-2000-7000-8000-003100000002",
+      "sessionId": "01990c31-1000-7000-8000-000000030031",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the payroll export",
+        "id": "01990c31-2000-7000-8000-003100000002",
+        "when": 1754413102000
+      }
+    },
+    {
+      "id": "01990c31-2000-7000-8000-003100000003",
+      "sessionId": "01990c31-1000-7000-8000-000000030031",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the payroll export; reading the page and reporting back.",
+        "id": "01990c31-2000-7000-8000-003100000003",
+        "when": 1754413103000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b31_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/31/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c31-2000-7000-8000-003100000004",
+      "sessionId": "01990c31-1000-7000-8000-000000030031",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the payroll export",
+        "id": "01990c31-2000-7000-8000-003100000004",
+        "when": 1754413104000
+      }
+    },
+    {
+      "id": "01990c31-2000-7000-8000-003100000005",
+      "sessionId": "01990c31-1000-7000-8000-000000030031",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the payroll export; reading the page and reporting back.",
+        "id": "01990c31-2000-7000-8000-003100000005",
+        "when": 1754413105000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    },
+    {
+      "id": "01990c32-2000-7000-8000-003200000000",
+      "sessionId": "01990c32-1000-7000-8000-000000030032",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "step 1 on the expense policy page",
+        "id": "01990c32-2000-7000-8000-003200000000",
+        "when": 1754413200000
+      }
+    },
+    {
+      "id": "01990c32-2000-7000-8000-003200000001",
+      "sessionId": "01990c32-1000-7000-8000-000000030032",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 1 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c32-2000-7000-8000-003200000001",
+        "when": 1754413201000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b32_1",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/32/1"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c32-2000-7000-8000-003200000002",
+      "sessionId": "01990c32-1000-7000-8000-000000030032",
+      "seq": 2,
+      "message": {
+        "role": "user",
+        "content": "step 2 on the expense policy page",
+        "id": "01990c32-2000-7000-8000-003200000002",
+        "when": 1754413202000
+      }
+    },
+    {
+      "id": "01990c32-2000-7000-8000-003200000003",
+      "sessionId": "01990c32-1000-7000-8000-000000030032",
+      "seq": 3,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 2 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c32-2000-7000-8000-003200000003",
+        "when": 1754413203000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_b32_3",
+            "name": "fetch_url",
+            "input": {
+              "url": "https://example.test/32/3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "01990c32-2000-7000-8000-003200000004",
+      "sessionId": "01990c32-1000-7000-8000-000000030032",
+      "seq": 4,
+      "message": {
+        "role": "user",
+        "content": "step 3 on the expense policy page",
+        "id": "01990c32-2000-7000-8000-003200000004",
+        "when": 1754413204000
+      }
+    },
+    {
+      "id": "01990c32-2000-7000-8000-003200000005",
+      "sessionId": "01990c32-1000-7000-8000-000000030032",
+      "seq": 5,
+      "message": {
+        "role": "assistant",
+        "content": "Working step 3 of the expense policy page; reading the page and reporting back.",
+        "id": "01990c32-2000-7000-8000-003200000005",
+        "when": 1754413205000,
+        "model": "claude-haiku-4-5",
+        "provider": "anthropic",
+        "stopReason": "end_turn"
+      }
+    }
+  ],
+  "hooks": [
+    {
+      "id": "block-paste-secrets",
+      "event": "pre-tool-use",
+      "kind": "declarative",
+      "match": "type",
+      "order": 50,
+      "rule": {
+        "matchArg": "text",
+        "pattern": "sk-[a-zA-Z0-9]{20,}",
+        "onMatch": "block",
+        "reason": "looks like an API key"
+      },
+      "doc": "Block the `type` tool from typing anything that looks like an API key.",
+      "unknownHookFieldFromANewerBuild": "keep-me"
+    },
+    {
+      "id": "no-writes-to-vat-portal",
+      "event": "pre-tool-use",
+      "kind": "declarative",
+      "match": "*",
+      "order": 30,
+      "enabled": false,
+      "rule": {
+        "matchArg": "url",
+        "pattern": "^https://vat\\.example\\.test/",
+        "onMatch": "block",
+        "reason": "the VAT portal is read-only for the agent"
+      },
+      "unknownHookFieldFromANewerBuild": "keep-me"
+    },
+    {
+      "id": "annotate-tool-results",
+      "event": "post-tool-use",
+      "kind": "js",
+      "match": "*",
+      "order": 90,
+      "enabled": true,
+      "trusted": true,
+      "body": "return { action: 'allow', reason: `saw ${inv.toolName}` };",
+      "unknownHookFieldFromANewerBuild": "keep-me"
+    }
+  ],
+  "memory": {
+    "version": 1,
+    "exportedAt": 1754500000000,
+    "docs": [
+      {
+        "id": "user",
+        "kind": "user",
+        "workspace": "",
+        "body": "# About me\n\nFinance ops, solo. Terse answers; sourced numbers.\n",
+        "createdAt": 1750000000000,
+        "updatedAt": 1754500000000,
+        "unknownDocFieldFromANewerBuild": 7
+      },
+      {
+        "id": "project:vat.example.test",
+        "kind": "project",
+        "workspace": "vat.example.test",
+        "body": "# vat.example.test\n\nReturns live at /returns/<quarter>.\n",
+        "createdAt": 1751000000000,
+        "updatedAt": 1754500000000
+      },
+      {
+        "id": "project:api.ledger.example.test",
+        "kind": "project",
+        "workspace": "api.ledger.example.test",
+        "body": "# ledger API\n\nPostings: GET /v3/postings?from=&to=.\n",
+        "createdAt": 1752000000000,
+        "updatedAt": 1754500000000,
+        "futureDocFieldFromANewerBuild": [
+          "planted"
+        ]
+      },
+      {
+        "id": "subtree:vat.example.test:/returns",
+        "kind": "subtree",
+        "workspace": "vat.example.test",
+        "subpath": "/returns",
+        "body": "# /returns\n\nThe submit button is disabled until every box is filled.\n",
+        "createdAt": 1752500000000,
+        "updatedAt": 1754500000000
+      },
+      {
+        "id": "subtree:api.ledger.example.test:/v3",
+        "kind": "subtree",
+        "workspace": "api.ledger.example.test",
+        "subpath": "/v3",
+        "body": "# /v3\n\nCursor pagination; 500 rows per page.\n",
+        "createdAt": 1752600000000,
+        "updatedAt": 1754500000000
+      }
+    ]
+  },
+  "exportEnvelope": {
+    "format": "peerd-export",
+    "version": 1,
+    "exportedAt": "2026-08-05T08:00:00.000Z",
+    "channel": "preview",
+    "settings": {
+      "backgroundTabsEnabled": false,
+      "voiceVariant": "small",
+      "advancedAutomationEnabled": false,
+      "vaultAutoLockMs": 60000,
+      "prewalkEnabled": true,
+      "dwebEnabled": true,
+      "aSettingThisBuildNeverHeardOf": 42
+    },
+    "providerEndpoints": {
+      "endpoints": [
+        {
+          "url": "https://gateway.example.test/v1"
+        },
+        {
+          "url": "http://localhost:11434"
+        }
+      ]
+    },
+    "secrets": {
+      "kdf": "PBKDF2-SHA256",
+      "iterations": 600000,
+      "salt": "bWF4aW1hbHNhbHRieXRlcw==",
+      "cipher": "AES-GCM",
+      "data": "aXZpdml2aXZpdml2aXZtYXhpbWFsY2lwaGVydGV4dA=="
+    },
+    "memory": {
+      "version": 1,
+      "docs": [
+        {
+          "id": "user",
+          "body": "# About me\n",
+          "updatedAt": 1754500000000
+        },
+        {
+          "id": "project:vat.example.test",
+          "body": "# vat\n",
+          "updatedAt": 1754500000000
+        },
+        {
+          "id": "project:api.ledger.example.test",
+          "body": "# ledger\n",
+          "updatedAt": 1754500000000
+        }
+      ]
+    },
+    "hooks": [
+      {
+        "id": "block-paste-secrets",
+        "event": "pre-tool-use",
+        "kind": "declarative"
+      },
+      {
+        "id": "no-writes-to-vat-portal",
+        "event": "pre-tool-use",
+        "kind": "declarative"
+      },
+      {
+        "id": "annotate-tool-results",
+        "event": "post-tool-use",
+        "kind": "js"
+      }
+    ],
+    "skills": [
+      {
+        "id": "sk-vat",
+        "name": "vat-filer"
+      },
+      {
+        "id": "sk-ledger",
+        "name": "ledger-matcher"
+      },
+      {
+        "id": "sk-csv",
+        "name": "csv-reader"
+      }
+    ],
+    "dweb": {
+      "identity": {
+        "did": "did:key:z6MkexampleMaximalFixtureIdentity",
+        "createdAt": 1754000000000
+      }
+    },
+    "durability": {
+      "tiers": {
+        "vault": "profile",
+        "memory": "portable",
+        "skills": "portable",
+        "hooks": "portable"
+      },
+      "omittedDeviceBound": [
+        "dpop-keys",
+        "engine-registries",
+        "opfs-workspaces"
+      ]
+    },
+    "unknownEnvelopeSectionFromANewerBuild": {
+      "keep": true
+    }
+  }
+}

--- a/tests/peerd-runtime/lifecycle/fixtures/profile-v0.1.0.json
+++ b/tests/peerd-runtime/lifecycle/fixtures/profile-v0.1.0.json
@@ -1,0 +1,210 @@
+{
+  "_provenance": {
+    "peerdVersion": "0.1.0",
+    "shapeCommit": "bd7a135",
+    "shapeDate": "2026-06-21",
+    "notes": [
+      "Session/settings/export shapes as written by peerd 0.1.0 (bd7a135:package.json). Unchanged through 0.1.5 (caed35e).",
+      "Every session here is in the PRE-per-message-store v1 shape: inline `messages`, no messagesV2/msgIndex — a profile last written before the split. That shape predates the flattened-history root (bd7a135 already writes v2), so it is reconstructed from the v1 -> v2 header note + the migrate() path sessions/store.js still carries and still reads on every get().",
+      "kind:'subagent' is the value bd7a135:sessions/types.js declared; renamed to 'spawned' in 67d46d5 (0.2.6).",
+      "actTier is the pre-collapse Codex-style Act tier; bd7a135:docs/DECISIONS.md section 18 promised it would be 'read forever' by confirmActionsFromRecord. Those docs were deleted in 5b386dd (0.2.1).",
+      "toolManifest.allow carries the tool names bd7a135's `research` preset listed (do/get/check/list_tabs/read_article/call_api/web_search/inspect_*) — do/get/check + the browser-runner were culled in 8d78709 (#133), the inspect_* family folded into one `inspect` tool.",
+      "settings keys are the bd7a135:packaging/default-settings.mjs set, plus backgroundTabsEnabled (removed 2026-06-12, still on disk for an upgraded profile) and voiceVariant:'small' (the old default) — both named as removed in today's packaging/default-settings.mjs.",
+      "exportEnvelope is bd7a135:transfer/transfer.js buildExport output: no `durability` block (added in 70f6e42).",
+      "storeVersions is null because the lifecycle store registry landed 2026-08-05, after 0.4.0 — every real 0.x profile is UNSTAMPED."
+    ]
+  },
+
+  "storeVersions": null,
+
+  "settings": {
+    "providerName": "anthropic",
+    "providerModel": "claude-sonnet-4-5",
+    "devMode": true,
+    "reasoningEnabled": true,
+    "reasoningEffort": "high",
+    "voiceEnabled": true,
+    "voiceVariant": "small",
+    "advancedAutomationEnabled": true,
+    "autoMemoryEnabled": true,
+    "spendLimitUsd": 25,
+    "vaultAutoLockMs": 900000,
+    "backgroundTabsEnabled": false,
+    "unknownSettingFromANewerBuild": { "shape": "forward-compat", "keep": true }
+  },
+
+  "sessions": [
+    {
+      "sessionId": "0197c4a1-1000-7000-8000-00000000a001",
+      "createdAt": 1750464000000,
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-5",
+      "title": "read the changelog and summarize it",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "actTier": "suggest",
+      "messages": [
+        {
+          "role": "user",
+          "content": "read the changelog and summarize it",
+          "id": "0197c4a1-1001-7000-8000-00000000b001",
+          "when": 1750464000100
+        },
+        {
+          "role": "assistant",
+          "content": "Opening the page now.",
+          "id": "0197c4a1-1002-7000-8000-00000000b002",
+          "when": 1750464001000,
+          "model": "claude-sonnet-4-5",
+          "provider": "anthropic",
+          "stopReason": "tool_use",
+          "toolUses": [
+            { "id": "toolu_legacy_1", "name": "get", "input": { "url": "https://example.test/changelog" } }
+          ]
+        }
+      ],
+      "cost": {
+        "inputTokens": 1820,
+        "outputTokens": 310,
+        "cacheReadTokens": 0,
+        "cacheWriteTokens": 0,
+        "cost": 0.0121,
+        "turns": 1
+      },
+      "unknownRecordFieldFromANewerBuild": { "why": "forward-compat: must survive every read path" }
+    },
+    {
+      "sessionId": "0197c4a1-2000-7000-8000-00000000a002",
+      "createdAt": 1750464100000,
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-5",
+      "title": "check the pricing table",
+      "kind": "subagent",
+      "parentSessionId": "0197c4a1-1000-7000-8000-00000000a001",
+      "task": "open the pricing page and report the per-seat price",
+      "depth": 1,
+      "messages": [
+        {
+          "role": "user",
+          "content": "open the pricing page and report the per-seat price",
+          "id": "0197c4a1-2001-7000-8000-00000000b003",
+          "when": 1750464100100
+        }
+      ],
+      "futureSubagentField": ["planted", "unknown"]
+    },
+    {
+      "sessionId": "0197c4a1-3000-7000-8000-00000000a003",
+      "createdAt": 1750464200000,
+      "provider": "openrouter",
+      "model": "anthropic/claude-3.7-sonnet",
+      "title": "research: competitor landscape",
+      "kind": "chat",
+      "depth": 0,
+      "confirmActions": true,
+      "customSystemPrompt": "Prefer primary sources. Cite every claim.",
+      "toolManifest": {
+        "preset": "research",
+        "allow": [
+          "do", "get", "check", "list_tabs", "open_tab",
+          "read_article", "call_api", "web_search", "capture",
+          "inspect_storage", "inspect_audit_log", "inspect_denylist",
+          "inspect_provider_config", "inspect_session_access"
+        ]
+      },
+      "trimSummary": {
+        "v": 1,
+        "covered": 12,
+        "coveredLastId": "0197c4a1-3009-7000-8000-00000000b099",
+        "users": 4,
+        "assistants": 4,
+        "toolResults": 4,
+        "errors": 0,
+        "tools": { "get": 3, "web_search": 1 },
+        "task": "map the competitor landscape",
+        "goal": "compare per-seat pricing across four competitors",
+        "facts": ["Acme lists $12/seat/mo"],
+        "decisions": ["use the public pricing pages, not sales decks"],
+        "threads": [],
+        "artifacts": [],
+        "handles": [],
+        "lastWhen": 1750464250000
+      },
+      "messages": [
+        {
+          "role": "user",
+          "content": "map the competitor landscape",
+          "id": "0197c4a1-3001-7000-8000-00000000b004",
+          "when": 1750464200100
+        }
+      ]
+    }
+  ],
+
+  "sessionMessages": [],
+
+  "hooks": [
+    {
+      "id": "block-paste-secrets",
+      "event": "pre-tool-use",
+      "kind": "declarative",
+      "match": "type",
+      "order": 50,
+      "rule": {
+        "matchArg": "text",
+        "pattern": "sk-[a-zA-Z0-9]{20,}",
+        "onMatch": "block",
+        "reason": "looks like an API key"
+      },
+      "doc": "Block the `type` tool from typing anything that looks like an API key.",
+      "unknownHookFieldFromANewerBuild": "keep-me"
+    }
+  ],
+
+  "memory": {
+    "version": 1,
+    "exportedAt": 1750464300000,
+    "docs": [
+      {
+        "id": "user",
+        "kind": "user",
+        "workspace": "",
+        "body": "# About me\n\nSolo dev. Prefers terse answers.\n",
+        "createdAt": 1750000000000,
+        "updatedAt": 1750464300000,
+        "unknownDocFieldFromANewerBuild": 7
+      },
+      {
+        "id": "project:example.test",
+        "kind": "project",
+        "workspace": "example.test",
+        "body": "# example.test\n\nChangelog lives at /changelog.\n",
+        "createdAt": 1750100000000,
+        "updatedAt": 1750464300000
+      }
+    ]
+  },
+
+  "exportEnvelope": {
+    "format": "peerd-export",
+    "version": 1,
+    "exportedAt": "2026-06-21T12:00:00.000Z",
+    "channel": "preview",
+    "settings": {
+      "devMode": true,
+      "reasoningEffort": "high",
+      "backgroundTabsEnabled": false,
+      "voiceVariant": "small"
+    },
+    "providerEndpoints": { "endpoints": [{ "url": "https://gateway.example.test/v1" }] },
+    "secrets": null,
+    "memory": {
+      "version": 1,
+      "docs": [{ "id": "user", "body": "# About me\n", "updatedAt": 1750464300000 }]
+    },
+    "hooks": [{ "id": "block-paste-secrets", "event": "pre-tool-use", "kind": "declarative" }],
+    "skills": [{ "id": "sk-1", "name": "changelog-reader" }],
+    "unknownEnvelopeSectionFromANewerBuild": { "keep": true }
+  }
+}

--- a/tests/peerd-runtime/lifecycle/fixtures/profile-v0.2.2.json
+++ b/tests/peerd-runtime/lifecycle/fixtures/profile-v0.2.2.json
@@ -1,0 +1,217 @@
+{
+  "_provenance": {
+    "peerdVersion": "0.2.2",
+    "shapeCommit": "e66d6b9",
+    "shapeDate": "2026-07-04",
+    "notes": [
+      "peerd 0.2.2 (e66d6b9:package.json). The actor arc has landed but the rename has not.",
+      "747ed0b (the web-actor architecture, shipped 0.2.0/0.2.1) added kind:'actor' plus instanceId / actorType ('webvm'|'notebook'|'app'|'web') / backing ('tab'|'api') to sessions/types.js.",
+      "0f280da (#134/#135, 2026-07-03) added spawnedTrusted — the per-hop trusted-lineage verdict. A PARENTED record written BEFORE it (see the v0.1.0 fixture) reads as untrusted, fail-closed.",
+      "509c946 (#138, the heap split, 2026-07-03) added grantedTools — the child's persisted narrowed toolset.",
+      "2818b13 (#141, 2026-07-04) widened actorType with 'dweb'.",
+      "kind is still 'subagent' here: 67d46d5 (#178) renamed it to 'spawned' two days later, in 0.2.6.",
+      "STILL ABSENT at this version: todos + prewalk (65bac25, 0.2.8), review (419ecb6, 0.3.0), originState (1455923, 0.3.0).",
+      "Records are v2-shaped (msgIndex + messagesV2:true, bodies in the sibling session_messages store) — that split predates the flattened-history root.",
+      "settings keys are the e66d6b9:packaging/default-settings.mjs set (ollamaHost had landed in 0e9d159; watchAgentTab/prewalk*/frontDoorView had not).",
+      "exportEnvelope is the transfer.js shape after bf7484a (#168) — still no `durability` block (added in 70f6e42, 2026-08-05).",
+      "storeVersions is null: the lifecycle store registry landed 2026-08-05, after 0.4.0."
+    ]
+  },
+
+  "storeVersions": null,
+
+  "settings": {
+    "providerName": "anthropic",
+    "providerModel": "claude-sonnet-4-6",
+    "ollamaHost": "http://127.0.0.1:11434",
+    "advancedAutomationEnabled": true,
+    "confirmWebWrites": true,
+    "autoResumeInterruptedTurns": true,
+    "providerFailoverEnabled": true,
+    "providerFallbacks": [{ "provider": "openrouter", "model": "anthropic/claude-3.7-sonnet" }],
+    "auditLogMaxEntries": 5000,
+    "dwebEnabled": true,
+    "dwebAgentEnabled": true,
+    "unknownSettingFromANewerBuild": { "shape": "forward-compat", "keep": true }
+  },
+
+  "sessions": [
+    {
+      "sessionId": "0198a2b0-1000-7000-8000-00000000c001",
+      "createdAt": 1751587200000,
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "title": "file the expense report",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "messagesV2": true,
+      "msgIndex": [
+        "0198a2b0-1001-7000-8000-00000000d001",
+        "0198a2b0-1002-7000-8000-00000000d002"
+      ],
+      "cost": {
+        "inputTokens": 9400,
+        "outputTokens": 1210,
+        "cacheReadTokens": 6100,
+        "cacheWriteTokens": 900,
+        "cost": 0.0487,
+        "turns": 3
+      },
+      "unknownRecordFieldFromANewerBuild": { "why": "forward-compat: must survive every read path" }
+    },
+    {
+      "sessionId": "0198a2b0-2000-7000-8000-00000000c002",
+      "createdAt": 1751587300000,
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "kind": "actor",
+      "parentSessionId": "0198a2b0-1000-7000-8000-00000000c001",
+      "depth": 1,
+      "instanceId": "481",
+      "actorType": "web",
+      "backing": "tab",
+      "spawnedTrusted": true,
+      "grantedTools": [
+        "snapshot", "read_page", "read_state", "query_dom",
+        "click", "type", "navigate", "page_keys", "fetch_url"
+      ],
+      "permissionMode": "act",
+      "messagesV2": true,
+      "msgIndex": ["0198a2b0-2001-7000-8000-00000000d003"],
+      "futureActorField": ["planted", "unknown"]
+    },
+    {
+      "sessionId": "0198a2b0-3000-7000-8000-00000000c003",
+      "createdAt": 1751587400000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "kind": "subagent",
+      "parentSessionId": "0198a2b0-1000-7000-8000-00000000c001",
+      "task": "extract every line item from the receipt PDF",
+      "depth": 1,
+      "grantedTools": ["read_pdf", "read_doc"],
+      "toolManifest": { "allow": ["read_pdf", "read_doc"] },
+      "messagesV2": true,
+      "msgIndex": ["0198a2b0-3001-7000-8000-00000000d004"]
+    }
+  ],
+
+  "sessionMessages": [
+    {
+      "id": "0198a2b0-1001-7000-8000-00000000d001",
+      "sessionId": "0198a2b0-1000-7000-8000-00000000c001",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "file the expense report from the receipt in my downloads",
+        "id": "0198a2b0-1001-7000-8000-00000000d001",
+        "when": 1751587200100
+      }
+    },
+    {
+      "id": "0198a2b0-1002-7000-8000-00000000d002",
+      "sessionId": "0198a2b0-1000-7000-8000-00000000c001",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Delegating the page work to the tab's actor.",
+        "id": "0198a2b0-1002-7000-8000-00000000d002",
+        "when": 1751587201000,
+        "model": "claude-sonnet-4-6",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "toolUses": [
+          {
+            "id": "toolu_022",
+            "name": "message_actor",
+            "input": { "target": "tab:481", "message": "open the expenses form" }
+          }
+        ],
+        "unknownMessageFieldFromANewerBuild": "keep-me"
+      }
+    },
+    {
+      "id": "0198a2b0-2001-7000-8000-00000000d003",
+      "sessionId": "0198a2b0-2000-7000-8000-00000000c002",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "open the expenses form",
+        "id": "0198a2b0-2001-7000-8000-00000000d003",
+        "when": 1751587300100
+      }
+    },
+    {
+      "id": "0198a2b0-3001-7000-8000-00000000d004",
+      "sessionId": "0198a2b0-3000-7000-8000-00000000c003",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "extract every line item from the receipt PDF",
+        "id": "0198a2b0-3001-7000-8000-00000000d004",
+        "when": 1751587400100
+      }
+    }
+  ],
+
+  "hooks": [
+    {
+      "id": "no-checkout-clicks",
+      "event": "pre-tool-use",
+      "kind": "declarative",
+      "match": "click",
+      "order": 40,
+      "enabled": true,
+      "rule": {
+        "matchArg": "selector",
+        "pattern": "(checkout|place-order)",
+        "onMatch": "block",
+        "reason": "never click a purchase control unattended"
+      },
+      "unknownHookFieldFromANewerBuild": "keep-me"
+    }
+  ],
+
+  "memory": {
+    "version": 1,
+    "exportedAt": 1751587500000,
+    "docs": [
+      {
+        "id": "user",
+        "kind": "user",
+        "workspace": "",
+        "body": "# About me\n\nExpenses go to the finance portal, never email.\n",
+        "createdAt": 1750000000000,
+        "updatedAt": 1751587500000,
+        "unknownDocFieldFromANewerBuild": 7
+      }
+    ]
+  },
+
+  "exportEnvelope": {
+    "format": "peerd-export",
+    "version": 1,
+    "exportedAt": "2026-07-04T09:30:00.000Z",
+    "channel": "preview",
+    "settings": {
+      "providerName": "anthropic",
+      "ollamaHost": "http://127.0.0.1:11434",
+      "dwebAgentEnabled": true
+    },
+    "providerEndpoints": null,
+    "secrets": {
+      "kdf": "PBKDF2-SHA256",
+      "iterations": 600000,
+      "salt": "AAAAAAAAAAAAAAAAAAAAAA==",
+      "cipher": "AES-GCM",
+      "data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "memory": { "version": 1, "docs": [{ "id": "user", "body": "# About me\n", "updatedAt": 1751587500000 }] },
+    "hooks": [{ "id": "no-checkout-clicks", "event": "pre-tool-use", "kind": "declarative" }],
+    "skills": [],
+    "dweb": { "note": "preview-channel dweb state — a store build must DROP this with the section-10 notice" },
+    "unknownEnvelopeSectionFromANewerBuild": { "keep": true }
+  }
+}

--- a/tests/peerd-runtime/lifecycle/fixtures/profile-v0.2.8.json
+++ b/tests/peerd-runtime/lifecycle/fixtures/profile-v0.2.8.json
@@ -1,0 +1,248 @@
+{
+  "_provenance": {
+    "peerdVersion": "0.2.8",
+    "shapeCommit": "9eeda20",
+    "shapeDate": "2026-07-19",
+    "notes": [
+      "peerd 0.2.8 (9eeda20:package.json). The last shape before the 0.3.0 security arc.",
+      "67d46d5 (#178, 2026-07-06, shipped 0.2.6) renamed SessionKind 'subagent' -> 'spawned'. Records written before it keep 'subagent' forever (see the v0.1.0 / v0.2.2 fixtures) — there is no rewrite pass.",
+      "65bac25 (#210, 2026-07-15, shipped 0.2.8) added session.todos (todo/core.js TodoItem[]) and session.prewalk (loop/prewalk.js PrewalkState), plus the prewalkEnabled / enginePrewalkEnabled / prewalkExecutorModel settings; a94df66 (#216) extended prewalk to engine actors.",
+      "9f9d0bc (#219, 2026-07-19) added the watchAgentTab setting.",
+      "STILL ABSENT at this version: review (419ecb6, #228, 0.3.0) and originState (1455923, #255, 0.3.0) — so a 0.2.8 review child and a 0.2.8 bound web actor both read as unmarked/unbound today, fail-closed.",
+      "exportEnvelope still carries no `durability` block (added 70f6e42, 2026-08-05).",
+      "storeVersions is null: the lifecycle store registry landed 2026-08-05, after 0.4.0."
+    ]
+  },
+
+  "storeVersions": null,
+
+  "settings": {
+    "providerName": "anthropic",
+    "providerModel": "claude-sonnet-4-6",
+    "prewalkEnabled": true,
+    "enginePrewalkEnabled": true,
+    "prewalkExecutorModel": "claude-haiku-4-5",
+    "watchAgentTab": true,
+    "webActorActionSurface": "code",
+    "spendLimitUsd": 50,
+    "vaultAutoLockMs": 1800000,
+    "unknownSettingFromANewerBuild": { "shape": "forward-compat", "keep": true }
+  },
+
+  "sessions": [
+    {
+      "sessionId": "0198f7c0-1000-7000-8000-00000000e001",
+      "createdAt": 1752883200000,
+      "provider": "anthropic",
+      "model": "claude-opus-4-1",
+      "title": "migrate the docs site to the new theme",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "messagesV2": true,
+      "msgIndex": [
+        "0198f7c0-1001-7000-8000-00000000f001",
+        "0198f7c0-1002-7000-8000-00000000f002"
+      ],
+      "todos": [
+        { "id": 1, "text": "inventory the current theme tokens", "status": "done" },
+        { "id": 2, "text": "port the tokens to the new theme", "status": "pending", "validation": "the built site renders with no unresolved token" },
+        { "id": 3, "text": "spot-check three pages in light and dark", "status": "pending" }
+      ],
+      "prewalk": {
+        "phase": "executing",
+        "plannerProvider": "anthropic",
+        "plannerModel": "claude-opus-4-1",
+        "executorProvider": "anthropic",
+        "executorModel": "claude-haiku-4-5",
+        "armedAt": 1752883200500,
+        "swappedAt": 1752883260000
+      },
+      "cost": {
+        "inputTokens": 41200,
+        "outputTokens": 5300,
+        "cacheReadTokens": 33000,
+        "cacheWriteTokens": 4100,
+        "cost": 0.3142,
+        "turns": 9
+      },
+      "unknownRecordFieldFromANewerBuild": { "why": "forward-compat: must survive every read path" }
+    },
+    {
+      "sessionId": "0198f7c0-2000-7000-8000-00000000e002",
+      "createdAt": 1752883300000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "kind": "spawned",
+      "parentSessionId": "0198f7c0-1000-7000-8000-00000000e001",
+      "task": "list every CSS custom property the old theme defines",
+      "depth": 1,
+      "spawnedTrusted": true,
+      "grantedTools": ["js_notebook", "read_doc"],
+      "messagesV2": true,
+      "msgIndex": ["0198f7c0-2001-7000-8000-00000000f003"],
+      "futureSpawnedField": ["planted", "unknown"]
+    },
+    {
+      "sessionId": "0198f7c0-3000-7000-8000-00000000e003",
+      "createdAt": 1752883400000,
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "kind": "actor",
+      "parentSessionId": "0198f7c0-1000-7000-8000-00000000e001",
+      "depth": 1,
+      "instanceId": "nb_01H9Z0",
+      "actorType": "notebook",
+      "spawnedTrusted": true,
+      "grantedTools": ["js_notebook", "notebook_write", "notebook_read"],
+      "prewalk": {
+        "phase": "planning",
+        "plannerProvider": "anthropic",
+        "plannerModel": "claude-sonnet-4-6",
+        "executorProvider": "anthropic",
+        "executorModel": "claude-haiku-4-5",
+        "armedAt": 1752883400500
+      },
+      "messagesV2": true,
+      "msgIndex": ["0198f7c0-3001-7000-8000-00000000f004"]
+    }
+  ],
+
+  "sessionMessages": [
+    {
+      "id": "0198f7c0-1001-7000-8000-00000000f001",
+      "sessionId": "0198f7c0-1000-7000-8000-00000000e001",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "migrate the docs site to the new theme",
+        "id": "0198f7c0-1001-7000-8000-00000000f001",
+        "when": 1752883200100
+      }
+    },
+    {
+      "id": "0198f7c0-1002-7000-8000-00000000f002",
+      "sessionId": "0198f7c0-1000-7000-8000-00000000e001",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Planned it out; starting on the token inventory.",
+        "id": "0198f7c0-1002-7000-8000-00000000f002",
+        "when": 1752883201000,
+        "model": "claude-opus-4-1",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "thinking": "The theme tokens are the load-bearing part; enumerate before porting.",
+        "thinkingBlocks": [
+          { "type": "thinking", "thinking": "enumerate before porting", "signature": "sig_opaque_0198f7c0" }
+        ],
+        "toolUses": [
+          { "id": "toolu_101", "name": "todo_init", "input": { "items": [{ "text": "inventory the current theme tokens" }] } }
+        ],
+        "unknownMessageFieldFromANewerBuild": "keep-me"
+      }
+    },
+    {
+      "id": "0198f7c0-2001-7000-8000-00000000f003",
+      "sessionId": "0198f7c0-2000-7000-8000-00000000e002",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "list every CSS custom property the old theme defines",
+        "id": "0198f7c0-2001-7000-8000-00000000f003",
+        "when": 1752883300100
+      }
+    },
+    {
+      "id": "0198f7c0-3001-7000-8000-00000000f004",
+      "sessionId": "0198f7c0-3000-7000-8000-00000000e003",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "port the tokens in the notebook",
+        "id": "0198f7c0-3001-7000-8000-00000000f004",
+        "when": 1752883400100
+      }
+    }
+  ],
+
+  "hooks": [
+    {
+      "id": "audit-every-write",
+      "event": "post-tool-use",
+      "kind": "declarative",
+      "match": "*",
+      "order": 90,
+      "enabled": false,
+      "rule": {
+        "matchArg": "path",
+        "pattern": "^/etc/",
+        "onMatch": "block",
+        "reason": "system paths are out of scope"
+      },
+      "unknownHookFieldFromANewerBuild": "keep-me"
+    }
+  ],
+
+  "memory": {
+    "version": 1,
+    "exportedAt": 1752883500000,
+    "docs": [
+      {
+        "id": "user",
+        "kind": "user",
+        "workspace": "",
+        "body": "# About me\n\nDark mode first. Never ship a theme without a light check.\n",
+        "createdAt": 1750000000000,
+        "updatedAt": 1752883500000,
+        "unknownDocFieldFromANewerBuild": 7
+      },
+      {
+        "id": "project:docs.example.test",
+        "kind": "project",
+        "workspace": "docs.example.test",
+        "body": "# docs.example.test\n\nTokens live in tokens.css.\n",
+        "createdAt": 1751000000000,
+        "updatedAt": 1752883500000
+      },
+      {
+        "id": "subtree:docs.example.test:/themes",
+        "kind": "subtree",
+        "workspace": "docs.example.test",
+        "subpath": "/themes",
+        "body": "# /themes\n\nThe old theme is theme-classic.css.\n",
+        "createdAt": 1751500000000,
+        "updatedAt": 1752883500000
+      }
+    ]
+  },
+
+  "exportEnvelope": {
+    "format": "peerd-export",
+    "version": 1,
+    "exportedAt": "2026-07-19T18:00:00.000Z",
+    "channel": "store",
+    "settings": {
+      "prewalkEnabled": true,
+      "prewalkExecutorModel": "claude-haiku-4-5",
+      "watchAgentTab": true,
+      "aSettingThisBuildNeverHeardOf": 42
+    },
+    "providerEndpoints": { "endpoints": [{ "url": "https://proxy.example.test/v1" }] },
+    "secrets": null,
+    "memory": {
+      "version": 1,
+      "docs": [
+        { "id": "user", "body": "# About me\n", "updatedAt": 1752883500000 },
+        { "id": "project:docs.example.test", "body": "# docs\n", "updatedAt": 1752883500000 }
+      ]
+    },
+    "hooks": [{ "id": "audit-every-write", "event": "post-tool-use", "kind": "declarative" }],
+    "skills": [
+      { "id": "sk-theme", "name": "theme-porter" },
+      { "id": "sk-a11y", "name": "contrast-checker" }
+    ],
+    "unknownEnvelopeSectionFromANewerBuild": { "keep": true }
+  }
+}

--- a/tests/peerd-runtime/lifecycle/fixtures/profile-v0.4.0.json
+++ b/tests/peerd-runtime/lifecycle/fixtures/profile-v0.4.0.json
@@ -1,0 +1,378 @@
+{
+  "_provenance": {
+    "peerdVersion": "0.4.0",
+    "shapeCommit": "86aaa0a",
+    "shapeDate": "2026-08-01",
+    "notes": [
+      "peerd 0.4.0 (86aaa0a:package.json, the CURRENT release) — the shapes today's build itself writes, so this fixture is the 'no drift on the way out' anchor the three older files can't be: a regression here means the build stopped round-tripping its OWN records.",
+      "Sessions are v2 (msgIndex + messagesV2:true, bodies in the sibling session_messages store) and carry the full modern field set: todos (todo/core.js TodoItem[]), prewalk (loop/prewalk.js PrewalkState), toolManifest (tools/manifests.js), trimSummary, customSystemPrompt, cost.",
+      "419ecb6 (#228, 0.3.0) added session.review — the SW-stamped review-exemption marker on a SPAWNED child (never on a chat), so the review child below is where the field can honestly appear.",
+      "1455923 (#255, 0.3.0) added session.originState — a TAB-backed web actor's origin authority (actor/origin-lock.js ActorOriginState: mode, ownedOrigin, provisional, excursion, excursionsUsed). Durable BECAUSE it is the authority: losing it across an eviction turns a bound actor back into an unbounded one.",
+      "There is no settings-level confirm toggle: the Act sub-axis is persisted PER SESSION as `confirmActions` (sessions/types.js; permissions/policy.js confirmActionsFromRecord). So 'confirmations disabled' is the explicit `confirmActions:false` on the two chats here — an explicit false, not an absent key, which is the only value that turns confirmation off.",
+      "settings hold NON-DEFAULT values on purpose (advancedAutomationEnabled false against the preview default true, a 5-minute vaultAutoLockMs against 45 minutes, confirmWebWrites false, autoMemoryEnabled false, watchAgentTab true): §11 Option A says a stored value always wins over CHANNEL_DEFAULTS, so a fixture full of defaults would prove nothing about the upgrade path.",
+      "exportEnvelope is today's transfer.js buildExport output — the FIRST fixture carrying the §12 `durability` block (70f6e42, 2026-08-05): tier labels for the sections actually present plus omittedDeviceBound, the device-bound surfaces an export structurally cannot carry.",
+      "storeVersions is null: the lifecycle store registry landed 2026-08-05 (3c5566d/70f6e42), AFTER the 0.4.0 release — so even a profile written by the CURRENT release is unstamped, and checkStores must read that as a fresh profile, never as a version skew.",
+      "Planted `unknown*FromANewerBuild` / `future*` fields at every level (settings, session record, message body, hook, memory doc, export envelope) — forward-compat data a LATER build wrote that today's build must carry through untouched."
+    ]
+  },
+
+  "storeVersions": null,
+
+  "settings": {
+    "providerName": "anthropic",
+    "providerModel": "claude-opus-4-1",
+    "reasoningEnabled": true,
+    "reasoningEffort": "high",
+    "advancedAutomationEnabled": false,
+    "watchAgentTab": true,
+    "frontDoorView": "home",
+    "webActorActionSurface": "code",
+    "schemaValidatedReplies": true,
+    "prewalkEnabled": true,
+    "enginePrewalkEnabled": true,
+    "prewalkExecutorModel": "claude-haiku-4-5",
+    "runnerModel": "",
+    "ollamaHost": "http://192.168.1.4:11434",
+    "openrouterModels": ["anthropic/claude-3.7-sonnet", "google/gemini-2.5-pro"],
+    "spendLimitUsd": 125,
+    "pricingOverrides": { "claude-opus-4-1": { "input": 15, "output": 75 } },
+    "confirmWebWrites": false,
+    "autoMemoryEnabled": false,
+    "autoResumeInterruptedTurns": true,
+    "providerFailoverEnabled": true,
+    "providerFallbacks": ["openrouter", "ollama"],
+    "vaultAutoLockMs": 300000,
+    "auditLogMaxEntries": 20000,
+    "dwebEnabled": true,
+    "dwebAgentEnabled": true,
+    "unknownSettingFromANewerBuild": { "shape": "forward-compat", "keep": true }
+  },
+
+  "sessions": [
+    {
+      "sessionId": "01990a00-1000-7000-8000-000000010001",
+      "createdAt": 1754049600000,
+      "provider": "anthropic",
+      "model": "claude-opus-4-1",
+      "title": "reconcile the July invoices against the ledger",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "act",
+      "confirmActions": false,
+      "customSystemPrompt": "Never guess a figure. If a number isn't on the page, say so.",
+      "toolManifest": {
+        "preset": "research",
+        "allow": ["fetch_url", "read_web_cache", "actor_list", "open_tab", "message_actor", "inspect"]
+      },
+      "messagesV2": true,
+      "msgIndex": [
+        "01990a00-1001-7000-8000-000000011001",
+        "01990a00-1002-7000-8000-000000011002"
+      ],
+      "todos": [
+        { "id": 1, "text": "pull the July invoice list", "status": "done" },
+        { "id": 2, "text": "match each invoice to a ledger line", "status": "pending", "validation": "every invoice id appears exactly once in the ledger export" },
+        { "id": 3, "text": "report the unmatched rows", "status": "pending" }
+      ],
+      "prewalk": {
+        "phase": "executing",
+        "plannerProvider": "anthropic",
+        "plannerModel": "claude-opus-4-1",
+        "executorProvider": "anthropic",
+        "executorModel": "claude-haiku-4-5",
+        "armedAt": 1754049601000,
+        "swappedAt": 1754049688000
+      },
+      "trimSummary": {
+        "v": 1,
+        "covered": 22,
+        "coveredLastId": "01990a00-1009-7000-8000-000000011099",
+        "users": 6,
+        "assistants": 8,
+        "toolResults": 8,
+        "errors": 0,
+        "tools": { "fetch_url": 5, "message_actor": 3 },
+        "task": "reconcile the July invoices",
+        "goal": "every invoice matched or explicitly reported unmatched",
+        "facts": ["the ledger export is CSV, one row per posting"],
+        "decisions": ["match on invoice id, not amount"],
+        "threads": [],
+        "artifacts": [],
+        "handles": ["web:1734"],
+        "lastWhen": 1754049700000
+      },
+      "cost": {
+        "inputTokens": 128400,
+        "outputTokens": 9120,
+        "cacheReadTokens": 96000,
+        "cacheWriteTokens": 12400,
+        "cost": 1.2871,
+        "turns": 14
+      },
+      "unknownRecordFieldFromANewerBuild": { "why": "forward-compat: must survive every read path" }
+    },
+    {
+      "sessionId": "01990a00-2000-7000-8000-000000010002",
+      "createdAt": 1754053200000,
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "title": "read up on the new invoicing rules",
+      "kind": "chat",
+      "depth": 0,
+      "permissionMode": "plan",
+      "confirmActions": false,
+      "toolManifest": { "preset": "browse-only" },
+      "messagesV2": true,
+      "msgIndex": ["01990a00-2001-7000-8000-000000011003"],
+      "todos": [
+        { "id": 1, "text": "find the rules page", "status": "done" },
+        { "id": 2, "text": "summarize the changes that affect us", "status": "pending" }
+      ],
+      "cost": {
+        "inputTokens": 8100,
+        "outputTokens": 640,
+        "cacheReadTokens": 4200,
+        "cacheWriteTokens": 900,
+        "cost": 0.0412,
+        "turns": 2
+      },
+      "futureChatFieldFromANewerBuild": ["planted", "unknown"]
+    },
+    {
+      "sessionId": "01990a00-3000-7000-8000-000000010003",
+      "createdAt": 1754049660000,
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "kind": "actor",
+      "parentSessionId": "01990a00-1000-7000-8000-000000010001",
+      "depth": 1,
+      "instanceId": "1734",
+      "actorType": "web",
+      "backing": "tab",
+      "spawnedTrusted": true,
+      "grantedTools": [
+        "snapshot", "read_page", "read_state", "click", "type", "navigate",
+        "query_dom", "fetch_url", "read_web_cache", "site_client_run"
+      ],
+      "originState": {
+        "mode": "bound",
+        "ownedOrigin": "https://billing.example.test",
+        "provisional": false,
+        "excursion": null,
+        "excursionsUsed": 1
+      },
+      "prewalk": {
+        "phase": "planning",
+        "plannerProvider": "anthropic",
+        "plannerModel": "claude-opus-4-1",
+        "executorProvider": "anthropic",
+        "executorModel": "claude-haiku-4-5",
+        "armedAt": 1754049661000
+      },
+      "messagesV2": true,
+      "msgIndex": ["01990a00-3001-7000-8000-000000011004"],
+      "unknownActorFieldFromANewerBuild": { "boundSince": 1754049661000 }
+    },
+    {
+      "sessionId": "01990a00-4000-7000-8000-000000010004",
+      "createdAt": 1754049900000,
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "kind": "spawned",
+      "parentSessionId": "01990a00-1000-7000-8000-000000010001",
+      "task": "review the reconciliation notebook for off-by-one errors",
+      "depth": 1,
+      "spawnedTrusted": true,
+      "review": true,
+      "grantedTools": ["js_read_file", "app_read_file", "read_doc"],
+      "messagesV2": true,
+      "msgIndex": ["01990a00-4001-7000-8000-000000011005"],
+      "futureReviewFieldFromANewerBuild": "keep-me"
+    }
+  ],
+
+  "sessionMessages": [
+    {
+      "id": "01990a00-1001-7000-8000-000000011001",
+      "sessionId": "01990a00-1000-7000-8000-000000010001",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "reconcile the July invoices against the ledger",
+        "id": "01990a00-1001-7000-8000-000000011001",
+        "when": 1754049600100
+      }
+    },
+    {
+      "id": "01990a00-1002-7000-8000-000000011002",
+      "sessionId": "01990a00-1000-7000-8000-000000010001",
+      "seq": 1,
+      "message": {
+        "role": "assistant",
+        "content": "Planning first: I'll pull the invoice list, then match line by line.",
+        "id": "01990a00-1002-7000-8000-000000011002",
+        "when": 1754049601500,
+        "model": "claude-opus-4-1",
+        "provider": "anthropic",
+        "stopReason": "tool_use",
+        "thinking": "Matching on id is the only stable key; amounts repeat.",
+        "thinkingBlocks": [
+          { "type": "thinking", "thinking": "match on id, not amount", "signature": "sig_opaque_01990a00" }
+        ],
+        "toolUses": [
+          { "id": "toolu_401", "name": "todo_init", "input": { "items": [{ "text": "pull the July invoice list" }] } },
+          { "id": "toolu_402", "name": "message_actor", "input": { "handle": "web:1734", "message": "open the billing portal's July invoice list" } }
+        ],
+        "unknownMessageFieldFromANewerBuild": "keep-me"
+      }
+    },
+    {
+      "id": "01990a00-2001-7000-8000-000000011003",
+      "sessionId": "01990a00-2000-7000-8000-000000010002",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "read up on the new invoicing rules",
+        "id": "01990a00-2001-7000-8000-000000011003",
+        "when": 1754053200100
+      }
+    },
+    {
+      "id": "01990a00-3001-7000-8000-000000011004",
+      "sessionId": "01990a00-3000-7000-8000-000000010003",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "open the billing portal's July invoice list",
+        "id": "01990a00-3001-7000-8000-000000011004",
+        "when": 1754049661100
+      }
+    },
+    {
+      "id": "01990a00-4001-7000-8000-000000011005",
+      "sessionId": "01990a00-4000-7000-8000-000000010004",
+      "seq": 0,
+      "message": {
+        "role": "user",
+        "content": "review the reconciliation notebook for off-by-one errors",
+        "id": "01990a00-4001-7000-8000-000000011005",
+        "when": 1754049900100
+      }
+    }
+  ],
+
+  "hooks": [
+    {
+      "id": "no-writes-to-billing",
+      "event": "pre-tool-use",
+      "kind": "declarative",
+      "match": "call_api",
+      "order": 40,
+      "enabled": true,
+      "rule": {
+        "matchArg": "url",
+        "pattern": "^https://billing\\.example\\.test/",
+        "onMatch": "block",
+        "reason": "the billing portal is read-only for the agent"
+      },
+      "doc": "Refuse any API write against the billing portal.",
+      "unknownHookFieldFromANewerBuild": "keep-me"
+    },
+    {
+      "id": "tag-every-result",
+      "event": "post-tool-use",
+      "kind": "js",
+      "match": "*",
+      "order": 95,
+      "enabled": false,
+      "trusted": true,
+      "body": "return { action: 'allow', reason: `saw ${inv.toolName}` };",
+      "doc": "A trusted JS hook — kind:'js' only compiles with trusted:true.",
+      "unknownHookFieldFromANewerBuild": "keep-me"
+    }
+  ],
+
+  "memory": {
+    "version": 1,
+    "exportedAt": 1754054000000,
+    "docs": [
+      {
+        "id": "user",
+        "kind": "user",
+        "workspace": "",
+        "body": "# About me\n\nFinance ops. Numbers must be sourced, never inferred.\n",
+        "createdAt": 1750000000000,
+        "updatedAt": 1754054000000,
+        "unknownDocFieldFromANewerBuild": 7
+      },
+      {
+        "id": "project:billing.example.test",
+        "kind": "project",
+        "workspace": "billing.example.test",
+        "body": "# billing.example.test\n\nInvoice list is at /invoices?period=YYYY-MM.\n",
+        "createdAt": 1751000000000,
+        "updatedAt": 1754054000000
+      },
+      {
+        "id": "subtree:billing.example.test:/invoices",
+        "kind": "subtree",
+        "workspace": "billing.example.test",
+        "subpath": "/invoices",
+        "body": "# /invoices\n\nThe export button is behind the 'More' menu.\n",
+        "createdAt": 1751500000000,
+        "updatedAt": 1754054000000
+      }
+    ]
+  },
+
+  "exportEnvelope": {
+    "format": "peerd-export",
+    "version": 1,
+    "exportedAt": "2026-08-01T09:30:00.000Z",
+    "channel": "preview",
+    "settings": {
+      "reasoningEffort": "high",
+      "advancedAutomationEnabled": false,
+      "vaultAutoLockMs": 300000,
+      "confirmWebWrites": false,
+      "prewalkEnabled": true,
+      "dwebEnabled": true,
+      "dwebAgentEnabled": true,
+      "aSettingThisBuildNeverHeardOf": 42
+    },
+    "providerEndpoints": { "endpoints": [{ "url": "https://gateway.example.test/v1" }] },
+    "secrets": {
+      "kdf": "PBKDF2-SHA256",
+      "iterations": 600000,
+      "salt": "c2FsdHNhbHRzYWx0c2FsdA==",
+      "cipher": "AES-GCM",
+      "data": "aXZpdml2aXZpdml2aXZjaXBoZXJ0ZXh0Ynl0ZXNoZXJl"
+    },
+    "memory": {
+      "version": 1,
+      "docs": [
+        { "id": "user", "body": "# About me\n", "updatedAt": 1754054000000 },
+        { "id": "project:billing.example.test", "body": "# billing\n", "updatedAt": 1754054000000 },
+        { "id": "subtree:billing.example.test:/invoices", "body": "# /invoices\n", "updatedAt": 1754054000000 }
+      ]
+    },
+    "hooks": [
+      { "id": "no-writes-to-billing", "event": "pre-tool-use", "kind": "declarative" },
+      { "id": "tag-every-result", "event": "post-tool-use", "kind": "js" }
+    ],
+    "skills": [
+      { "id": "sk-ledger", "name": "ledger-matcher" },
+      { "id": "sk-csv", "name": "csv-reader" }
+    ],
+    "durability": {
+      "tiers": {
+        "vault": "profile",
+        "memory": "portable",
+        "skills": "portable",
+        "hooks": "portable"
+      },
+      "omittedDeviceBound": ["dpop-keys", "engine-registries", "opfs-workspaces"]
+    },
+    "unknownEnvelopeSectionFromANewerBuild": { "keep": true }
+  }
+}

--- a/tests/peerd-runtime/lifecycle/generation.test.ts
+++ b/tests/peerd-runtime/lifecycle/generation.test.ts
@@ -1,0 +1,88 @@
+// SW generations + stale-authority refusal — guarantees 3 and 7: security
+// authority is re-derived after restart, never resumed; a restart never
+// extends a credential/approval/capability lifetime.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  mintGeneration, authorityValid, sweepStaleAuthority, acceptActorMessage,
+} from '../../../extension/peerd-runtime/lifecycle/generation.js';
+
+const gen1 = mintGeneration(null, { nonce: 'nonce-aaaa', now: 1000 });
+const gen2 = mintGeneration(gen1, { nonce: 'nonce-bbbb', now: 2000 });
+
+describe('minting', () => {
+  test('seq is monotonic and the id embeds the nonce', () => {
+    expect(gen1.seq).toBe(1);
+    expect(gen2.seq).toBe(2);
+    expect(gen1.id).toBe('gen-1-nonce-aaaa');
+    expect(gen2.id).not.toBe(gen1.id);
+  });
+
+  test('a lost seq write cannot collide ids — the nonce disambiguates', () => {
+    const replay = mintGeneration(null, { nonce: 'nonce-cccc', now: 3000 });
+    expect(replay.seq).toBe(gen1.seq); // seq repeated (write was lost) …
+    expect(replay.id).not.toBe(gen1.id); // … but the identity still differs
+  });
+
+  test('garbage previous records are tolerated; weak nonces are not', () => {
+    expect(mintGeneration({ seq: Number.NaN, id: 'x', mintedAt: 0 },
+      { nonce: 'nonce-dddd', now: 1 }).seq).toBe(1);
+    expect(() => mintGeneration(null, { nonce: 'abc', now: 1 })).toThrow(TypeError);
+  });
+});
+
+describe('authorityValid — fail closed', () => {
+  const ctx = { generation: gen2, now: 5000 };
+
+  test('current-generation, unexpired authority is valid', () => {
+    expect(authorityValid({ generationId: gen2.id }, ctx).valid).toBe(true);
+    expect(authorityValid({ generationId: gen2.id, expiresAt: 6000 }, ctx).valid).toBe(true);
+  });
+
+  test('prior-generation authority is refused wholesale', () => {
+    const verdict = authorityValid({ generationId: gen1.id }, ctx);
+    expect(verdict.valid).toBe(false);
+    expect(verdict.reason).toContain('stale generation');
+  });
+
+  test('a restart cannot extend a lifetime: expiry is judged against the original window', () => {
+    // Stamped by the CURRENT generation but past its window — still refused.
+    const verdict = authorityValid({ generationId: gen2.id, expiresAt: 4000 }, ctx);
+    expect(verdict.valid).toBe(false);
+    expect(verdict.reason).toContain('expired');
+  });
+
+  test('missing/garbage stamps are refused', () => {
+    expect(authorityValid(null, ctx).valid).toBe(false);
+    expect(authorityValid({} as any, ctx).valid).toBe(false);
+  });
+});
+
+describe('startup sweep', () => {
+  test('partitions live from stale and names the reason', () => {
+    const records = [
+      { generationId: gen2.id, kind: 'tab-ownership' },
+      { generationId: gen1.id, kind: 'actor-grant' },
+      { generationId: gen2.id, expiresAt: 1, kind: 'approval-token' },
+    ];
+    const { live, stale } = sweepStaleAuthority(records, { generation: gen2, now: 5000 });
+    expect(live.map((r) => r.kind)).toEqual(['tab-ownership']);
+    expect(stale.map((s) => s.record.kind).sort()).toEqual(['actor-grant', 'approval-token']);
+    for (const s of stale) expect(s.reason.length).toBeGreaterThan(0);
+  });
+
+  test('non-array input yields an empty sweep, not a crash', () => {
+    const { live, stale } = sweepStaleAuthority(undefined as any, { generation: gen2, now: 0 });
+    expect(live).toEqual([]);
+    expect(stale).toEqual([]);
+  });
+});
+
+describe('actor generations — old runs cannot speak into new ones', () => {
+  test('messages from the current actor generation pass; prior ones are discarded', () => {
+    expect(acceptActorMessage({ generation: 3 }, 3)).toBe(true);
+    expect(acceptActorMessage({ generation: 2 }, 3)).toBe(false);
+    expect(acceptActorMessage({}, 3)).toBe(false);
+    expect(acceptActorMessage({ generation: '3' }, 3)).toBe(false);
+  });
+});

--- a/tests/peerd-runtime/lifecycle/historical-fixtures.test.ts
+++ b/tests/peerd-runtime/lifecycle/historical-fixtures.test.ts
@@ -1,0 +1,623 @@
+// Historical profile fixtures — the upgrade path, tested against the shapes
+// REAL older peerd releases actually wrote (contract §11.3 "tested against
+// real old fixtures", §16.7 "migrations are tested from real historical
+// fixtures"). The bar this file defends: opening an old profile with today's
+// build never silently resets it and never silently drops a field.
+//
+// ── PROVENANCE ────────────────────────────────────────────────────────────
+// There are no version tags in this repo, so each fixture's shape was mined
+// out of `git log` and labelled with the version that shipped it
+// (`git log -p -- package.json`). Every claim below is a commit you can read.
+//
+//   fixtures/profile-v0.1.0.json   peerd 0.1.0 — bd7a135 (2026-06-21), the
+//     flattened-history root; shape unchanged through 0.1.5 (caed35e).
+//       · SessionKind was 'chat' | 'subagent' (bd7a135:sessions/types.js).
+//       · No instanceId / actorType / backing (747ed0b), no spawnedTrusted
+//         (0f280da), no grantedTools (509c946), no todos|prewalk (65bac25),
+//         no review (419ecb6), no originState (1455923).
+//       · `actTier` — the pre-collapse Codex-style Act tier. bd7a135:
+//         docs/DECISIONS.md §18 promised it would be "read forever" and
+//         normalized (full-auto→off, suggest AND auto-edit→on). Those docs
+//         were deleted in 5b386dd (0.2.1). See the FINDING below.
+//       · toolManifest.allow carries the names bd7a135's `research` preset
+//         listed — do/get/check/list_tabs/read_article/call_api/web_search
+//         and the inspect_* family. do/get/check + the browser-runner were
+//         culled in 8d78709 (#133); inspect_* folded into one `inspect`.
+//       · settings: bd7a135:packaging/default-settings.mjs keys, plus
+//         `backgroundTabsEnabled` and `voiceVariant:'small'` — both named
+//         as removed in today's packaging/default-settings.mjs.
+//       · Sessions are in the pre-per-message-store v1 shape (inline
+//         `messages`, no msgIndex/messagesV2). That split predates bd7a135,
+//         so the shape is reconstructed from the v1→v2 header note and the
+//         migrate() path sessions/store.js STILL runs on every get().
+//
+//   fixtures/profile-v0.2.2.json   peerd 0.2.2 — e66d6b9 (2026-07-04).
+//       · 747ed0b added kind:'actor' + instanceId/actorType/backing.
+//       · 0f280da (#134/#135) added spawnedTrusted.
+//       · 509c946 (#138, the heap split) added grantedTools.
+//       · 2818b13 (#141) widened actorType with 'dweb'.
+//       · kind is STILL 'subagent' — 67d46d5 (#178) renamed it two days
+//         later, in 0.2.6.
+//
+//   fixtures/profile-v0.2.8.json   peerd 0.2.8 — 9eeda20 (2026-07-19).
+//       · 67d46d5 (#178) renamed 'subagent' → 'spawned'; old records keep
+//         'subagent' forever (there is no rewrite pass).
+//       · 65bac25 (#210) added session.todos + session.prewalk and the
+//         prewalk* settings; 9f9d0bc (#219) added watchAgentTab.
+//       · review (419ecb6) and originState (1455923) land later, in 0.3.0.
+//
+// All three carry `storeVersions: null`: the lifecycle store registry landed
+// 2026-08-05 (3c5566d/70f6e42), AFTER 0.4.0 (86aaa0a) — so every real 0.x
+// profile on disk today is UNSTAMPED, which checkStores must read as a fresh
+// profile, never as a version skew.
+//
+// Each fixture also carries deliberately-planted `unknown*FromANewerBuild`
+// fields: forward-compat data a future build wrote that today's build must
+// carry through untouched.
+
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { createSessionStore } from '/peerd-runtime/sessions/store.js';
+import {
+  normalizeMode, normalizeConfirmActions, confirmActionsFromRecord,
+  PERMISSION_MODES, DEFAULT_PERMISSION_MODE,
+} from '/peerd-runtime/permissions/index.js';
+import { normalizeToolManifest } from '/peerd-runtime/tools/manifests.js';
+import { compileUserHook } from '/peerd-runtime/tools/hooks/compile.js';
+import { orderAlwaysLoaded, assembleAlwaysLoaded } from '/peerd-runtime/memory/memory.js';
+import { inspectImport, EXPORT_FORMAT, EXPORT_VERSION } from '/peerd-runtime/transfer/transfer.js';
+import { runMigration, guardStore } from '/peerd-runtime/lifecycle/store-version.js';
+import { checkStores, storeEntry, STORE_REGISTRY } from '/peerd-runtime/lifecycle/store-registry.js';
+import { CHANNEL_DEFAULTS } from '/shared/channel-config.js';
+
+// ── fixture loading ───────────────────────────────────────────────────────
+
+type Rec = Record<string, any>;
+
+type Fixture = {
+  _provenance: { peerdVersion: string, shapeCommit: string, shapeDate: string, notes: string[] },
+  storeVersions: Record<string, number> | null,
+  settings: Rec,
+  sessions: Rec[],
+  sessionMessages: Rec[],
+  hooks: Rec[],
+  memory: { version: number, exportedAt: number, docs: Rec[] },
+  exportEnvelope: Rec,
+};
+
+const FIXTURE_NAMES = ['profile-v0.1.0', 'profile-v0.2.2', 'profile-v0.2.8'] as const;
+
+/** Raw bytes too: the no-loss checks below are anchored on the file's own text. */
+const readFixture = (name: string): { text: string, data: Fixture } => {
+  const text = readFileSync(join(import.meta.dir, 'fixtures', `${name}.json`), 'utf8');
+  return { text, data: JSON.parse(text) as Fixture };
+};
+
+const FIXTURES = FIXTURE_NAMES.map((name) => ({ name, ...readFixture(name) }));
+
+// The session store's OWN internals — the only keys `present()` is allowed to
+// remove from a record on the way out (msgIndex/messagesV2 are the v2 storage
+// shape; `messages` is re-attached as the assembled array). Everything else
+// disappearing would be silent data loss.
+const DECLARED_STORE_DROPS = new Set(['msgIndex', 'messagesV2', 'messages']);
+
+// A keyPath-aware in-memory IDB, same shape as the real egress wrapper
+// (sessions keyed by sessionId, session_messages by id) — matches the fake in
+// tests/peerd-runtime/sessions/per-message-store.test.ts.
+const makeIdb = (fixture: Fixture) => {
+  const stores = new Map<string, Map<string, any>>();
+  const tbl = (name: string) => {
+    if (!stores.has(name)) stores.set(name, new Map());
+    return stores.get(name)!;
+  };
+  for (const record of fixture.sessions) tbl('sessions').set(record.sessionId, structuredClone(record));
+  for (const row of fixture.sessionMessages) tbl('session_messages').set(row.id, structuredClone(row));
+  return {
+    _tbl: tbl,
+    get: async (store: string, key: string) => tbl(store).get(key),
+    getMany: async (store: string, keys: string[]) => (keys ?? []).map((k) => tbl(store).get(k)),
+    put: async (store: string, val: any) => { tbl(store).set(val.id ?? val.sessionId, val); },
+    getAll: async (store: string) => [...tbl(store).values()],
+  };
+};
+
+const openStore = (fixture: Fixture) => {
+  const idb = makeIdb(fixture);
+  return { idb, store: createSessionStore({ idb, now: () => 1_770_000_000_000, makeId: () => 'new-id' }) };
+};
+
+// ── 1. old session records load through today's store ─────────────────────
+
+describe.each(FIXTURES)('$name — session records survive today\'s store', ({ data }) => {
+  test('every record loads, in the old shape, without throwing', async () => {
+    const { store } = openStore(data);
+    const listed = await store.list();
+    expect(listed).toHaveLength(data.sessions.length);
+    for (const original of data.sessions) {
+      const loaded = await store.get(original.sessionId);
+      expect(loaded).toBeDefined();
+      expect(Array.isArray(loaded!.messages)).toBe(true);
+    }
+  });
+
+  test('no field is silently discarded — every original key survives except the store\'s declared internals', async () => {
+    const { store } = openStore(data);
+    for (const original of data.sessions) {
+      const loaded = (await store.get(original.sessionId)) as Rec;
+      for (const [key, value] of Object.entries(original)) {
+        if (DECLARED_STORE_DROPS.has(key)) continue;
+        expect(loaded).toHaveProperty(key);
+        expect(loaded[key]).toEqual(value);
+      }
+    }
+  });
+
+  test('planted forward-compat fields survive get() AND list()', async () => {
+    const { store } = openStore(data);
+    const planted = data.sessions.filter((s) =>
+      Object.keys(s).some((k) => k.startsWith('unknown') || k.startsWith('future')));
+    expect(planted.length).toBeGreaterThan(0); // the fixture must actually plant some
+    const listed = await store.list();
+    for (const original of planted) {
+      const unknownKeys = Object.keys(original).filter((k) => k.startsWith('unknown') || k.startsWith('future'));
+      const fromGet = (await store.get(original.sessionId)) as Rec;
+      const fromList = listed.find((s: Rec) => s.sessionId === original.sessionId) as Rec;
+      for (const key of unknownKeys) {
+        expect(fromGet[key]).toEqual(original[key]);
+        expect(fromList[key]).toEqual(original[key]);
+      }
+    }
+  });
+
+  test('kind/depth are DEFAULTED, never overwritten — a legacy kind value is preserved verbatim', async () => {
+    const { store } = openStore(data);
+    for (const original of data.sessions) {
+      const loaded = (await store.get(original.sessionId)) as Rec;
+      expect(loaded.kind).toBe(original.kind ?? 'chat');
+      expect(loaded.depth).toBe(original.depth ?? 0);
+    }
+  });
+
+  test('a mutating write (update) carries the unknown fields forward', async () => {
+    const { store, idb } = openStore(data);
+    const target = data.sessions[0]!;
+    await store.update(target.sessionId, { model: 'claude-opus-5' });
+    const raw = idb._tbl('sessions').get(target.sessionId);
+    for (const [key, value] of Object.entries(target)) {
+      if (DECLARED_STORE_DROPS.has(key) || key === 'model') continue;
+      expect(raw).toHaveProperty(key);
+      expect(raw[key]).toEqual(value);
+    }
+  });
+});
+
+describe('profile-v0.1.0 — the pre-per-message-store (v1 inline) shape', () => {
+  const fixture = FIXTURES[0]!.data;
+
+  test('the fixture really is v1-shaped (this is what makes the migration test real)', () => {
+    for (const record of fixture.sessions) {
+      expect(record.messagesV2).toBeUndefined();
+      expect(record.msgIndex).toBeUndefined();
+      expect(Array.isArray(record.messages)).toBe(true);
+    }
+  });
+
+  test('get() externalizes the inline messages, in order, losing nothing', async () => {
+    const { store, idb } = openStore(fixture);
+    for (const original of fixture.sessions) {
+      const loaded = (await store.get(original.sessionId)) as Rec;
+      expect(loaded.messages).toEqual(original.messages);
+      // The record on disk is now v2; the bodies moved to session_messages.
+      const raw = idb._tbl('sessions').get(original.sessionId);
+      expect(raw.messagesV2).toBe(true);
+      expect(raw.msgIndex).toHaveLength(original.messages.length);
+      expect('messages' in raw).toBe(false);
+      for (const [seq, id] of raw.msgIndex.entries()) {
+        expect(idb._tbl('session_messages').get(id).message).toEqual(original.messages[seq]);
+      }
+    }
+  });
+
+  test('the migration is idempotent — a second read is a no-op with identical output', async () => {
+    const { store } = openStore(fixture);
+    const first = await store.get(fixture.sessions[0]!.sessionId);
+    const second = await store.get(fixture.sessions[0]!.sessionId);
+    expect(second).toEqual(first);
+  });
+
+  test('list() reads the v1 shape WITHOUT migrating (opening the chat list writes nothing)', async () => {
+    const { store, idb } = openStore(fixture);
+    const listed = await store.list();
+    expect(listed).toHaveLength(fixture.sessions.length);
+    for (const record of fixture.sessions) {
+      expect(idb._tbl('sessions').get(record.sessionId).messagesV2).toBeUndefined();
+    }
+    expect(idb._tbl('session_messages').size).toBe(0);
+  });
+});
+
+// ── 2. permission fields off a historical record ───────────────────────────
+
+describe('permissions — legacy records normalize instead of throwing', () => {
+  const legacy = FIXTURES[0]!.data.sessions[0]!;
+
+  test('the v0.1.0 record\'s permissionMode still reads as Act', () => {
+    expect(legacy.permissionMode).toBe('act');
+    expect(normalizeMode(legacy.permissionMode)).toBe(PERMISSION_MODES.ACT);
+  });
+
+  test('the removed Codex tiers coerce to the read-only floor, never throw', () => {
+    for (const tier of ['suggest', 'auto-edit', 'full-auto']) {
+      expect(normalizeMode(tier)).toBe(DEFAULT_PERMISSION_MODE);
+    }
+    expect(normalizeMode(undefined)).toBe(DEFAULT_PERMISSION_MODE);
+  });
+
+  test('confirmActions: only an explicit false turns confirmation off', () => {
+    expect(normalizeConfirmActions(undefined)).toBe(true);
+    expect(normalizeConfirmActions('full-auto')).toBe(true);
+    expect(normalizeConfirmActions(false)).toBe(false);
+    // The v0.1.0 research chat DID persist the boolean; it round-trips.
+    const withBoolean = FIXTURES[0]!.data.sessions[2]!;
+    expect(confirmActionsFromRecord(withBoolean)).toBe(true);
+  });
+
+  // FINDING (characterization, not endorsement). bd7a135:docs/DECISIONS.md §18
+  // said legacy `actTier` records would be "read forever" and normalized
+  // conservatively — "a migration must never widen authority", so suggest AND
+  // auto-edit were to map to confirm-ON. Today's confirmActionsFromRecord reads
+  // only `confirmActions`, so an actTier-only record yields undefined and the
+  // SW's resolution chain (service-worker.js resolvePermission:
+  // `confirmActionsFromRecord(session) ?? cachedConfirm ?? false`) lands on
+  // confirm-OFF — a WIDENING of a 'suggest' user's authority. The FIELD is not
+  // lost (asserted below); its MEANING is. Pinned here so the behavior can't
+  // drift again unnoticed, and so restoring §18 is a visible, deliberate change.
+  test('actTier: the field survives AND its §18 semantics hold — suggest confirms, never widened', async () => {
+    // RESTORED: the FINDING this test originally pinned (an actTier-only
+    // record falling through to confirm-OFF — a silent authority widening)
+    // is fixed in confirmActionsFromRecord: 'suggest'/'auto-edit' → ON,
+    // only 'full-auto' → OFF, unknown tiers fail safe to ON.
+    expect(legacy.actTier).toBe('suggest');
+    expect(confirmActionsFromRecord(legacy)).toBe(true);
+    expect(confirmActionsFromRecord({ actTier: 'auto-edit' })).toBe(true);
+    expect(confirmActionsFromRecord({ actTier: 'full-auto' })).toBe(false);
+    expect(confirmActionsFromRecord({ actTier: 'mystery-tier' })).toBe(true);
+    // An explicit boolean still outranks the legacy tier.
+    expect(confirmActionsFromRecord({ confirmActions: false, actTier: 'suggest' })).toBe(false);
+
+    // No data loss: the field is still on the record after a full store cycle.
+    const { store } = openStore(FIXTURES[0]!.data);
+    const loaded = (await store.get(legacy.sessionId)) as Rec;
+    expect(loaded.actTier).toBe('suggest');
+  });
+});
+
+// ── 3. a v0.1.0 tool manifest naming culled tools ─────────────────────────
+
+describe('tool manifests — culled tool names are kept, not scrubbed', () => {
+  const research = FIXTURES[0]!.data.sessions[2]!;
+
+  test('normalizeToolManifest preserves every historical name verbatim', () => {
+    const normalized = normalizeToolManifest(research.toolManifest);
+    expect(normalized).not.toBeNull();
+    expect(normalized!.preset).toBe('research');
+    expect(normalized!.allow).toEqual(research.toolManifest.allow);
+    // The names culled in 8d78709 (#133) and the inspect consolidation are
+    // still there — a manifest NARROWS at dispatch; it is not a registry.
+    for (const gone of ['do', 'get', 'check', 'list_tabs', 'web_search', 'inspect_storage']) {
+      expect(normalized!.allow).toContain(gone);
+    }
+  });
+
+  test('the manifest object round-trips through the store untouched', async () => {
+    const { store } = openStore(FIXTURES[0]!.data);
+    const loaded = (await store.get(research.sessionId)) as Rec;
+    expect(loaded.toolManifest).toEqual(research.toolManifest);
+  });
+});
+
+// ── 4. old hook + memory records ──────────────────────────────────────────
+
+describe.each(FIXTURES)('$name — hooks and memory docs', ({ data }) => {
+  test('every hook record compiles and keeps its unknown fields on _record', () => {
+    for (const record of data.hooks) {
+      const compiled = compileUserHook(record as any);
+      expect(compiled.id).toBe(record.id);
+      expect(compiled.enabled).toBe(record.enabled !== false);
+      expect(compiled._record).toEqual(record as any);
+      expect((compiled._record as Rec).unknownHookFieldFromANewerBuild).toBe('keep-me');
+    }
+  });
+
+  test('memory docs assemble without throwing and keep their unknown fields', () => {
+    const ordered = orderAlwaysLoaded(data.memory.docs as any);
+    expect(ordered.length).toBeGreaterThan(0);
+    const assembled = assembleAlwaysLoaded(ordered, {});
+    expect(assembled.text.length).toBeGreaterThan(0);
+    expect(assembled.truncated).toBe(false);
+    // orderAlwaysLoaded filters by scope kind; it must not REWRITE a doc.
+    const user = ordered.find((d: Rec) => d.id === 'user') as Rec;
+    expect(user.unknownDocFieldFromANewerBuild).toBe(7);
+  });
+});
+
+// ── 5. the old transfer export envelope ───────────────────────────────────
+
+const KNOWN_SETTING_KEYS = Object.keys(CHANNEL_DEFAULTS);
+
+describe.each(FIXTURES)('$name — the export envelope this release wrote', ({ data }) => {
+  const envelope = () => data.exportEnvelope;
+
+  test('the format/version this build still speaks', () => {
+    expect(envelope().format).toBe(EXPORT_FORMAT);
+    expect(envelope().version).toBe(EXPORT_VERSION);
+  });
+
+  test('inspectImport accepts it and the summary is sane', () => {
+    const result = inspectImport({
+      payload: envelope(), channel: 'preview', knownSettingKeys: KNOWN_SETTING_KEYS,
+    });
+    expect(result.ok).toBe(true);
+    // narrow inspectImport's union for TS — expect() does not (same idiom as
+    // tests/peerd-runtime/transfer/transfer.test.ts).
+    if (!result.summary) throw new Error(`expected ok result: ${result.error}`);
+    const { summary } = result;
+    expect(summary.exportedAt).toBe(envelope().exportedAt);
+    expect(summary.sourceChannel).toBe(envelope().channel);
+    expect(summary.memoryDocs).toBe(envelope().memory.docs.length);
+    expect(summary.hooks).toBe(envelope().hooks.length);
+    expect(summary.skills).toHaveLength(envelope().skills.length);
+    for (const notice of summary.notices) expect(typeof notice).toBe('string');
+  });
+
+  test('every settings key is ACCOUNTED FOR — kept or declared dropped, never silently gone', () => {
+    const result = inspectImport({
+      payload: envelope(), channel: 'preview', knownSettingKeys: KNOWN_SETTING_KEYS,
+    });
+    if (!result.summary) throw new Error(`expected ok result: ${result.error}`);
+    const accounted = [...result.summary.settingsKeys, ...result.summary.settingsDropped].sort();
+    expect(accounted).toEqual(Object.keys(envelope().settings).sort());
+    // A drop is only legitimate if the user is TOLD about it.
+    if (result.summary.settingsDropped.length > 0) {
+      expect(result.summary.notices.some((n) => n.includes('not recognized by this build'))).toBe(true);
+      for (const key of result.summary.settingsDropped) {
+        expect(result.summary.notices.join(' ')).toContain(key);
+      }
+    }
+  });
+
+  test('§12 durability labels are absent, which means "unlabelled" — not "nothing was omitted"', () => {
+    // The durability block landed in 70f6e42 (2026-08-05); none of these files
+    // carry it. Absent must read as empty defaults with NO omission notice.
+    expect(envelope().durability).toBeUndefined();
+    const result = inspectImport({
+      payload: envelope(), channel: 'preview', knownSettingKeys: KNOWN_SETTING_KEYS,
+    });
+    if (!result.summary) throw new Error(`expected ok result: ${result.error}`);
+    expect(result.summary.durabilityTiers).toEqual({});
+    expect(result.summary.omittedDeviceBound).toEqual([]);
+    expect(result.summary.notices.some((n) => n.includes('Device-bound state'))).toBe(false);
+  });
+
+  test('the authority-redirecting sections are named loudly (R6)', () => {
+    const result = inspectImport({
+      payload: envelope(), channel: 'preview', knownSettingKeys: KNOWN_SETTING_KEYS,
+    });
+    if (!result.summary) throw new Error(`expected ok result: ${result.error}`);
+    const expectedUrls = (envelope().providerEndpoints?.endpoints ?? []).map((e: Rec) => e.url);
+    expect(result.summary.endpointUrls).toEqual(expectedUrls);
+    expect(result.summary.hookIds).toEqual(envelope().hooks.map((h: Rec) => h.id));
+  });
+});
+
+describe('the v0.2.2 preview export landing on a store build', () => {
+  const envelope = FIXTURES[1]!.data.exportEnvelope;
+
+  test('the dweb section is dropped WITH the §10 notice, never silently', () => {
+    const result = inspectImport({
+      payload: envelope, channel: 'store', knownSettingKeys: KNOWN_SETTING_KEYS,
+    });
+    if (!result.summary) throw new Error(`expected ok result: ${result.error}`);
+    expect(result.summary.dwebPresent).toBe(true);
+    expect(result.summary.dwebDropped).toBe(true);
+    expect(result.summary.notices).toContain(
+      'Dweb state in this export is not supported in the store package and was skipped.');
+  });
+
+  test('inspectImport does not mutate the payload it inspects', () => {
+    const before = JSON.stringify(envelope);
+    inspectImport({ payload: envelope, channel: 'store', knownSettingKeys: KNOWN_SETTING_KEYS });
+    expect(JSON.stringify(envelope)).toBe(before);
+  });
+});
+
+// ── 6. the migration driver over a whole historical profile ───────────────
+
+const identityStep = (from: number, to: number) => ({
+  from, to, migrate: (d: Record<string, unknown>) => ({ ...d }),
+});
+
+describe.each(FIXTURES)('$name — runMigration over the whole profile', ({ data, text }) => {
+  test('a no-op step chain preserves the profile byte-for-byte', () => {
+    const result = runMigration({
+      store: 'sessions',
+      data: JSON.parse(text) as Record<string, unknown>,
+      fromVersion: 1, toVersion: 3,
+      steps: [identityStep(1, 2), identityStep(2, 3)],
+    });
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.version).toBe(3);
+    expect(result.completedSteps).toEqual([2, 3]);
+    // Byte-anchored: re-serializing the migrated profile reproduces the file.
+    expect(JSON.stringify(result.data)).toBe(JSON.stringify(JSON.parse(text)));
+  });
+
+  test('every planted forward-compat field is still there after the chain', () => {
+    const result = runMigration({
+      store: 'sessions',
+      data: JSON.parse(text) as Record<string, unknown>,
+      fromVersion: 1, toVersion: 2, steps: [identityStep(1, 2)],
+    });
+    if (!result.ok) throw new Error(result.reason);
+    const migrated = result.data as unknown as Fixture;
+    expect((migrated.settings as Rec).unknownSettingFromANewerBuild)
+      .toEqual((data.settings as Rec).unknownSettingFromANewerBuild);
+    expect((migrated.exportEnvelope as Rec).unknownEnvelopeSectionFromANewerBuild)
+      .toEqual((data.exportEnvelope as Rec).unknownEnvelopeSectionFromANewerBuild);
+    expect(migrated.sessions[0]!.unknownRecordFieldFromANewerBuild)
+      .toEqual(data.sessions[0]!.unknownRecordFieldFromANewerBuild);
+  });
+
+  test('a step that DROPS an undeclared planted field is refused, original retained', () => {
+    const original = JSON.parse(text) as Record<string, unknown>;
+    const result = runMigration({
+      store: 'sessions',
+      data: original,
+      fromVersion: 1, toVersion: 2,
+      steps: [{
+        from: 1, to: 2,
+        // A plausible-looking "clean up the file container" step that quietly
+        // eats a section it did not declare. This must fail the run.
+        migrate: ({ _provenance, ...rest }: Record<string, unknown>) => rest,
+      }],
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.diagnosticId).toBe('migrate-sessions-step-v1-dropped-_provenance');
+    expect(result.failedStep).toEqual({ from: 1, to: 2 });
+    // The original is handed back untouched, byte-for-byte.
+    expect(JSON.stringify(result.data)).toBe(JSON.stringify(JSON.parse(text)));
+  });
+
+  test('the same drop, DECLARED, is allowed — the guard is about silence, not about dropping', () => {
+    const result = runMigration({
+      store: 'sessions',
+      data: JSON.parse(text) as Record<string, unknown>,
+      fromVersion: 1, toVersion: 2,
+      steps: [{
+        from: 1, to: 2, drops: ['_provenance'],
+        migrate: ({ _provenance, ...rest }: Record<string, unknown>) => rest,
+      }],
+    });
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.data._provenance).toBeUndefined();
+    expect(result.data.sessions).toEqual(data.sessions as unknown as Record<string, unknown>[]);
+  });
+
+  test('a throwing step leaves the profile exactly as found', () => {
+    const result = runMigration({
+      store: 'sessions',
+      data: JSON.parse(text) as Record<string, unknown>,
+      fromVersion: 1, toVersion: 2,
+      steps: [{ from: 1, to: 2, migrate: () => { throw new Error('interrupted'); } }],
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.diagnosticId).toBe('migrate-sessions-step-v1-threw');
+    expect(JSON.stringify(result.data)).toBe(JSON.stringify(JSON.parse(text)));
+  });
+});
+
+// ── 7. how the guard classifies a real 0.x profile ────────────────────────
+
+describe.each(FIXTURES)('$name — store-version classification', ({ data }) => {
+  test('the fixture is unstamped, because the registry postdates every 0.x release', () => {
+    expect(data.storeVersions).toBeNull();
+  });
+
+  test('unstamped reads as firstRun + read-write for every surface — never a skew, never a reset', async () => {
+    const check = await checkStores({ read: async () => undefined });
+    expect(check.ok).toBe(true);
+    expect(check.stores).toHaveLength(STORE_REGISTRY.length);
+    for (const entry of check.stores) {
+      expect(entry.firstRun).toBe(true);
+      expect(entry.stamped).toBeUndefined();
+      expect(entry.mode).toBe('read-write');
+      expect(entry.versionClass).toBe('current');
+      expect(entry.diagnosticId).toBeUndefined();
+    }
+  });
+});
+
+describe('guardStore over a stamped profile', () => {
+  const sessions = storeEntry('sessions')!;
+
+  test('an OLDER stamp asks for a migration', () => {
+    const guard = guardStore({
+      store: sessions.store, found: sessions.version - 1, supported: sessions.version,
+    });
+    expect(guard.mode).toBe('migrate');
+    expect(guard.versionClass).toBe('migratable');
+  });
+
+  test('a NEWER stamp fails read-only with a diagnostic — the §11.5 downgrade refusal', () => {
+    const guard = guardStore({
+      store: sessions.store, found: sessions.version + 1, supported: sessions.version,
+    });
+    expect(guard.mode).toBe('read-only');
+    expect(guard.versionClass).toBe('newer');
+    expect(guard.diagnosticId).toBe(`store-${sessions.store}-newer-v${sessions.version + 1}`);
+  });
+
+  test('checkStores routes an older stamp to migrate and keeps the rest read-write', async () => {
+    const check = await checkStores({
+      read: async () => ({ [sessions.store]: sessions.version - 1 }),
+    });
+    expect(check.ok).toBe(true);
+    const found = check.stores.find((s) => s.store === sessions.store)!;
+    expect(found.mode).toBe('migrate');
+    expect(found.firstRun).toBeUndefined();
+    for (const other of check.stores.filter((s) => s.store !== sessions.store)) {
+      expect(other.mode).toBe('read-write');
+      expect(other.firstRun).toBe(true);
+    }
+  });
+
+  test('checkStores refuses the WHOLE profile when any surface is newer', async () => {
+    const check = await checkStores({
+      read: async () => ({ [sessions.store]: sessions.version + 5 }),
+    });
+    expect(check.ok).toBe(false);
+    expect(check.stores.find((s) => s.store === sessions.store)!.mode).toBe('read-only');
+  });
+});
+
+// ── 8. the byte-anchored no-loss sweep ────────────────────────────────────
+
+describe.each(FIXTURES)('$name — byte-anchored no-loss sweep', ({ data, text }) => {
+  test('a JSON round-trip of the fixture is lossless', () => {
+    expect(JSON.parse(JSON.stringify(data))).toEqual(JSON.parse(text));
+  });
+
+  test('every top-level key of every session record is accounted for after the store path', async () => {
+    const { store } = openStore(data);
+    const listed = await store.list();
+    for (const original of data.sessions) {
+      const loaded = listed.find((s: Rec) => s.sessionId === original.sessionId) as Rec;
+      const originalKeys = Object.keys(original);
+      const survivors = new Set(Object.keys(loaded));
+      const lost = originalKeys.filter((k) => !survivors.has(k) && !DECLARED_STORE_DROPS.has(k));
+      expect(lost).toEqual([]);
+      // The assembled shape always exposes `messages`, whichever storage
+      // shape the record was in.
+      expect(survivors.has('messages')).toBe(true);
+    }
+  });
+
+  test('every message body survives the store path', async () => {
+    const { store } = openStore(data);
+    const expected = new Map<string, Rec[]>();
+    for (const record of data.sessions) {
+      expected.set(record.sessionId, Array.isArray(record.messages)
+        ? record.messages
+        : (record.msgIndex ?? []).map((id: string) =>
+          data.sessionMessages.find((row) => row.id === id)!.message));
+    }
+    for (const [sessionId, messages] of expected) {
+      const loaded = (await store.get(sessionId)) as Rec;
+      expect(loaded.messages).toEqual(messages);
+    }
+  });
+});

--- a/tests/peerd-runtime/lifecycle/historical-fixtures.test.ts
+++ b/tests/peerd-runtime/lifecycle/historical-fixtures.test.ts
@@ -621,3 +621,521 @@ describe.each(FIXTURES)('$name — byte-anchored no-loss sweep', ({ data, text }
     }
   });
 });
+
+// ══ 9. the breadth the three files above cannot cover ══════════════════════
+//
+// The fixtures above all stop at 0.2.8, and each is a SINGLE release's
+// output. Two gaps follow from that, and these two files close them:
+//
+//   fixtures/profile-v0.4.0.json   the CURRENT release (86aaa0a, 0.4.0 —
+//     package.json). Everything above tests "can today's build read an OLD
+//     profile"; nothing tested "can today's build read ITS OWN". It carries
+//     the modern field set (todos / prewalk / toolManifest / review /
+//     originState / backing / grantedTools / spawnedTrusted), settings whose
+//     values are deliberately NON-default (§11 Option A: a stored value wins
+//     over CHANNEL_DEFAULTS, so an all-defaults fixture proves nothing), and
+//     the first export envelope carrying the §12 `durability` block
+//     (70f6e42) — the tier labels + the device-bound surfaces an export
+//     structurally cannot carry.
+//
+//   fixtures/profile-maximal-historical.json   a COMPOSITE torture profile,
+//     labelled as one in its own `_provenance` (it is NOT a release
+//     snapshot — do not cite it as evidence of what any version wrote). It
+//     mixes eras inside ONE profile, which is what a long-lived install
+//     actually is: pre-per-message-store v1 records carrying `actTier` next
+//     to v2 records; modern actors (origin-locked tab actor, DESIGN-18 API
+//     actor, the dweb daemon, a #160 review child); a PARTIALLY stamped
+//     storeVersions map (some surfaces at 1, the rest absent — an
+//     interrupted stamping run); memory at every scope; user hooks; and ~40
+//     sessions of bulk so the store path is exercised at a real size.
+//
+// Both plant `unknown*FromANewerBuild` / `future*` fields throughout.
+
+import { omittedDeviceBoundStores } from '/peerd-runtime/lifecycle/store-registry.js';
+import { HOOKS_STORAGE_KEY } from '/peerd-runtime/tools/hooks/registry.js';
+
+const CURRENT_FIXTURE = { name: 'profile-v0.4.0', ...readFixture('profile-v0.4.0') };
+const MAXIMAL_FIXTURE = { name: 'profile-maximal-historical', ...readFixture('profile-maximal-historical') };
+const NEW_FIXTURES = [CURRENT_FIXTURE, MAXIMAL_FIXTURE];
+
+/** The messages a record is EXPECTED to assemble to, whichever storage shape it is in. */
+const expectedMessages = (fixture: Fixture, record: Rec): Rec[] => (Array.isArray(record.messages)
+  ? record.messages
+  : (record.msgIndex ?? []).map((id: string) =>
+    fixture.sessionMessages.find((row) => row.id === id)!.message));
+
+// ── 9a. both new profiles round-trip through today's store with no loss ────
+
+describe.each(NEW_FIXTURES)('$name — store round-trip is lossless', ({ data }) => {
+  test('every record loads, in its own shape, without throwing', async () => {
+    const { store } = openStore(data);
+    const listed = await store.list();
+    expect(listed).toHaveLength(data.sessions.length);
+    for (const original of data.sessions) {
+      const loaded = await store.get(original.sessionId);
+      expect(loaded).toBeDefined();
+      expect(Array.isArray(loaded!.messages)).toBe(true);
+    }
+  });
+
+  test('every original key survives except the store\'s declared internals', async () => {
+    const { store } = openStore(data);
+    for (const original of data.sessions) {
+      const loaded = (await store.get(original.sessionId)) as Rec;
+      for (const [key, value] of Object.entries(original)) {
+        if (DECLARED_STORE_DROPS.has(key)) continue;
+        expect(loaded).toHaveProperty(key);
+        expect(loaded[key]).toEqual(value);
+      }
+    }
+  });
+
+  test('planted forward-compat fields survive get() AND list()', async () => {
+    const { store } = openStore(data);
+    const planted = data.sessions.filter((s) =>
+      Object.keys(s).some((k) => k.startsWith('unknown') || k.startsWith('future')));
+    expect(planted.length).toBeGreaterThan(0); // the fixture must actually plant some
+    const listed = await store.list();
+    for (const original of planted) {
+      const unknownKeys = Object.keys(original).filter((k) => k.startsWith('unknown') || k.startsWith('future'));
+      const fromGet = (await store.get(original.sessionId)) as Rec;
+      const fromList = listed.find((s: Rec) => s.sessionId === original.sessionId) as Rec;
+      for (const key of unknownKeys) {
+        expect(fromGet[key]).toEqual(original[key]);
+        expect(fromList[key]).toEqual(original[key]);
+      }
+    }
+  });
+
+  test('every message body survives the store path, in order', async () => {
+    const { store } = openStore(data);
+    for (const original of data.sessions) {
+      const loaded = (await store.get(original.sessionId)) as Rec;
+      expect(loaded.messages).toEqual(expectedMessages(data, original));
+    }
+  });
+
+  test('a mutating write (update) carries the unknown fields forward', async () => {
+    const { store, idb } = openStore(data);
+    const target = data.sessions.find((s) =>
+      Object.keys(s).some((k) => k.startsWith('unknown') || k.startsWith('future')))!;
+    await store.update(target.sessionId, { model: 'claude-opus-5' });
+    const raw = idb._tbl('sessions').get(target.sessionId);
+    for (const [key, value] of Object.entries(target)) {
+      if (DECLARED_STORE_DROPS.has(key) || key === 'model') continue;
+      expect(raw).toHaveProperty(key);
+      expect(raw[key]).toEqual(value);
+    }
+  });
+
+  test('the modern actor fields are preserved verbatim, never re-defaulted', async () => {
+    const { store } = openStore(data);
+    const actors = data.sessions.filter((s) => s.kind === 'actor');
+    expect(actors.length).toBeGreaterThan(0);
+    for (const original of actors) {
+      const loaded = (await store.get(original.sessionId)) as Rec;
+      // Each of these is load-bearing at read time — dropping any one silently
+      // widens or breaks the actor (backing → an API actor behaving as a tab
+      // actor; originState → a bound actor becoming unbounded; grantedTools →
+      // the offscreen re-check losing its allow-list).
+      for (const field of ['instanceId', 'actorType', 'backing', 'grantedTools', 'originState', 'spawnedTrusted']) {
+        if (!Object.hasOwn(original, field)) continue;
+        expect(loaded[field]).toEqual(original[field]);
+      }
+    }
+  });
+});
+
+// ── 9b. the mixed-era profile: lazy v1→v2 touches ONLY the v1 records ──────
+
+describe('profile-maximal-historical — mixed-era lazy v1 → v2 migration', () => {
+  const fixture = MAXIMAL_FIXTURE.data;
+  const v1Records = fixture.sessions.filter((s) => Array.isArray(s.messages));
+  const v2Records = fixture.sessions.filter((s) => s.messagesV2 === true);
+
+  test('the fixture really mixes both storage shapes (this is what makes the test real)', () => {
+    expect(v1Records.length).toBeGreaterThan(0);
+    expect(v2Records.length).toBeGreaterThan(0);
+    expect(v1Records.length + v2Records.length).toBe(fixture.sessions.length);
+    for (const record of v1Records) {
+      expect(record.messagesV2).toBeUndefined();
+      expect(record.msgIndex).toBeUndefined();
+    }
+  });
+
+  test('reading a v1 record migrates it; its v2 NEIGHBOURS are left byte-identical', async () => {
+    const { store, idb } = openStore(fixture);
+    const before = new Map<string, string>(
+      v2Records.map((r) => [r.sessionId as string, JSON.stringify(idb._tbl('sessions').get(r.sessionId))]));
+    for (const original of v1Records) {
+      const loaded = (await store.get(original.sessionId)) as Rec;
+      expect(loaded.messages).toEqual(original.messages);
+      const raw = idb._tbl('sessions').get(original.sessionId);
+      expect(raw.messagesV2).toBe(true);
+      expect(raw.msgIndex).toHaveLength(original.messages.length);
+      expect('messages' in raw).toBe(false);
+      for (const [seq, id] of raw.msgIndex.entries()) {
+        expect(idb._tbl('session_messages').get(id).message).toEqual(original.messages[seq]);
+      }
+    }
+    // The untouched half: not re-put, not re-shaped, not re-ordered.
+    for (const record of v2Records) {
+      expect(JSON.stringify(idb._tbl('sessions').get(record.sessionId))).toBe(before.get(record.sessionId)!);
+    }
+    // Exactly the v1 bodies were externalized — nothing else was written.
+    const externalized = v1Records.reduce((n, r) => n + r.messages.length, 0);
+    expect(idb._tbl('session_messages').size).toBe(fixture.sessionMessages.length + externalized);
+  });
+
+  test('the migration is idempotent — a second read is a no-op with identical output', async () => {
+    const { store, idb } = openStore(fixture);
+    const target = v1Records[0]!.sessionId;
+    const first = await store.get(target);
+    const afterFirst = JSON.stringify(idb._tbl('sessions').get(target));
+    const second = await store.get(target);
+    expect(second).toEqual(first);
+    expect(JSON.stringify(idb._tbl('sessions').get(target))).toBe(afterFirst);
+  });
+
+  test('list() reads BOTH shapes and writes nothing', async () => {
+    const { store, idb } = openStore(fixture);
+    const listed = await store.list();
+    expect(listed).toHaveLength(fixture.sessions.length);
+    for (const record of v1Records) {
+      expect(idb._tbl('sessions').get(record.sessionId).messagesV2).toBeUndefined();
+    }
+    expect(idb._tbl('session_messages').size).toBe(fixture.sessionMessages.length);
+    for (const original of fixture.sessions) {
+      const loaded = listed.find((s: Rec) => s.sessionId === original.sessionId) as Rec;
+      expect(loaded.messages).toEqual(expectedMessages(fixture, original));
+    }
+  });
+});
+
+// ── 9c. permissions over the NON-DEFAULT settings + the mixed-era tiers ────
+
+describe('the new fixtures — permission normalization over non-default values', () => {
+  const current = CURRENT_FIXTURE.data;
+  const maximal = MAXIMAL_FIXTURE.data;
+
+  test('the settings really are non-default — otherwise this proves nothing (§11 Option A)', () => {
+    const defaults = CHANNEL_DEFAULTS as Rec;
+    for (const settings of [current.settings, maximal.settings]) {
+      const known = Object.keys(settings).filter((k) => Object.hasOwn(defaults, k));
+      const differing = known.filter((k) => JSON.stringify(settings[k]) !== JSON.stringify(defaults[k]));
+      expect(differing.length).toBeGreaterThan(0);
+      // The three the reviewer named, where this build still knows the key.
+      expect(settings.vaultAutoLockMs).not.toEqual(defaults.vaultAutoLockMs);
+      expect(settings.advancedAutomationEnabled).not.toEqual(defaults.advancedAutomationEnabled);
+    }
+  });
+
+  test('confirmations are disabled the only way the schema allows: an EXPLICIT false on the record', async () => {
+    // There is no settings-level confirm toggle — the Act sub-axis is
+    // per-session (`confirmActions`), so "confirmations off" is this field.
+    const chats = current.sessions.filter((s) => s.kind === 'chat');
+    expect(chats.length).toBeGreaterThanOrEqual(2);
+    for (const chat of chats) {
+      expect(chat.confirmActions).toBe(false);
+      expect(confirmActionsFromRecord(chat)).toBe(false);
+      expect(normalizeConfirmActions(chat.confirmActions)).toBe(false);
+    }
+    // ...and it survives a full store cycle, so an eviction can't re-arm it.
+    const { store } = openStore(current);
+    for (const chat of chats) {
+      expect(((await store.get(chat.sessionId)) as Rec).confirmActions).toBe(false);
+    }
+  });
+
+  test('permissionMode normalizes; an absent one falls to the read-only floor', () => {
+    for (const record of [...current.sessions, ...maximal.sessions]) {
+      if (record.permissionMode === undefined) {
+        expect(normalizeMode(record.permissionMode)).toBe(DEFAULT_PERMISSION_MODE);
+        continue;
+      }
+      expect(Object.values(PERMISSION_MODES)).toContain(normalizeMode(record.permissionMode));
+    }
+    expect(normalizeMode('act')).toBe(PERMISSION_MODES.ACT);
+    expect(normalizeMode('plan')).toBe(PERMISSION_MODES.PLAN);
+  });
+
+  test('the maximal profile\'s legacy actTier records keep their §18 meaning — auto-edit CONFIRMS', async () => {
+    const autoEdit = maximal.sessions.find((s) => s.actTier === 'auto-edit')!;
+    const fullAuto = maximal.sessions.find((s) => s.actTier === 'full-auto')!;
+    expect(autoEdit).toBeDefined();
+    expect(fullAuto).toBeDefined();
+    // §18, restored: a migration must never widen authority — suggest AND
+    // auto-edit map to confirm-ON; only full-auto turns confirmation off.
+    expect(confirmActionsFromRecord(autoEdit)).toBe(true);
+    expect(confirmActionsFromRecord(fullAuto)).toBe(false);
+    // The tier is READ, never rewritten: both survive the store path intact.
+    const { store } = openStore(maximal);
+    expect(((await store.get(autoEdit.sessionId)) as Rec).actTier).toBe('auto-edit');
+    expect(((await store.get(fullAuto.sessionId)) as Rec).actTier).toBe('full-auto');
+  });
+
+  test('a modern explicit boolean still outranks a legacy tier sitting beside it', () => {
+    expect(confirmActionsFromRecord({ confirmActions: false, actTier: 'auto-edit' })).toBe(false);
+    expect(confirmActionsFromRecord({ confirmActions: true, actTier: 'full-auto' })).toBe(true);
+  });
+});
+
+// ── 9d. the export envelopes: the §12 durability block finally has a fixture ─
+
+describe.each(NEW_FIXTURES)('$name — inspectImport over the export envelope', ({ data }) => {
+  const envelope = () => data.exportEnvelope;
+
+  test('the format/version this build still speaks', () => {
+    expect(envelope().format).toBe(EXPORT_FORMAT);
+    expect(envelope().version).toBe(EXPORT_VERSION);
+  });
+
+  test('inspectImport accepts it and the summary is sane', () => {
+    const result = inspectImport({
+      payload: envelope(), channel: 'preview', knownSettingKeys: KNOWN_SETTING_KEYS,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.summary) throw new Error(`expected ok result: ${result.error}`);
+    const { summary } = result;
+    expect(summary.exportedAt).toBe(envelope().exportedAt);
+    expect(summary.sourceChannel).toBe(envelope().channel);
+    expect(summary.memoryDocs).toBe(envelope().memory.docs.length);
+    expect(summary.hooks).toBe(envelope().hooks.length);
+    expect(summary.skills).toHaveLength(envelope().skills.length);
+    expect(summary.hasSecrets).toBe(true); // both carry an encrypted secrets box
+  });
+
+  test('every settings key is ACCOUNTED FOR — kept or declared dropped, never silently gone', () => {
+    const result = inspectImport({
+      payload: envelope(), channel: 'preview', knownSettingKeys: KNOWN_SETTING_KEYS,
+    });
+    if (!result.summary) throw new Error(`expected ok result: ${result.error}`);
+    const accounted = [...result.summary.settingsKeys, ...result.summary.settingsDropped].sort();
+    expect(accounted).toEqual(Object.keys(envelope().settings).sort());
+    expect(result.summary.settingsDropped.length).toBeGreaterThan(0); // both plant an unknown key
+    expect(result.summary.notices.some((n) => n.includes('not recognized by this build'))).toBe(true);
+  });
+
+  test('§12 durability labels SURFACE — tiers per section, and the omitted device-bound surfaces', () => {
+    const durability = envelope().durability as Rec;
+    expect(durability).toBeDefined();
+    const result = inspectImport({
+      payload: envelope(), channel: 'preview', knownSettingKeys: KNOWN_SETTING_KEYS,
+    });
+    if (!result.summary) throw new Error(`expected ok result: ${result.error}`);
+    expect(result.summary.durabilityTiers).toEqual(durability.tiers);
+    expect(Object.keys(result.summary.durabilityTiers).length).toBeGreaterThan(0);
+    expect(result.summary.omittedDeviceBound).toEqual(durability.omittedDeviceBound);
+    // Every name the file omits is a REAL device-bound surface in today's
+    // registry — including the dpop-keys handle store, which can only ever
+    // appear in a fixture as an omission (rung 2 cannot be exported).
+    expect(result.summary.omittedDeviceBound).toContain('dpop-keys');
+    for (const name of result.summary.omittedDeviceBound) {
+      expect(omittedDeviceBoundStores()).toContain(name);
+    }
+    // A silent omission is the failure mode; the notice is the fix.
+    expect(result.summary.notices.some((n) => n.includes('Device-bound state'))).toBe(true);
+  });
+
+  test('the authority-redirecting sections are named loudly (R6)', () => {
+    const result = inspectImport({
+      payload: envelope(), channel: 'preview', knownSettingKeys: KNOWN_SETTING_KEYS,
+    });
+    if (!result.summary) throw new Error(`expected ok result: ${result.error}`);
+    const expectedUrls = (envelope().providerEndpoints?.endpoints ?? []).map((e: Rec) => e.url);
+    expect(result.summary.endpointUrls).toEqual(expectedUrls);
+    expect(result.summary.hookIds).toEqual(envelope().hooks.map((h: Rec) => h.id));
+  });
+
+  test('inspectImport does not mutate the payload it inspects', () => {
+    const before = JSON.stringify(envelope());
+    inspectImport({ payload: envelope(), channel: 'store', knownSettingKeys: KNOWN_SETTING_KEYS });
+    expect(JSON.stringify(envelope())).toBe(before);
+  });
+});
+
+describe('the maximal envelope landing on a store build', () => {
+  const envelope = MAXIMAL_FIXTURE.data.exportEnvelope;
+
+  test('the dweb section drops WITH the §10 notice, and the durability labels still surface', () => {
+    const result = inspectImport({
+      payload: envelope, channel: 'store', knownSettingKeys: KNOWN_SETTING_KEYS,
+    });
+    if (!result.summary) throw new Error(`expected ok result: ${result.error}`);
+    expect(result.summary.dwebPresent).toBe(true);
+    expect(result.summary.dwebDropped).toBe(true);
+    expect(result.summary.notices).toContain(
+      'Dweb state in this export is not supported in the store package and was skipped.');
+    // Two independent disclosures, both required — one must not mask the other.
+    expect(result.summary.omittedDeviceBound).toContain('dpop-keys');
+    expect(result.summary.notices.some((n) => n.includes('Device-bound state'))).toBe(true);
+  });
+});
+
+// ── 9e. hooks + memory carried by the new profiles ────────────────────────
+
+describe.each(NEW_FIXTURES)('$name — hooks and memory docs', ({ data }) => {
+  test('every hook record compiles and keeps its unknown fields on _record', () => {
+    expect(data.hooks.length).toBeGreaterThan(0);
+    for (const record of data.hooks) {
+      const compiled = compileUserHook(record as any);
+      expect(compiled.id).toBe(record.id);
+      expect(compiled.enabled).toBe(record.enabled !== false);
+      expect(compiled._record).toEqual(record as any);
+      expect((compiled._record as Rec).unknownHookFieldFromANewerBuild).toBe('keep-me');
+    }
+  });
+
+  test('memory docs at every scope assemble without throwing and keep their unknown fields', () => {
+    const kinds = new Set(data.memory.docs.map((d) => d.kind));
+    expect(kinds.size).toBeGreaterThan(1); // genuinely multi-scope
+    const ordered = orderAlwaysLoaded(data.memory.docs as any);
+    expect(ordered.length).toBeGreaterThan(0);
+    // Subtree docs load ON DEMAND — the always-loaded set must not carry them.
+    expect(ordered.some((d: Rec) => d.kind === 'subtree')).toBe(false);
+    const assembled = assembleAlwaysLoaded(ordered, {});
+    expect(assembled.text.length).toBeGreaterThan(0);
+    expect(assembled.truncated).toBe(false);
+    const user = ordered.find((d: Rec) => d.id === 'user') as Rec;
+    expect(user.unknownDocFieldFromANewerBuild).toBe(7);
+  });
+});
+
+describe('profile-maximal-historical — the hooks surface it stands in for', () => {
+  test('the fixture\'s hook array is the value stored under HOOKS_STORAGE_KEY', () => {
+    expect((MAXIMAL_FIXTURE.data as Rec).hooksStorageKey).toBe(HOOKS_STORAGE_KEY);
+  });
+});
+
+// ── 9f. store-version classification over a PARTIALLY stamped profile ──────
+
+describe('profile-maximal-historical — checkStores over a partially stamped map', () => {
+  const stamps = MAXIMAL_FIXTURE.data.storeVersions as Record<string, number>;
+
+  test('the map really is partial — some surfaces stamped, the rest absent', () => {
+    const names = Object.keys(stamps);
+    expect(names.length).toBeGreaterThan(0);
+    expect(names.length).toBeLessThan(STORE_REGISTRY.length);
+    // A stamp for a surface that no longer exists would be a silent no-op.
+    for (const name of names) expect(storeEntry(name)).toBeDefined();
+  });
+
+  test('stamped surfaces classify FROM their stamp; absent ones read as firstRun', async () => {
+    const check = await checkStores({ read: async () => stamps });
+    expect(check.ok).toBe(true);
+    expect(check.stores).toHaveLength(STORE_REGISTRY.length);
+    for (const entry of check.stores) {
+      const found = stamps[entry.store];
+      if (found === undefined) {
+        expect(entry.firstRun).toBe(true);
+        expect(entry.stamped).toBeUndefined();
+        expect(entry.mode).toBe('read-write');
+        expect(entry.versionClass).toBe('current');
+        continue;
+      }
+      expect(entry.firstRun).toBeUndefined();
+      expect(entry.stamped).toBe(found);
+      // Read the verdict off the guard rather than pinning today's numbers:
+      // the registry's versions ratchet independently (§11.1).
+      const guard = guardStore({ store: entry.store, found, supported: storeEntry(entry.store)!.version });
+      expect(entry.mode).toBe(guard.mode);
+      expect(entry.versionClass).toBe(guard.versionClass);
+      expect(entry.diagnosticId).toBe(guard.diagnosticId);
+    }
+  });
+
+  test('a partial map with ONE stamp behind asks to migrate that surface only', async () => {
+    const sessions = storeEntry('sessions')!;
+    const skewed = { ...stamps, [sessions.store]: sessions.version - 1 };
+    const check = await checkStores({ read: async () => skewed });
+    expect(check.ok).toBe(true);
+    expect(check.stores.find((s) => s.store === sessions.store)!.mode).toBe('migrate');
+    for (const other of check.stores.filter((s) => s.store !== sessions.store)) {
+      expect(other.mode).toBe('read-write');
+      // The other stamped surfaces are current, the unstamped ones firstRun —
+      // one surface migrating never drags the rest along (§11.1).
+      expect(other.firstRun).toBe(Object.hasOwn(skewed, other.store) ? undefined : true);
+    }
+  });
+
+  test('the CURRENT release\'s profile is still UNSTAMPED — the registry postdates 0.4.0', async () => {
+    expect(CURRENT_FIXTURE.data.storeVersions).toBeNull();
+    const check = await checkStores({ read: async () => undefined });
+    expect(check.ok).toBe(true);
+    for (const entry of check.stores) {
+      expect(entry.firstRun).toBe(true);
+      expect(entry.mode).toBe('read-write');
+    }
+  });
+});
+
+// ── 9g. runMigration over each new profile ────────────────────────────────
+
+describe.each(NEW_FIXTURES)('$name — runMigration identity chain', ({ data, text }) => {
+  test('a no-op step chain preserves the profile byte-for-byte', () => {
+    const result = runMigration({
+      store: 'sessions',
+      data: JSON.parse(text) as Record<string, unknown>,
+      fromVersion: 1, toVersion: 3,
+      steps: [identityStep(1, 2), identityStep(2, 3)],
+    });
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.version).toBe(3);
+    expect(result.completedSteps).toEqual([2, 3]);
+    expect(JSON.stringify(result.data)).toBe(JSON.stringify(JSON.parse(text)));
+  });
+
+  test('every planted forward-compat field is still there after the chain', () => {
+    const result = runMigration({
+      store: 'sessions',
+      data: JSON.parse(text) as Record<string, unknown>,
+      fromVersion: 1, toVersion: 2, steps: [identityStep(1, 2)],
+    });
+    if (!result.ok) throw new Error(result.reason);
+    const migrated = result.data as unknown as Fixture;
+    expect((migrated.settings as Rec).unknownSettingFromANewerBuild)
+      .toEqual((data.settings as Rec).unknownSettingFromANewerBuild);
+    expect((migrated.exportEnvelope as Rec).unknownEnvelopeSectionFromANewerBuild)
+      .toEqual((data.exportEnvelope as Rec).unknownEnvelopeSectionFromANewerBuild);
+    expect(migrated.sessions).toEqual(data.sessions);
+    expect(migrated.sessionMessages).toEqual(data.sessionMessages);
+  });
+});
+
+describe('profile-maximal-historical — the undeclared-drop refusal, spot-checked', () => {
+  const { text } = MAXIMAL_FIXTURE;
+
+  test('a step that quietly eats a section it did not declare fails the run, original retained', () => {
+    const result = runMigration({
+      store: 'sessions',
+      data: JSON.parse(text) as Record<string, unknown>,
+      fromVersion: 1, toVersion: 2,
+      steps: [{
+        from: 1, to: 2,
+        // "just tidying up the bulk sessions" — and the profile's whole
+        // message store goes with it. Silence is the failure, not the drop.
+        migrate: ({ sessionMessages, ...rest }: Record<string, unknown>) => rest,
+      }],
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.diagnosticId).toBe('migrate-sessions-step-v1-dropped-sessionMessages');
+    expect(result.failedStep).toEqual({ from: 1, to: 2 });
+    expect(JSON.stringify(result.data)).toBe(JSON.stringify(JSON.parse(text)));
+  });
+
+  test('the same drop, DECLARED, is allowed — the guard is about silence, not about dropping', () => {
+    const result = runMigration({
+      store: 'sessions',
+      data: JSON.parse(text) as Record<string, unknown>,
+      fromVersion: 1, toVersion: 2,
+      steps: [{
+        from: 1, to: 2, drops: ['sessionMessages'],
+        migrate: ({ sessionMessages, ...rest }: Record<string, unknown>) => rest,
+      }],
+    });
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.data.sessionMessages).toBeUndefined();
+    expect(result.data.sessions).toEqual(MAXIMAL_FIXTURE.data.sessions as unknown as Record<string, unknown>[]);
+  });
+});

--- a/tests/peerd-runtime/lifecycle/operation-log.test.ts
+++ b/tests/peerd-runtime/lifecycle/operation-log.test.ts
@@ -211,6 +211,27 @@ describe('newAttempt — Class B retries', () => {
   });
 });
 
+describe('poisoned entries', () => {
+  test('a null/garbage value in the stored map never crashes the recovery sweep', async () => {
+    const { adapter, map } = makeStorage();
+    const log = createOperationLog({ storage: adapter, now: () => 1 });
+    await log.begin(beginInput);
+    // Poison the stored map the way corruption or an in-origin writer would.
+    const stored = structuredClone(map.get(OPERATION_LOG_KEY)) as Record<string, unknown>;
+    stored.poison = null;
+    stored.garbage = 'not-a-record';
+    stored.noId = { state: 'running' };
+    map.set(OPERATION_LOG_KEY, stored);
+
+    const open = await log.listNonterminal(); // must not throw
+    expect(open.map((r) => r.operationId)).toEqual(['op-1']);
+    // The next persist self-heals: invalid entries are gone.
+    await log.transition('op-1', S.RUNNING);
+    const healed = map.get(OPERATION_LOG_KEY) as Record<string, unknown>;
+    expect(Object.keys(healed).sort()).toEqual(['op-1']);
+  });
+});
+
 describe('bounded growth', () => {
   test('oldest terminal records are pruned past the cap; nonterminal ones survive', async () => {
     const { adapter } = makeStorage();

--- a/tests/peerd-runtime/lifecycle/operation-log.test.ts
+++ b/tests/peerd-runtime/lifecycle/operation-log.test.ts
@@ -3,11 +3,11 @@
 
 import { describe, test, expect } from 'bun:test';
 import {
-  createOperationLog, OperationNotFoundError, OPERATION_LOG_KEY,
-  OPERATION_LOG_MAX_TERMINAL,
+  createOperationLog, OperationNotFoundError, OperationExistsError,
+  RetryRefusedError, OPERATION_LOG_KEY, OPERATION_LOG_MAX_TERMINAL,
 } from '../../../extension/peerd-runtime/lifecycle/operation-log.js';
 import {
-  OPERATION_STATES, IllegalTransitionError,
+  OPERATION_STATES, IllegalTransitionError, UnknownOutcomeUnresolvedError,
 } from '../../../extension/peerd-runtime/lifecycle/operation-state.js';
 
 const S = OPERATION_STATES;
@@ -58,6 +58,30 @@ describe('begin — recorded before dispatch', () => {
     await expect(log.begin({ ...beginInput, generationId: '' } as any))
       .rejects.toThrow(TypeError);
   });
+
+  test('a duplicate operationId refuses — a re-drive must not erase dispatch evidence', async () => {
+    const { adapter } = makeStorage();
+    const log = createOperationLog({ storage: adapter, now: () => 1 });
+    await log.begin(beginInput);
+    await log.transition('op-1', S.RUNNING);
+    await log.markDispatched('op-1');
+    await expect(log.begin(beginInput)).rejects.toThrow(OperationExistsError);
+    // The dispatched flag — what decides interrupted vs outcome_unknown on
+    // recovery — survived the attempted overwrite.
+    expect((await log.get('op-1'))!.dispatched).toBe(true);
+  });
+
+  test('concurrent begins both land — the mutation queue prevents lost updates', async () => {
+    const { adapter } = makeStorage();
+    const log = createOperationLog({ storage: adapter, now: () => 1 });
+    await Promise.all([
+      log.begin({ ...beginInput, operationId: 'op-A' }),
+      log.begin({ ...beginInput, operationId: 'op-B' }),
+      log.begin({ ...beginInput, operationId: 'op-C' }),
+    ]);
+    const open = await log.listNonterminal();
+    expect(open.map((r) => r.operationId).sort()).toEqual(['op-A', 'op-B', 'op-C']);
+  });
 });
 
 describe('transitions', () => {
@@ -106,6 +130,54 @@ describe('listNonterminal — the reconciler input', () => {
   });
 });
 
+describe('settle and resolveUnknown — the recovery regime', () => {
+  test('settle applies a reconcile verdict the live table would refuse', async () => {
+    const { adapter } = makeStorage();
+    const log = createOperationLog({ storage: adapter, now: () => 1 });
+    await log.begin(beginInput);
+    await log.transition('op-1', S.RUNNING);
+    await log.markDispatched('op-1'); // awaiting_remote
+    // awaiting_remote → cancelled is illegal live (the route is via
+    // cancelling) but legal as a recovery settle.
+    const settled = await log.settle('op-1', {
+      state: S.CANCELLED, autoRetry: false, retryRequires: [],
+      keepIdempotencyKey: false, verificationRequired: false,
+      recreateResource: false, reason: 'cancel won the race',
+    });
+    expect(settled.state).toBe(S.CANCELLED);
+  });
+
+  test('settle refuses the awaiting_user → outcome_unknown carve-out and terminal sources', async () => {
+    const { adapter } = makeStorage();
+    const log = createOperationLog({ storage: adapter, now: () => 1 });
+    await log.begin(beginInput);
+    await log.transition('op-1', S.RUNNING);
+    await log.transition('op-1', S.AWAITING_USER);
+    const unknownVerdict = {
+      state: S.OUTCOME_UNKNOWN, autoRetry: false, retryRequires: [],
+      keepIdempotencyKey: false, verificationRequired: true,
+      recreateResource: false, reason: 'x',
+    };
+    await expect(log.settle('op-1', unknownVerdict)).rejects.toThrow('refused');
+  });
+
+  test('resolveUnknown is the one exit: positive evidence settles, a timeout does not', async () => {
+    const { adapter } = makeStorage();
+    const log = createOperationLog({ storage: adapter, now: () => 1 });
+    await log.begin(beginInput);
+    await log.transition('op-1', S.RUNNING);
+    await log.transition('op-1', S.OUTCOME_UNKNOWN, { dispatched: true });
+    await expect(log.resolveUnknown('op-1', { kind: 'timeout' }))
+      .rejects.toThrow(UnknownOutcomeUnresolvedError);
+    const resolved = await log.resolveUnknown('op-1', { kind: 'verified-state' });
+    expect(resolved.state).toBe(S.COMPLETED);
+    expect(resolved.evidence).toEqual({ kind: 'verified-state' });
+    // Only outcome_unknown records qualify.
+    await expect(log.resolveUnknown('op-1', { kind: 'verified-state' }))
+      .rejects.toThrow('outcome_unknown');
+  });
+});
+
 describe('newAttempt — Class B retries', () => {
   test('re-queues an interrupted operation with a fresh attempt number', async () => {
     const { adapter } = makeStorage();
@@ -122,10 +194,19 @@ describe('newAttempt — Class B retries', () => {
   test('refused for any state but interrupted — settled outcomes are never re-driven', async () => {
     const { adapter } = makeStorage();
     const log = createOperationLog({ storage: adapter, now: () => 1 });
-    await log.begin(beginInput);
+    await log.begin({ ...beginInput, retryClass: 'B' });
     await log.transition('op-1', S.RUNNING);
     await log.transition('op-1', S.OUTCOME_UNKNOWN);
-    await expect(log.newAttempt('op-1')).rejects.toThrow('interrupted');
+    await expect(log.newAttempt('op-1')).rejects.toThrow(RetryRefusedError);
+  });
+
+  test('refused for Class E — a user-instructed repeat is a NEW operation, never a re-drive', async () => {
+    const { adapter } = makeStorage();
+    const log = createOperationLog({ storage: adapter, now: () => 1 });
+    await log.begin(beginInput); // Class E
+    await log.transition('op-1', S.RUNNING);
+    await log.transition('op-1', S.INTERRUPTED);
+    await expect(log.newAttempt('op-1')).rejects.toThrow(RetryRefusedError);
   });
 });
 
@@ -146,5 +227,23 @@ describe('bounded growth', () => {
     expect(terminal.length).toBe(OPERATION_LOG_MAX_TERMINAL);
     expect(stored['op-0']).toBeUndefined(); // oldest pruned
     expect(stored['op-live']).toBeDefined();
+  });
+
+  test('outcome_unknown records are never pruned — deleting one discards the uncertainty', async () => {
+    const { adapter } = makeStorage();
+    let t = 0;
+    const log = createOperationLog({ storage: adapter, now: () => ++t });
+    await log.begin({ ...beginInput, operationId: 'op-unknown' });
+    await log.transition('op-unknown', S.RUNNING);
+    await log.transition('op-unknown', S.OUTCOME_UNKNOWN, { dispatched: true });
+    for (let i = 0; i < OPERATION_LOG_MAX_TERMINAL + 5; i += 1) {
+      const id = `op-${i}`;
+      await log.begin({ ...beginInput, operationId: id });
+      await log.transition(id, S.RUNNING);
+      await log.transition(id, S.COMPLETED);
+    }
+    const stored = await adapter.get(OPERATION_LOG_KEY) as Record<string, { state: string }>;
+    expect(stored['op-unknown']).toBeDefined(); // oldest record of all, still here
+    expect(stored['op-unknown'].state).toBe(S.OUTCOME_UNKNOWN);
   });
 });

--- a/tests/peerd-runtime/lifecycle/operation-log.test.ts
+++ b/tests/peerd-runtime/lifecycle/operation-log.test.ts
@@ -5,6 +5,7 @@ import { describe, test, expect } from 'bun:test';
 import {
   createOperationLog, OperationNotFoundError, OperationExistsError,
   RetryRefusedError, OPERATION_LOG_KEY, OPERATION_LOG_MAX_TERMINAL,
+  OPERATION_LOG_MAX_UNKNOWN,
 } from '../../../extension/peerd-runtime/lifecycle/operation-log.js';
 import {
   OPERATION_STATES, IllegalTransitionError, UnknownOutcomeUnresolvedError,
@@ -229,7 +230,24 @@ describe('bounded growth', () => {
     expect(stored['op-live']).toBeDefined();
   });
 
-  test('outcome_unknown records are never pruned — deleting one discards the uncertainty', async () => {
+  test('outcome_unknown has its own larger bound — oldest dropped past OPERATION_LOG_MAX_UNKNOWN', async () => {
+    const { adapter } = makeStorage();
+    let t = 0;
+    const log = createOperationLog({ storage: adapter, now: () => ++t });
+    for (let i = 0; i < OPERATION_LOG_MAX_UNKNOWN + 3; i += 1) {
+      const id = `unk-${i}`;
+      await log.begin({ ...beginInput, operationId: id });
+      await log.transition(id, S.RUNNING);
+      await log.transition(id, S.OUTCOME_UNKNOWN, { dispatched: true });
+    }
+    const stored = await adapter.get(OPERATION_LOG_KEY) as Record<string, { state: string }>;
+    const unknowns = Object.values(stored).filter((r) => r.state === S.OUTCOME_UNKNOWN);
+    expect(unknowns.length).toBe(OPERATION_LOG_MAX_UNKNOWN);
+    expect(stored['unk-0']).toBeUndefined();
+    expect(stored[`unk-${OPERATION_LOG_MAX_UNKNOWN + 2}`]).toBeDefined();
+  });
+
+  test('outcome_unknown records are not pruned by the terminal cap — the uncertainty outlives ordinary history', async () => {
     const { adapter } = makeStorage();
     let t = 0;
     const log = createOperationLog({ storage: adapter, now: () => ++t });

--- a/tests/peerd-runtime/lifecycle/operation-log.test.ts
+++ b/tests/peerd-runtime/lifecycle/operation-log.test.ts
@@ -55,7 +55,7 @@ describe('begin — recorded before dispatch', () => {
   test('missing identities throw', async () => {
     const { adapter } = makeStorage();
     const log = createOperationLog({ storage: adapter });
-    expect(log.begin({ ...beginInput, generationId: '' } as any))
+    await expect(log.begin({ ...beginInput, generationId: '' } as any))
       .rejects.toThrow(TypeError);
   });
 });
@@ -80,16 +80,15 @@ describe('transitions', () => {
     const log = createOperationLog({ storage: adapter, now: () => 1 });
     await log.begin(beginInput);
     const before = writes.length;
-    expect(log.transition('op-1', S.OUTCOME_UNKNOWN))
+    await expect(log.transition('op-1', S.OUTCOME_UNKNOWN))
       .rejects.toThrow(IllegalTransitionError);
-    await Bun.sleep(0);
     expect(writes.length).toBe(before);
   });
 
   test('unknown operations throw the named error', async () => {
     const { adapter } = makeStorage();
     const log = createOperationLog({ storage: adapter });
-    expect(log.transition('nope', S.RUNNING))
+    await expect(log.transition('nope', S.RUNNING))
       .rejects.toThrow(OperationNotFoundError);
   });
 });
@@ -126,7 +125,7 @@ describe('newAttempt — Class B retries', () => {
     await log.begin(beginInput);
     await log.transition('op-1', S.RUNNING);
     await log.transition('op-1', S.OUTCOME_UNKNOWN);
-    expect(log.newAttempt('op-1')).rejects.toThrow('interrupted');
+    await expect(log.newAttempt('op-1')).rejects.toThrow('interrupted');
   });
 });
 

--- a/tests/peerd-runtime/lifecycle/operation-log.test.ts
+++ b/tests/peerd-runtime/lifecycle/operation-log.test.ts
@@ -1,0 +1,151 @@
+// The durable operation log — persist-before-report, legality-enforced
+// transitions, sanitized result metadata, attempt numbering for Class B.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  createOperationLog, OperationNotFoundError, OPERATION_LOG_KEY,
+  OPERATION_LOG_MAX_TERMINAL,
+} from '../../../extension/peerd-runtime/lifecycle/operation-log.js';
+import {
+  OPERATION_STATES, IllegalTransitionError,
+} from '../../../extension/peerd-runtime/lifecycle/operation-state.js';
+
+const S = OPERATION_STATES;
+
+const makeStorage = () => {
+  const map = new Map<string, unknown>();
+  const writes: unknown[] = [];
+  return {
+    adapter: {
+      get: async (key: string) => map.get(key),
+      set: async (key: string, value: unknown) => {
+        map.set(key, structuredClone(value));
+        writes.push(structuredClone(value));
+      },
+    },
+    map, writes,
+  };
+};
+
+const beginInput = {
+  operationId: 'op-1', sessionId: 'sess-1', toolName: 'submit_form',
+  retryClass: 'E', generationId: 'gen-1-aaaa', target: 'https://example.com',
+};
+
+describe('begin — recorded before dispatch', () => {
+  test('persists the §8 record shape with created state, attempt 1, class normalized', async () => {
+    const { adapter, writes } = makeStorage();
+    const log = createOperationLog({ storage: adapter, now: () => 42 });
+    const record = await log.begin(beginInput);
+    expect(record).toMatchObject({
+      operationId: 'op-1', sessionId: 'sess-1', toolName: 'submit_form',
+      retryClass: 'E', createdAt: 42, attempt: 1, state: S.CREATED,
+      generationId: 'gen-1-aaaa', dispatched: false,
+    });
+    expect(writes.length).toBe(1); // durably written before begin() returned
+  });
+
+  test('unclassified tools are stored as Class E (fail closed)', async () => {
+    const { adapter } = makeStorage();
+    const log = createOperationLog({ storage: adapter, now: () => 1 });
+    const record = await log.begin({ ...beginInput, retryClass: 'nonsense' });
+    expect(record.retryClass).toBe('E');
+  });
+
+  test('missing identities throw', async () => {
+    const { adapter } = makeStorage();
+    const log = createOperationLog({ storage: adapter });
+    expect(log.begin({ ...beginInput, generationId: '' } as any))
+      .rejects.toThrow(TypeError);
+  });
+});
+
+describe('transitions', () => {
+  test('the dispatch path: created → running → awaiting_remote (dispatched) → completed', async () => {
+    const { adapter } = makeStorage();
+    const log = createOperationLog({ storage: adapter, now: () => 1 });
+    await log.begin(beginInput);
+    await log.transition('op-1', S.RUNNING);
+    const dispatched = await log.markDispatched('op-1');
+    expect(dispatched.state).toBe(S.AWAITING_REMOTE);
+    expect(dispatched.dispatched).toBe(true);
+    const done = await log.transition('op-1', S.COMPLETED,
+      { evidence: { kind: 'success-response' }, resultDigest: 'sha256:abc' });
+    expect(done.state).toBe(S.COMPLETED);
+    expect(done.resultDigest).toBe('sha256:abc');
+  });
+
+  test('illegal transitions throw and persist nothing', async () => {
+    const { adapter, writes } = makeStorage();
+    const log = createOperationLog({ storage: adapter, now: () => 1 });
+    await log.begin(beginInput);
+    const before = writes.length;
+    expect(log.transition('op-1', S.OUTCOME_UNKNOWN))
+      .rejects.toThrow(IllegalTransitionError);
+    await Bun.sleep(0);
+    expect(writes.length).toBe(before);
+  });
+
+  test('unknown operations throw the named error', async () => {
+    const { adapter } = makeStorage();
+    const log = createOperationLog({ storage: adapter });
+    expect(log.transition('nope', S.RUNNING))
+      .rejects.toThrow(OperationNotFoundError);
+  });
+});
+
+describe('listNonterminal — the reconciler input', () => {
+  test('returns only unsettled records', async () => {
+    const { adapter } = makeStorage();
+    const log = createOperationLog({ storage: adapter, now: () => 1 });
+    await log.begin(beginInput);
+    await log.begin({ ...beginInput, operationId: 'op-2' });
+    await log.transition('op-2', S.RUNNING);
+    await log.transition('op-2', S.COMPLETED);
+    const open = await log.listNonterminal();
+    expect(open.map((r) => r.operationId)).toEqual(['op-1']);
+  });
+});
+
+describe('newAttempt — Class B retries', () => {
+  test('re-queues an interrupted operation with a fresh attempt number', async () => {
+    const { adapter } = makeStorage();
+    const log = createOperationLog({ storage: adapter, now: () => 1 });
+    await log.begin({ ...beginInput, retryClass: 'B' });
+    await log.transition('op-1', S.RUNNING);
+    await log.transition('op-1', S.INTERRUPTED);
+    const retried = await log.newAttempt('op-1');
+    expect(retried.attempt).toBe(2);
+    expect(retried.state).toBe(S.QUEUED);
+    expect(retried.dispatched).toBe(false);
+  });
+
+  test('refused for any state but interrupted — settled outcomes are never re-driven', async () => {
+    const { adapter } = makeStorage();
+    const log = createOperationLog({ storage: adapter, now: () => 1 });
+    await log.begin(beginInput);
+    await log.transition('op-1', S.RUNNING);
+    await log.transition('op-1', S.OUTCOME_UNKNOWN);
+    expect(log.newAttempt('op-1')).rejects.toThrow('interrupted');
+  });
+});
+
+describe('bounded growth', () => {
+  test('oldest terminal records are pruned past the cap; nonterminal ones survive', async () => {
+    const { adapter } = makeStorage();
+    let t = 0;
+    const log = createOperationLog({ storage: adapter, now: () => ++t });
+    for (let i = 0; i < OPERATION_LOG_MAX_TERMINAL + 5; i += 1) {
+      const id = `op-${i}`;
+      await log.begin({ ...beginInput, operationId: id });
+      await log.transition(id, S.RUNNING);
+      await log.transition(id, S.COMPLETED);
+    }
+    await log.begin({ ...beginInput, operationId: 'op-live' });
+    const stored = await adapter.get(OPERATION_LOG_KEY) as Record<string, { state: string }>;
+    const terminal = Object.values(stored).filter((r) => r.state === S.COMPLETED);
+    expect(terminal.length).toBe(OPERATION_LOG_MAX_TERMINAL);
+    expect(stored['op-0']).toBeUndefined(); // oldest pruned
+    expect(stored['op-live']).toBeDefined();
+  });
+});

--- a/tests/peerd-runtime/lifecycle/operation-state.test.ts
+++ b/tests/peerd-runtime/lifecycle/operation-state.test.ts
@@ -8,7 +8,7 @@
 import { describe, test, expect } from 'bun:test';
 import {
   OPERATION_STATES, TERMINAL_STATES, isTerminal, isOperationState,
-  canTransition, assertTransition, IllegalTransitionError,
+  canTransition, assertTransition, canRecoverySettle, IllegalTransitionError,
   provesCompletion, provesFailure, resolveUnknownOutcome,
   UnknownOutcomeUnresolvedError,
 } from '../../../extension/peerd-runtime/lifecycle/operation-state.js';
@@ -79,6 +79,25 @@ describe('transition legality', () => {
     expect(() => assertTransition(S.COMPLETED, S.RUNNING))
       .toThrow(IllegalTransitionError);
     expect(assertTransition(S.RUNNING, S.COMPLETED)).toBe(S.COMPLETED);
+  });
+});
+
+describe('recovery settling — the reconcile regime', () => {
+  test('any nonterminal state may settle to any terminal state…', () => {
+    const nonterminal = Object.values(S).filter((s) => !TERMINAL_STATES.has(s));
+    for (const from of nonterminal) {
+      for (const to of TERMINAL_STATES) {
+        if (from === S.AWAITING_USER && to === S.OUTCOME_UNKNOWN) continue;
+        expect(canRecoverySettle(from, to)).toBe(true);
+      }
+    }
+  });
+
+  test('…except awaiting_user → outcome_unknown, and never terminal→anything or →nonterminal', () => {
+    expect(canRecoverySettle(S.AWAITING_USER, S.OUTCOME_UNKNOWN)).toBe(false);
+    expect(canRecoverySettle(S.COMPLETED, S.FAILED)).toBe(false);
+    expect(canRecoverySettle(S.RUNNING, S.QUEUED)).toBe(false);
+    expect(canRecoverySettle('exploded', S.FAILED)).toBe(false);
   });
 });
 

--- a/tests/peerd-runtime/lifecycle/operation-state.test.ts
+++ b/tests/peerd-runtime/lifecycle/operation-state.test.ts
@@ -1,0 +1,115 @@
+// Canonical operation states — legality table + outcome_unknown resolution.
+//
+// The contract's guarantee 1 lives here: an uncertain side effect is never
+// silently reported as definitely failed or definitely completed. The
+// tests lock the transition table's edges and prove outcome_unknown has
+// exactly one exit — positive evidence.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  OPERATION_STATES, TERMINAL_STATES, isTerminal, isOperationState,
+  canTransition, assertTransition, IllegalTransitionError,
+  provesCompletion, provesFailure, resolveUnknownOutcome,
+  UnknownOutcomeUnresolvedError,
+} from '../../../extension/peerd-runtime/lifecycle/operation-state.js';
+
+const S = OPERATION_STATES;
+
+describe('state vocabulary', () => {
+  test('exactly the contract §3 states, no extras', () => {
+    expect(Object.values(S).sort()).toEqual([
+      'awaiting_remote', 'awaiting_user', 'cancelled', 'cancelling',
+      'completed', 'created', 'failed', 'interrupted', 'outcome_unknown',
+      'queued', 'running',
+    ]);
+  });
+
+  test('the five §3.1 terminal states, and only those', () => {
+    expect([...TERMINAL_STATES].sort()).toEqual([
+      'cancelled', 'completed', 'failed', 'interrupted', 'outcome_unknown',
+    ]);
+    expect(isTerminal(S.RUNNING)).toBe(false);
+    expect(isTerminal(S.OUTCOME_UNKNOWN)).toBe(true);
+  });
+
+  test('isOperationState rejects garbage', () => {
+    expect(isOperationState('running')).toBe(true);
+    expect(isOperationState('exploded')).toBe(false);
+    expect(isOperationState(undefined)).toBe(false);
+    expect(isOperationState(42)).toBe(false);
+  });
+});
+
+describe('transition legality', () => {
+  test('the ordinary forward path is legal', () => {
+    expect(canTransition(S.CREATED, S.QUEUED)).toBe(true);
+    expect(canTransition(S.QUEUED, S.RUNNING)).toBe(true);
+    expect(canTransition(S.RUNNING, S.AWAITING_REMOTE)).toBe(true);
+    expect(canTransition(S.AWAITING_REMOTE, S.COMPLETED)).toBe(true);
+    expect(canTransition(S.RUNNING, S.AWAITING_USER)).toBe(true);
+    expect(canTransition(S.AWAITING_USER, S.RUNNING)).toBe(true);
+  });
+
+  test('no transition leaves any terminal state', () => {
+    for (const from of TERMINAL_STATES) {
+      for (const to of Object.values(S)) {
+        expect(canTransition(from, to)).toBe(false);
+      }
+    }
+  });
+
+  test('awaiting_user can never reach outcome_unknown (no side effect is in flight while waiting on the user)', () => {
+    expect(canTransition(S.AWAITING_USER, S.OUTCOME_UNKNOWN)).toBe(false);
+    expect(canTransition(S.AWAITING_USER, S.INTERRUPTED)).toBe(true);
+  });
+
+  test('cancelling may still land completed — a landed effect is reported truthfully', () => {
+    expect(canTransition(S.CANCELLING, S.COMPLETED)).toBe(true);
+    expect(canTransition(S.CANCELLING, S.CANCELLED)).toBe(true);
+    expect(canTransition(S.CANCELLING, S.OUTCOME_UNKNOWN)).toBe(true);
+    expect(canTransition(S.CANCELLING, S.RUNNING)).toBe(false);
+  });
+
+  test('unknown states are never movable (fail closed)', () => {
+    expect(canTransition('exploded', S.FAILED)).toBe(false);
+    expect(canTransition(S.RUNNING, 'exploded')).toBe(false);
+  });
+
+  test('assertTransition throws a named error on illegal moves', () => {
+    expect(() => assertTransition(S.COMPLETED, S.RUNNING))
+      .toThrow(IllegalTransitionError);
+    expect(assertTransition(S.RUNNING, S.COMPLETED)).toBe(S.COMPLETED);
+  });
+});
+
+describe('outcome_unknown resolution — positive evidence only', () => {
+  test('completion evidence resolves to completed', () => {
+    for (const kind of ['success-response', 'verified-state',
+      'idempotency-key-lookup', 'durable-commit-check']) {
+      expect(provesCompletion(kind)).toBe(true);
+      expect(resolveUnknownOutcome({ kind })).toBe(S.COMPLETED);
+    }
+  });
+
+  test('failure evidence resolves to failed', () => {
+    for (const kind of ['error-response-before-effect', 'verified-absent',
+      'user-verified-absent']) {
+      expect(provesFailure(kind)).toBe(true);
+      expect(resolveUnknownOutcome({ kind })).toBe(S.FAILED);
+    }
+  });
+
+  test('a timeout or lost connection NEVER resolves outcome_unknown', () => {
+    for (const kind of ['timeout', 'connection-lost', 'probably-failed',
+      undefined, null, '']) {
+      expect(() => resolveUnknownOutcome({ kind }))
+        .toThrow(UnknownOutcomeUnresolvedError);
+    }
+  });
+
+  test('there is no automatic outcome_unknown → failed path anywhere', () => {
+    // Belt and braces: the transition table refuses it too.
+    expect(canTransition(S.OUTCOME_UNKNOWN, S.FAILED)).toBe(false);
+    expect(canTransition(S.OUTCOME_UNKNOWN, S.COMPLETED)).toBe(false);
+  });
+});

--- a/tests/peerd-runtime/lifecycle/reconcile.test.ts
+++ b/tests/peerd-runtime/lifecycle/reconcile.test.ts
@@ -6,7 +6,9 @@ import {
   reconcileAtStartup, buildTurnRecoveryRecord,
 } from '../../../extension/peerd-runtime/lifecycle/reconcile.js';
 import { mintGeneration } from '../../../extension/peerd-runtime/lifecycle/generation.js';
-import { OPERATION_STATES } from '../../../extension/peerd-runtime/lifecycle/operation-state.js';
+import {
+  OPERATION_STATES, TERMINAL_STATES, canRecoverySettle,
+} from '../../../extension/peerd-runtime/lifecycle/operation-state.js';
 import { LIFECYCLE_EVENTS } from '../../../extension/peerd-runtime/lifecycle/audit-events.js';
 
 const S = OPERATION_STATES;
@@ -105,6 +107,55 @@ describe('settling by retry class', () => {
   });
 });
 
+describe('every planned transition is applicable', () => {
+  test('exhaustive sweep: the plan only ever emits transitions settle() accepts', () => {
+    // The applicator is operationLog.settle (canRecoverySettle); a plan the
+    // applicator throws on would strand the orphan nonterminal forever.
+    const nonterminal = Object.values(OPERATION_STATES)
+      .filter((s) => !TERMINAL_STATES.has(s));
+    const evidences = [undefined, { kind: 'success-response' },
+      { kind: 'verified-absent' }, { kind: 'timeout' }];
+    const records = [];
+    let i = 0;
+    for (const state of nonterminal) {
+      for (const retryClass of ['A', 'B', 'C', 'D', 'E', 'F', undefined]) {
+        for (const dispatched of [false, true]) {
+          for (const cancelRequested of [false, true]) {
+            for (const evidence of evidences) {
+              records.push(record({
+                operationId: `op-${i += 1}`, state, retryClass,
+                dispatched, cancelRequested, evidence,
+              }));
+            }
+          }
+        }
+      }
+    }
+    const plan = reconcileAtStartup({ records, generation });
+    expect(plan.transitions.length).toBe(records.length);
+    for (const t of plan.transitions) {
+      expect(canRecoverySettle(t.from, t.to)).toBe(true);
+    }
+  });
+});
+
+describe('stale authority sweep', () => {
+  test('prior-generation and expired stamps land in staleAuthority with audit entries', () => {
+    const plan = reconcileAtStartup({
+      records: [],
+      generation,
+      authorityRecords: [
+        { generationId: generation.id },                    // live
+        { generationId: 'gen-6-old' },                      // stale generation
+        { generationId: generation.id, expiresAt: 1 },      // expired window
+      ],
+    });
+    expect(plan.staleAuthority.length).toBe(2);
+    const staleEvents = plan.auditEvents.filter((e) => e.event === 'lifecycle.grant.stale-refused');
+    expect(staleEvents.length).toBe(2);
+  });
+});
+
 describe('notifications and audit', () => {
   test('each settled operation notifies its parent session with the §5.4 record', () => {
     const plan = reconcileAtStartup({
@@ -138,6 +189,26 @@ describe('notifications and audit', () => {
     );
     expect(rr.sideEffectStatus).toBe('none attempted');
     expect(rr).not.toHaveProperty('verificationRequired');
+  });
+
+  test('an awaiting_user record with a bogus dispatched flag still reports "none attempted"', () => {
+    const plan = reconcileAtStartup({
+      records: [record({ state: S.AWAITING_USER, dispatched: true })],
+      generation,
+    });
+    expect(plan.notifications[0].recoveryRecord.sideEffectStatus).toBe('none attempted');
+  });
+
+  test('an evidence-settled operation records the COMPLETED audit event, not "interrupted"', () => {
+    const plan = reconcileAtStartup({
+      records: [record({
+        state: S.AWAITING_REMOTE, dispatched: true,
+        evidence: { kind: 'success-response' },
+      })],
+      generation,
+    });
+    expect(plan.transitions[0].to).toBe(S.COMPLETED);
+    expect(plan.auditEvents[1].event).toBe(LIFECYCLE_EVENTS.OPERATION_COMPLETED);
   });
 
   test('the plan always opens with the generation-changed audit event, and settles append theirs', () => {

--- a/tests/peerd-runtime/lifecycle/reconcile.test.ts
+++ b/tests/peerd-runtime/lifecycle/reconcile.test.ts
@@ -1,0 +1,165 @@
+// Startup reconciliation (§5.3) — a fresh SW generation settling the durable
+// records the last one left behind, plus the §5.4 recovery record shape.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  reconcileAtStartup, buildTurnRecoveryRecord,
+} from '../../../extension/peerd-runtime/lifecycle/reconcile.js';
+import { mintGeneration } from '../../../extension/peerd-runtime/lifecycle/generation.js';
+import { OPERATION_STATES } from '../../../extension/peerd-runtime/lifecycle/operation-state.js';
+import { LIFECYCLE_EVENTS } from '../../../extension/peerd-runtime/lifecycle/audit-events.js';
+
+const S = OPERATION_STATES;
+const generation = mintGeneration({ seq: 6, id: 'gen-6-old', mintedAt: 0 },
+  { nonce: 'fresh-nonce', now: 100 });
+
+const record = (overrides: Record<string, unknown>) => ({
+  operationId: 'op-1', sessionId: 'sess-1', toolName: 'fetch_url',
+  retryClass: 'B', createdAt: 1, attempt: 1, state: S.RUNNING,
+  generationId: 'gen-6-old',
+  ...overrides,
+});
+
+describe('which records reconcile', () => {
+  test('terminal records are immutable history', () => {
+    const plan = reconcileAtStartup({
+      records: [
+        record({ operationId: 'done', state: S.COMPLETED }),
+        record({ operationId: 'unk', state: S.OUTCOME_UNKNOWN }),
+        record({ operationId: 'gone', state: S.CANCELLED }),
+      ],
+      generation,
+    });
+    expect(plan.transitions).toEqual([]);
+  });
+
+  test('records stamped with the CURRENT generation are left alone', () => {
+    const plan = reconcileAtStartup({
+      records: [record({ generationId: generation.id })],
+      generation,
+    });
+    expect(plan.transitions).toEqual([]);
+  });
+
+  test('garbage records are skipped, not crashed on', () => {
+    const plan = reconcileAtStartup({
+      records: [null, {}, record({})] as any,
+      generation,
+    });
+    expect(plan.transitions.length).toBe(1);
+  });
+});
+
+describe('settling by retry class', () => {
+  test('an orphaned running Class B read lands interrupted', () => {
+    const plan = reconcileAtStartup({ records: [record({})], generation });
+    expect(plan.transitions[0]).toMatchObject({
+      operationId: 'op-1', from: S.RUNNING, to: S.INTERRUPTED,
+    });
+  });
+
+  test('a dispatched Class E side effect lands outcome_unknown with verification required', () => {
+    const plan = reconcileAtStartup({
+      records: [record({
+        toolName: 'submit_form', retryClass: 'E',
+        state: S.AWAITING_REMOTE, dispatched: true,
+      })],
+      generation,
+    });
+    const [t] = plan.transitions;
+    expect(t.to).toBe(S.OUTCOME_UNKNOWN);
+    expect(t.verdict.autoRetry).toBe(false);
+    expect(t.verdict.verificationRequired).toBe(true);
+  });
+
+  test('awaiting_user always lands interrupted — the dead confirmation cannot leave a side effect in flight', () => {
+    const plan = reconcileAtStartup({
+      records: [record({
+        toolName: 'submit_form', retryClass: 'E',
+        state: S.AWAITING_USER,
+        // Even a (bogus) dispatched flag cannot push awaiting_user into
+        // outcome_unknown — waiting on the user means nothing left peerd.
+        dispatched: true,
+      })],
+      generation,
+    });
+    expect(plan.transitions[0].to).toBe(S.INTERRUPTED);
+  });
+
+  test('a cancelling record honors the cancel: cancelled when undispatched', () => {
+    const plan = reconcileAtStartup({
+      records: [record({
+        retryClass: 'E', state: S.CANCELLING, cancelRequested: true,
+      })],
+      generation,
+    });
+    expect(plan.transitions[0].to).toBe(S.CANCELLED);
+  });
+
+  test('an unclassified record is treated as Class E (fail closed)', () => {
+    const plan = reconcileAtStartup({
+      records: [record({ retryClass: undefined, state: S.AWAITING_REMOTE, dispatched: true })],
+      generation,
+    });
+    expect(plan.transitions[0].to).toBe(S.OUTCOME_UNKNOWN);
+  });
+});
+
+describe('notifications and audit', () => {
+  test('each settled operation notifies its parent session with the §5.4 record', () => {
+    const plan = reconcileAtStartup({
+      records: [record({
+        actorId: 'actor-7', retryClass: 'E',
+        state: S.AWAITING_REMOTE, dispatched: true, lastDurableStep: 7,
+      })],
+      generation,
+    });
+    expect(plan.notifications).toEqual([{
+      sessionId: 'sess-1',
+      actorId: 'actor-7',
+      recoveryRecord: {
+        operation: 'fetch_url',
+        operationId: 'op-1',
+        previousState: S.AWAITING_REMOTE,
+        recoveryState: S.OUTCOME_UNKNOWN,
+        lastDurableStep: 7,
+        sideEffectStatus: 'outcome_unknown',
+        verificationRequired: true,
+      },
+    }]);
+  });
+
+  test('the safe shape says "none attempted"', () => {
+    const rr = buildTurnRecoveryRecord(
+      record({ state: S.RUNNING }) as any,
+      { state: S.INTERRUPTED, autoRetry: true, retryRequires: [],
+        keepIdempotencyKey: false, verificationRequired: false,
+        recreateResource: false, reason: 'r' },
+    );
+    expect(rr.sideEffectStatus).toBe('none attempted');
+    expect(rr).not.toHaveProperty('verificationRequired');
+  });
+
+  test('the plan always opens with the generation-changed audit event, and settles append theirs', () => {
+    const plan = reconcileAtStartup({
+      records: [record({}), record({
+        operationId: 'op-2', retryClass: 'E',
+        state: S.AWAITING_REMOTE, dispatched: true,
+      })],
+      generation,
+    });
+    expect(plan.auditEvents[0].event).toBe(LIFECYCLE_EVENTS.SW_GENERATION_CHANGED);
+    expect(plan.auditEvents[0].generationId).toBe(generation.id);
+    const events = plan.auditEvents.slice(1).map((e) => e.event);
+    expect(events).toEqual([
+      LIFECYCLE_EVENTS.OPERATION_INTERRUPTED,
+      LIFECYCLE_EVENTS.OUTCOME_UNKNOWN,
+    ]);
+    // Correlation: session → actor → operation → attempt → result.
+    const entry = plan.auditEvents[2];
+    expect(entry.sessionId).toBe('sess-1');
+    expect(entry.operationId).toBe('op-2');
+    expect(entry.attempt).toBe(1);
+    expect(entry.result).toBe(S.OUTCOME_UNKNOWN);
+  });
+});

--- a/tests/peerd-runtime/lifecycle/resource-recovery.test.ts
+++ b/tests/peerd-runtime/lifecycle/resource-recovery.test.ts
@@ -1,0 +1,307 @@
+// Engine-resource recovery (§9) — the four per-resource decision cores: what
+// a fresh generation may adopt from a surviving tab, how a notebook cell is
+// labelled, what a recreated WebVM must verify, and what an App rebuild
+// refuses to restore.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  revalidateDrivenTab, notebookCellState, vmRecoveryPlan, appSandboxRebuild,
+  NOTEBOOK_CELL_STATES,
+} from '../../../extension/peerd-runtime/lifecycle/resource-recovery.js';
+import { mintGeneration } from '../../../extension/peerd-runtime/lifecycle/generation.js';
+import { OPERATION_STATES } from '../../../extension/peerd-runtime/lifecycle/operation-state.js';
+
+const generation = mintGeneration({ seq: 3, id: 'gen-3-old', mintedAt: 0 },
+  { nonce: 'fresh-nonce', now: 1_000 });
+
+const ownership = (overrides: Record<string, unknown> = {}) => ({
+  tabId: 42,
+  sessionId: 'sess-1',
+  generationId: generation.id,
+  ...overrides,
+});
+
+describe('§9.4 revalidateDrivenTab — refusal paths', () => {
+  test('a vanished tab releases the ownership', () => {
+    const v = revalidateDrivenTab({
+      ownership: ownership(), liveTab: null, generation,
+    });
+    expect(v).toMatchObject({ adopt: false, disposition: 'release' });
+    expect(v.reason).toContain('gone or identity changed');
+  });
+
+  test('a tab id that no longer matches releases (ids are reused after a close)', () => {
+    const v = revalidateDrivenTab({
+      ownership: ownership(),
+      liveTab: { id: 43, url: 'https://example.com/x' },
+      generation,
+    });
+    expect(v.disposition).toBe('release');
+  });
+
+  test('a missing ownership record releases rather than adopting an unowned tab', () => {
+    const v = revalidateDrivenTab({
+      ownership: undefined as any,
+      liveTab: { id: 42, url: 'https://example.com/' },
+      generation,
+    });
+    expect(v).toMatchObject({ adopt: false, disposition: 'release' });
+  });
+
+  test('an unparseable live URL releases — an unnameable page cannot be policy-checked', () => {
+    for (const url of ['', 'not a url', 'about:blank', undefined as any]) {
+      const v = revalidateDrivenTab({
+        ownership: ownership(), liveTab: { id: 42, url }, generation,
+      });
+      expect(v.disposition).toBe('release');
+    }
+  });
+
+  test('a bound actor whose page navigated off its origin releases', () => {
+    const v = revalidateDrivenTab({
+      ownership: ownership({ boundOrigin: 'https://github.com' }),
+      liveTab: { id: 42, url: 'https://evil.example/pwn' },
+      generation,
+    });
+    expect(v.adopt).toBe(false);
+    expect(v.reason).toContain('navigated away');
+  });
+
+  test('an unparseable boundOrigin fails closed to release', () => {
+    const v = revalidateDrivenTab({
+      ownership: ownership({ boundOrigin: 'garbage' }),
+      liveTab: { id: 42, url: 'https://github.com/x' },
+      generation,
+    });
+    expect(v.disposition).toBe('release');
+  });
+
+  test('a bound actor still on its own origin adopts (port/case normalized)', () => {
+    const v = revalidateDrivenTab({
+      ownership: ownership({ boundOrigin: 'HTTPS://GitHub.com:443' }),
+      liveTab: { id: 42, url: 'https://github.com/peerd/pulls' },
+      generation,
+    });
+    expect(v).toMatchObject({ adopt: true, disposition: 'adopt' });
+  });
+
+  test('a sensitive live origin refuses the ACTOR, not the tab', () => {
+    const v = revalidateDrivenTab({
+      ownership: ownership(),
+      liveTab: { id: 42, url: 'https://mail.example.com/inbox' },
+      generation,
+      isSensitiveOrigin: (origin) => origin === 'https://mail.example.com',
+    });
+    expect(v).toMatchObject({ adopt: false, disposition: 'refuse-actor' });
+    expect(v.reason).toContain('sensitive origin');
+  });
+
+  test('sensitivity outranks the grant: a re-derived grant cannot buy a signed-in page', () => {
+    const v = revalidateDrivenTab({
+      ownership: ownership({ generationId: 'gen-3-old' }),
+      liveTab: { id: 42, url: 'https://mail.example.com/inbox' },
+      generation,
+      isSensitiveOrigin: () => true,
+      allowedByGrant: true,
+    });
+    expect(v.disposition).toBe('refuse-actor');
+  });
+});
+
+describe('§9.4 revalidateDrivenTab — generation and the grant', () => {
+  test('current-generation ownership adopts with no grant argument at all', () => {
+    const v = revalidateDrivenTab({
+      ownership: ownership(),
+      liveTab: { id: 42, url: 'https://example.com/x' },
+      generation,
+    });
+    expect(v).toMatchObject({ adopt: true, disposition: 'adopt' });
+  });
+
+  test('prior-generation ownership re-adopts ONLY with a re-derived grant', () => {
+    const v = revalidateDrivenTab({
+      ownership: ownership({ generationId: 'gen-3-old' }),
+      liveTab: { id: 42, url: 'https://example.com/x' },
+      generation,
+      allowedByGrant: true,
+    });
+    expect(v).toMatchObject({ adopt: true, disposition: 'adopt' });
+    expect(v.reason).toContain('re-derived grant');
+  });
+
+  test('fail closed: absent, false, and truthy-but-not-true all release', () => {
+    for (const allowedByGrant of [undefined, false, 'yes' as any, 1 as any]) {
+      const v = revalidateDrivenTab({
+        ownership: ownership({ generationId: 'gen-3-old' }),
+        liveTab: { id: 42, url: 'https://example.com/x' },
+        generation,
+        allowedByGrant,
+      });
+      expect(v.adopt).toBe(false);
+      expect(v.disposition).toBe('release');
+    }
+  });
+
+  test('an ownership record with NO generation stamp is a prior generation', () => {
+    const unstamped = revalidateDrivenTab({
+      ownership: ownership({ generationId: undefined }),
+      liveTab: { id: 42, url: 'https://example.com/x' },
+      generation,
+    });
+    expect(unstamped.disposition).toBe('release');
+    expect(revalidateDrivenTab({
+      ownership: ownership({ generationId: undefined }),
+      liveTab: { id: 42, url: 'https://example.com/x' },
+      generation,
+      allowedByGrant: true,
+    }).adopt).toBe(true);
+  });
+
+  test('no usable current generation releases even with a grant', () => {
+    const v = revalidateDrivenTab({
+      ownership: ownership(),
+      liveTab: { id: 42, url: 'https://example.com/x' },
+      generation: undefined as any,
+    });
+    expect(v.disposition).toBe('release');
+  });
+});
+
+describe('§9.2 notebookCellState', () => {
+  test('all four labels', () => {
+    expect(notebookCellState({ cell: { source: 'x = 1' }, currentGeneration: 4 }))
+      .toBe(NOTEBOOK_CELL_STATES.PERSISTED_SOURCE);
+    expect(notebookCellState({
+      cell: { source: 'x', output: '1', completedGeneration: 4 }, currentGeneration: 4,
+    })).toBe(NOTEBOOK_CELL_STATES.COMPLETED_RESULT);
+    expect(notebookCellState({ cell: { source: 'x', running: true }, currentGeneration: 4 }))
+      .toBe(NOTEBOOK_CELL_STATES.INTERRUPTED);
+    expect(notebookCellState({
+      cell: { source: 'x', output: '1', completedGeneration: 3 }, currentGeneration: 4,
+    })).toBe(NOTEBOOK_CELL_STATES.STALE_OUTPUT);
+  });
+
+  test('running outranks a stored output — the heap died mid-run', () => {
+    expect(notebookCellState({
+      cell: { running: true, output: 'old', completedGeneration: 4 },
+      currentGeneration: 4,
+    })).toBe('interrupted');
+  });
+
+  test('an output with a missing generation is stale, never completed', () => {
+    expect(notebookCellState({ cell: { output: '1' }, currentGeneration: 4 }))
+      .toBe('stale-output');
+    expect(notebookCellState({
+      cell: { output: '1', completedGeneration: '4' as any }, currentGeneration: 4,
+    })).toBe('stale-output');
+    expect(notebookCellState({
+      cell: { output: '1', completedGeneration: 4 }, currentGeneration: NaN,
+    })).toBe('stale-output');
+  });
+
+  test('an empty-string output is a real result, not unrun source', () => {
+    expect(notebookCellState({
+      cell: { output: '', completedGeneration: 2 }, currentGeneration: 2,
+    })).toBe('completed-result');
+    expect(notebookCellState({ cell: { output: null }, currentGeneration: 2 }))
+      .toBe('persisted-source');
+  });
+
+  test('garbage falls to persisted-source — the only claim needing no evidence', () => {
+    for (const input of [{}, { cell: null }, { cell: 'nope' }, null, undefined] as any[]) {
+      expect(notebookCellState(input)).toBe('persisted-source');
+    }
+  });
+});
+
+describe('§9.1 vmRecoveryPlan', () => {
+  const plan = vmRecoveryPlan({
+    vmRecord: { instanceId: 'vm-1', filesystemPersisted: true },
+    interruptedCommands: [
+      { commandId: 'c-read', retryClass: 'A' },
+      { commandId: 'c-opaque', dispatched: true },           // unclassified
+      { commandId: 'c-cancelled', retryClass: 'A', dispatched: true, cancelRequested: true },
+    ],
+  });
+
+  test('a persisted filesystem is VERIFIED, not trusted — it may be partly committed', () => {
+    expect(plan.verifyFilesystem).toBe(true);
+    expect(vmRecoveryPlan({ vmRecord: { instanceId: 'vm-2' } }).verifyFilesystem).toBe(false);
+  });
+
+  test('process state, imports and credentials always land the same way', () => {
+    for (const p of [plan, vmRecoveryPlan({}), vmRecoveryPlan(undefined as any)]) {
+      expect(p.processStateLost).toBe(true);
+      expect(p.revalidateImports).toBe(true);
+      expect(p.credentialsResident).toBe(false);
+    }
+  });
+
+  test('a Class A command lands interrupted and may auto-retry', () => {
+    const [readCommand] = plan.commands;
+    expect(readCommand.commandId).toBe('c-read');
+    expect(readCommand.verdict.state).toBe(OPERATION_STATES.INTERRUPTED);
+    expect(readCommand.verdict.autoRetry).toBe(true);
+  });
+
+  test('an unclassified dispatched command fails closed to outcome_unknown', () => {
+    const opaque = plan.commands[1];
+    expect(opaque.verdict.state).toBe(OPERATION_STATES.OUTCOME_UNKNOWN);
+    expect(opaque.verdict.autoRetry).toBe(false);
+    expect(opaque.verdict.verificationRequired).toBe(true);
+  });
+
+  test('an explicit cancel dominates recovery', () => {
+    expect(plan.commands[2].verdict.state).toBe(OPERATION_STATES.CANCELLED);
+    expect(plan.commands[2].verdict.autoRetry).toBe(false);
+  });
+
+  test('garbage commands are skipped, not crashed on', () => {
+    const p = vmRecoveryPlan({
+      vmRecord: { instanceId: 'vm-3' },
+      interruptedCommands: [null, {}, { commandId: 7 }, { commandId: 'ok' }] as any,
+    });
+    expect(p.commands.map((c) => c.commandId)).toEqual(['ok']);
+  });
+});
+
+describe('§9.3 appSandboxRebuild', () => {
+  test('restores the app\'s own files and nothing else', () => {
+    const rebuild = appSandboxRebuild({
+      appRecord: {
+        appId: 'app-7',
+        files: [
+          'index.html',
+          'peerd-apps/app-7/main.js',
+          'peerd-apps/app-9/secrets.js',   // another app's namespace
+          '../../etc/passwd',              // traversal
+          '/absolute/path.js',
+          '',
+          42,
+        ] as any,
+      },
+      tier: 'network-full',
+    });
+    expect(rebuild.restoredFiles).toEqual(['index.html', 'peerd-apps/app-7/main.js']);
+  });
+
+  test('an unnamed app or garbage record restores nothing', () => {
+    expect(appSandboxRebuild({ appRecord: { files: ['a.js'] } }).restoredFiles).toEqual([]);
+    expect(appSandboxRebuild({} as any).restoredFiles).toEqual([]);
+    expect(appSandboxRebuild(undefined as any).restoredFiles).toEqual([]);
+  });
+
+  test('the network tier is RE-DERIVED — a recorded tier never carries over', () => {
+    expect(appSandboxRebuild({
+      appRecord: { appId: 'app-7' }, tier: 'network-full',
+    }).networkTier).toBe('re-derive');
+  });
+
+  test('popups, downloads and in-flight actions are never restored or replayed', () => {
+    const rebuild = appSandboxRebuild({ appRecord: { appId: 'app-7', files: [] } });
+    expect(rebuild.popups).toBe('not-restored');
+    expect(rebuild.downloads).toBe('not-restored');
+    expect(rebuild.inFlightActions).toBe('not-replayed');
+    expect(rebuild.blobUrls).toBe('regenerate');
+  });
+});

--- a/tests/peerd-runtime/lifecycle/retry-class.test.ts
+++ b/tests/peerd-runtime/lifecycle/retry-class.test.ts
@@ -1,0 +1,181 @@
+// Retry classes A–F × interruption phases — the §15 fault matrix at the
+// pure-decision level. Each class is asserted against the three dispatch
+// phases the SW-eviction fault injections name (before dispatch, after
+// dispatch before response, with positive evidence), plus the cancellation
+// races: the explicit user action must win.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  RETRY_CLASSES, isRetryClass, normalizeRetryClass, decideRecovery,
+} from '../../../extension/peerd-runtime/lifecycle/retry-class.js';
+import { OPERATION_STATES } from '../../../extension/peerd-runtime/lifecycle/operation-state.js';
+
+const S = OPERATION_STATES;
+const C = RETRY_CLASSES;
+
+describe('class vocabulary', () => {
+  test('the six contract classes', () => {
+    expect(Object.values(C).sort()).toEqual(['A', 'B', 'C', 'D', 'E', 'F']);
+    expect(isRetryClass('E')).toBe(true);
+    expect(isRetryClass('G')).toBe(false);
+  });
+
+  test('unclassified actions fail closed to Class E', () => {
+    expect(normalizeRetryClass(undefined)).toBe(C.SIDE_EFFECT);
+    expect(normalizeRetryClass('yolo')).toBe(C.SIDE_EFFECT);
+    expect(normalizeRetryClass(3)).toBe(C.SIDE_EFFECT);
+    expect(normalizeRetryClass('A')).toBe(C.PURE_READ);
+  });
+});
+
+describe('the eviction matrix: interrupted before dispatch', () => {
+  test('Class A: interrupted, auto-retry free', () => {
+    const v = decideRecovery({ retryClass: 'A', dispatched: false });
+    expect(v.state).toBe(S.INTERRUPTED);
+    expect(v.autoRetry).toBe(true);
+  });
+
+  test('Class B: interrupted, auto-retry within budget as a new attempt with fresh credentials', () => {
+    const v = decideRecovery({ retryClass: 'B', dispatched: false });
+    expect(v.state).toBe(S.INTERRUPTED);
+    expect(v.autoRetry).toBe(true);
+    expect(v.retryRequires).toEqual(['new-attempt', 'fresh-credentials']);
+  });
+
+  test('Class B with budget exhausted: no auto-retry, budget is a precondition', () => {
+    const v = decideRecovery({ retryClass: 'B', dispatched: false, budgetRemaining: false });
+    expect(v.autoRetry).toBe(false);
+    expect(v.retryRequires).toContain('budget');
+  });
+
+  test('Class C: interrupted, auto-retry with the SAME idempotency key', () => {
+    const v = decideRecovery({ retryClass: 'C', dispatched: false });
+    expect(v.state).toBe(S.INTERRUPTED);
+    expect(v.autoRetry).toBe(true);
+    expect(v.keepIdempotencyKey).toBe(true);
+  });
+
+  test('Class D undispatched: interrupted, retry keeps the original key', () => {
+    const v = decideRecovery({ retryClass: 'D', dispatched: false });
+    expect(v.state).toBe(S.INTERRUPTED);
+    expect(v.autoRetry).toBe(true);
+    expect(v.keepIdempotencyKey).toBe(true);
+  });
+
+  test('Class E undispatched: interrupted and safe, but NEVER auto-retried', () => {
+    const v = decideRecovery({ retryClass: 'E', dispatched: false });
+    expect(v.state).toBe(S.INTERRUPTED);
+    expect(v.autoRetry).toBe(false);
+    expect(v.retryRequires).toEqual(['user-instruction']);
+  });
+
+  test('Class F: interrupted, resource recreated, grants re-derived, no continuation', () => {
+    const v = decideRecovery({ retryClass: 'F', dispatched: false });
+    expect(v.state).toBe(S.INTERRUPTED);
+    expect(v.autoRetry).toBe(false);
+    expect(v.recreateResource).toBe(true);
+    expect(v.retryRequires).toEqual(['rederive-grants']);
+  });
+});
+
+describe('the eviction matrix: dispatched, no acknowledgement', () => {
+  test('Class A/B/C reads and idempotent writes stay interrupted and retryable', () => {
+    for (const retryClass of ['A', 'B', 'C']) {
+      const v = decideRecovery({ retryClass, dispatched: true });
+      expect(v.state).toBe(S.INTERRUPTED);
+      expect(v.autoRetry).toBe(true);
+    }
+  });
+
+  test('Class D dispatched: outcome_unknown, verification before retry, original key retained', () => {
+    const v = decideRecovery({ retryClass: 'D', dispatched: true });
+    expect(v.state).toBe(S.OUTCOME_UNKNOWN);
+    expect(v.autoRetry).toBe(false);
+    expect(v.verificationRequired).toBe(true);
+    expect(v.keepIdempotencyKey).toBe(true);
+    expect(v.retryRequires).toContain('external-verification');
+  });
+
+  test('Class E dispatched: outcome_unknown, never automatic retry — the ambiguous-ack case', () => {
+    // The fake-external-service scenario (§15): effect performed, connection
+    // dropped before the ack. peerd must say outcome_unknown, not retry.
+    const v = decideRecovery({ retryClass: 'E', dispatched: true });
+    expect(v.state).toBe(S.OUTCOME_UNKNOWN);
+    expect(v.autoRetry).toBe(false);
+    expect(v.verificationRequired).toBe(true);
+    expect(v.retryRequires).toEqual(['external-verification', 'user-instruction']);
+  });
+
+  test('a generic timeout is not failed: no evidence means no failed verdict for any dispatched class', () => {
+    for (const retryClass of ['A', 'B', 'C', 'D', 'E', 'F']) {
+      const v = decideRecovery({ retryClass, dispatched: true });
+      expect(v.state).not.toBe(S.FAILED);
+      expect(v.state).not.toBe(S.COMPLETED);
+    }
+  });
+});
+
+describe('positive evidence settles everything', () => {
+  test('completion evidence → completed, for every class', () => {
+    for (const retryClass of ['A', 'B', 'C', 'D', 'E', 'F']) {
+      const v = decideRecovery({
+        retryClass, dispatched: true, evidence: { kind: 'success-response' },
+      });
+      expect(v.state).toBe(S.COMPLETED);
+    }
+  });
+
+  test('failure evidence → failed', () => {
+    const v = decideRecovery({
+      retryClass: 'E', dispatched: true,
+      evidence: { kind: 'error-response-before-effect' },
+    });
+    expect(v.state).toBe(S.FAILED);
+  });
+
+  test('timeout is not evidence — a Class E call with only a timeout stays outcome_unknown', () => {
+    const v = decideRecovery({
+      retryClass: 'E', dispatched: true, evidence: { kind: 'timeout' },
+    });
+    expect(v.state).toBe(S.OUTCOME_UNKNOWN);
+  });
+});
+
+describe('cancellation races: the explicit user action wins', () => {
+  test('cancel before dispatch: cancelled, for every class', () => {
+    for (const retryClass of ['A', 'B', 'C', 'D', 'E', 'F']) {
+      const v = decideRecovery({ retryClass, dispatched: false, cancelRequested: true });
+      expect(v.state).toBe(S.CANCELLED);
+      expect(v.autoRetry).toBe(false);
+    }
+  });
+
+  test('cancel after a Class E dispatch: outcome_unknown, not a false "cancelled"', () => {
+    const v = decideRecovery({ retryClass: 'E', dispatched: true, cancelRequested: true });
+    expect(v.state).toBe(S.OUTCOME_UNKNOWN);
+    expect(v.verificationRequired).toBe(true);
+  });
+
+  test('cancel after an idempotent dispatch: cancelled cleanly (duplicates are harmless)', () => {
+    for (const retryClass of ['A', 'B', 'C']) {
+      const v = decideRecovery({ retryClass, dispatched: true, cancelRequested: true });
+      expect(v.state).toBe(S.CANCELLED);
+    }
+  });
+
+  test('cancel + completion evidence: reported completed — a landed effect is never hidden', () => {
+    const v = decideRecovery({
+      retryClass: 'E', dispatched: true, cancelRequested: true,
+      evidence: { kind: 'verified-state' },
+    });
+    expect(v.state).toBe(S.COMPLETED);
+  });
+
+  test('cancel + proven-absent: a clean cancelled', () => {
+    const v = decideRecovery({
+      retryClass: 'E', dispatched: true, cancelRequested: true,
+      evidence: { kind: 'verified-absent' },
+    });
+    expect(v.state).toBe(S.CANCELLED);
+  });
+});

--- a/tests/peerd-runtime/lifecycle/store-registry.test.ts
+++ b/tests/peerd-runtime/lifecycle/store-registry.test.ts
@@ -1,0 +1,221 @@
+// The durable-surface registry (§11.1 independent per-store versions,
+// §12 durability tiers) — registry invariants, the check/stamp pair
+// (including the §11.5 downgrade refusal), and the transfer surface's
+// §12 disclosure of omitted device-bound state.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  DURABILITY_TIERS, STORE_REGISTRY, VERSION_STAMP_KEY,
+  storeEntry, portableStores, omittedDeviceBoundStores,
+  checkStores, stampStores,
+} from '../../../extension/peerd-runtime/lifecycle/store-registry.js';
+import { buildExport, inspectImport, EXPORT_FORMAT, EXPORT_VERSION } from '/peerd-runtime/transfer/transfer.js';
+
+/** An in-memory stand-in for the SW's kv adapter: the WHOLE stamp map. */
+const stampIo = (initial?: Record<string, number>) => {
+  let map = initial ? { ...initial } : undefined;
+  const writes: Array<Record<string, number>> = [];
+  return {
+    get current() { return map; },
+    writes,
+    read: async () => (map ? { ...map } : undefined),
+    write: async (next: Record<string, number>) => { map = { ...next }; writes.push({ ...next }); },
+  };
+};
+
+describe('registry invariants', () => {
+  test('names are unique and lowercase-hyphenated', () => {
+    const names = STORE_REGISTRY.map((entry) => entry.store);
+    expect(new Set(names).size).toBe(names.length);
+    for (const name of names) expect(name).toMatch(/^[a-z]+(-[a-z]+)*$/);
+  });
+
+  test('every version is a positive integer', () => {
+    for (const entry of STORE_REGISTRY) {
+      expect(Number.isInteger(entry.version)).toBe(true);
+      expect(entry.version).toBeGreaterThan(0);
+    }
+  });
+
+  test('tiers are from the §12 vocabulary; nothing durable is ephemeral', () => {
+    const tiers = new Set(Object.values(DURABILITY_TIERS));
+    for (const entry of STORE_REGISTRY) {
+      expect(tiers.has(entry.tier)).toBe(true);
+      // EPHEMERAL exists so callers can LABEL non-durable state; a store
+      // in this registry survives the process by definition.
+      expect(entry.tier).not.toBe(DURABILITY_TIERS.EPHEMERAL);
+      expect(typeof entry.portable).toBe('boolean');
+    }
+  });
+
+  test('device-bound surfaces are never portable — dpop-keys is the archetype', () => {
+    const dpop = storeEntry('dpop-keys');
+    if (!dpop) throw new Error('dpop-keys must be registered');
+    expect(dpop.deviceBound).toBe(true);
+    expect(dpop.portable).toBe(false);
+    for (const entry of STORE_REGISTRY) {
+      if (entry.deviceBound) expect(entry.portable).toBe(false);
+    }
+    expect(omittedDeviceBoundStores()).toContain('dpop-keys');
+    expect(portableStores().map((e) => e.store)).not.toContain('dpop-keys');
+  });
+
+  test('the registry is frozen and the stamp key is stable', () => {
+    expect(Object.isFrozen(STORE_REGISTRY)).toBe(true);
+    expect(Object.isFrozen(STORE_REGISTRY[0])).toBe(true);
+    expect(VERSION_STAMP_KEY).toBe('peerd.lifecycle.storeVersions');
+    expect(storeEntry('nope')).toBeUndefined();
+  });
+});
+
+describe('checkStores', () => {
+  test('an unstamped profile is firstRun and writable', async () => {
+    const io = stampIo();
+    const result = await checkStores(io);
+    expect(result.ok).toBe(true);
+    for (const check of result.stores) {
+      expect(check.firstRun).toBe(true);
+      expect(check.stamped).toBeUndefined();
+      expect(check.mode).toBe('read-write');
+      expect(check.versionClass).toBe('current');
+    }
+  });
+
+  test('a current stamp is read-write and NOT firstRun', async () => {
+    const io = stampIo(Object.fromEntries(STORE_REGISTRY.map((e) => [e.store, e.version])));
+    const result = await checkStores(io);
+    expect(result.ok).toBe(true);
+    const sessions = result.stores.find((s) => s.store === 'sessions');
+    expect(sessions?.mode).toBe('read-write');
+    expect(sessions?.firstRun).toBeUndefined();
+    expect(sessions?.stamped).toBe(storeEntry('sessions')!.version);
+  });
+
+  test('a NEWER stamp fails read-only with a diagnostic and sinks ok (§11.5)', async () => {
+    const supported = storeEntry('memory')!.version;
+    const io = stampIo({ memory: supported + 4 });
+    const result = await checkStores(io);
+    expect(result.ok).toBe(false);
+    const memory = result.stores.find((s) => s.store === 'memory');
+    expect(memory?.mode).toBe('read-only');
+    expect(memory?.versionClass).toBe('newer');
+    expect(memory?.diagnosticId).toBe(`store-memory-newer-v${supported + 4}`);
+    expect(memory?.reason).toContain('newer than this peerd supports');
+    // Independent versions (§11.1): the skew is memory's alone.
+    expect(result.stores.find((s) => s.store === 'sessions')?.mode).toBe('read-write');
+  });
+
+  test('a malformed stamp fails closed too', async () => {
+    const io = stampIo({ audit: 'v1' as unknown as number });
+    const result = await checkStores(io);
+    expect(result.ok).toBe(false);
+    const audit = result.stores.find((s) => s.store === 'audit');
+    expect(audit?.mode).toBe('read-only');
+    expect(audit?.diagnosticId).toBe('store-audit-malformed-version');
+    expect(audit?.firstRun).toBeUndefined(); // stamped, just unreadable
+  });
+});
+
+describe('stampStores', () => {
+  test('stamps every unstamped surface at this build\'s version', async () => {
+    const io = stampIo();
+    const stamped = await stampStores(io);
+    expect(stamped).toEqual(STORE_REGISTRY.map((e) => e.store));
+    expect(io.current).toEqual(Object.fromEntries(STORE_REGISTRY.map((e) => [e.store, e.version])));
+    // ...and the freshly stamped profile now checks out as current.
+    const after = await checkStores(io);
+    expect(after.ok).toBe(true);
+    expect(after.stores.every((s) => s.firstRun === undefined)).toBe(true);
+  });
+
+  test('never lowers a NEWER stamp — that is the downgrade refusal', async () => {
+    const io = stampIo({ sessions: storeEntry('sessions')!.version + 7 });
+    const stamped = await stampStores(io);
+    expect(stamped).not.toContain('sessions');
+    expect(io.current?.sessions).toBe(storeEntry('sessions')!.version + 7);
+  });
+
+  test('never raises an OLDER stamp — stamping is a migration\'s final act', async () => {
+    const io = stampIo({ hooks: 0 });
+    const stamped = await stampStores(io);
+    expect(stamped).not.toContain('hooks');
+    expect(io.current?.hooks).toBe(0);
+    // A malformed stamp is left for diagnosis rather than clobbered.
+    const malformed = stampIo({ audit: 'nope' as unknown as number });
+    await stampStores(malformed);
+    expect(malformed.current?.audit).toBe('nope' as unknown as number);
+  });
+
+  test('idempotent on rerun: same list, no second write', async () => {
+    const io = stampIo();
+    const first = await stampStores(io);
+    const second = await stampStores(io);
+    expect(second).toEqual(first);
+    expect(io.writes.length).toBe(1);
+  });
+});
+
+describe('transfer carries the §12 durability labels', () => {
+  const exportArgs = {
+    channel: 'preview' as const,
+    storedSettings: { devMode: true },
+    providerEndpoints: null,
+    secrets: { anthropic: 'sk-1' },
+    passphrase: 'a long passphrase',
+    memory: { version: 1, docs: [{ id: 'user', body: 'x', updatedAt: 5 }] },
+    hooks: [{ id: 'h1', event: 'pre-tool-use' }],
+    skills: [{ id: 's1', name: 'review' }],
+  };
+
+  test('buildExport names the omitted device-bound surfaces and labels included sections', async () => {
+    const payload = await buildExport(exportArgs);
+    expect(payload.version).toBe(EXPORT_VERSION); // purely additive
+    expect(payload.durability.omittedDeviceBound).toContain('dpop-keys');
+    expect(payload.durability.omittedDeviceBound).toEqual(omittedDeviceBoundStores());
+    expect(payload.durability.tiers).toEqual({
+      vault: DURABILITY_TIERS.PROFILE,
+      memory: DURABILITY_TIERS.PORTABLE,
+      skills: DURABILITY_TIERS.PORTABLE,
+      hooks: DURABILITY_TIERS.PORTABLE,
+    });
+  });
+
+  test('absent sections are not labelled', async () => {
+    const payload = await buildExport({
+      ...exportArgs, secrets: {}, passphrase: '', memory: null, hooks: [], skills: [],
+    });
+    expect(payload.durability.tiers).toEqual({});
+    expect(payload.durability.omittedDeviceBound).toContain('dpop-keys');
+  });
+
+  test('inspectImport surfaces the block, with a notice', async () => {
+    const payload = await buildExport(exportArgs);
+    const res = inspectImport({ payload, channel: 'preview', knownSettingKeys: ['devMode'] });
+    if (!res.ok || !res.summary) throw new Error('expected ok summary'); // narrow the union for TS
+    expect(res.summary.omittedDeviceBound).toContain('dpop-keys');
+    expect(res.summary.durabilityTiers.memory).toBe(DURABILITY_TIERS.PORTABLE);
+    expect(res.summary.notices.some((n: string) => n.includes('Device-bound state'))).toBe(true);
+  });
+
+  test('a LEGACY payload without the block still imports cleanly', () => {
+    const legacy = {
+      format: EXPORT_FORMAT,
+      version: EXPORT_VERSION,
+      exportedAt: '2026-06-11T00:00:00.000Z',
+      channel: 'preview',
+      settings: { devMode: true },
+      providerEndpoints: null,
+      secrets: null,
+      memory: null,
+      hooks: [],
+      skills: [],
+    };
+    const res = inspectImport({ payload: legacy, channel: 'preview', knownSettingKeys: ['devMode'] });
+    expect(res.ok).toBe(true);
+    if (!res.summary) throw new Error('expected ok summary');
+    // Absent means UNLABELLED, never "nothing was omitted" — so no notice.
+    expect(res.summary.durabilityTiers).toEqual({});
+    expect(res.summary.omittedDeviceBound).toEqual([]);
+    expect(res.summary.notices).toEqual([]);
+  });
+});

--- a/tests/peerd-runtime/lifecycle/store-version.test.ts
+++ b/tests/peerd-runtime/lifecycle/store-version.test.ts
@@ -40,8 +40,14 @@ describe('the downgrade contract: newer schemas fail read-only', () => {
 });
 
 const steps = [
-  { from: 1, to: 2, migrate: (d: Record<string, unknown>) => ({ ...d, renamed: d.old, old: undefined as unknown }), drops: [] },
-  { from: 2, to: 3, migrate: (d: Record<string, unknown>) => { const { legacy, ...rest } = d; return { ...rest, count: 0 }; }, drops: ['legacy'] },
+  {
+    from: 1, to: 2, drops: ['old'],
+    migrate: (d: Record<string, unknown>) => { const { old, ...rest } = d; return { ...rest, renamed: old }; },
+  },
+  {
+    from: 2, to: 3, drops: ['legacy'],
+    migrate: (d: Record<string, unknown>) => { const { legacy, ...rest } = d; return { ...rest, count: 0 }; },
+  },
 ];
 
 describe('runMigration — the happy chain', () => {
@@ -107,6 +113,44 @@ describe('runMigration — failure preserves the original', () => {
     if (result.ok) return;
     expect(result.diagnosticId).toBe('migrate-memory-step-v1-dropped-quietly_dropped');
     expect(result.data).toEqual({ keep: 1, quietly_dropped: 2 });
+  });
+
+  test('setting a key to undefined is a drop too — it would vanish at the persistence layer', () => {
+    const result = runMigration({
+      store: 'memory', data: { keep: 1, erased: 2 },
+      fromVersion: 1, toVersion: 2,
+      steps: [{ from: 1, to: 2, migrate: (d: Record<string, unknown>) => ({ ...d, erased: undefined }) }],
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.diagnosticId).toBe('migrate-memory-step-v1-dropped-erased');
+  });
+
+  test('a step mutating a NESTED object cannot corrupt the caller\'s original', () => {
+    const data = { settings: { theme: 'dark' } };
+    const result = runMigration({
+      store: 'settings', data, fromVersion: 1, toVersion: 2,
+      steps: [{
+        from: 1, to: 2,
+        migrate: (d: Record<string, unknown>) => {
+          (d.settings as Record<string, unknown>).theme = 'CLOBBERED';
+          throw new Error('boom after mutation');
+        },
+      }],
+    });
+    expect(result.ok).toBe(false);
+    expect(data.settings.theme).toBe('dark'); // original untouched at depth
+  });
+
+  test('a malformed checkpoint fails closed instead of re-running or NaN-ing the cursor', () => {
+    const result = runMigration({
+      store: 's', data: { a: 1 }, fromVersion: 1, toVersion: 3, steps,
+      checkpointVersion: Number.NaN,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.diagnosticId).toBe('migrate-s-malformed-checkpoint');
+    expect(result.resumeFrom).toBe(1);
   });
 
   test('downgrade is refused', () => {

--- a/tests/peerd-runtime/lifecycle/store-version.test.ts
+++ b/tests/peerd-runtime/lifecycle/store-version.test.ts
@@ -1,0 +1,161 @@
+// Versioned stores + migration (§11) — forward-only, restart-safe,
+// idempotent, refuse-newer fails read-only, failure preserves the original
+// with a diagnostic id, undeclared field drops fail the run.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  classifyStoreVersion, guardStore, runMigration,
+} from '../../../extension/peerd-runtime/lifecycle/store-version.js';
+
+describe('classification', () => {
+  test('the five classes', () => {
+    expect(classifyStoreVersion({ found: 3, supported: 3 })).toBe('current');
+    expect(classifyStoreVersion({ found: 2, supported: 3 })).toBe('migratable');
+    expect(classifyStoreVersion({ found: 4, supported: 3 })).toBe('newer');
+    expect(classifyStoreVersion({ found: 1, supported: 3, oldestMigratable: 2 })).toBe('unsupported');
+    expect(classifyStoreVersion({ found: 'v3' as any, supported: 3 })).toBe('malformed');
+    expect(classifyStoreVersion({ found: -1, supported: 3 })).toBe('malformed');
+  });
+});
+
+describe('the downgrade contract: newer schemas fail read-only', () => {
+  test('a newer profile is refused for mutation, never reinterpreted as empty or corrupt', () => {
+    const guard = guardStore({ store: 'sessions', found: 9, supported: 3 });
+    expect(guard.mode).toBe('read-only');
+    expect(guard.versionClass).toBe('newer');
+    expect(guard.reason).toContain('newer than this peerd supports');
+    expect(guard.diagnosticId).toBe('store-sessions-newer-v9');
+  });
+
+  test('malformed versions also fail closed with a diagnostic, original retained', () => {
+    const guard = guardStore({ store: 'vault', found: undefined, supported: 2 });
+    expect(guard.mode).toBe('read-only');
+    expect(guard.diagnosticId).toBe('store-vault-malformed-version');
+  });
+
+  test('current and migratable open normally', () => {
+    expect(guardStore({ store: 's', found: 2, supported: 2 }).mode).toBe('read-write');
+    expect(guardStore({ store: 's', found: 1, supported: 2 }).mode).toBe('migrate');
+  });
+});
+
+const steps = [
+  { from: 1, to: 2, migrate: (d: Record<string, unknown>) => ({ ...d, renamed: d.old, old: undefined as unknown }), drops: [] },
+  { from: 2, to: 3, migrate: (d: Record<string, unknown>) => { const { legacy, ...rest } = d; return { ...rest, count: 0 }; }, drops: ['legacy'] },
+];
+
+describe('runMigration — the happy chain', () => {
+  test('runs forward, preserves unknown fields, stamps only on success', () => {
+    const result = runMigration({
+      store: 'sessions',
+      data: { old: 'x', legacy: true, mystery: 'keep-me' },
+      fromVersion: 1, toVersion: 3, steps,
+    });
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.version).toBe(3);
+    expect(result.data.mystery).toBe('keep-me'); // unknown field survived
+    expect(result.data.renamed).toBe('x');
+    expect(result.completedSteps).toEqual([2, 3]);
+  });
+
+  test('already-current input is a no-op success (idempotent rerun)', () => {
+    const result = runMigration({
+      store: 'sessions', data: { a: 1 }, fromVersion: 3, toVersion: 3, steps,
+    });
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.version).toBe(3);
+    expect(result.data).toEqual({ a: 1 });
+  });
+
+  test('restart-safety: a checkpoint resumes past completed steps', () => {
+    // The v1→v2 step already ran before the interruption; the rerun must
+    // skip it (rerunning it would misread already-migrated data).
+    const result = runMigration({
+      store: 'sessions',
+      data: { renamed: 'x', legacy: true, mystery: 'keep-me' },
+      fromVersion: 1, toVersion: 3, steps, checkpointVersion: 2,
+    });
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.completedSteps).toEqual([3]);
+    expect(result.data.renamed).toBe('x');
+    expect(result.data.mystery).toBe('keep-me');
+  });
+});
+
+describe('runMigration — failure preserves the original', () => {
+  const original = { old: 'x', legacy: true };
+
+  test('a throwing step returns the ORIGINAL data and a deterministic diagnostic', () => {
+    const result = runMigration({
+      store: 'skills', data: original, fromVersion: 1, toVersion: 3,
+      steps: [{ from: 1, to: 2, migrate: () => { throw new Error('boom'); } }],
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.data).toEqual(original);
+    expect(result.diagnosticId).toBe('migrate-skills-step-v1-threw');
+    expect(result.failedStep).toEqual({ from: 1, to: 2 });
+  });
+
+  test('an undeclared field drop fails the run — silent discard is structurally impossible', () => {
+    const result = runMigration({
+      store: 'memory', data: { keep: 1, quietly_dropped: 2 },
+      fromVersion: 1, toVersion: 2,
+      steps: [{ from: 1, to: 2, migrate: ({ keep }) => ({ keep }) }],
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.diagnosticId).toBe('migrate-memory-step-v1-dropped-quietly_dropped');
+    expect(result.data).toEqual({ keep: 1, quietly_dropped: 2 });
+  });
+
+  test('downgrade is refused', () => {
+    const result = runMigration({
+      store: 'audit', data: original, fromVersion: 5, toVersion: 3, steps,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.diagnosticId).toBe('migrate-audit-downgrade-v5');
+  });
+
+  test('backward or gapped chains are refused', () => {
+    const backward = runMigration({
+      store: 's', data: original, fromVersion: 1, toVersion: 2,
+      steps: [{ from: 2, to: 1, migrate: (d: Record<string, unknown>) => d }],
+    });
+    expect(backward.ok).toBe(false);
+
+    const gapped = runMigration({
+      store: 's', data: original, fromVersion: 1, toVersion: 3,
+      steps: [{ from: 2, to: 3, migrate: (d: Record<string, unknown>) => d }],
+    });
+    expect(gapped.ok).toBe(false);
+    if (gapped.ok) return;
+    expect(gapped.reason).toContain('no migration step from v1');
+  });
+
+  test('malformed payloads and versions fail closed, data untouched', () => {
+    for (const data of [null, 'string', 42, ['array']]) {
+      const result = runMigration({
+        store: 's', data, fromVersion: 1, toVersion: 2, steps,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) continue;
+      expect(result.data).toBe(data);
+    }
+    const badVersion = runMigration({
+      store: 's', data: {}, fromVersion: '1' as any, toVersion: 2, steps,
+    });
+    expect(badVersion.ok).toBe(false);
+  });
+
+  test('a step returning a non-record fails, original retained', () => {
+    const result = runMigration({
+      store: 's', data: original, fromVersion: 1, toVersion: 2,
+      steps: [{ from: 1, to: 2, migrate: () => null as any }],
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.data).toEqual(original);
+  });
+});

--- a/tests/peerd-runtime/lifecycle/tool-retry-class.test.ts
+++ b/tests/peerd-runtime/lifecycle/tool-retry-class.test.ts
@@ -1,0 +1,217 @@
+// Tool → retry class: the derivation rules, and §16.1's inventory obligation
+// ("every side-effecting tool has a retry classification") asserted against the
+// REAL registered tool list rather than a hand-copied one — so a new tool def
+// that lands without a considered class fails here, not in production recovery.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  retryClassForTool, RETRY_CLASS_OVERRIDES,
+} from '../../../extension/peerd-runtime/lifecycle/tool-retry-class.js';
+import { isRetryClass } from '../../../extension/peerd-runtime/lifecycle/retry-class.js';
+
+// why the stub + dynamic import: the tool defs are BROWSER modules — the
+// barrels transitively pull in vendor/browser-polyfill.js, which throws unless
+// `chrome.runtime.id` exists. A static import would hoist above any assignment
+// in this file, so the globals are planted first and the inventory is pulled in
+// with top-level `await import`. Only the surface the defs touch AT MODULE LOAD
+// is stubbed; nothing here executes a tool.
+(globalThis as unknown as { chrome: unknown }).chrome = {
+  runtime: {
+    id: 'peerd-test',
+    getURL: (path: string) => `chrome-extension://peerd-test/${path}`,
+    getManifest: () => ({ version: '0.0.0' }),
+    onMessage: { addListener: () => {} },
+    sendMessage: async () => undefined,
+  },
+  storage: {
+    local: { get: async () => ({}), set: async () => {}, remove: async () => {} },
+    session: { get: async () => ({}), set: async () => {} },
+  },
+  tabs: {
+    query: async () => [],
+    onUpdated: { addListener: () => {} },
+    onRemoved: { addListener: () => {} },
+  },
+  alarms: { onAlarm: { addListener: () => {} } },
+};
+
+const { BUILTIN_TOOLS } = await import('../../../extension/peerd-runtime/tools/defs/index.js');
+const { WEB_TOOLS } = await import('../../../extension/peerd-runtime/tools/web/index.js');
+const { CLOCK_TOOLS } = await import('../../../extension/peerd-runtime/clock/index.js');
+
+/** The whole registered inventory the SW assembles at boot. */
+const ALL_TOOLS = [...BUILTIN_TOOLS, ...WEB_TOOLS, ...CLOCK_TOOLS];
+
+const byName = new Map(ALL_TOOLS.map((t) => [t.name, t] as const));
+
+const classOf = (name: string): string => {
+  const tool = byName.get(name);
+  if (!tool) throw new Error(`no registered tool named ${name}`);
+  return retryClassForTool(tool);
+};
+
+describe('explicit declaration precedence', () => {
+  test('a valid explicit retryClass wins over every derivation', () => {
+    // A tab click would derive E; the def says A, and the def is honoured.
+    expect(retryClassForTool({
+      name: 'click', sideEffect: 'write', primitive: 'tab', retryClass: 'A',
+    })).toBe('A');
+    expect(retryClassForTool({
+      name: 'inspect', sideEffect: 'read', primitive: 'inspect', retryClass: 'F',
+    })).toBe('F');
+  });
+
+  test('an INVALID explicit retryClass is ignored, never coerced — derivation still runs', () => {
+    // Garbage that looked authoritative must not license a replay: it falls
+    // through to the taxonomy, which here says "pure read".
+    expect(retryClassForTool({
+      name: 'read_page', sideEffect: 'read', primitive: 'tab', retryClass: 'Z',
+    })).toBe('A');
+    // …and on a non-read the fallthrough is the closed one.
+    expect(retryClassForTool({
+      name: 'submit', sideEffect: 'mutate_external', primitive: 'tab', retryClass: 'Z',
+    })).toBe('E');
+    for (const junk of ['', 'a', 'AA', 3, null, {}, [], true]) {
+      expect(retryClassForTool({
+        name: 'x', sideEffect: 'write', primitive: 'tab', retryClass: junk,
+      })).toBe('E');
+    }
+  });
+});
+
+describe('derivation from the declared taxonomy', () => {
+  test('an unnamed read is Class A — local reads cost nothing to repeat', () => {
+    expect(retryClassForTool({ name: 'inspect', sideEffect: 'read', primitive: 'inspect' })).toBe('A');
+    expect(retryClassForTool({ name: 'anything', sideEffect: 'read', primitive: 'web' })).toBe('A');
+  });
+
+  test('a named network read is Class B — repeatable, but it spends something', () => {
+    expect(retryClassForTool({ name: 'fetch_url', sideEffect: 'read', primitive: 'web' })).toBe('B');
+    expect(retryClassForTool({ name: 'read_doc', sideEffect: 'read', primitive: 'web' })).toBe('B');
+  });
+
+  test('a write on a workspace primitive is Class C', () => {
+    for (const primitive of ['webvm', 'notebook', 'app', 'engine', 'dweb']) {
+      expect(retryClassForTool({ name: 'w', sideEffect: 'write', primitive })).toBe('C');
+    }
+  });
+
+  test('a write on a tab primitive is Class E — a click on a live page is not idempotent', () => {
+    expect(retryClassForTool({ name: 'w', sideEffect: 'write', primitive: 'tab' })).toBe('E');
+  });
+
+  test('a write on any other primitive fails CLOSED to Class E', () => {
+    for (const primitive of ['web', 'spawned', 'memory', 'schedule', 'time', 'nonsense', '']) {
+      expect(retryClassForTool({ name: 'w', sideEffect: 'write', primitive })).toBe('E');
+    }
+  });
+
+  test('mutate_external is Class E by default, Class D only where named', () => {
+    expect(retryClassForTool({ name: 'w', sideEffect: 'mutate_external', primitive: 'dweb' })).toBe('E');
+    expect(retryClassForTool({ name: 'dweb_share', sideEffect: 'mutate_external', primitive: 'dweb' })).toBe('D');
+  });
+
+  test('destructive is Class E, and no name override can soften it', () => {
+    expect(retryClassForTool({ name: 'w', sideEffect: 'destructive', primitive: 'app' })).toBe('E');
+    // fetch_url is a Class B name; declared destructive it is still E.
+    expect(retryClassForTool({ name: 'fetch_url', sideEffect: 'destructive', primitive: 'web' })).toBe('E');
+    expect(retryClassForTool({ name: 'dweb_share', sideEffect: 'destructive', primitive: 'dweb' })).toBe('E');
+  });
+});
+
+describe('garbage in, Class E out', () => {
+  test('null / undefined / non-objects / empty descriptors all fail closed', () => {
+    expect(retryClassForTool(null)).toBe('E');
+    expect(retryClassForTool(undefined)).toBe('E');
+    expect(retryClassForTool({})).toBe('E');
+    for (const junk of [42, 'fetch_url', true, Symbol('x')]) {
+      expect(retryClassForTool(junk as unknown as { name?: string })).toBe('E');
+    }
+  });
+
+  test('an unknown sideEffect is not a read', () => {
+    expect(retryClassForTool({ name: 'mystery', sideEffect: 'reads', primitive: 'inspect' })).toBe('E');
+    expect(retryClassForTool({ name: 'mystery', primitive: 'inspect' })).toBe('E');
+  });
+});
+
+describe('§16.1 — the whole registered inventory is classified', () => {
+  test('the inventory actually loaded', () => {
+    expect(ALL_TOOLS.length).toBeGreaterThan(50);
+    expect(byName.size).toBe(ALL_TOOLS.length);
+  });
+
+  test('EVERY registered tool resolves to a valid retry class', () => {
+    const unclassified = ALL_TOOLS
+      .map((tool) => [tool.name, retryClassForTool(tool)] as const)
+      .filter(([, cls]) => !isRetryClass(cls));
+    expect(unclassified).toEqual([]);
+  });
+
+  test('no side-effecting tool is classified as a retry-freely READ class', () => {
+    const readClasses = new Set(['A', 'B']);
+    const offenders = ALL_TOOLS
+      .filter((tool) => tool.sideEffect !== 'read')
+      .filter((tool) => readClasses.has(retryClassForTool(tool)))
+      .map((tool) => tool.name);
+    expect(offenders).toEqual([]);
+  });
+
+  test('every destructive tool lands on Class E', () => {
+    const destructive = ALL_TOOLS.filter((tool) => tool.sideEffect === 'destructive');
+    expect(destructive.length).toBeGreaterThan(0);
+    for (const tool of destructive) expect(retryClassForTool(tool)).toBe('E');
+  });
+
+  test('the override table has no dead entries — every name is a registered tool', () => {
+    const dead = Object.keys(RETRY_CLASS_OVERRIDES).filter((name) => !byName.has(name));
+    expect(dead).toEqual([]);
+  });
+
+  test('the override table is frozen', () => {
+    expect(Object.isFrozen(RETRY_CLASS_OVERRIDES)).toBe(true);
+  });
+});
+
+describe('spot checks against the real defs', () => {
+  const EXPECTED: ReadonlyArray<readonly [string, string]> = [
+    // A — local reads; a duplicate is invisible.
+    ['inspect', 'A'],
+    ['read_page', 'A'],
+    ['read_web_cache', 'A'],
+    ['now', 'A'],
+    // B — reads that cross the network.
+    ['fetch_url', 'B'],
+    ['read_pdf', 'B'],
+    ['dweb_discover', 'B'],
+    // C — deterministic local workspace writes.
+    ['js_write_file', 'C'],
+    ['vm_write_file', 'C'],
+    ['app_write_file', 'C'],
+    ['dweb_block', 'C'],
+    // D — content-addressed publish: verify, then reuse the key.
+    ['dweb_share', 'D'],
+    // E — live-page actions, external mutations, arbitrary code, deletes.
+    ['click', 'E'],
+    ['type', 'E'],
+    ['navigate', 'E'],
+    ['open_tab', 'E'],
+    ['js_notebook', 'E'],
+    ['script', 'E'],
+    ['a2a_run', 'E'],
+    ['message_actor', 'E'],
+    ['vm_delete', 'E'],
+    ['app_delete', 'E'],
+    // F — long-lived resources: recreate, never continue.
+    ['sandbox_create', 'F'],
+    ['vm_boot', 'F'],
+    ['actor_create', 'F'],
+    ['request_review', 'F'],
+  ];
+
+  for (const [name, expected] of EXPECTED) {
+    test(`${name} → Class ${expected}`, () => {
+      expect(classOf(name)).toBe(expected);
+    });
+  }
+});

--- a/tests/peerd-runtime/lifecycle/write-guard.test.ts
+++ b/tests/peerd-runtime/lifecycle/write-guard.test.ts
@@ -1,0 +1,111 @@
+// The §11.5 write guard — read-only verdicts enforced at the adapter
+// chokepoint: blocked surfaces refuse writes with a named error, reads
+// always pass, unblocked surfaces are untouched.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  makeWriteGuard, StoreReadOnlyError,
+} from '../../../extension/peerd-runtime/lifecycle/write-guard.js';
+import { STORE_REGISTRY } from '../../../extension/peerd-runtime/lifecycle/store-registry.js';
+
+const makeKv = () => {
+  const map = new Map<string, unknown>();
+  return {
+    map,
+    get: async (k: string) => map.get(k),
+    set: async (k: string, v: unknown) => { map.set(k, v); },
+    delete: async (k: string) => { map.delete(k); },
+    list: async () => Object.fromEntries(map),
+  };
+};
+
+const makeIdb = () => {
+  const ops: string[] = [];
+  return {
+    ops,
+    get: async (store: string, key: string) => { ops.push(`get:${store}:${key}`); return undefined; },
+    put: async (store: string) => { ops.push(`put:${store}`); },
+    del: async (store: string) => { ops.push(`del:${store}`); },
+    getAll: async (store: string) => { ops.push(`getAll:${store}`); return []; },
+    clear: async (store: string) => { ops.push(`clear:${store}`); },
+  };
+};
+
+describe('registry physical mapping', () => {
+  test('every registry entry declares where its bytes live', () => {
+    for (const entry of STORE_REGISTRY) {
+      const physical = (entry as { physical?: Record<string, string[]> }).physical;
+      expect(physical).toBeDefined();
+      const locations = [
+        ...(physical!.kvKeys ?? []), ...(physical!.kvPrefixes ?? []),
+        ...(physical!.idbStores ?? []), ...(physical!.selfHosted ?? []),
+      ];
+      expect(locations.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('kv enforcement', () => {
+  test('blocking a store refuses writes to its keys and prefixes, reads pass', async () => {
+    const guard = makeWriteGuard();
+    const kv = guard.wrapKv(makeKv());
+    await kv.set('hooks.user.v1', { a: 1 });          // pre-block: fine
+    guard.block(['hooks', 'vault']);
+    expect(() => kv.set('hooks.user.v1', { a: 2 })).toThrow(StoreReadOnlyError);
+    expect(() => kv.set('secret:openai-key', 'x')).toThrow(StoreReadOnlyError); // vault prefix
+    expect(() => kv.delete('hooks.user.v1')).toThrow(StoreReadOnlyError);
+    await expect(kv.get('hooks.user.v1')).resolves.toEqual({ a: 1 }); // reads pass
+    await kv.set('settings.v1', {});                   // unrelated key untouched
+    await kv.set('peerd.lifecycle.operations', {});    // lifecycle keys never blocked
+  });
+
+  test('the thrown error names the store and promises no data changed', () => {
+    const guard = makeWriteGuard();
+    const kv = guard.wrapKv(makeKv());
+    guard.block(['hooks']);
+    try {
+      kv.set('hooks.user.v1', {});
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect((e as StoreReadOnlyError).name).toBe('StoreReadOnlyError');
+      expect((e as Error).message).toContain("'hooks'");
+      expect((e as Error).message).toContain('no data was changed');
+    }
+  });
+});
+
+describe('idb enforcement', () => {
+  test('write verbs refuse for blocked object stores; reads and other stores pass', async () => {
+    const guard = makeWriteGuard();
+    const raw = makeIdb();
+    const idb = guard.wrapIdb(raw);
+    guard.block(['sessions', 'audit']);
+    expect(() => idb.put('sessions')).toThrow(StoreReadOnlyError);
+    expect(() => idb.del('session_messages')).toThrow(StoreReadOnlyError);
+    expect(() => idb.clear('audit_log')).toThrow(StoreReadOnlyError);
+    await idb.get('sessions', 'x');                    // read passes
+    await idb.put('contacts');                         // unblocked store passes
+    expect(raw.ops).toEqual(['get:sessions:x', 'put:contacts']);
+  });
+
+  test('idbKV adapters wrap per object store', async () => {
+    const guard = makeWriteGuard();
+    const sets: string[] = [];
+    const adapter = { get: async () => undefined, set: async (k: string) => { sets.push(k); } };
+    const vms = guard.wrapIdbKvAdapter('vms', adapter);
+    await vms.set('webvms.v1', {});
+    guard.block(['engine-registries']);
+    expect(() => vms.set('webvms.v1', {})).toThrow(StoreReadOnlyError);
+    expect(sets).toEqual(['webvms.v1']);
+  });
+});
+
+describe('bookkeeping', () => {
+  test('block is additive and idempotent; unknown names are ignored', () => {
+    const guard = makeWriteGuard();
+    guard.block(['hooks']);
+    guard.block(['hooks', 'no-such-store']);
+    guard.block(['memory']);
+    expect(guard.blockedStores().sort()).toEqual(['hooks', 'memory']);
+  });
+});

--- a/tests/peerd-runtime/observability.test.ts
+++ b/tests/peerd-runtime/observability.test.ts
@@ -49,6 +49,13 @@ describe('classifyFailure — the strings the codebase actually produces', () =>
     ['the actor turn failed: pytest exited 1', 'agent'],
     ['(the actor produced no text reply)', 'agent'],
     ['TypeError: cannot read properties of undefined', 'internal'],
+    // The lifecycle contract's stable result prefixes (PR #314).
+    ['outcome_unknown: This action may have completed, but peerd did not receive confirmation. Check the target before repeating it. (submit_form: request timed out)', 'environment'],
+    ['interrupted: The read or model call was interrupted. Retrying may incur additional network or model cost. (fetch_url: connection reset)', 'environment'],
+    ['cancelled: submit_form was stopped before its effect landed (aborted)', 'aborted'],
+    ['outcome_unknown: submit_form was already dispatched and its result is lost. It may have completed — verify the external state before repeating it. Not re-executing automatically.', 'policy'],
+    ['completed: submit_form already completed on a previous dispatch of this same call — not re-executing. Use the recorded result or issue a NEW operation.', 'policy'],
+    ['failed: submit_form was NOT executed — lifecycle tracking is unavailable (quota exceeded) and a non-idempotent action must not run untracked: an interruption could then never be reported or guarded against. Retry once storage recovers, or run a read-only alternative.', 'policy'],
   ];
   for (const [text, kind] of cases) {
     test(`"${text.slice(0, 52)}…" → ${kind}`, () => {

--- a/tests/peerd-runtime/page-call-handler.test.ts
+++ b/tests/peerd-runtime/page-call-handler.test.ts
@@ -100,3 +100,18 @@ describe('page-call handler — failures surface as the worker sees them', () =>
     expect(dispatchToolCall).not.toHaveBeenCalled();
   });
 });
+
+describe('dispatch call identity', () => {
+  test('every page.* dispatch mints a UNIQUE call id — even with no rid', async () => {
+    // The lifecycle tracker keys operations on (sessionId, call id); a
+    // constant id made the second page write in a session read as a replay
+    // of the first and refuse (wiring-review finding, PR #314).
+    const { handle, dispatched } = harness();
+    await handle({ method: 'click', args: { selector: 'a' }, sessionId: 's1', tabId: 42 });
+    await handle({ method: 'click', args: { selector: 'a' }, sessionId: 's1', tabId: 42 });
+    await handle({ method: 'goto', args: { url: 'https://example.com' }, sessionId: 's1', tabId: 42 });
+    const ids = dispatched.map((d) => d.call.id);
+    expect(new Set(ids).size).toBe(3);
+    for (const id of ids) expect(id.startsWith('page-')).toBe(true);
+  });
+});


### PR DESCRIPTION
## What & why

Implements the peerd Lifecycle and Recovery Contract end to end: a pure-core module (`extension/peerd-runtime/lifecycle/` — 18 files) plus the wiring that makes it live in the real extension. Four waves on this branch:

### Wave 1 — the functional core

- **`operation-state.js`** — canonical states, transition legality, `outcome_unknown`'s single evidence-gated exit; recovery settling as its own sanctioned regime.
- **`retry-class.js` / `tool-retry-class.js`** — Class A–F + `decideRecovery`; every live tool resolves to a class (fail-closed to E), inventory-tested (§16.1).
- **`generation.js` / `confirmation.js`** — SW generations with wholesale stale-authority refusal; single-use approvals bound to one action/normalized target/operation/generation/window.
- **`reconcile.js` / `operation-log.js`** — the startup recovery plan; the durable §8 record with mutation-queue serialization, duplicate-begin refusal, corruption tolerance, and bounded retention.
- **`store-version.js` / `store-registry.js`** — independent per-store schema versions with physical location mapping; forward-only checkpoint-resumable idempotent migrations that structurally refuse undeclared field drops.
- **`audit-events.js` / `recovery-report.js` / `failure-taxonomy.js`** — the audit vocabulary; paired user/agent §14 categories; typed failure outcomes.

### Wave 2 — wired into the live extension

- **Dispatcher tracking** (`dispatch-tracking.js` + an optional seam in `tools/dispatcher.js`): durable operation recorded *before* execute, settled from the outcome; the generation-gated **replay guard**; `beginTracking` can never reject into fail-open.
- **SW boot** (`boot.js`): generation mint → orphan reconcile → audit → per-store schema check/stamp → queue-serialized recovery notices routed to the root chat; `purgeSession` wires §2.5 cancellation dominance into session archive.
- **§9 engines** (`resource-recovery.js` + `engine-liveness.js`): pure recovery decisions + a durable liveness ledger; the boot sweep reaps dead-tab instances with audit + resource-lost notices.
- **Downstream truthfulness**: failure-classifier rows for the recovery prefixes; the orphan-repair tool_result defers to the interruption-recovery note; the Stop-race message no longer asserts a definite "never happened".

### Wave 3 — fault injection + historical fixtures

- `fault-injection.test.ts`: 14 kill-point tests over a programmable faulty-storage adapter.
- `historical-fixtures.test.ts`: real profiles reconstructed from the shapes peerd 0.1.0/0.2.2/0.2.8 wrote (provenance commits cited) — which caught and fixed a real authority-widening regression (legacy `actTier` falling through to confirm-OFF against DECISIONS §18).

### Wave 4 — the pre-merge hardening pass (external review's six requirements)

1. **Self-hosted stores guarded**: `peerd-skills` and `peerd-app-bodies` (own databases, unreachable through the wrapped adapters) now take injected write gates bound to the shared guard's verdict — "older peerd never mutates a newer profile" holds **universally**.
2. **Burden of proof inverted**: a dispatched Class D/E failure settles `failed` only on a typed `pre-effect-failure`; any unrecognized error defaults to `outcome_unknown` — string heuristics may widen ambiguity, never establish non-execution. `click`/`type` stamp their provable pre-effect refusals.
3. **Fail-closed proven at the boundary**: `dispatch-boundary-guarantees.test.ts` drives the real `dispatchToolCall` with execution spies — begin-throws/boot-failed/pending-boot × Class D/E never enter `execute()`; persist-before-report ordering; formatter id preservation. Each test is named for the guarantee whose mutation would break it.
4. **Tombstones + overflow evidence**: pruned D/E records mint compact tombstones (5,000-cap) the tracker consults before `begin` — replay identity outlives the diagnostic cap; compacted unknowns leave an audited overflow record parked as a user notice — never a silent forget.
5. **Confirmation forensic chain**: an approved confirm mints a single-use, generation-bound proof, consumed pre-dispatch and persisted on the durable record; C/D records carry deterministic args-hash idempotency keys.
6. **Fixture breadth**: `profile-v0.4.0.json` (current shapes, non-default settings, bound actor, the first durability-block envelope) + `profile-maximal-historical.json` (a labelled composite torture profile: mixed-era records, an actor mid-excursion, partial store stamping, 41 sessions) — +49 no-loss cases.

### Review process

**Five multi-agent review rounds** (opus + fable swarms with adversarial verification) plus an external human-style verdict pass: **21 swarm-confirmed defects fixed** in dedicated commits, the external review's six requirements all closed in wave 4. A pre-existing ~1/256 DPoP test flake was also fixed.

### Verified

`bun test` 4569 pass (354 files; ~600 lifecycle-specific) · in-browser 718 pass (headless CDP) · `e2e:verify` 128/128 checks across 21 states against the live unpacked extension · strict typecheck · ESLint · dweb boundary · tscheck floor 618.

### Documented tradeoffs / follow-ups

- Composite operation identity (turn id + ordinal + name alongside the provider call id) — the current session-scoped identity is formatter-tested; the richer identity is follow-up.
- Structured completion evidence required from Class D/E tools (today `ok:true` maps to `success-response` evidence at the tracker).
- Firefox e2e parity (the repo's e2e lane is Chrome-pinned; bun + in-browser tiers are browser-agnostic).
- Contract §17 non-goals: stream resumption, VM snapshots, exactly-once across arbitrary services.

Closes #

## Checklist

- [x] All gates green locally; CI running on the final head
- [x] Only original code — no GPL / AGPL / copyleft
- [x] Tests added: 21 Bun test files, 3 in-browser real-storage fault tests, 5 historical fixtures with cited provenance
- [x] No hand-edited generated files
- [x] Danger zone: touches the dispatcher seam, SW boot, turn-driver context, tab trackers, storage adapters, and the skills/app-bodies stores — reads fail open, non-idempotent writes fail closed, all e2e-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011p1G83iPX9SxYSyt3xe45K