### PR TITLE
feat(distributed): add portable identity backup and restore

### DIFF
--- a/docs/design/portable-identity/01-identity-capsule.md
+++ b/docs/design/portable-identity/01-identity-capsule.md
@@ -1,0 +1,23 @@
+# Identity capsule
+
+Status: implemented for manual backup and restore.
+
+The identity remains a random Ed25519 seed stored under the local vault. For
+portability, the seed and public key are encrypted with AES-GCM under a fresh
+capsule key. A credential-derived AES-KW key wraps that capsule key.
+
+This extra layer matters: credentials can be added or removed by rewrapping a
+small random key without changing the root identity or re-encrypting its
+contents.
+
+The landed backup flow creates one Argon2id password wrapper. No passkey wrapper
+or hosted-record locator ships before its product ceremony and relying-party
+boundary are designed end to end.
+
+The local runtime still loads the vault-protected seed directly. This change
+does not claim that the root is non-extractable or that routine signing has
+moved to a device key.
+
+Security checks live with the implementation: record, wrapper, base64, and KDF
+inputs are bounded; temporary key bytes are cleared where JavaScript permits;
+and capsule authentication failures use typed errors.

--- a/docs/design/portable-identity/02-recovery-record.md
+++ b/docs/design/portable-identity/02-recovery-record.md
@@ -1,0 +1,45 @@
+# Recovery record and manual transfer
+
+Status: implemented for preview backup files.
+
+The recovery record contains an advertised did, an encrypted capsule, credential
+wrappers, and version metadata. It can be carried as ciphertext, but it is still
+sensitive: anyone who steals it can guess the backup passphrase offline against
+a permanent signing root. Use a long, unique passphrase and protect the file as
+carefully as an account recovery code. Its did and wrapper metadata are not
+private.
+
+On export, the existing peerd backup passphrase creates the identity wrapper.
+Every new passphrase-protected section uses the same fixed Argon2id policy, so
+the credentials section cannot become a cheaper password oracle for the
+permanent identity. Older PBKDF2 credential boxes remain import-only for
+backup compatibility. New files use the current export version so older builds
+reject them clearly instead of misreporting a correct password as wrong.
+Raw identity and device-key vault entries are excluded before any generic-secret
+decryption or payload shaping. If an existing identity cannot be protected, the
+whole export fails instead of silently producing an incomplete backup.
+
+On import, password decryption and the identity decision happen before any
+write. The record is accepted only when the recovered seed/public-key pair
+proves itself and derives the advertised did. A record for the same did must
+still authenticate. A different did stops the import and asks the user to keep
+the local identity or explicitly replace it. Adoption is then the final import
+commit, after every ordinary settings/data write has succeeded.
+
+Replacement is refused while locally authored apps are shared because their
+publisher and content identifiers are derived from the current did. Unshare
+them first; this release does not pretend to migrate identity-bound app state.
+
+Chrome hosts record crypto in the existing offscreen dweb page. Raw identity
+material and the passphrase travel only over dedicated ports accepted from the
+exact options page and exact offscreen document, never over extension-wide
+broadcast messaging. A static test keeps the service worker as the only shipped
+runtime connection receiver because Chrome ports can otherwise have multiple
+receivers.
+Firefox, which has no offscreen API, loads the preview dweb client in its
+background context. Both paths use the same crypto core and serialized vault
+mutation lane.
+
+The record is not persisted as a second local identity store. It is constructed
+for export and consumed during import; the existing vault secret remains the
+single local source of truth.

--- a/docs/design/portable-identity/03-device-subkeys.md
+++ b/docs/design/portable-identity/03-device-subkeys.md
@@ -1,0 +1,15 @@
+# Device subkeys
+
+Status: proposal; no device-key or certificate code is shipped by this change.
+
+Portable roots increase the cost of using the permanent identity key for daily
+traffic. A later design may let the person root certify short-lived,
+per-install Ed25519 device keys while peers continue to key trust, blocks, and
+rate limits by the person did.
+
+That cannot land as isolated certificate helpers. The wire verifier must first
+accept both root-signed and certificate-backed forms across handshakes, Agent
+Cards, envelopes, manifests, and A2A. Only after that compatibility path is
+tested can routine signing switch to a device key.
+
+Until then, the root remains the routine signer and documentation must say so.

--- a/docs/design/portable-identity/04-canonical-rp.md
+++ b/docs/design/portable-identity/04-canonical-rp.md
@@ -1,0 +1,16 @@
+# Canonical relying party
+
+Status: proposal; blocked on an owner decision and work in the separate site
+repository.
+
+The extension-origin vault passkey cannot be a portable website credential:
+WebAuthn binds it to the extension origin, and an extension cannot claim
+`peerd.ai` as its relying-party ID.
+
+A future portable passkey therefore needs a stable HTTPS relying party, such as
+`id.peerd.ai`, with a small auditable ceremony page. Choosing that RP is
+effectively permanent because changing it orphans credentials. Hosting,
+deployment integrity, recovery-record storage, challenge binding, and the
+extension-to-page transport all require their own threat model and live tests.
+
+None of that surface is part of the manual backup implementation.

--- a/docs/design/portable-identity/05-peerd-connect.md
+++ b/docs/design/portable-identity/05-peerd-connect.md
@@ -1,0 +1,15 @@
+# Website identity capabilities
+
+Status: proposal.
+
+A website-facing identity API must issue narrow, origin-bound capabilities; it
+must never return seeds, capsule keys, PRF outputs, the vault key, or an
+unsupervised signing oracle.
+
+Any future protocol needs transport-derived origins, explicit user consent,
+short expiry, revocation, and signature-domain separation so site-requested
+bytes cannot verify as peerd envelopes, certificates, or manifests. Its first
+useful subset would be identity disclosure and namespaced message signing.
+
+This depends on the canonical relying party and a real person/device key split.
+It is intentionally not scaffolded by the manual backup change.

--- a/docs/design/portable-identity/README.md
+++ b/docs/design/portable-identity/README.md
@@ -1,0 +1,54 @@
+# Portable identity
+
+The implemented feature is deliberately small: a preview user can include the
+existing `did:key` identity in a password-protected peerd backup and restore it
+on another preview install. The random Ed25519 seed stays the identity root; it
+is encrypted in a capsule rather than derived from a password or passkey.
+
+The code is the specification:
+
+- Capsule and credential wrappers: `extension/peerd-distributed/identity/`
+- Chrome/Firefox crypto hosting and vault custody: `extension/background/dweb-transfer.js`
+- Backup shaping and import staging: `extension/peerd-runtime/transfer/transfer.js`
+- User flow: `extension/options/sections/transfer.js`
+
+## What is implemented
+
+- AES-GCM capsule encryption under a random key.
+- One fixed Argon2id policy for new credential boxes and identity wrappers,
+  with legacy PBKDF2 credential boxes accepted only on import.
+- A bounded, versioned recovery record that binds the decrypted seed and public
+  key to its advertised did.
+- Manual backup/restore in preview builds. Chrome runs record crypto in the
+  offscreen host; Firefox runs the same dweb client in its background context.
+- Fail-loud export, targeted custody RPC, authenticated same-did import,
+  serialized custody reads and changes, and a two-step keep/replace decision
+  when the local did differs or its stored material is unreadable.
+- An exact-options backup Port, guarded transfer routes, and a static
+  single-receiver check keep backup passwords off broadcast messaging.
+- Structural exclusion of raw identity and device-key secrets from the generic
+  encrypted-secrets section.
+
+## What is not implemented
+
+- Passkey wrappers, enrollment, or recovery ceremonies.
+- Device subkeys. The permanent root remains the routine mesh signer.
+- QR transfer, hosted recovery records, or automatic synchronization.
+- A canonical `peerd.ai` relying party or a website-facing identity protocol.
+- A checked-in live Chrome-to-Firefox end-to-end proof. Both host paths have
+  automated boundary coverage; a real two-browser ceremony remains release
+  validation work.
+
+## Invariants
+
+1. The did is derived from the recovered public key and must match the record.
+2. The recovered seed must sign a proof verifiable by the supplied public key.
+3. The raw custody secret never travels through the generic secrets map.
+4. A wrong password, malformed record, or identity conflict found during
+   preflight causes no ordinary writes. A final identity-commit failure reports
+   the exact ordinary sections already restored and never claims atomicity.
+5. Replacing a different local identity requires a separate explicit action.
+6. Replacement is refused while local shared apps remain identity-bound.
+7. Store packages stay dweb-free.
+
+The remaining documents separate the landed mechanisms from later proposals.

--- a/extension/background/dweb-custody-client.js
+++ b/extension/background/dweb-custody-client.js
@@ -1,0 +1,174 @@
+// @ts-check
+// Targeted service-worker client for portable-identity custody operations.
+//
+// why a Port: runtime.sendMessage broadcasts its request to every extension
+// page. These calls carry the permanent identity seed and backup passphrase,
+// so they must travel only over the exact offscreen document's verified port.
+
+export class DwebCustodyPortError extends Error {
+  /** @param {string} message @param {string} code @param {{ cause?: unknown }} [options] */
+  constructor(message, code, options = {}) {
+    super(message, options);
+    this.name = 'DwebCustodyPortError';
+    this.code = code;
+  }
+}
+
+/**
+ * Cache only a successful boot reset. A timed-out or disconnected attempt is
+ * cleared so the next caller can retry on the reconnected custody port.
+ * @param {{ enabled: boolean, hostAvailable: boolean, reset: () => Promise<void> }} deps
+ */
+export const makeRetryableCustodyReset = ({ enabled, hostAvailable, reset }) => {
+  let complete = false;
+  /** @type {Promise<void> | null} */
+  let inFlight = null;
+  const ensure = async () => {
+    if (!enabled || !hostAvailable) return;
+    if (complete) return;
+    if (!inFlight) {
+      inFlight = Promise.resolve()
+        .then(reset)
+        .then(() => { complete = true; })
+        .finally(() => { inFlight = null; });
+    }
+    await inFlight;
+  };
+  return { ensure };
+};
+
+/**
+ * @param {Object} deps
+ * @param {() => Promise<void>} deps.ensureOffscreen
+ * @param {(operation: 'get'|'set', args: any) => Promise<any>} deps.handleSecretRequest
+ * @param {number} [deps.timeoutMs]
+ * @param {() => string} [deps.newRequestId]
+ */
+export const makeDwebCustodyClient = ({
+  ensureOffscreen, handleSecretRequest, timeoutMs = 60_000,
+  newRequestId = () => crypto.randomUUID(),
+}) => {
+  /** @type {import('webextension-polyfill').Runtime.Port | null} */
+  let activePort = null;
+  /** @type {Set<() => void>} */
+  const connectedWaiters = new Set();
+  /** @type {Map<string, { resolve: (value: any) => void, reject: (reason: any) => void, timer: ReturnType<typeof setTimeout> }>} */
+  const pending = new Map();
+
+  /** @param {string} code @param {string} message */
+  const rejectPending = (code, message) => {
+    for (const entry of pending.values()) {
+      clearTimeout(entry.timer);
+      entry.reject(new DwebCustodyPortError(message, code));
+    }
+    pending.clear();
+  };
+
+  /**
+   * Attach only after the service worker has verified `port.sender` with
+   * isOffscreenSender. The client deliberately does not duplicate that browser-
+   * owned provenance check with payload data.
+   * @param {import('webextension-polyfill').Runtime.Port} port
+   */
+  const attach = (port) => {
+    if (activePort && activePort !== port) {
+      rejectPending('port-replaced', 'the identity custody host reconnected');
+      try { activePort.disconnect(); } catch { /* already disconnected */ }
+    }
+    activePort = port;
+    for (const resolve of connectedWaiters) resolve();
+    connectedWaiters.clear();
+
+    port.onMessage.addListener((/** @type {any} */ message) => {
+      if (message?.type === 'custody/response' && typeof message.requestId === 'string') {
+        const entry = pending.get(message.requestId);
+        if (!entry) return;
+        pending.delete(message.requestId);
+        clearTimeout(entry.timer);
+        if (message.ok) entry.resolve(message.result);
+        else entry.reject(new DwebCustodyPortError(
+          'identity custody operation failed',
+          typeof message.error === 'string' ? message.error : 'host-failed',
+        ));
+        return;
+      }
+      if (message?.type !== 'custody/secret-request'
+          || typeof message.requestId !== 'string'
+          || !['get', 'set'].includes(message.operation)) return;
+      /** @param {any} response */
+      const respond = (response) => {
+        if (activePort !== port) return;
+        try { port.postMessage(response); } catch { /* caller observes disconnect */ }
+      };
+      Promise.resolve(handleSecretRequest(message.operation, message.args ?? {}))
+        .then((result) => respond({
+            type: 'custody/secret-response', requestId: message.requestId,
+            ok: true, result,
+          }))
+        .catch((cause) => respond({
+            type: 'custody/secret-response', requestId: message.requestId,
+            ok: false,
+            error: /** @type {{ code?: string, message?: string }} */ (cause)?.code
+              ?? /** @type {{ message?: string }} */ (cause)?.message ?? 'secret-host-failed',
+          }));
+    });
+    port.onDisconnect.addListener(() => {
+      if (activePort !== port) return;
+      activePort = null;
+      rejectPending('port-disconnected', 'the identity custody host disconnected');
+    });
+  };
+
+  const waitForPort = async () => {
+    if (activePort) return activePort;
+    await ensureOffscreen();
+    if (activePort) return activePort;
+    await new Promise((resolve, reject) => {
+      const connected = () => {
+        clearTimeout(timer);
+        connectedWaiters.delete(connected);
+        resolve(undefined);
+      };
+      connectedWaiters.add(connected);
+      const timer = setTimeout(() => {
+        connectedWaiters.delete(connected);
+        reject(new DwebCustodyPortError(
+          'identity custody host did not connect', 'port-timeout',
+        ));
+      }, timeoutMs);
+    });
+    if (!activePort) throw new DwebCustodyPortError(
+      'identity custody host disconnected before use', 'port-disconnected',
+    );
+    return activePort;
+  };
+
+  /** @param {'export'|'adopt'|'suspend'|'resume'|'reset'} operation @param {any} [args] */
+  const call = async (operation, args = {}) => {
+    const port = await waitForPort();
+    if (activePort !== port) throw new DwebCustodyPortError(
+      'identity custody host disconnected before use', 'port-disconnected',
+    );
+    const requestId = newRequestId();
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(requestId);
+        reject(new DwebCustodyPortError(
+          `identity custody ${operation} timed out`, 'operation-timeout',
+        ));
+      }, timeoutMs);
+      pending.set(requestId, { resolve, reject, timer });
+      try {
+        port.postMessage({ type: 'custody/request', requestId, operation, args });
+      } catch (cause) {
+        pending.delete(requestId);
+        clearTimeout(timer);
+        reject(new DwebCustodyPortError(
+          `identity custody ${operation} could not be sent`, 'post-failed', { cause },
+        ));
+      }
+    });
+  };
+
+  return { attach, call };
+};

--- a/extension/background/dweb-identity-custody.js
+++ b/extension/background/dweb-identity-custody.js
@@ -1,0 +1,68 @@
+// @ts-check
+// Vault-backed custody for the permanent peer identity.
+//
+// why this is not a runtime message route: reads and first-mint writes carry
+// the permanent signing seed. Only the sender-verified offscreen custody Port
+// may reach this handler.
+
+/** @param {any[]} apps */
+export const identityChangeBlockedByApps = (apps) => apps.some((app) =>
+  app?.shared === true
+  || (app?.dweb?.local === true
+    && typeof app.dweb.publisher === 'string'
+    && app.dweb.publisher.length > 0));
+
+/**
+ * @param {Object} deps
+ * @param {boolean} deps.enabled
+ * @param {() => boolean} deps.active
+ * @param {{ isLocked: () => boolean, getSecret: (name: string) => Promise<string | null>, setSecret: (name: string, value: string) => Promise<void> }} deps.vault
+ * @param {{ append: (entry: { type: string, details: object }) => Promise<unknown> }} deps.auditLog
+ * @param {string} deps.identitySecretName
+ * @param {<T>(operation: () => Promise<T>) => Promise<T>} deps.withIdentityMutation
+ * @param {() => Promise<boolean>} deps.canChangeIdentity
+ */
+export const makeDwebIdentityCustody = ({
+  enabled, active, vault, auditLog, identitySecretName,
+  withIdentityMutation, canChangeIdentity,
+}) => {
+  const available = () => enabled && active();
+
+  /** @param {'get'|'set'} operation @param {any} [args] */
+  const handle = async (operation, args = {}) => {
+    if (!available()) return { ok: false, error: 'dweb-disabled' };
+    if (vault.isLocked()) return { ok: false, error: 'vault-locked' };
+
+    if (operation === 'get') {
+      try {
+        return { ok: true, value: await vault.getSecret(identitySecretName) };
+      } catch (cause) {
+        return { ok: false, error: /** @type {{ message?: string }} */ (cause)?.message ?? String(cause) };
+      }
+    }
+
+    if (operation !== 'set') return { ok: false, error: 'unknown-secret-operation' };
+    if (typeof args?.value !== 'string') return { ok: false, error: 'value-required' };
+    try {
+      return await withIdentityMutation(async () => {
+        // get, mint, and set cross the page/SW boundary. Re-check inside the
+        // same custody lane used by restore so stale mint work cannot overwrite
+        // a recovered root.
+        const existing = await vault.getSecret(identitySecretName);
+        if (existing) return { ok: false, error: 'identity-already-exists' };
+        // A surviving local share is derived from the missing root. Minting a
+        // replacement would orphan its publisher and app identifiers.
+        if (!await canChangeIdentity()) return { ok: false, error: 'identity-in-use' };
+        await vault.setSecret(identitySecretName, args.value);
+        // The root is already durable. Audit failure must not report the mint as
+        // failed and prompt a misleading retry against committed state.
+        await auditLog.append({ type: 'dweb_identity_issued', details: {} }).catch(() => {});
+        return { ok: true };
+      });
+    } catch (cause) {
+      return { ok: false, error: /** @type {{ message?: string }} */ (cause)?.message ?? String(cause) };
+    }
+  };
+
+  return { handle };
+};

--- a/extension/background/dweb-share.js
+++ b/extension/background/dweb-share.js
@@ -1,0 +1,70 @@
+// @ts-check
+// One identity-bound app-share transaction. Both user and agent entry points
+// call this shell so publisher-derived metadata and custody serialization cannot
+// drift apart again.
+
+/**
+ * @param {Object} deps
+ * @param {boolean} deps.enabled
+ * @param {() => boolean} deps.active
+ * @param {<T>(operation: () => Promise<T>) => Promise<T>} deps.withIdentityMutation
+ * @param {{ get: (id: string) => Promise<any>, update: (id: string, patch: any) => Promise<any> }} deps.appRegistry
+ * @param {(parts: string[]) => { list: () => Promise<any[]>, read: (path: string) => Promise<any> }} deps.opfsHelpers
+ * @param {() => Promise<any>} deps.prepareRuntime
+ * @param {(message: any) => Promise<any>} deps.sendMessage
+ */
+export const makeDwebShare = ({
+  enabled, active, withIdentityMutation, appRegistry, opfsHelpers,
+  prepareRuntime, sendMessage,
+}) => async (/** @type {string} */ appId, /** @type {string | undefined} */ slug) => {
+  if (!enabled || !active()) return { ok: false, error: 'dweb-disabled' };
+
+  // why: a cold host mints its first identity through the custody lane. Start
+  // it before owning that lane or first-share waits on its own queued mint.
+  const started = await prepareRuntime();
+  if (!started?.ok) return started ?? { ok: false, error: 'dweb-start-failed' };
+
+  return withIdentityMutation(async () => {
+    if (!enabled || !active()) return { ok: false, error: 'dweb-disabled' };
+    const record = await appRegistry.get(appId);
+    if (!record) return { ok: false, error: 'app-not-found' };
+    const opfs = opfsHelpers(['peerd-apps', appId]);
+    /** @type {Record<string, any>} */
+    const files = {};
+    for (const file of await opfs.list()) {
+      const path = file.path.replace(/^\/+/, '');
+      files[path] = await opfs.read(path);
+    }
+    const useSlug = record.dweb?.slug || slug || undefined;
+    const reply = await sendMessage({
+      type: 'dweb/base-host/share-app',
+      name: record.name, entry: record.entryFile, files, slug: useSlug,
+    });
+    if (!reply?.ok) return reply;
+    try {
+      const updated = await appRegistry.update(appId, {
+        shared: true,
+        dweb: {
+          uri: reply.uri, publisher: reply.publisher ?? null, hash: reply.hash,
+          version_id: reply.hash, slug: reply.slug, dwapp_id: reply.dwapp_id,
+          seq: reply.seq, local: true,
+        },
+      });
+      if (!updated) throw new Error('app was deleted before share metadata was stored');
+    } catch (cause) {
+      // Best-effort rollback: never report a successful share whose
+      // identity-derived deletion metadata was not durably recorded.
+      const rollback = await sendMessage({
+        type: 'dweb/base-host/unshare-app',
+        name: record.name, slug: reply.slug,
+        publisher: reply.publisher ?? null, hash: reply.hash ?? null,
+      }).catch(() => null);
+      return {
+        ok: false,
+        error: rollback?.ok ? 'share-metadata-store-failed' : 'share-rollback-failed',
+        cause: /** @type {{ message?: string }} */ (cause)?.message ?? String(cause),
+      };
+    }
+    return reply;
+  });
+};

--- a/extension/background/dweb-transfer.js
+++ b/extension/background/dweb-transfer.js
@@ -1,0 +1,210 @@
+// @ts-check
+// Portable identity transfer shell. The cryptographic core stays behind the
+// dweb client; this helper owns vault custody, Chrome-offscreen vs Firefox-
+// background hosting, mutation serialization, and fail-loud backup semantics.
+
+export class IdentityTransferError extends Error {
+  /** @param {string} message @param {string} code @param {{ cause?: unknown }} [options] */
+  constructor(message, code, options = {}) {
+    super(message, options);
+    this.name = 'IdentityTransferError';
+    this.code = code;
+  }
+}
+
+/** @param {string} material */
+const materialRevision = async (material) => {
+  const encoded = new TextEncoder().encode(material);
+  try {
+    const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', encoded));
+    return Array.from(digest, (byte) => byte.toString(16).padStart(2, '0')).join('');
+  } finally {
+    encoded.fill(0);
+  }
+};
+
+/**
+ * @param {Object} deps
+ * @param {boolean} deps.enabled
+ * @param {boolean} deps.offscreenAvailable
+ * @param {{ isLocked: () => boolean, getSecret: (name: string) => Promise<string|null>, setSecret: (name: string, value: string) => Promise<void> }} deps.vault
+ * @param {string} deps.identitySecretName
+ * @param {(operation: 'export'|'adopt', args: any) => Promise<any>} deps.runCustodyOperation
+ * @param {() => Promise<any>} deps.loadDweb
+ * @param {<T>(operation: () => Promise<T>) => Promise<T>} deps.withIdentityMutation
+ * @param {() => Promise<boolean>} deps.canReplaceIdentity
+ * @param {(leaseId: string) => Promise<void>} deps.stopIdentityRuntime
+ * @param {(leaseId: string) => Promise<void>} deps.startIdentityRuntime
+ * @param {() => string} [deps.newLeaseId]
+ * @param {(event: any) => Promise<any>} deps.audit
+ */
+export const makeDwebTransfer = ({
+  enabled, offscreenAvailable, vault, identitySecretName,
+  runCustodyOperation, loadDweb, withIdentityMutation,
+  canReplaceIdentity, stopIdentityRuntime, startIdentityRuntime,
+  newLeaseId = () => crypto.randomUUID(), audit,
+}) => {
+  /** @param {'export'|'adopt'} operation @param {any} args */
+  const runCrypto = async (operation, args) => {
+    if (offscreenAvailable) {
+      try {
+        return await runCustodyOperation(operation, args);
+      } catch (cause) {
+        throw new IdentityTransferError(
+          `identity ${operation} host failed`,
+          /** @type {{ code?: string }} */ (cause)?.code ?? 'host-failed',
+          { cause },
+        );
+      }
+    }
+
+    // Firefox MV3 has an event-page background and no offscreen API. Its
+    // background can host this pure crypto directly through the package-gated
+    // loader; the store loader remains a stub and `enabled` is false there.
+    const client = await loadDweb();
+    const method = operation === 'export'
+      ? client?.identityRecordExport
+      : client?.identityRecordAdopt;
+    if (!client?.available || typeof method !== 'function') {
+      throw new IdentityTransferError(`identity ${operation} is unavailable`, 'unsupported');
+    }
+    return method(args);
+  };
+
+  return Object.freeze({
+    /** @param {string} passphrase */
+    exportRecord: (passphrase) => withIdentityMutation(async () => {
+      if (!enabled) return null;
+      if (vault.isLocked()) throw new IdentityTransferError('vault is locked', 'vault-locked');
+      const material = await vault.getSecret(identitySecretName);
+      if (typeof material !== 'string' || material.length === 0) return null;
+      let parsed;
+      try { parsed = JSON.parse(material); }
+      catch (cause) { throw new IdentityTransferError('local identity is malformed', 'bad-local-identity', { cause }); }
+      const record = await runCrypto('export', { material: parsed, passphrase });
+      if (!record) throw new IdentityTransferError('identity export returned no record', 'empty-record');
+      return { identityRecord: record };
+    }),
+
+    /**
+     * Authenticate and classify a record without changing custody.
+     * @param {any} record @param {string} passphrase
+     * @param {{ replaceExisting?: boolean }} [options]
+     */
+    prepareRecord: (record, passphrase, { replaceExisting = false } = {}) =>
+      withIdentityMutation(async () => {
+        if (!enabled) return { adopted: false, did: null, reason: 'dweb-disabled' };
+        if (vault.isLocked()) return { adopted: false, did: null, reason: 'vault-locked' };
+        const existingMaterial = await vault.getSecret(identitySecretName);
+        const outcome = await runCrypto('adopt', {
+          record, passphrase, existingMaterial, replaceExisting,
+        });
+        const existingUnreadable = outcome?.reason === 'invalid-local-identity'
+          || outcome?.reason === 'replaced-invalid-local';
+        const existingRevision = existingUnreadable
+          && typeof existingMaterial === 'string' && existingMaterial.length > 0
+          ? await materialRevision(existingMaterial)
+          : undefined;
+        const changesIdentity = outcome?.adopted && typeof outcome.material === 'string';
+        if (changesIdentity && !await canReplaceIdentity()) {
+          const { material: _material, ...blockedOutcome } = outcome ?? {};
+          return {
+            ...blockedOutcome, adopted: false, reason: 'identity-in-use',
+            ...(existingUnreadable ? { existingUnreadable: true, existingRevision } : {}),
+          };
+        }
+        // Root material stays inside this background shell; preparation returns
+        // only the authenticated decision used to stage the rest of the import.
+        const { material: _material, ...publicOutcome } = outcome ?? {};
+        if (existingUnreadable) {
+          return {
+            ...publicOutcome,
+            existingUnreadable: true,
+            existingRevision,
+          };
+        }
+        return publicOutcome;
+      }),
+
+    /**
+     * @param {any} record @param {string} passphrase
+     * @param {{ replaceExisting?: boolean, expectedExistingDid?: string | null, expectedExistingRevision?: string, expectedIncomingDid?: string }} [options]
+     */
+    adoptRecord: async (record, passphrase, {
+      replaceExisting = false, expectedExistingDid, expectedExistingRevision, expectedIncomingDid,
+    } = {}) => {
+      // Preparation supplies the expected incoming did for every real import.
+      // Suspend BEFORE entering the custody lane: a first-run host may itself
+      // be waiting to auto-mint through that lane, so the reverse order would
+      // deadlock runtime stop against a concurrent first-mint custody write.
+      const suspendForCommit = replaceExisting || typeof expectedIncomingDid === 'string';
+      let suspensionAttempted = false;
+      let committed = false;
+      let outcomeResult;
+      const leaseId = newLeaseId();
+      try {
+        if (suspendForCommit) {
+          suspensionAttempted = true;
+          await stopIdentityRuntime(leaseId);
+        }
+        outcomeResult = await withIdentityMutation(async () => {
+          if (!enabled) return { adopted: false, did: null, reason: 'dweb-disabled' };
+          if (vault.isLocked()) return { adopted: false, did: null, reason: 'vault-locked' };
+          const existingMaterial = await vault.getSecret(identitySecretName);
+          const outcome = await runCrypto('adopt', {
+            record, passphrase, existingMaterial, replaceExisting,
+          });
+
+          // Bind the commit to the exact A→B transition authenticated during
+          // preparation. Another import or auto-mint may have won while ordinary
+          // sections were applying; explicit approval for A never authorizes
+          // silently replacing C.
+          const revisionChanged = typeof expectedExistingRevision === 'string'
+            && (typeof existingMaterial !== 'string'
+              || await materialRevision(existingMaterial) !== expectedExistingRevision);
+          if ((expectedExistingDid !== undefined
+                && (outcome?.existingDid ?? null) !== expectedExistingDid)
+              || revisionChanged
+              || (typeof expectedIncomingDid === 'string'
+                && outcome?.incomingDid !== expectedIncomingDid)) {
+            return { ...outcome, adopted: false, material: null, reason: 'identity-changed' };
+          }
+          if (!outcome?.adopted || typeof outcome.material !== 'string') return outcome;
+
+          const changesIdentity = outcome.adopted && typeof outcome.material === 'string';
+          if (changesIdentity && !await canReplaceIdentity()) {
+            return { ...outcome, adopted: false, material: null, reason: 'identity-in-use' };
+          }
+          try {
+            await vault.setSecret(identitySecretName, outcome.material);
+          } catch (cause) {
+            throw new IdentityTransferError('identity could not be stored', 'store-failed', { cause });
+          }
+          committed = true;
+          const replacing = outcome.reason === 'replaced' || outcome.reason === 'replaced-invalid-local';
+          await audit({
+            type: replacing ? 'dweb_identity_replaced' : 'dweb_identity_adopted',
+            details: { did: outcome.did ?? null, previousDid: outcome.existingDid ?? null },
+          }).catch(() => {});
+          return outcome;
+        });
+      } finally {
+        // Resume on every path, including stop/close and pre-commit failures.
+        // The service-worker shell also schedules recovery and clears stale
+        // suspension on boot, so a lost acknowledgement cannot wedge the host.
+        if (suspensionAttempted || committed) {
+          try {
+            await startIdentityRuntime(leaseId);
+          } catch {
+            // The custody write, if any, is already durable and must not be
+            // misreported as rolled back. The shell retries this exact lease
+            // and boot recovery clears a predecessor lease after SW eviction;
+            // surface the degraded runtime state until one of those succeeds.
+            if (outcomeResult) outcomeResult = { ...outcomeResult, runtimeRecoveryPending: true };
+          }
+        }
+      }
+      return outcomeResult;
+    },
+  });
+};

--- a/extension/background/private-transfer-port.js
+++ b/extension/background/private-transfer-port.js
@@ -1,0 +1,45 @@
+// @ts-check
+// Dedicated options-page RPC for backup and restore requests.
+//
+// why a Port plus a static exclusivity test: runtime.sendMessage broadcasts the
+// passphrase and import payload to every extension listener. The shipped source
+// registers onConnect only in the service worker, so this named connection has
+// one receiver and the exact options-page sender is verified before attachment.
+
+const PRIVATE_TRANSFER_TYPES = new Set([
+  'transfer/export', 'transfer/inspectImport', 'transfer/import',
+]);
+
+/**
+ * @param {Object} deps
+ * @param {Record<string, (message: any) => Promise<any>>} deps.handlers
+ * @param {symbol} deps.authorization
+ */
+export const makePrivateTransferPort = ({ handlers, authorization }) => ({
+  /** @param {import('webextension-polyfill').Runtime.Port} port */
+  attach(port) {
+    port.onMessage.addListener((/** @type {any} */ request) => {
+      if (request?.type !== 'private-transfer/request'
+          || typeof request.requestId !== 'string'
+          || !request.message || typeof request.message !== 'object'
+          || !PRIVATE_TRANSFER_TYPES.has(request.message.type)) return;
+      const handler = handlers[request.message.type];
+      if (typeof handler !== 'function') return;
+      const respond = (/** @type {any} */ response) => {
+        try { port.postMessage(response); } catch { /* page observes disconnect */ }
+      };
+      Promise.resolve(handler({
+        ...request.message, privateTransferAuthorization: authorization,
+      }))
+        .then((reply) => respond({
+          type: 'private-transfer/response', requestId: request.requestId,
+          ok: true, reply,
+        }))
+        .catch((cause) => respond({
+          type: 'private-transfer/response', requestId: request.requestId,
+          ok: false,
+          error: /** @type {{ message?: string }} */ (cause)?.message ?? 'transfer-failed',
+        }));
+    });
+  },
+});

--- a/extension/background/routes/dweb.js
+++ b/extension/background/routes/dweb.js
@@ -22,8 +22,8 @@
 export const makeDwebRoutes = (deps) => {
   const {
     vault, auditLog, kv, ensureOffscreen, browser,
-    appRegistry, appClient, appTabTracker, opfsHelpers, settingsStore,
-    DWEB_ENABLED, DWEB_IDENTITY_SECRET, APP_TAB_GROUP_TITLE,
+    appRegistry, appClient, appTabTracker, settingsStore, shareLocalApp,
+    DWEB_ENABLED, APP_TAB_GROUP_TITLE,
     onBaseNetworkStopped,
   } = deps;
 
@@ -31,34 +31,6 @@ export const makeDwebRoutes = (deps) => {
   const dwebOn = () => DWEB_ENABLED && settingsStore.get().dwebEnabled;
 
   return {
-    // Persistent-identity storage for the room-hosting page. The MODULE CODE that
-    // mints the Ed25519 material runs in the PAGE (app-tab, via loadDweb); the SW
-    // only owns the vault and exposes these two routes scoped to the single
-    // identity secret. The hardcoded name is store-safe (not the dweb module path).
-    'dweb/identity-get': async () => {
-      if (!dwebOn()) return { ok: false, error: 'dweb-disabled' };
-      if (vault.isLocked()) return { ok: false, error: 'vault-locked' };
-      try {
-        return { ok: true, value: await vault.getSecret(DWEB_IDENTITY_SECRET) };
-      } catch (e) {
-        return { ok: false, error: /** @type {{ message?: string }} */ (e)?.message ?? String(e) };
-      }
-    },
-    'dweb/identity-set': async ({ value }) => {
-      if (!dwebOn()) return { ok: false, error: 'dweb-disabled' };
-      if (vault.isLocked()) return { ok: false, error: 'vault-locked' };
-      if (typeof value !== 'string') return { ok: false, error: 'value-required' };
-      try {
-        await vault.setSecret(DWEB_IDENTITY_SECRET, value);
-        // Fires once, on first-run creation (the page only sets when get
-        // returned null). did is not parsed SW-side — it shows on room-join.
-        await auditLog.append({ type: 'dweb_identity_issued', details: {} });
-        return { ok: true };
-      } catch (e) {
-        return { ok: false, error: /** @type {{ message?: string }} */ (e)?.message ?? String(e) };
-      }
-    },
-
     // Dweb pages append their security events to the ONE audit log
     // (ARCHITECTURE §7: no new logging subsystem; new event types only).
     'dweb/audit': async ({ type, details }) => {
@@ -244,30 +216,7 @@ export const makeDwebRoutes = (deps) => {
     // dwapp_id stays stable. On success we persist the version identity.
     'dweb/base/share-app': async ({ appId, slug } = {}) => {
       if (!dwebOn()) return { ok: false, error: 'dweb-disabled' };
-      const record = await appRegistry.get(appId);
-      if (!record) return { ok: false, error: 'app-not-found' };
-      const opfs = opfsHelpers(['peerd-apps', appId]);
-      /** @type {Record<string, any>} */
-      const files = {};
-      for (const f of await opfs.list()) { const path = f.path.replace(/^\/+/, ''); files[path] = await opfs.read(path); }
-      // Reshare locks to the stored slug; first share takes the dialog's edited slug.
-      const useSlug = record.dweb?.slug || slug || undefined;
-      await ensureOffscreen();
-      const r = await browser.runtime.sendMessage({ type: 'dweb/base-host/share-app', name: record.name, entry: record.entryFile, files, slug: useSlug });
-      if (r?.ok) {
-        // `shared` drives the "you're seeding this" delete confirm + the un-share path;
-        // the dweb slot records the version identity (merged, so it survives reshares).
-        try {
-          await appRegistry.update(appId, {
-            shared: true,
-            dweb: {
-              uri: r.uri, publisher: r.publisher ?? null, hash: r.hash, version_id: r.hash,
-              slug: r.slug, dwapp_id: r.dwapp_id, seq: r.seq, local: record.dweb?.local ?? true,
-            },
-          });
-        } catch (e) { console.debug('[share-app] persist version slot failed', e); }
-      }
-      return r;
+      return shareLocalApp(appId, slug);
     },
     // Discover: what peers have announced (gossip cache + DHT hits).
     'dweb/base/heard': async () => {

--- a/extension/background/routes/engine.js
+++ b/extension/background/routes/engine.js
@@ -168,6 +168,7 @@ export const makeEngineRoutes = (deps) => {
             await browser.runtime.sendMessage({
               type: 'dweb/base-host/unshare-app',
               name: record.name,
+              slug: record.dweb?.slug ?? null,
               publisher: record.dweb?.publisher ?? null,
               hash: record.dweb?.hash ?? null,
             });

--- a/extension/background/routes/settings.js
+++ b/extension/background/routes/settings.js
@@ -17,8 +17,9 @@ export const makeSettingsRoutes = (deps) => {
     vault, auditLog, pushState, kv, memory, settingsStore,
     normalizeSettingsPatch, normalizeVariant, normalizeEngine, listProviders,
     REASONING_EFFORT_LEVELS, DWEB_ENABLED, DEFAULT_SETTINGS,
-    buildExport, CHANNEL, exportHooks, skillRegistry,
-    onSettingsChanged,
+    buildExport, CHANNEL, exportHooks, skillRegistry, dwebTransfer,
+    EXPORT_PASSPHRASE_MIN_LENGTH, isCustodySecretName,
+    onSettingsChanged, privateTransferAuthorization,
   } = deps;
 
   return {
@@ -70,20 +71,32 @@ export const makeSettingsRoutes = (deps) => {
     // The ONLY migration path between installs (store ↔ preview). No background
     // sync, no shared storage — different extension IDs keep the two builds
     // isolated; the user moves state by file, in the clear about what travels
-    // (API keys ride encrypted under an export passphrase; the vault DK never
+    // (credentials ride encrypted under an export passphrase; the vault DK never
     // leaves the vault). The import half lives in routes/system.js.
-    'transfer/export': async ({ passphrase }) => {
+    'transfer/export': async ({ passphrase, privateTransferAuthorization: authorization }) => {
+      if (authorization !== privateTransferAuthorization) {
+        return { ok: false, error: 'private-transfer-required' };
+      }
       if (vault.isLocked()) return { ok: false, error: 'vault-locked' };
       const names = await vault.listSecretNames();
-      if (names.length > 0 && (typeof passphrase !== 'string' || passphrase.length < 8)) {
-        // Same floor as the vault passphrase — this file unlocks API keys.
+      if (names.length > 0
+          && (typeof passphrase !== 'string' || passphrase.length < EXPORT_PASSPHRASE_MIN_LENGTH)) {
+        // A backup may unlock both stored credentials and a permanent peer identity.
         return { ok: false, error: 'passphrase-required' };
       }
       /** @type {Record<string, string>} */
       const secrets = {};
-      for (const name of names) {
+      for (const name of names.filter((/** @type {string} */ candidate) => !isCustodySecretName(candidate))) {
         const value = await vault.getSecret(name);
         if (typeof value === 'string') secrets[name] = value;
+      }
+      let dweb = null;
+      try {
+        dweb = await dwebTransfer.exportRecord(passphrase);
+      } catch {
+        // Once a local identity exists, omitting it would create a backup that
+        // looks successful but cannot restore the user's permanent did.
+        return { ok: false, error: 'identity-export-failed' };
       }
       const payload = await buildExport({
         channel: CHANNEL,
@@ -94,9 +107,18 @@ export const makeSettingsRoutes = (deps) => {
         memory: await memory.exportAll(),
         hooks: exportHooks(),
         skills: await skillRegistry.list(),
+        // The did:key travels ONLY as this capsule record (built offscreen,
+        // openable with the same export passphrase) — buildExport excludes
+        // the raw identity/device-key secrets from the secrets box.
+        dweb,
       });
-      auditLog.append({ type: 'settings_exported', secretCount: names.length }).catch(() => {});
-      return { ok: true, payload };
+      auditLog.append({ type: 'settings_exported', secretCount: Object.keys(secrets).length }).catch(() => {});
+      return {
+        ok: true,
+        payload,
+        identityIncluded: !!dweb?.identityRecord,
+        identityDid: dweb?.identityRecord?.did ?? null,
+      };
     },
   };
 };

--- a/extension/background/routes/system.js
+++ b/extension/background/routes/system.js
@@ -19,7 +19,8 @@ export const makeSystemRoutes = (deps) => {
     vault, auditLog, sessions, pushState, kv, memory,
     buildStateSnapshot, closeSidePanel, uiPorts, loadUserEndpoints,
     inspectImport, applyImport, settingsStore, saveUserHook,
-    CHANNEL, DEFAULT_SETTINGS, ExportPassphraseError,
+    CHANNEL, DEFAULT_SETTINGS, ExportPassphraseError, dwebTransfer,
+    privateTransferAuthorization,
   } = deps;
 
   return {
@@ -105,12 +106,23 @@ export const makeSystemRoutes = (deps) => {
     // Pre-flight: what would this import overwrite? The UI shows the
     // summary (and the dweb-dropped notice on store packages) BEFORE
     // the user confirms.
-    'transfer/inspectImport': async ({ payload }) => inspectImport({
-      payload, channel: CHANNEL, knownSettingKeys: Object.keys(DEFAULT_SETTINGS),
-    }),
+    'transfer/inspectImport': async ({ payload, privateTransferAuthorization: authorization }) =>
+      authorization !== privateTransferAuthorization
+        ? { ok: false, error: 'private-transfer-required' }
+        : inspectImport({
+            payload, channel: CHANNEL, knownSettingKeys: Object.keys(DEFAULT_SETTINGS),
+          }),
 
-    'transfer/import': async ({ payload, passphrase }) => {
-      if (payload?.secrets != null && vault.isLocked()) {
+    'transfer/import': async ({
+      payload, passphrase, replaceDwebIdentity = false, skipDwebIdentity = false,
+      approvedExistingDwebDid, approvedExistingDwebRevision, approvedIncomingDwebDid,
+      privateTransferAuthorization: authorization,
+    }) => {
+      if (authorization !== privateTransferAuthorization) {
+        return { ok: false, error: 'private-transfer-required' };
+      }
+      const identityImport = CHANNEL !== 'store' && payload?.dweb?.identityRecord != null;
+      if ((payload?.secrets != null || identityImport) && vault.isLocked()) {
         return { ok: false, error: 'vault-locked' };
       }
       try {
@@ -128,15 +140,33 @@ export const makeSystemRoutes = (deps) => {
             setSecret: (/** @type {string} */ name, /** @type {string} */ value) => vault.setSecret(name, value),
             importMemory: (/** @type {any} */ p) => memory.importAll(p),
             saveHook: (/** @type {any} */ record) => saveUserHook({ kv }, record),
+            // Preview-channel identity adoption (applyImport gates on
+            // channel; the helper itself refuses when the build has no dweb).
+            adoptDwebIdentity: dwebTransfer
+              ? (/** @type {any} */ record, /** @type {string} */ pass, /** @type {any} */ options) => options?.prepareOnly
+                ? dwebTransfer.prepareRecord(record, pass, options)
+                : dwebTransfer.adoptRecord(record, pass, options)
+              : undefined,
           },
+          replaceDwebIdentity: replaceDwebIdentity === true,
+          skipDwebIdentity: skipDwebIdentity === true,
+          approvedExistingDwebDid,
+          approvedExistingDwebRevision,
+          approvedIncomingDwebDid,
         });
         if (result.ok) {
           auditLog.append({ type: 'settings_imported', counts: result.imported }).catch(() => {});
+          pushState();
+        } else if (result.partial) {
+          auditLog.append({ type: 'settings_import_partial', counts: result.partial, details: { failure: result.failure ?? result.error } }).catch(() => {});
           pushState();
         }
         return result;
       } catch (e) {
         if (e instanceof ExportPassphraseError) return { ok: false, error: 'wrong-passphrase' };
+        if ((/** @type {{ name?: string, code?: string }} */ (e))?.name === 'IdentityTransferError') {
+          return { ok: false, error: `dweb-identity-${(/** @type {{ code?: string }} */ (e)).code ?? 'transfer-failed'}` };
+        }
         throw e;
       }
     },

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -29,7 +29,10 @@
 
 import browser from '/vendor/browser-polyfill.js';
 import { makeDispatcher, isTrustedSender } from '/shared/messaging.js';
-import { isOffscreenSender as senderIsOffscreen } from '/shared/sender-trust.js';
+import {
+  isOffscreenSender as senderIsOffscreen, isOptionsSender,
+} from '/shared/sender-trust.js';
+import { loadDweb } from '/shared/dweb-loader.js';
 import { CHANNEL_DEFAULTS, CHANNEL, DWEB_ENABLED } from '/shared/channel-config.js';
 import { REMOTE_SKILL_INSTALL } from '/shared/flags.js';
 
@@ -247,6 +250,8 @@ import {
   inspectImport,
   applyImport,
   ExportPassphraseError,
+  EXPORT_PASSPHRASE_MIN_LENGTH,
+  isCustodySecretName,
   // design js-superpower/06 — the toolbox: durable agent-authored modules
   // (peerd:toolbox/<name>; store + the write-time import-resolution check).
   createToolboxStore,
@@ -377,6 +382,13 @@ import { makeModelCatalog } from './model-catalog.js';
 import { makeTabAffordances } from './tab-affordances.js';
 import { makeMintOnce } from './mint-once.js';
 import { makeDwebInboundRateCap } from './dweb-inbound-rate-cap.js';
+import { makeDwebTransfer, IdentityTransferError } from './dweb-transfer.js';
+import { makeDwebShare } from './dweb-share.js';
+import { makeDwebCustodyClient, makeRetryableCustodyReset } from './dweb-custody-client.js';
+import {
+  identityChangeBlockedByApps, makeDwebIdentityCustody,
+} from './dweb-identity-custody.js';
+import { makePrivateTransferPort } from './private-transfer-port.js';
 import { downgradesActorConfirm, a2aConsentOutcome } from './a2a-consent.js';
 import { makeVaultRoutes } from './routes/vault.js';
 import { makeProviderRoutes } from './routes/providers.js';
@@ -1776,19 +1788,7 @@ const buildToolContext = async (/** @type {any} */ { sessionId: overrideSessionI
     // (and dweb-off) ctx.dweb is null and the tools (already hidden by exposure)
     // also no-op. share reads the app's OPFS bundle like export does.
     dweb: (DWEB_ENABLED && settingsStore.get().dwebEnabled) ? {
-      share: async (/** @type {string} */ appId) => {
-        const record = await appRegistry.get(appId);
-        if (!record) return { ok: false, error: 'app-not-found' };
-        const opfs = opfsHelpers(['peerd-apps', appId]);
-        /** @type {Record<string, any>} */ const files = {};
-        for (const f of await opfs.list()) { const path = f.path.replace(/^\/+/, ''); files[path] = await opfs.read(path); }
-        await ensureOffscreen();
-        const r = /** @type {any} */ (await browser.runtime.sendMessage({ type: 'dweb/base-host/share-app', name: record.name, entry: record.entryFile, files }));
-        // Mark shared so deleting this app later un-shares it (stops serving the
-        // bytes) — same bookkeeping as the Library's Share button.
-        if (r?.ok) { try { await appRegistry.update(appId, { shared: true }); } catch (e) { console.debug('[dweb.share] mark shared failed', e); } }
-        return r;
-      },
+      share: (/** @type {string} */ appId) => shareLocalApp(appId, undefined),
       discover: async () => { await ensureOffscreen(); return browser.runtime.sendMessage({ type: 'dweb/base-host/heard' }); },
       install: async (/** @type {any} */ { uri, name } = {}) => { await ensureOffscreen(); return browser.runtime.sendMessage({ type: 'dweb/base-host/install-app', uri, name }); },
       peers: async () => { await ensureOffscreen(); return browser.runtime.sendMessage({ type: 'dweb/base-host/peers' }); },
@@ -2602,6 +2602,76 @@ const ensureOffscreen = async () => {
 // the agent can act on, instead of dispatching a job message no context answers
 // and surfacing an opaque "headless job failed".
 const offscreenAvailable = typeof (/** @type {any} */ (browser)).offscreen?.createDocument === 'function';
+// Relays that redeem an offscreen worker's authority need the exact browser-
+// owned host, not the broader "one of our extension pages" sender check.
+const isOffscreenSender = (/** @type {any} */ sender) => senderIsOffscreen(sender, {
+  runtimeId: browser.runtime?.id,
+  extensionOrigin: browser.runtime?.getURL?.('') ?? '',
+  offscreenUrl: browser.runtime?.getURL?.(OFFSCREEN_URL) ?? '',
+});
+const isActualOptionsSender = (/** @type {any} */ sender) => isOptionsSender(sender, {
+  runtimeId: browser.runtime?.id,
+  extensionOrigin: browser.runtime?.getURL?.('') ?? '',
+  optionsUrl: browser.runtime?.getURL?.('options/options.html') ?? '',
+});
+
+// Root creation and recovery share one serialized custody lane. Without it,
+// base-network auto-start and two concurrent imports can all observe "missing"
+// and last-write-wins different permanent identities.
+let dwebIdentityMutationTail = Promise.resolve();
+let dwebIdentityMutationActive = false;
+let dwebStartDeferredByIdentityMutation = false;
+/** @template T @param {() => Promise<T>} operation @returns {Promise<T>} */
+const withDwebIdentityMutation = (operation) => {
+  const run = async () => {
+    dwebIdentityMutationActive = true;
+    try { return await operation(); }
+    finally {
+      dwebIdentityMutationActive = false;
+      if (dwebStartDeferredByIdentityMutation) {
+        dwebStartDeferredByIdentityMutation = false;
+        setTimeout(() => maybeStartBaseNetwork('identity-mutation-finished'), 0);
+      }
+    }
+  };
+  const result = dwebIdentityMutationTail.then(run, run);
+  dwebIdentityMutationTail = result.then(() => undefined, () => undefined);
+  return result;
+};
+
+const canChangeDwebIdentity = async () => {
+  const apps = await appRegistry.list();
+  // Treat legacy rows that predate shared:true conservatively when they still
+  // carry a local publisher binding. Remote installs and unshared local stubs
+  // do not prevent identity recovery.
+  return !identityChangeBlockedByApps(apps);
+};
+const dwebIdentityCustody = makeDwebIdentityCustody({
+  enabled: DWEB_ENABLED,
+  active: () => settingsStore.get().dwebEnabled,
+  vault,
+  auditLog,
+  identitySecretName: DWEB_IDENTITY_SECRET,
+  withIdentityMutation: withDwebIdentityMutation,
+  canChangeIdentity: canChangeDwebIdentity,
+});
+const dwebCustodyClient = makeDwebCustodyClient({
+  ensureOffscreen,
+  handleSecretRequest: dwebIdentityCustody.handle,
+});
+/** @type {ReturnType<typeof makePrivateTransferPort> | null} */
+let privateTransferPort = null;
+const dwebCustodyReset = makeRetryableCustodyReset({
+  enabled: DWEB_ENABLED,
+  hostAvailable: offscreenAvailable,
+  reset: async () => { await dwebCustodyClient.call('reset'); },
+});
+const ensureDwebSuspensionRecovery = dwebCustodyReset.ensure;
+void ensureDwebSuspensionRecovery().catch((error) => {
+  // A later start/share/rotation retries. Do not poison the worker lifetime if
+  // the offscreen port was still reconnecting during cold boot.
+  console.error('[sw] stale identity suspension recovery failed', error);
+});
 
 // The headless-JS client (the script tool). execHeadless ensures the offscreen
 // doc, then dispatches a 'job/run' message to job-runner.js hosted there.
@@ -2615,14 +2685,6 @@ const jsOffscreenClient = offscreenAvailable ? makeOffscreenJsClient({
 // pending asks + terminate the worker. Declared here (before buildToolContext
 // consumers run) and read by the actors/call route below.
 const scriptRuns = createScriptRunRegistry({ actorOpLimit: ACTORS_RUN_MAX_OPS });
-
-// Relays that redeem an offscreen worker's authority need an exact host
-// predicate, not the dispatcher's broader "one of our extension pages" check.
-const isOffscreenSender = (/** @type {any} */ sender) => senderIsOffscreen(sender, {
-  runtimeId: browser.runtime?.id,
-  extensionOrigin: browser.runtime?.getURL?.('') ?? '',
-  offscreenUrl: browser.runtime?.getURL?.(OFFSCREEN_URL) ?? '',
-});
 
 // The context inspector's capture ring — "what did the model see" per
 // session, SW-memory only. Fed from the two seams that together cover
@@ -3277,6 +3339,14 @@ browser.runtime.onConnect.addListener((port) => {
   // so an untrusted connector must never get it. Same boundary as the
   // message dispatcher.
   if (!isTrustedSender(port.sender)) { try { port.disconnect(); } catch { /* already gone */ } return; }
+  if (port.name === 'private-transfer') {
+    if (!privateTransferPort || !isActualOptionsSender(port.sender)) {
+      try { port.disconnect(); } catch { /* already gone */ }
+      return;
+    }
+    privateTransferPort.attach(/** @type {any} */ (port));
+    return;
+  }
   if (port.name === 'sidepanel' || port.name === 'home' || port.name === 'eval') {
     // The side panel and the full-page home are equal live surfaces (DESIGN-12);
     // the 'eval' surface (the Lab section + the standalone eval page) also needs
@@ -3343,6 +3413,13 @@ browser.runtime.onConnect.addListener((port) => {
       keepalivePorts.delete(/** @type {any} */ (port));
     });
     return;
+  }
+  if (port.name === 'dweb-custody') {
+    if (!isOffscreenSender(port.sender)) {
+      try { port.disconnect(); } catch { /* already disconnected */ }
+      return;
+    }
+    dwebCustodyClient.attach(/** @type {any} */ (port));
   }
 });
 
@@ -5420,6 +5497,96 @@ const resumeSchedules = () => Promise.resolve(/** @type {any} */ (goalRunner)?.r
   .catch((e) => console.error('[sw] schedule catch-up failed', e));
 const ensureSession = ensureCurrentSession;
 
+const shareLocalApp = makeDwebShare({
+  enabled: DWEB_ENABLED,
+  active: () => settingsStore.get().dwebEnabled,
+  withIdentityMutation: withDwebIdentityMutation,
+  appRegistry,
+  opfsHelpers,
+  prepareRuntime: async () => {
+    await ensureDwebSuspensionRecovery();
+    await ensureOffscreen();
+    return browser.runtime.sendMessage({ type: 'dweb/base-host/start' });
+  },
+  sendMessage: (message) => browser.runtime.sendMessage(message),
+});
+
+const dwebTransfer = makeDwebTransfer({
+  enabled: DWEB_ENABLED,
+  offscreenAvailable,
+  vault,
+  identitySecretName: DWEB_IDENTITY_SECRET,
+  runCustodyOperation: (operation, args) => dwebCustodyClient.call(operation, args),
+  loadDweb,
+  withIdentityMutation: withDwebIdentityMutation,
+  canReplaceIdentity: canChangeDwebIdentity,
+  stopIdentityRuntime: async (leaseId) => {
+    if (!offscreenAvailable) return;
+    await ensureDwebSuspensionRecovery();
+    try {
+      await dwebCustodyClient.call('suspend', { leaseId });
+    } catch {
+      throw new IdentityTransferError('existing identity runtime could not be stopped', 'stop-failed');
+    }
+    onBaseNetworkStopped();
+  },
+  startIdentityRuntime: async (leaseId) => {
+    if (!offscreenAvailable) return;
+    const releaseLease = async () => {
+      const reply = /** @type {any} */ (await dwebCustodyClient.call('resume', { leaseId }));
+      if (!reply?.resumed) {
+        throw new IdentityTransferError('identity runtime could not resume', 'resume-failed');
+      }
+    };
+    const retryRelease = () => {
+      releaseLease()
+        .then(() => maybeStartBaseNetwork('identity-resume-retry'))
+        .catch(() => setTimeout(retryRelease, 1000));
+    };
+    try {
+      await releaseLease();
+    } catch (cause) {
+      // Retry only with the same owner token. A normal start can observe the
+      // lease but can never release it, and a lost success acknowledgement is
+      // harmless because release is idempotent once no owner remains.
+      setTimeout(retryRelease, 1000);
+      throw cause;
+    }
+    setTimeout(() => maybeStartBaseNetwork('identity-import'), 0);
+  },
+  audit: (event) => auditLog.append(event),
+});
+
+// Backup requests carry passwords and recovery records. They are present in
+// the normal route modules for shared business logic, but every transfer route
+// requires this non-serializable capability and the options page reaches them
+// only through its exact-sender verified Port.
+const privateTransferAuthorization = Symbol('private-transfer');
+const makeSystemRouteSet = () => makeSystemRoutes({
+  vault, auditLog, sessions, pushState, kv, memory, buildStateSnapshot, closeSidePanel,
+  uiPorts, loadUserEndpoints, inspectImport, applyImport, settingsStore, saveUserHook,
+  CHANNEL, DEFAULT_SETTINGS, ExportPassphraseError, dwebTransfer,
+  privateTransferAuthorization,
+});
+const makeSettingsRouteSet = () => makeSettingsRoutes({
+  vault, auditLog, pushState, kv, memory, settingsStore,
+  normalizeSettingsPatch, normalizeVariant, normalizeEngine, listProviders,
+  REASONING_EFFORT_LEVELS, DWEB_ENABLED, DEFAULT_SETTINGS,
+  buildExport, CHANNEL, exportHooks, skillRegistry, dwebTransfer,
+  EXPORT_PASSPHRASE_MIN_LENGTH, isCustodySecretName,
+  onSettingsChanged, privateTransferAuthorization,
+});
+const systemMessageRoutes = makeSystemRouteSet();
+const settingsMessageRoutes = makeSettingsRouteSet();
+privateTransferPort = makePrivateTransferPort({
+  authorization: privateTransferAuthorization,
+  handlers: {
+    'transfer/export': settingsMessageRoutes['transfer/export'],
+    'transfer/inspectImport': systemMessageRoutes['transfer/inspectImport'],
+    'transfer/import': systemMessageRoutes['transfer/import'],
+  },
+});
+
 // Message routes live in background/routes/*.js as import-free, deps-injected
 // factories. Each is wired with an EXPLICIT per-module deps object naming
 // exactly the stable collaborators that module needs — so the coupling is
@@ -5511,11 +5678,7 @@ browser.runtime.onMessage.addListener(/** @type {any} */ (makeDispatcher({
     ArtifactTooLargeError, EnvelopeFormatError, EnvelopeIntegrityError,
     ensureOffscreen, settingsStore, DWEB_ENABLED, applyWebExtract,
   }),
-  ...makeSystemRoutes({
-    vault, auditLog, sessions, pushState, kv, memory, buildStateSnapshot, closeSidePanel,
-    uiPorts, loadUserEndpoints, inspectImport, applyImport, settingsStore, saveUserHook,
-    CHANNEL, DEFAULT_SETTINGS, ExportPassphraseError,
-  }),
+  ...systemMessageRoutes,
   // denylistNetGuard: an edit changes what the network backstop blocks, so the
   // rule is rebuilt on every edit — including the removal path, where a stale
   // rule would keep blocking a site the user just unblocked.
@@ -5558,15 +5721,7 @@ browser.runtime.onMessage.addListener(/** @type {any} */ (makeDispatcher({
       })(),
     };
   },
-  ...makeSettingsRoutes({
-    vault, auditLog, pushState, kv, memory, settingsStore,
-    normalizeSettingsPatch, normalizeVariant, normalizeEngine, listProviders,
-    REASONING_EFFORT_LEVELS, DWEB_ENABLED, DEFAULT_SETTINGS,
-    buildExport, CHANNEL, exportHooks, skillRegistry,
-    // React to the dweb-agent toggle: join/leave the inbox room so a disable
-    // withdraws mesh presence immediately (idempotent; no-op for other keys).
-    onSettingsChanged,
-  }),
+  ...settingsMessageRoutes,
   ...makeSessionMutationRoutes({
     vault, auditLog, pushState, sessions, sessionCache, sessionState, autoMemory,
     resolvePermission, normalizeMode, normalizeConfirmActions, SessionNotFoundError,
@@ -5583,8 +5738,8 @@ browser.runtime.onMessage.addListener(/** @type {any} */ (makeDispatcher({
   ...makeLocalModelRoutes({ ensureOffscreen, browser, localModelState }),
   ...makeDwebRoutes({
     vault, auditLog, kv, ensureOffscreen, browser,
-    appRegistry, appClient, appTabTracker, opfsHelpers, settingsStore,
-    DWEB_ENABLED, DWEB_IDENTITY_SECRET, APP_TAB_GROUP_TITLE,
+    appRegistry, appClient, appTabTracker, settingsStore, shareLocalApp,
+    DWEB_ENABLED, APP_TAB_GROUP_TITLE,
     onBaseNetworkStopped,
   }),
 
@@ -5657,9 +5812,18 @@ setInterval(() => {
 // false) — and this file names no dweb module, so the store verifier stays clean.
 function maybeStartBaseNetwork(/** @type {string} */ reason) {
   if (!DWEB_ENABLED || !settingsStore.get().dwebEnabled) return;
+  if (dwebIdentityMutationActive) {
+    dwebStartDeferredByIdentityMutation = true;
+    console.log('[sw] dweb base network — start deferred during identity custody mutation');
+    return;
+  }
   console.log('[sw] dweb base network — auto-start on', reason);
   (async () => {
+    await ensureDwebSuspensionRecovery();
     await ensureOffscreen();
+    // The host owns its suspension lease. A normal start may race a rotation,
+    // but it cannot release that lease and will fail harmlessly until the owner
+    // resumes with the matching token.
     const r = /** @type {any} */ (await browser.runtime.sendMessage({ type: 'dweb/base-host/start' }));
     if (r?.ok) {
       console.log('[sw] dweb base network ONLINE', { did: r.did, peers: r.peers, present: r.present });
@@ -5718,7 +5882,10 @@ async function reseedSharedApps() {
 // window. The offscreen doc holds the keepalive port and voice host;
 // the WebVMs live in their own tabs (vm-tab/index.html).
 console.log('[sw] boot — ensuring offscreen for keepalive + voice');
-ensureOffscreen().catch((e) => console.error('[sw] boot ensureOffscreen failed', e));
+ensureOffscreen().then(async () => {
+  if (!DWEB_ENABLED) return;
+  await ensureDwebSuspensionRecovery();
+}).catch((e) => console.error('[sw] boot ensureOffscreen failed', e));
 
 // Instance registry + tracker init for all three kinds: pull persisted
 // catalogs and re-discover live tabs (a SW restart while tabs are open

--- a/extension/offscreen/dweb-base.js
+++ b/extension/offscreen/dweb-base.js
@@ -20,6 +20,7 @@
 import browser from '/vendor/browser-polyfill.js';
 import { DWEB_ENABLED } from '/shared/channel-config.js';
 import { loadDweb } from '/shared/dweb-loader.js';
+import { makeStartStopBarrier } from '/offscreen/start-stop-barrier.js';
 
 /** @param {...any} a */
 const log = (...a) => console.log('[offscreen/dweb]', ...a);
@@ -33,8 +34,6 @@ const warn = (...a) => console.warn('[offscreen/dweb]', ...a);
 // rather than widening the shared stub (the dweb boundary stays intact).
 /** @type {any} */
 let handle = null;    // { base, room, close } once the lobby is joined
-/** @type {Promise<any> | null} */
-let starting = null;  // in-flight start, so concurrent callers share it
 /** @type {ReturnType<typeof setInterval> | null} */
 let resubTimer = null; // periodic re-subscribe — self-heals a missed onPeer SUB
 
@@ -65,6 +64,65 @@ const rooms = new Map();        // roomId -> { room, refs, name, topicSubs:Map, 
 
 /** @param {string} type @param {object} [payload] @returns {Promise<any>} */
 const swCall = (type, payload = {}) => browser.runtime.sendMessage({ type, ...payload });
+
+// The permanent identity seed and backup passphrase never ride swCall. This
+// dedicated channel is accepted only after the service worker verifies the
+// browser-owned offscreen sender metadata.
+const CUSTODY_PORT_NAME = 'dweb-custody';
+const CUSTODY_RECONNECT_MS = 500;
+const CUSTODY_TIMEOUT_MS = 60_000;
+/** @type {import('webextension-polyfill').Runtime.Port | null} */
+let custodyPort = null;
+/** @type {Set<{ resolve: (port: import('webextension-polyfill').Runtime.Port) => void, reject: (reason: any) => void, timer: ReturnType<typeof setTimeout> }>} */
+const custodyWaiters = new Set();
+/** @type {Map<string, { resolve: (value: any) => void, reject: (reason: any) => void, timer: ReturnType<typeof setTimeout> }>} */
+const custodySecretPending = new Map();
+
+const rejectCustodySecretPending = () => {
+  for (const entry of custodySecretPending.values()) {
+    clearTimeout(entry.timer);
+    entry.reject(new Error('identity custody port disconnected'));
+  }
+  custodySecretPending.clear();
+};
+
+const waitForCustodyPort = async () => {
+  if (custodyPort) return custodyPort;
+  return new Promise((resolve, reject) => {
+    const waiter = {
+      resolve,
+      reject,
+      timer: setTimeout(() => {
+        custodyWaiters.delete(waiter);
+        reject(new Error('identity custody port timed out'));
+      }, CUSTODY_TIMEOUT_MS),
+    };
+    custodyWaiters.add(waiter);
+  });
+};
+
+/** @param {'get'|'set'} operation @param {any} [args] */
+const callIdentitySecret = async (operation, args = {}) => {
+  const port = await waitForCustodyPort();
+  if (custodyPort !== port) throw new Error('identity custody port disconnected');
+  const requestId = crypto.randomUUID();
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      custodySecretPending.delete(requestId);
+      reject(new Error(`identity custody ${operation} timed out`));
+    }, CUSTODY_TIMEOUT_MS);
+    custodySecretPending.set(requestId, { resolve, reject, timer });
+    try {
+      port.postMessage({
+        type: 'custody/secret-request', requestId, operation, args,
+      });
+    } catch (cause) {
+      custodySecretPending.delete(requestId);
+      clearTimeout(timer);
+      reject(cause);
+    }
+  });
+};
 
 // peerd notifications: emit a runtime 'dweb/notify' for genuinely-NEW peers and
 // apps so the UI surfaces them (the bell + an in-chat banner), each linking to
@@ -99,57 +157,148 @@ const startNotifications = (h) => {
 
 // Join the lobby once. Identity comes from the vault via the SW (the offscreen
 // doc has no vault access) — so this only succeeds once the vault is unlocked.
-const start = async () => {
-  if (handle) return handle;
-  if (!starting) {
-    starting = (async () => {
-      log('starting base network…');
-      // why any: the live dweb module's surface exceeds the stub interface (see top).
-      const client = /** @type {any} */ (await loadDweb());
-      if (!client.available || !client.joinBaseNetwork) { warn('dweb module unavailable here — inert'); return null; }
-      let identity;
-      try {
-        const material = await client.identityMaterial({
-          getSecret: async () => {
-            const r = await swCall('dweb/identity-get');
-            if (!r?.ok) throw new Error(r?.error === 'vault-locked' ? 'vault is locked — unlock peerd first' : (r?.error ?? 'identity unavailable'));
-            return r.value;
-          },
-          setSecret: async (/** @type {string} */ _n, /** @type {string} */ value) => {
-            const r = await swCall('dweb/identity-set', { value });
-            if (!r?.ok) throw new Error(r?.error ?? 'identity store failed');
-          },
-        });
-        identity = await client.identityFromMaterial(material);
-      } catch (e) {
-        warn('identity step failed:', /** @type {{ message?: string }} */ (e)?.message ?? e);
-        starting = null; // let a later call retry (e.g. after unlock)
-        throw e;
-      }
-      log(`joining lobby "${client.BASE_TOPIC}" as …${identity.did.slice(-8)}`);
-      handle = await client.joinBaseNetwork({ identity });
-      handle.base.start();
-      startNotifications(handle);
-      // Late joiners now discover via the sovereign subscription plane (they ASK
-      // on connect), so there is no periodic re-announce timer to run — the card
-      // streams to subscribers and a snapshot answers each new SUBSCRIBE.
-      handle.base.onDwappAnnounce((/** @type {any} */ a) => log('discovery card:', a?.dwapp_id?.slice(0, 12), `from …${String(a?.publisher).slice(-8)}`));
-      // Self-heal the discovery subscription. The SUB is sent on mesh.onPeer when a
-      // link forms, but that fire-once handshake is racy over real WebRTC (a SUB can
-      // land before the channel is fully ready, or onPeer can be missed) — and a
-      // missed SUB means a peer's shares never reach our Library. Re-subscribing to
-      // every linked peer on a timer makes it eventually-consistent: each SUB is
-      // idempotent and triggers a fresh SNAPSHOT back, so a peer's already-shared
-      // apps arrive within one interval even if the initial subscribe was lost.
-      if (!resubTimer) {
-        resubTimer = setInterval(() => { try { handle?.base?.discovery?.subscribeAll(); } catch { /* best-effort */ } }, 12_000);
-      }
-      log('✅ base network ONLINE — lobby joined, presence beaconing');
-      return handle;
-    })();
+// The barrier makes stop a real lifecycle fence even while this async setup is
+// between reading the old identity and publishing its eventual handle.
+const baseLifecycle = makeStartStopBarrier({
+  getActive: () => handle,
+  create: async () => {
+    log('starting base network…');
+    // why any: the live dweb module's surface exceeds the stub interface (see top).
+    const client = /** @type {any} */ (await loadDweb());
+    if (!client.available || !client.joinBaseNetwork) { warn('dweb module unavailable here — inert'); return null; }
+    let identity;
+    try {
+      const material = await client.identityMaterial({
+        getSecret: async () => {
+          const r = await callIdentitySecret('get');
+          if (!r?.ok) throw new Error(r?.error === 'vault-locked' ? 'vault is locked — unlock peerd first' : (r?.error ?? 'identity unavailable'));
+          return r.value;
+        },
+        setSecret: async (/** @type {string} */ _n, /** @type {string} */ value) => {
+          const r = await callIdentitySecret('set', { value });
+          if (!r?.ok) throw new Error(r?.error ?? 'identity store failed');
+        },
+      });
+      identity = await client.identityFromMaterial(material);
+    } catch (e) {
+      warn('identity step failed:', /** @type {{ message?: string }} */ (e)?.message ?? e);
+      throw e;
+    }
+    log(`joining lobby "${client.BASE_TOPIC}" as …${identity.did.slice(-8)}`);
+    return client.joinBaseNetwork({ identity });
+  },
+  activate: (candidate) => {
+    candidate.base.start();
+    handle = candidate;
+    startNotifications(candidate);
+    // Late joiners discover through the sovereign subscription plane.
+    candidate.base.onDwappAnnounce((/** @type {any} */ a) => log('discovery card:', a?.dwapp_id?.slice(0, 12), `from …${String(a?.publisher).slice(-8)}`));
+    // Self-heal discovery if the initial subscription races WebRTC readiness.
+    if (!resubTimer) {
+      resubTimer = setInterval(() => { try { handle?.base?.discovery?.subscribeAll(); } catch { /* best-effort */ } }, 12_000);
+    }
+    log('✅ base network ONLINE — lobby joined, presence beaconing');
+  },
+  close: (candidate) => {
+    candidate.close();
+    if (handle !== candidate) return;
+    // Once close succeeds the identity is no longer live. Listener cleanup is
+    // best-effort so a stale unsubscribe cannot turn a successful stop into a
+    // false failure that blocks identity recovery.
+    for (const entry of rooms.values()) {
+      for (const off of entry.offs) { try { off(); } catch { /* already closed */ } }
+      for (const off of entry.topicSubs.values()) { try { off(); } catch { /* already closed */ } }
+    }
+    rooms.clear();
+    if (resubTimer) { clearInterval(resubTimer); resubTimer = null; }
+    handle = null;
+    log('base network stopped');
+  },
+});
+
+const start = () => baseLifecycle.start();
+
+/** @param {'export'|'adopt'|'suspend'|'resume'|'reset'} operation @param {any} args */
+const runCustodyOperation = async (operation, args) => {
+  if (operation === 'suspend') {
+    if (typeof args?.leaseId !== 'string' || args.leaseId.length === 0) {
+      throw new Error('lease-required');
+    }
+    await baseLifecycle.stop({ suspensionOwner: args.leaseId });
+    return { suspended: true };
   }
-  return starting;
+  if (operation === 'resume') {
+    if (typeof args?.leaseId !== 'string' || args.leaseId.length === 0) {
+      throw new Error('lease-required');
+    }
+    return { resumed: baseLifecycle.resume(args.leaseId) };
+  }
+  if (operation === 'reset') {
+    baseLifecycle.resetSuspension();
+    return { reset: true };
+  }
+  const client = await loadDweb();
+  if (operation === 'export') {
+    if (!client.identityRecordExport) throw new Error('portable identity export is unsupported');
+    return client.identityRecordExport(args);
+  }
+  if (operation === 'adopt') {
+    if (!client.identityRecordAdopt) throw new Error('portable identity restore is unsupported');
+    return client.identityRecordAdopt(args);
+  }
+  throw new Error('unknown identity custody operation');
 };
+
+const connectCustodyPort = () => {
+  if (!DWEB_ENABLED) return;
+  try {
+    const port = browser.runtime.connect({ name: CUSTODY_PORT_NAME });
+    custodyPort = port;
+    for (const waiter of custodyWaiters) {
+      clearTimeout(waiter.timer);
+      waiter.resolve(port);
+    }
+    custodyWaiters.clear();
+    /** @param {any} response */
+    const respond = (response) => {
+      try { port.postMessage(response); } catch { /* disconnect rejects the SW-side request */ }
+    };
+    port.onMessage.addListener((/** @type {any} */ message) => {
+      if (message?.type === 'custody/secret-response'
+          && typeof message.requestId === 'string') {
+        const entry = custodySecretPending.get(message.requestId);
+        if (!entry) return;
+        custodySecretPending.delete(message.requestId);
+        clearTimeout(entry.timer);
+        if (message.ok) entry.resolve(message.result);
+        else entry.reject(new Error(message.error ?? 'identity secret operation failed'));
+        return;
+      }
+      if (message?.type !== 'custody/request'
+          || typeof message.requestId !== 'string'
+          || !['export', 'adopt', 'suspend', 'resume', 'reset'].includes(message.operation)) return;
+      Promise.resolve(runCustodyOperation(message.operation, message.args ?? {}))
+        .then((result) => respond({
+          type: 'custody/response', requestId: message.requestId, ok: true, result,
+        }))
+        .catch((cause) => respond({
+          type: 'custody/response', requestId: message.requestId, ok: false,
+          error: /** @type {{ code?: string, message?: string }} */ (cause)?.code
+            ?? /** @type {{ message?: string }} */ (cause)?.message ?? 'host-failed',
+        }));
+    });
+    port.onDisconnect.addListener(() => {
+      if (custodyPort === port) {
+        custodyPort = null;
+        rejectCustodySecretPending();
+      }
+      setTimeout(connectCustodyPort, CUSTODY_RECONNECT_MS);
+    });
+  } catch {
+    setTimeout(connectCustodyPort, CUSTODY_RECONNECT_MS);
+  }
+};
+connectCustodyPort();
 
 const status = () => (handle
   ? { running: true, did: handle.base.did, peers: handle.base.peers().length, present: handle.base.presence.list().length }
@@ -360,7 +509,7 @@ const onBaseHostMessage = (msg, _sender, sendResponse) => {
         // to unshare — answer ok so delete still succeeds.
         case 'dweb/base-host/unshare-app': {
           if (!handle) { sendResponse({ ok: true, unserved: false, removed: false }); return; }
-          const r = await handle.base.unshareApp({ slug: slugify(msg.name), publisher: msg.publisher || handle.base.did, hash: msg.hash || null });
+          const r = await handle.base.unshareApp({ slug: slugify(msg.slug || msg.name), publisher: msg.publisher || handle.base.did, hash: msg.hash || null });
           log(`unshared app "${msg.name}" — unserved:${r.unserved} removed:${r.removed}`);
           sendResponse({ ok: true, ...r });
           return;
@@ -416,13 +565,7 @@ const onBaseHostMessage = (msg, _sender, sendResponse) => {
           return;
         }
         case 'dweb/base-host/stop': {
-          if (handle) {
-            for (const e of rooms.values()) { for (const off of e.offs) off(); for (const off of e.topicSubs.values()) off(); }
-            rooms.clear();
-            if (resubTimer) { clearInterval(resubTimer); resubTimer = null; }
-            handle.close(); handle = null; starting = null;
-            log('base network stopped');
-          }
+          await baseLifecycle.stop();
           sendResponse({ ok: true });
           return;
         }

--- a/extension/offscreen/start-stop-barrier.js
+++ b/extension/offscreen/start-stop-barrier.js
@@ -1,0 +1,141 @@
+// @ts-check
+
+// why: MV3 messages can ask a long-starting host to stop before it has exposed
+// its handle. A generation barrier makes stop wait for that attempt and closes
+// any late candidate before reporting success, so callers may safely rotate the
+// identity or other custody material that the host captured at startup.
+
+export class HostStartCancelledError extends Error {
+  constructor() {
+    super('host start was cancelled by stop');
+    this.name = 'HostStartCancelledError';
+  }
+}
+
+export class HostStopFailedError extends Error {
+  /** @param {unknown} cause */
+  constructor(cause) {
+    super('host could not be stopped', { cause });
+    this.name = 'HostStopFailedError';
+  }
+}
+
+export class HostSuspendedError extends Error {
+  constructor() {
+    super('host start is suspended');
+    this.name = 'HostSuspendedError';
+  }
+}
+
+/**
+ * Serialize start/stop across an async host startup.
+ *
+ * @param {{
+ *   getActive: () => any,
+ *   create: () => Promise<any>,
+ *   activate: (candidate: any) => void | Promise<void>,
+ *   close: (candidate: any) => void | Promise<void>,
+ * }} dependencies
+ */
+export const makeStartStopBarrier = ({ getActive, create, activate, close }) => {
+  let generation = 0;
+  /** @type {string | null} */
+  let suspensionOwner = null;
+  let stopping = false;
+  /** @type {Promise<any> | null} */
+  let pending = null;
+
+  /** @param {any} candidate */
+  const closeForStop = async (candidate) => {
+    try {
+      await close(candidate);
+    } catch (cause) {
+      throw new HostStopFailedError(cause);
+    }
+  };
+
+  const start = () => {
+    if (suspensionOwner !== null || stopping) return Promise.reject(new HostSuspendedError());
+    const active = getActive();
+    if (active) return Promise.resolve(active);
+    if (!pending) {
+      const startGeneration = generation;
+      const attempt = (async () => {
+        const candidate = await create();
+        if (!candidate) return candidate;
+        if (startGeneration !== generation) {
+          await closeForStop(candidate);
+          throw new HostStartCancelledError();
+        }
+        try {
+          await activate(candidate);
+        } catch (cause) {
+          await closeForStop(candidate);
+          throw cause;
+        }
+        if (startGeneration !== generation) {
+          await closeForStop(candidate);
+          throw new HostStartCancelledError();
+        }
+        return candidate;
+      })();
+      pending = attempt;
+      // why: start callers still receive the rejection; this observer only
+      // releases the shared attempt without creating an unhandled finally()
+      // promise when no caller is waiting (for example, a background autostart).
+      void attempt.finally(() => {
+        if (pending === attempt) pending = null;
+      }).catch(() => {});
+    }
+    return pending;
+  };
+
+  /** @param {{ suspensionOwner?: string }} [options] */
+  const stop = async ({ suspensionOwner: requestedOwner } = {}) => {
+    // Flip this before observing pending/active state. No new start may enter
+    // the stop→custody-write gap while an identity rotation owns the lease.
+    if (requestedOwner !== undefined) {
+      if (!requestedOwner || (suspensionOwner !== null && suspensionOwner !== requestedOwner)) {
+        throw new HostSuspendedError();
+      }
+      suspensionOwner = requestedOwner;
+    }
+    stopping = true;
+    generation += 1;
+    try {
+      const inFlight = pending;
+      if (inFlight) {
+        try {
+          await inFlight;
+        } catch (cause) {
+          // A normal start failure or deliberate cancellation leaves no live
+          // candidate. A failed close is different: the caller must not rotate
+          // custody state while the old host may still be alive.
+          if (cause instanceof HostStopFailedError) throw cause;
+        }
+      }
+      const active = getActive();
+      if (active) await closeForStop(active);
+    } finally {
+      stopping = false;
+    }
+  };
+
+  /** @param {string} owner */
+  const resume = (owner) => {
+    // An acknowledgement can be lost after a successful release. Retrying the
+    // same release is safe when no owner remains; it can never clear another
+    // owner's live lease.
+    if (suspensionOwner === null) return true;
+    if (suspensionOwner !== owner) return false;
+    suspensionOwner = null;
+    return true;
+  };
+
+  // why: an offscreen document can outlive the MV3 service worker that owned
+  // a lease. Only the new worker's boot barrier calls this; normal starts and
+  // unrelated operations must never be able to release a live owner's lease.
+  const resetSuspension = () => { suspensionOwner = null; };
+
+  return { start, stop, resume, resetSuspension };
+};

--- a/extension/options/components/options-app.js
+++ b/extension/options/components/options-app.js
@@ -53,7 +53,7 @@ const NAV = [
     items: [
       ['memory', 'Memory'],
       ['costs', 'Costs'],
-      ['transfer', 'Export & import'],
+      ['transfer', 'Backup & restore'],
     ],
   },
   {

--- a/extension/options/options.css
+++ b/extension/options/options.css
@@ -110,8 +110,96 @@
 .options-page h3 { font-size: 13px; font-weight: 600; margin: 16px 0 4px; }
 .options-page h3:first-of-type { margin-top: 10px; }
 .options-page p { margin: 0 0 10px; color: var(--fg-muted); font-size: 13px; }
-.options-page p.error { color: var(--danger); }
+.options-page p.error { color: var(--danger-ink); }
 .options-page .hint { font-size: 12px; margin-top: 4px; }
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Identity replacement is the one destructive action on this page. The
+ * semantic error red is the brand rule's sanctioned exception. */
+.options-page button.danger {
+  background: transparent;
+  color: var(--danger-ink);
+  border-color: var(--danger);
+}
+.options-page button.danger:hover { background: color-mix(in srgb, var(--danger) 10%, transparent); }
+.identity-replace-confirmation {
+  border: 1px solid var(--danger);
+  border-radius: 6px;
+  padding: 10px 12px;
+  margin-top: 10px;
+}
+.import-summary h4 {
+  margin: 0 0 6px;
+  font-size: 13px;
+}
+
+.import-setting-values code {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.identity-did {
+  overflow-wrap: anywhere;
+  user-select: all;
+}
+.transfer-progress { color: var(--fg); }
+.transfer-progress-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+}
+.transfer-progress-row .transfer-progress { margin: 0; }
+.options-page .transfer-status--success { color: var(--fg); }
+.options-page .transfer-status--error { color: var(--danger-ink); }
+.identity-replace-confirmation:focus { outline: 2px solid var(--danger); outline-offset: 2px; }
+
+/* why transfer controls use neutral ink: cyan with light text misses AA text
+ * contrast in light mode, while the product's surface language is monochrome.
+ * The stronger neutral borders also keep form boundaries and focus visible. */
+.transfer-section button { min-height: 44px; }
+.transfer-section button:not(.secondary):not(.danger) {
+  background: var(--fg);
+  color: var(--bg);
+}
+.transfer-section button.secondary { border-color: var(--fg-muted); }
+.transfer-section input[type="password"] {
+  box-sizing: border-box;
+  min-height: 44px;
+  border-color: var(--fg-muted);
+}
+.transfer-section input[type="file"] {
+  box-sizing: border-box;
+  min-height: 44px;
+  color: var(--fg);
+}
+.transfer-section input[type="file"]::file-selector-button {
+  min-height: 44px;
+  margin-inline-end: 8px;
+  border: 1px solid var(--fg-muted);
+  border-radius: var(--radius);
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+  cursor: pointer;
+}
+.transfer-section input[type="password"]:focus,
+.transfer-section input[type="password"]:focus-visible,
+.transfer-section input[type="file"]:focus-visible,
+.transfer-section button:focus-visible {
+  border-color: var(--fg);
+  outline: 2px solid var(--fg);
+  outline-offset: 2px;
+}
 
 /* --- vault gate ----------------------------------------------------------- */
 

--- a/extension/options/options.js
+++ b/extension/options/options.js
@@ -22,6 +22,11 @@ import m from '/vendor/mithril/mithril.js';
 import browser from '/vendor/browser-polyfill.js';
 import { DWEB_ENABLED } from '/shared/channel-config.js';
 import { OptionsApp } from './components/options-app.js';
+import { makePrivateTransferClient } from './private-transfer-client.js';
+
+const privateTransferClient = makePrivateTransferClient({
+  connect: () => browser.runtime.connect({ name: 'private-transfer' }),
+});
 
 // null until the first snapshot lands — the shell renders a loading
 // gate rather than guessing at vault state (a flash of "set up peerd"
@@ -97,7 +102,9 @@ const foldReply = (msg, reply) => {
  * @returns {Promise<any>}
  */
 const send = async (msg) => {
-  const reply = await browser.runtime.sendMessage(msg);
+  const reply = msg.type.startsWith('transfer/')
+    ? await privateTransferClient.call(msg)
+    : await browser.runtime.sendMessage(msg);
   foldReply(msg, reply);
   return reply;
 };

--- a/extension/options/private-transfer-client.js
+++ b/extension/options/private-transfer-client.js
@@ -1,0 +1,84 @@
+// @ts-check
+// Options-side half of the sender-verified backup/restore Port.
+
+export class PrivateTransferPortError extends Error {
+  /** @param {string} message @param {string} code */
+  constructor(message, code) {
+    super(message);
+    this.name = 'PrivateTransferPortError';
+    this.code = code;
+  }
+}
+
+/**
+ * @param {Object} deps
+ * @param {() => import('webextension-polyfill').Runtime.Port} deps.connect
+ * @param {() => string} [deps.newRequestId]
+ * @param {number} [deps.timeoutMs]
+ */
+export const makePrivateTransferClient = ({
+  connect, newRequestId = () => crypto.randomUUID(), timeoutMs = 60_000,
+}) => {
+  /** @type {import('webextension-polyfill').Runtime.Port | null} */
+  let port = null;
+  /** @type {Map<string, { resolve: (value: any) => void, reject: (reason: any) => void, timer: ReturnType<typeof setTimeout> }>} */
+  const pending = new Map();
+
+  const rejectPending = () => {
+    for (const entry of pending.values()) {
+      clearTimeout(entry.timer);
+      entry.reject(new PrivateTransferPortError('backup connection closed', 'port-disconnected'));
+    }
+    pending.clear();
+  };
+
+  const ensurePort = () => {
+    if (port) return port;
+    const next = connect();
+    port = next;
+    next.onMessage.addListener((/** @type {any} */ response) => {
+      if (response?.type !== 'private-transfer/response'
+          || typeof response.requestId !== 'string') return;
+      const entry = pending.get(response.requestId);
+      if (!entry) return;
+      pending.delete(response.requestId);
+      clearTimeout(entry.timer);
+      if (response.ok) entry.resolve(response.reply);
+      else entry.reject(new PrivateTransferPortError(
+        typeof response.error === 'string' ? response.error : 'backup request failed',
+        'request-failed',
+      ));
+    });
+    next.onDisconnect.addListener(() => {
+      if (port !== next) return;
+      port = null;
+      rejectPending();
+    });
+    return next;
+  };
+
+  /** @param {{ type: string } & Record<string, any>} message */
+  const call = (message) => {
+    const active = ensurePort();
+    const requestId = newRequestId();
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(requestId);
+        reject(new PrivateTransferPortError('backup request timed out', 'timeout'));
+      }, timeoutMs);
+      pending.set(requestId, { resolve, reject, timer });
+      try {
+        active.postMessage({ type: 'private-transfer/request', requestId, message });
+      } catch (cause) {
+        pending.delete(requestId);
+        clearTimeout(timer);
+        reject(new PrivateTransferPortError(
+          /** @type {{ message?: string }} */ (cause)?.message ?? 'backup request could not be sent',
+          'post-failed',
+        ));
+      }
+    });
+  };
+
+  return { call };
+};

--- a/extension/options/sections/dweb.js
+++ b/extension/options/sections/dweb.js
@@ -72,7 +72,8 @@ export const DwebSection = {
       ui.dwebStatus ? m('p.hint', [
         `Protocol phase ${ui.dwebStatus.phase ?? '—'}. `,
         ui.dwebStatus.did
-          ? ['Identity: ', m('code', ui.dwebStatus.did), ' (ephemeral this view; the persistent one is vault-stored).']
+          ? ['Peer identity: ', m('code', ui.dwebStatus.did), '. ',
+            m('a', { href: '#!/transfer' }, 'Back up or restore this identity.')]
           : 'Identity is vault-stored and created on first room join.',
       ]) : null,
 

--- a/extension/options/sections/transfer.js
+++ b/extension/options/sections/transfer.js
@@ -1,13 +1,66 @@
 // @ts-check
-// Options → Export & import — the explicit migration path between
+// Options → Backup & restore — the explicit migration path between
 // installs, including between peerd (store) and peerd preview, which
 // are separate extensions with isolated storage by design. Ported
-// unchanged from the panel's "Export & import" section; the routes are
+// backed by the existing transfer routes:
 // transfer/export + transfer/inspectImport + transfer/import.
 
 import m from '/vendor/mithril/mithril.js';
 import { CHANNEL } from '/shared/channel-config.js';
-import { bundleToOtlp } from '/peerd-runtime/index.js';
+import { bundleToOtlp, EXPORT_PASSPHRASE_MIN_LENGTH } from '/peerd-runtime/index.js';
+
+const MAX_BACKUP_FILE_BYTES = 32 * 1024 * 1024;
+/** @param {string | null | undefined} did */
+const displayDid = (did) => did || 'unknown';
+/** @param {any} summary */
+const hasApplicableImport = (summary) => !!summary && (
+  summary.settingsKeys?.length > 0
+  || summary.hasSecrets
+  || (summary.hasIdentityRecord && !summary.dwebDropped)
+  || summary.memoryDocs > 0
+  || summary.hooks > 0
+  || summary.endpointUrls?.length > 0
+);
+/** @param {any} counts */
+const describeImportedCounts = (counts = {}) =>
+  `${counts.settings ?? 0} setting(s), ${counts.secrets ?? 0} stored credential(s), `
+  + `${counts.providerEndpoints ?? 0} provider endpoint(s), ${counts.memoryWritten ?? 0} memory doc(s), `
+  + `and ${counts.hooks ?? 0} hook(s)`;
+/** @param {string | null | undefined} failure */
+const describeImportFailure = (failure) => (/** @type {Record<string, string>} */ ({
+  'wrong-passphrase': 'The peer identity could not be unlocked with that passphrase.',
+  'dweb-identity-stop-failed': 'The peer network could not be paused safely.',
+  'dweb-identity-store-failed': 'The peer identity could not be stored.',
+  'dweb-identity-resume-failed': 'The peer network could not be resumed.',
+  'write-failed': 'A local write failed.',
+}))[failure ?? ''] ?? 'A local restore step failed.';
+/** @param {string | null | undefined} error */
+const describeImportError = (error) => {
+  if (error?.startsWith('unsupported-export-version-')) {
+    return 'This backup was created by an incompatible peerd version. Update peerd and try again.';
+  }
+  return (/** @type {Record<string, string>} */ ({
+    'wrong-passphrase': 'Wrong passphrase for this backup’s encrypted credentials or peer identity.',
+    'vault-locked': 'Vault is locked. Unlock it in the peerd panel, then try again.',
+    'dweb-identity-in-use': 'This identity cannot be replaced while locally authored apps are shared. Unshare them first, then try again.',
+    'dweb-identity-unavailable': 'Peer identity restore is unavailable in this build. Update peerd preview, then try again.',
+    'dweb-identity-dweb-disabled': 'Peer identity restore is unavailable because the peer network is disabled in this build.',
+    'dweb-identity-vault-locked': 'Vault is locked. Unlock it in the peerd panel, then try again.',
+    'dweb-identity-identity-changed': 'The local peer identity changed after review. Inspect the backup again before choosing whether to replace it.',
+    'dweb-identity-no-openable-wrapper': 'The peer identity could not be unlocked with that passphrase.',
+    'dweb-identity-invalid-local-identity': 'The local peer identity is damaged. Stop and restore it from a known-good backup before importing other state.',
+    'dweb-identity-unsupported': 'This backup uses a peer identity format this build cannot restore. Update peerd preview and try again.',
+    'dweb-identity-adopt-failed': 'The peer identity could not be restored. Reopen peerd and try again.',
+    'dweb-identity-approval-required': 'Identity replacement approval expired. Inspect the backup and review both identities again.',
+    'not-a-peerd-export': 'That file is not a peerd export.',
+    'invalid-export-sections': 'That peerd export has malformed or oversized sections and was refused.',
+  }))[error ?? ''] ?? 'Import failed. Reopen peerd, inspect the backup again, and retry.';
+};
+/** @param {unknown} value */
+const describeSettingValue = (value) => {
+  const encoded = JSON.stringify(value);
+  return typeof encoded === 'string' ? encoded : String(value);
+};
 
 /** @typedef {import('./reset-row.js').Send} Send */
 
@@ -22,8 +75,16 @@ export const TransferSection = {
     vnode.state.importSummary = null;         // inspectImport summary
     vnode.state.importPass = '';
     vnode.state.importBusy = false;
+    vnode.state.importInspectBusy = false;
     vnode.state.importMsg = null;             // { ok, text } | null
     vnode.state.importNotices = [];
+    vnode.state.identityConflict = null;
+    vnode.state.replacementPending = false;
+    vnode.state.importFileInput = null;
+    vnode.state.importInspectGeneration = 0;
+    vnode.state.restoreFocusToReview = false;
+    vnode.state.focusImportFileOnUpdate = false;
+    vnode.state.focusImportStatusOnUpdate = false;
     // Artifacts (.peerd app/notebook/vm files — DESIGN-10). Same
     // inspect-then-apply shape as the settings import above, but a
     // separate state island: artifacts and settings never mix.
@@ -83,8 +144,11 @@ export const TransferSection = {
     const doExport = async () => {
       if (ui.exportBusy) return;
       ui.exportMsg = null;
-      if (ui.exportPass.length < 8) {
-        ui.exportMsg = { ok: false, text: 'Passphrase must be at least 8 characters.' };
+      if (ui.exportPass.length < EXPORT_PASSPHRASE_MIN_LENGTH) {
+        ui.exportMsg = {
+          ok: false,
+          text: `Use a long, unique passphrase (${EXPORT_PASSPHRASE_MIN_LENGTH}+ characters).`,
+        };
         return;
       }
       if (ui.exportPass !== ui.exportConfirm) {
@@ -93,54 +157,93 @@ export const TransferSection = {
       }
       ui.exportBusy = true;
       m.redraw();
-      const reply = await send({ type: 'transfer/export', passphrase: ui.exportPass });
-      ui.exportBusy = false;
-      if (reply?.ok) {
-        const blob = new Blob([JSON.stringify(reply.payload, null, 2)], { type: 'application/json' });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `peerd-export-${new Date().toISOString().slice(0, 10)}.json`;
-        a.click();
-        URL.revokeObjectURL(url);
-        ui.exportPass = '';
-        ui.exportConfirm = '';
-        ui.exportMsg = { ok: true, text: 'Exported. Keep the file AND the passphrase — your API keys are encrypted with it.' };
-      } else {
-        ui.exportMsg = {
-          ok: false,
-          text: reply?.error === 'vault-locked' ? 'Vault is locked — unlock in the peerd panel first.'
-            : reply?.error === 'passphrase-required' ? 'A passphrase (8+ characters) is required because the vault holds API keys.'
-            : reply?.error ?? 'Export failed.',
-        };
+      try {
+        const reply = await send({ type: 'transfer/export', passphrase: ui.exportPass });
+        if (reply?.ok) {
+          const blob = new Blob([JSON.stringify(reply.payload, null, 2)], { type: 'application/json' });
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = `peerd-export-${new Date().toISOString().slice(0, 10)}.json`;
+          a.click();
+          URL.revokeObjectURL(url);
+          ui.exportPass = '';
+          ui.exportConfirm = '';
+          ui.exportMsg = {
+            ok: true,
+            text: reply.identityIncluded
+              ? `Backup saved with peer identity ${displayDid(reply.identityDid)}. Keep both the file and its passphrase safe.`
+              : CHANNEL === 'preview'
+                ? 'Backup saved without a peer identity because this install does not have one yet. Keep both the file and its passphrase safe.'
+                : 'Backup saved. This build does not carry a peer identity. Keep both the file and its passphrase safe.',
+          };
+        } else {
+          ui.exportMsg = {
+            ok: false,
+            text: reply?.error === 'vault-locked' ? 'Vault is locked — unlock in the peerd panel first.'
+              : reply?.error === 'passphrase-required' ? `A long passphrase (${EXPORT_PASSPHRASE_MIN_LENGTH}+ characters) is required to protect credentials and peer identity.`
+              : reply?.error === 'identity-export-failed' ? 'Backup stopped because your peer identity could not be protected. Nothing was downloaded; retry after reopening peerd.'
+              : reply?.error ?? 'Export failed.',
+          };
+        }
+      } catch {
+        ui.exportMsg = { ok: false, text: 'peerd became unavailable while creating the backup. Reopen peerd and retry.' };
+      } finally {
+        ui.exportBusy = false;
+        m.redraw();
       }
-      m.redraw();
     };
 
     const onImportFile = async (/** @type {{ target: HTMLInputElement }} */ e) => {
+      const generation = ++ui.importInspectGeneration;
       ui.importMsg = null;
       ui.importSummary = null;
       ui.importPayload = null;
       ui.importNotices = [];
+      ui.identityConflict = null;
+      ui.replacementPending = false;
       const file = e.target.files?.[0];
       if (!file) return;
+      ui.importInspectBusy = true;
+      m.redraw();
+      if (file.size > MAX_BACKUP_FILE_BYTES) {
+        ui.importMsg = { ok: false, text: 'That backup is too large to import safely (32 MB maximum).' };
+        e.target.value = '';
+        ui.importInspectBusy = false;
+        m.redraw();
+        return;
+      }
+      let payload;
       try {
-        const payload = JSON.parse(await file.text());
+        payload = JSON.parse(await file.text());
+      } catch {
+        if (generation !== ui.importInspectGeneration) return;
+        ui.importMsg = { ok: false, text: 'Could not parse that file as JSON.' };
+        e.target.value = '';
+        ui.importInspectBusy = false;
+        m.redraw();
+        return;
+      }
+      if (generation !== ui.importInspectGeneration) return;
+      try {
         const reply = await send({ type: 'transfer/inspectImport', payload });
+        if (generation !== ui.importInspectGeneration) return;
         if (reply?.ok) {
           ui.importPayload = payload;
           ui.importSummary = reply.summary;
         } else {
           ui.importMsg = {
             ok: false,
-            text: reply?.error === 'not-a-peerd-export'
-              ? 'That file is not a peerd export.'
-              : reply?.error ?? 'Could not read that file.',
+            text: describeImportError(reply?.error),
           };
+          e.target.value = '';
         }
       } catch {
-        ui.importMsg = { ok: false, text: 'Could not parse that file as JSON.' };
+        if (generation !== ui.importInspectGeneration) return;
+        ui.importMsg = { ok: false, text: 'peerd became unavailable while inspecting the backup. Reopen peerd and retry.' };
+        e.target.value = '';
       }
+      if (generation === ui.importInspectGeneration) ui.importInspectBusy = false;
       m.redraw();
     };
 
@@ -150,8 +253,15 @@ export const TransferSection = {
       ui.artifactEnvelope = null;
       const file = e.target.files?.[0];
       if (!file) return;
+      let envelope;
       try {
-        const envelope = JSON.parse(await file.text());
+        envelope = JSON.parse(await file.text());
+      } catch {
+        ui.artifactMsg = { ok: false, text: 'Could not parse that file as a .peerd envelope.' };
+        m.redraw();
+        return;
+      }
+      try {
         const reply = await send({ type: 'import/inspect', envelope });
         if (reply?.ok) {
           ui.artifactEnvelope = envelope;
@@ -160,7 +270,7 @@ export const TransferSection = {
           ui.artifactMsg = { ok: false, text: reply?.error ?? 'Could not read that file.' };
         }
       } catch {
-        ui.artifactMsg = { ok: false, text: 'Could not parse that file as a .peerd envelope.' };
+        ui.artifactMsg = { ok: false, text: 'peerd became unavailable while inspecting the artifact. Reopen peerd and retry.' };
       }
       m.redraw();
     };
@@ -170,67 +280,135 @@ export const TransferSection = {
       ui.artifactBusy = true;
       ui.artifactMsg = null;
       m.redraw();
-      const reply = await send({ type: 'import/apply', envelope: ui.artifactEnvelope });
-      ui.artifactBusy = false;
-      if (reply?.ok) {
-        ui.artifactMsg = {
-          ok: true,
-          text: reply.kind === 'vm'
-            ? `Imported as a new VM (${reply.id}). The base image is integrity-pinned; first boot streams it fresh.`
-            : `Imported as a new ${reply.kind} (${reply.id}).`,
-        };
-        ui.artifactEnvelope = null;
-        ui.artifactSummary = null;
-      } else {
-        ui.artifactMsg = { ok: false, text: reply?.error ?? 'Import failed.' };
+      try {
+        const reply = await send({ type: 'import/apply', envelope: ui.artifactEnvelope });
+        if (reply?.ok) {
+          ui.artifactMsg = {
+            ok: true,
+            text: reply.kind === 'vm'
+              ? `Imported as a new VM (${reply.id}). The base image is integrity-pinned; first boot streams it fresh.`
+              : `Imported as a new ${reply.kind} (${reply.id}).`,
+          };
+          ui.artifactEnvelope = null;
+          ui.artifactSummary = null;
+        } else {
+          ui.artifactMsg = { ok: false, text: reply?.error ?? 'Import failed.' };
+        }
+      } catch {
+        ui.artifactMsg = { ok: false, text: 'peerd became unavailable during the artifact import. Reopen peerd and retry.' };
+      } finally {
+        ui.artifactBusy = false;
+        m.redraw();
       }
-      m.redraw();
     };
 
-    const doImport = async () => {
+    /** @param {boolean} [focusFile] */
+    const clearImportSelection = (focusFile = false) => {
+      ui.importInspectGeneration++;
+      ui.importPayload = null; ui.importSummary = null; ui.importPass = '';
+      ui.identityConflict = null; ui.replacementPending = false;
+      ui.importNotices = [];
+      if (ui.importFileInput) ui.importFileInput.value = '';
+      if (focusFile) ui.focusImportFileOnUpdate = true;
+    };
+
+    /** @param {'normal'|'replace'|'skip'} identityChoice */
+    const doImport = async (identityChoice = 'normal') => {
       if (ui.importBusy || !ui.importPayload) return;
       ui.importBusy = true;
       ui.importMsg = null;
       m.redraw();
-      const reply = await send({ type: 'transfer/import', payload: ui.importPayload, passphrase: ui.importPass });
-      ui.importBusy = false;
-      if (reply?.ok) {
-        ui.importNotices = reply.notices ?? [];
-        ui.importMsg = {
-          ok: true,
-          text: `Imported ${reply.imported.settings} setting(s), ${reply.imported.secrets} API key(s), `
-            + `${reply.imported.memoryWritten} memory doc(s), ${reply.imported.hooks} hook(s).`,
-        };
-        ui.importPayload = null;
-        ui.importSummary = null;
-        ui.importPass = '';
-      } else {
+      try {
+        const reply = await send({
+          type: 'transfer/import',
+          payload: ui.importPayload,
+          passphrase: ui.importPass,
+          replaceDwebIdentity: identityChoice === 'replace',
+          skipDwebIdentity: identityChoice === 'skip',
+          ...(identityChoice === 'replace' ? {
+            approvedExistingDwebDid: ui.identityConflict?.existingDid,
+            approvedExistingDwebRevision: ui.identityConflict?.existingRevision,
+            approvedIncomingDwebDid: ui.identityConflict?.incomingDid,
+          } : {}),
+        });
+        if (reply?.ok) {
+          ui.importNotices = reply.notices ?? [];
+          const identityText = (/** @type {Record<string, string>} */ ({
+            restored: ' The peer identity was restored.',
+            replaced: ' The previous peer identity was replaced.',
+            'already-present': ' The backup’s peer identity was already present.',
+            'kept-local': ' The local peer identity was kept.',
+            unsupported: ' The backup’s peer identity was not supported by this build.',
+            'not-present': '',
+          }))[reply.identityOutcome ?? 'not-present'] ?? '';
+          const recoveryText = reply.runtimeRecoveryPending
+            ? ' The peer network is still recovering. Keep peerd open; it will retry automatically.'
+            : '';
+          ui.importMsg = {
+            ok: true,
+            text: `Imported ${reply.imported.settings} setting(s), ${reply.imported.secrets} stored credential(s), `
+              + `${reply.imported.providerEndpoints ?? 0} provider endpoint(s), `
+              + `${reply.imported.memoryWritten} memory doc(s), and ${reply.imported.hooks} hook(s).${identityText}${recoveryText}`,
+          };
+          ui.importPayload = null;
+          ui.importSummary = null;
+          ui.importPass = '';
+          ui.identityConflict = null;
+          ui.replacementPending = false;
+          ui.focusImportStatusOnUpdate = true;
+          if (ui.importFileInput) ui.importFileInput.value = '';
+        } else if (reply?.partial) {
+          ui.identityConflict = null;
+          ui.replacementPending = false;
+          ui.importMsg = {
+            ok: false,
+            text: `Import stopped after restoring ${describeImportedCounts(reply.partial)}. `
+              + `The peer identity was not changed. ${describeImportFailure(reply.failure)} `
+              + 'Review local state before choosing the backup file again.',
+          };
+          clearImportSelection(true);
+        } else if (reply?.error === 'dweb-identity-conflict') {
+          ui.identityConflict = reply.conflict;
+          ui.replacementPending = false;
+          ui.importMsg = null;
+        } else {
+          ui.importMsg = {
+            ok: false,
+            text: describeImportError(reply?.error),
+          };
+        }
+      } catch {
         ui.importMsg = {
           ok: false,
-          text: reply?.error === 'wrong-passphrase' ? 'Wrong passphrase for the API keys in this file.'
-            : reply?.error === 'vault-locked' ? 'Vault is locked — unlock in the peerd panel first.'
-            : reply?.error ?? 'Import failed.',
+          text: 'The connection to peerd was lost during the import, so its final state is unknown. Reopen peerd, inspect local state, then choose the backup file again.',
         };
+        clearImportSelection(true);
+      } finally {
+        ui.importBusy = false;
+        m.redraw();
       }
-      m.redraw();
     };
 
-    return m('div', [
-      m('h3', 'Export settings'),
+    return m('.transfer-section', [
+      m('h3', 'Back up peerd'),
       m('p', 'Download a JSON file with your settings, memory, hooks, '
-        + 'skill list, and provider endpoints. API keys are included '
-        + 'ENCRYPTED under a passphrase you choose now — the file is '
-        + 'useless without it. Use this to back up, or to move state '
+        + 'skill list, provider endpoints, encrypted credentials, and, in '
+        + 'preview builds, your encrypted peer identity. Most settings remain '
+        + 'readable in the file; the passphrase protects credentials and identity. '
+        + 'Use this to back up, or to move state '
         + 'between peerd and peerd preview (separate installs that never '
         + 'share storage automatically).'),
       m('.input-row', [
         m('label', { for: 'exppass' }, 'Export passphrase'),
         m('input', {
           id: 'exppass', type: 'password', autocomplete: 'new-password',
+          minlength: EXPORT_PASSPHRASE_MIN_LENGTH, 'aria-describedby': 'backup-passphrase-help',
           value: ui.exportPass, disabled: ui.exportBusy,
           oninput: (/** @type {{ target: HTMLInputElement }} */ e) => { ui.exportPass = e.target.value; },
         }),
       ]),
+      m('p.hint', { id: 'backup-passphrase-help' },
+        `Use ${EXPORT_PASSPHRASE_MIN_LENGTH}+ characters. You will need this passphrase to restore encrypted credentials or your peer identity.`),
       m('.input-row', [
         m('label', { for: 'exppass2' }, 'Confirm passphrase'),
         m('input', {
@@ -241,28 +419,62 @@ export const TransferSection = {
       ]),
       m('div', { style: 'display:flex; gap:8px; align-items:center;' }, [
         m('button', { type: 'button', disabled: ui.exportBusy, onclick: doExport },
-          ui.exportBusy ? '…' : 'Export settings'),
+          ui.exportBusy ? 'Creating backup…' : 'Download backup'),
       ]),
-      ui.exportMsg ? m(ui.exportMsg.ok ? 'p' : 'p.error',
-        ui.exportMsg.ok ? { style: 'color: var(--ok);' } : {}, ui.exportMsg.text) : null,
+      ui.exportMsg ? m(ui.exportMsg.ok ? 'p.transfer-status.transfer-status--success' : 'p.error.transfer-status.transfer-status--error',
+        { role: ui.exportMsg.ok ? 'status' : 'alert' },
+        ui.exportMsg.text) : null,
 
       m('.settings-divider'),
-      m('h3', 'Import settings'),
+      m('h3', 'Restore from backup'),
       m('p', 'Pick a peerd export file. You will see exactly what it '
         + 'contains — and what will be overwritten — before anything is '
         + 'applied.'),
+      m('label', { for: 'peerd-backup-file' }, 'Backup file'),
       m('input', {
-        type: 'file', accept: 'application/json,.json',
+        id: 'peerd-backup-file', type: 'file', accept: 'application/json,.json',
         disabled: ui.importBusy,
+        oncreate: (/** @type {{ dom: HTMLInputElement }} */ vnode) => { ui.importFileInput = vnode.dom; },
+        onupdate: (/** @type {{ dom: HTMLInputElement }} */ vnode) => {
+          if (ui.focusImportFileOnUpdate && !vnode.dom.disabled) {
+            ui.focusImportFileOnUpdate = false;
+            vnode.dom.focus();
+          }
+        },
         onchange: onImportFile,
       }),
-      ui.importSummary ? m('.import-summary', [
+      ui.importInspectBusy ? m('.transfer-progress-row', [
+        m('p.transfer-progress', { role: 'status', 'aria-live': 'polite' },
+          'Inspecting backup. Keep this page open, or cancel and choose another file.'),
+        m('button.secondary', {
+          type: 'button',
+          onclick: () => { ui.importInspectBusy = false; clearImportSelection(true); },
+        }, 'Cancel inspection'),
+      ]) : null,
+      ui.importSummary ? m('span.sr-only', { role: 'status' }, 'Backup inspected. Review the import summary and choose what to restore.') : null,
+      ui.importSummary ? m('.import-summary', {
+        id: 'restore-summary', tabindex: -1, 'aria-busy': ui.importBusy ? 'true' : 'false',
+        oncreate: (/** @type {{ dom: HTMLElement }} */ vnode) => vnode.dom.focus(),
+      }, [
         m('h3', 'This import will apply:'),
         m('ul', [
           ui.importSummary.settingsKeys.length > 0
-            ? m('li', `${ui.importSummary.settingsKeys.length} setting(s): ${ui.importSummary.settingsKeys.join(', ')} — these overwrite your current values`)
+            ? m('li', [
+                `${ui.importSummary.settingsKeys.length} setting(s) overwrite your current values.`,
+                m('details.import-setting-values', [
+                  m('summary', 'Review complete setting values'),
+                  m('ul', ui.importSummary.settingsKeys.map((/** @type {string} */ key) =>
+                    m('li', m('code', `${key} = ${describeSettingValue(ui.importPayload?.settings?.[key])}`)))),
+                ]),
+              ])
             : null,
-          ui.importSummary.hasSecrets ? m('li', 'API keys (encrypted — passphrase required below); existing keys with the same provider are overwritten') : null,
+          ui.importSummary.hasSecrets ? m('li', 'Stored credentials (encrypted — passphrase required below); existing credentials with the same name are overwritten') : null,
+          ui.importSummary.hasIdentityRecord
+            ? m('li', [
+                'Peer identity ', m('code.identity-did', displayDid(ui.importSummary.identityDid)),
+                ' (encrypted; restoring it may replace an identity created on this install)',
+              ])
+            : null,
           ui.importSummary.memoryDocs > 0 ? m('li', `${ui.importSummary.memoryDocs} memory doc(s) — newer local edits are kept (last-write-wins)`) : null,
           ui.importSummary.hooks > 0 ? m('li', `${ui.importSummary.hooks} hook(s) — hooks with the same id are replaced`) : null,
           ui.importSummary.skills.length > 0 ? m('li', `Skill list (metadata only): ${ui.importSummary.skills.join(', ')}`) : null,
@@ -271,26 +483,110 @@ export const TransferSection = {
         ui.importSummary.sourceChannel && ui.importSummary.sourceChannel !== CHANNEL
           ? m('p.hint', `This export came from a ${ui.importSummary.sourceChannel} build; you are on ${CHANNEL}. Your explicit values travel verbatim — channel defaults only apply to settings you have not touched.`)
           : null,
-        ui.importSummary.hasSecrets ? m('.input-row', [
+        ui.importSummary.requiresPassphrase ? m('.input-row', [
           m('label', { for: 'imppass' }, 'File passphrase'),
           m('input', {
             id: 'imppass', type: 'password', autocomplete: 'off',
+            'aria-describedby': 'restore-passphrase-help',
             value: ui.importPass, disabled: ui.importBusy,
             oninput: (/** @type {{ target: HTMLInputElement }} */ e) => { ui.importPass = e.target.value; },
           }),
+          m('p.hint', { id: 'restore-passphrase-help' },
+            'Enter the passphrase that was used when this backup was created.'),
         ]) : null,
-        m('div', { style: 'display:flex; gap:8px; align-items:center;' }, [
-          m('button', { type: 'button', disabled: ui.importBusy, onclick: doImport },
-            ui.importBusy ? '…' : 'Apply import'),
+        ui.identityConflict ? m('.import-summary', {
+          id: 'identity-conflict', tabindex: -1, role: 'alert',
+          'aria-labelledby': 'identity-conflict-title',
+          oncreate: (/** @type {{ dom: HTMLElement }} */ vnode) => vnode.dom.focus(),
+        }, [
+          m('h4', { id: 'identity-conflict-title' }, 'Identity conflict'),
+          ui.identityConflict.existingUnreadable
+            ? m('p', ['This install’s local peer identity is unreadable. The backup contains ',
+                m('code.identity-did', displayDid(ui.identityConflict.incomingDid)), '.'])
+            : m('p', ['This install uses ', m('code.identity-did', displayDid(ui.identityConflict.existingDid)),
+                '; the backup uses ', m('code.identity-did', displayDid(ui.identityConflict.incomingDid)), '.']),
+          m('p.hint', ui.identityConflict.existingUnreadable
+            ? 'Keeping the current data imports the other backup sections only. Restoring the backup discards the damaged identity data.'
+            : 'Keeping it imports the other backup sections only. Replacing changes the permanent peer identity seen by existing peers.'),
+        ]) : null,
+        ui.identityConflict && ui.replacementPending ? m('.identity-replace-confirmation', {
+          id: 'identity-replace-confirmation', role: 'alert', tabindex: -1,
+          oncreate: (/** @type {{ dom: HTMLElement }} */ vnode) => vnode.dom.focus(),
+        }, [
+          ui.identityConflict.existingUnreadable
+            ? m('p.error', ['Discard the unreadable local identity and restore ',
+                m('code.identity-did', displayDid(ui.identityConflict.incomingDid)), '?'])
+            : m('p.error', ['Replace permanent peer identity ',
+                m('code.identity-did', displayDid(ui.identityConflict.existingDid)), ' with ',
+                m('code.identity-did', displayDid(ui.identityConflict.incomingDid)), '?']),
+          m('p.hint', ui.identityConflict.existingUnreadable
+            ? 'This permanently discards damaged local identity data. Existing peers will see the restored backup identity. This cannot proceed while locally authored apps are shared.'
+            : 'Existing peers will see a new identity. You can restore the old identity only from another backup. This cannot proceed while locally authored apps are shared.'),
+        ]) : null,
+        ui.importBusy
+          ? m('p.transfer-progress', { role: 'status', 'aria-live': 'polite' },
+              'Restore in progress. It cannot be canceled. Identity checks may take a few seconds. Keep this page open.')
+          : null,
+        !ui.importBusy ? m('p.hint',
+          'After restore starts, it cannot be canceled. Keep this page open until it finishes.') : null,
+        m('div', { style: 'display:flex; gap:8px; align-items:center; flex-wrap:wrap;' }, [
+          ui.identityConflict
+              ? m('button', { type: 'button', disabled: ui.importBusy, onclick: () => doImport('skip') },
+                ui.importBusy ? 'Importing…' : 'Keep current identity & import rest')
+            : m('button', {
+                type: 'button',
+                disabled: ui.importBusy || !hasApplicableImport(ui.importSummary)
+                  || (ui.importSummary.requiresPassphrase && !ui.importPass),
+                onclick: () => doImport('normal'),
+              },
+                ui.importBusy ? 'Importing…' : hasApplicableImport(ui.importSummary) ? 'Apply import' : 'Nothing to restore'),
+          ui.identityConflict
+            ? ui.replacementPending
+              ? m('button.danger', { type: 'button', disabled: ui.importBusy, onclick: () => doImport('replace') },
+                  ui.importBusy ? 'Replacing identity…'
+                    : ui.identityConflict.existingUnreadable
+                      ? 'Discard damaged identity and restore'
+                      : 'Permanently replace identity')
+              : m('button.danger', {
+                  type: 'button', disabled: ui.importBusy,
+                  oncreate: (/** @type {{ dom: HTMLButtonElement }} */ vnode) => {
+                    if (ui.restoreFocusToReview) { ui.restoreFocusToReview = false; vnode.dom.focus(); }
+                  },
+                  onupdate: (/** @type {{ dom: HTMLButtonElement }} */ vnode) => {
+                    if (ui.restoreFocusToReview) { ui.restoreFocusToReview = false; vnode.dom.focus(); }
+                  },
+                  onclick: () => { ui.replacementPending = true; },
+                },
+                  'Review identity replacement')
+            : null,
+          ui.replacementPending
+            ? m('button.secondary', {
+                type: 'button', disabled: ui.importBusy,
+                onclick: () => { ui.restoreFocusToReview = true; ui.replacementPending = false; },
+              }, 'Go back')
+            : null,
           m('button.secondary', {
-            type: 'button',
-            onclick: () => { ui.importPayload = null; ui.importSummary = null; ui.importPass = ''; },
+            type: 'button', disabled: ui.importBusy,
+            onclick: () => {
+              ui.importMsg = null;
+              clearImportSelection(true);
+            },
           }, 'Cancel'),
         ]),
       ]) : null,
       ui.importNotices.map((/** @type {string} */ n) => m('p.hint', n)),
-      ui.importMsg ? m(ui.importMsg.ok ? 'p' : 'p.error',
-        ui.importMsg.ok ? { style: 'color: var(--ok);' } : {}, ui.importMsg.text) : null,
+      ui.importMsg ? m(ui.importMsg.ok ? 'p.transfer-status.transfer-status--success' : 'p.error.transfer-status.transfer-status--error',
+        {
+          id: 'transfer-import-status', tabindex: -1,
+          role: ui.importMsg.ok ? 'status' : 'alert',
+          oncreate: (/** @type {{ dom: HTMLElement }} */ vnode) => {
+            if (ui.focusImportStatusOnUpdate) { ui.focusImportStatusOnUpdate = false; vnode.dom.focus(); }
+          },
+          onupdate: (/** @type {{ dom: HTMLElement }} */ vnode) => {
+            if (ui.focusImportStatusOnUpdate) { ui.focusImportStatusOnUpdate = false; vnode.dom.focus(); }
+          },
+        },
+        ui.importMsg.text) : null,
 
       // --- Artifacts (.peerd files) — separate from settings & data ----
       // Apps, Notebooks, and VM recipes exported from their tabs.
@@ -303,7 +599,7 @@ export const TransferSection = {
         + 'the transcript (including every actor and actor it delegated to), the '
         + 'audit slice, cost, settings, and live context snapshots \u2014 or the same '
         + 'data as an OpenTelemetry trace for any OTel viewer. Nothing is sent '
-        + 'anywhere; API keys cannot appear in either file.'),
+        + 'anywhere; stored credentials cannot appear in either file.'),
       m('.input-row', [
         m('label', { for: 'dbgsess' }, 'Chat'),
         ui.debugSessions === null
@@ -335,8 +631,9 @@ export const TransferSection = {
         + 'carries one artifact, verified against its content hashes, and '
         + 'importing always creates a new copy — nothing you have is '
         + 'overwritten.'),
+      m('label', { for: 'peerd-artifact-file' }, 'Artifact file'),
       m('input', {
-        type: 'file', accept: '.peerd',
+        id: 'peerd-artifact-file', type: 'file', accept: '.peerd',
         disabled: ui.artifactBusy,
         onchange: onArtifactFile,
       }),
@@ -364,8 +661,8 @@ export const TransferSection = {
           }, 'Cancel'),
         ]),
       ]) : null,
-      ui.artifactMsg ? m(ui.artifactMsg.ok ? 'p' : 'p.error',
-        ui.artifactMsg.ok ? { style: 'color: var(--ok);' } : {}, ui.artifactMsg.text) : null,
+      ui.artifactMsg ? m(ui.artifactMsg.ok ? 'p.transfer-status.transfer-status--success' : 'p.error.transfer-status.transfer-status--error',
+        { role: ui.artifactMsg.ok ? 'status' : 'alert' }, ui.artifactMsg.text) : null,
     ]);
   },
 };

--- a/extension/peerd-distributed/client.js
+++ b/extension/peerd-distributed/client.js
@@ -8,11 +8,10 @@
 // and prunes this whole module).
 //
 // Keep the surface minimal. Growing it is a deliberate act — see
-// PACKAGING.md §"Adding dweb-only code". PHASE 1 grows it with exactly
-// what the hosting PAGES need — never the SW, which cannot import this
-// module (a ServiceWorker can't dynamic-import, and must not reference the
-// module path). All of these run in a page (options / app-tab via
-// loadDweb); the SW only owns the vault + audit + app registry + tabs:
+// PACKAGING.md §"Adding dweb-only code". Chrome hosts this client in an
+// offscreen page because its service worker cannot dynamic-import; Firefox
+// has no offscreen API and loads it in its MV3 background. The background
+// still owns vault custody, audit, app registry, and tabs:
 //   identityMaterial / identityFromMaterial — mint/rehydrate the Ed25519
 //     identity page-side, vault IO injected as scoped SW round-trips;
 //   loadSeedApp — read the commons seed files for first-run install;
@@ -20,6 +19,7 @@
 //     the dwapp postMessage bridge.
 
 import { generateIdentity, loadIdentityMaterial, identityFromMaterial } from './identity/keypair.js';
+import { buildIdentityRecord, adoptIdentityRecord } from './identity/recovery-record.js';
 import { joinRoom } from './transport/rooms.js';
 import { createBaseNetwork, BASE_TOPIC } from './base-network.js';
 import { installAppBundle } from './apps/loader.js';
@@ -81,6 +81,18 @@ export const createDwebClient = () => {
     // --- Phase 1 ---------------------------------------------------------
     identityMaterial: loadIdentityMaterial,
     identityFromMaterial,
+
+    // --- portable identity (docs/design/portable-identity/) --------------
+    // Record build/open runs in the channel's dweb crypto host (Chrome
+    // offscreen page; Firefox background). The background owns the vault
+    // reads/writes on either side and passes material through the one
+    // extension-internal boundary keypair.js already documents.
+    /** @param {{ material: { seed: string, pub: string }, passphrase: string }} args */
+    identityRecordExport: async ({ material, passphrase }) =>
+      buildIdentityRecord({ material, wrappers: [{ kind: 'passphrase', passphrase }] }),
+    /** @param {{ record: any, passphrase?: string, existingMaterial?: string | null, replaceExisting?: boolean }} args */
+    identityRecordAdopt: async ({ record, passphrase, existingMaterial, replaceExisting }) =>
+      adoptIdentityRecord({ record, passphrase, existingMaterial, replaceExisting }),
     installAppBundle,
     // Host a dwapp's bridge. The app-tab passes `frame` (the iframe) and gets
     // the default iframe transport; an offscreen host can pass `transport`

--- a/extension/peerd-distributed/identity/capsule.js
+++ b/extension/peerd-distributed/identity/capsule.js
@@ -1,0 +1,121 @@
+// @ts-check
+// peerd-distributed/identity/capsule.js — the identity capsule.
+//
+// The portable form of the persistent identity (docs/design/
+// portable-identity/ 01): the vault-random Ed25519 material sealed
+// AES-GCM under a random capsule key (CapK). The capsule ciphertext can
+// travel anywhere — export file, hosted record, QR, a peer — because
+// opening it requires CapK, and CapK exists only wrapped under
+// per-credential KEKs (credential-wrapper.js).
+//
+// why a random CapK between credential and capsule (not the credential
+// KEK directly): adding or revoking a credential then re-wraps 40 bytes
+// instead of re-encrypting the capsule. The wrapper list remains sensitive
+// because it lets an attacker test passphrase guesses offline. Protect the
+// combined record even though every entry is ciphertext.
+//
+// why NOT the vault's keys.js: that file is the vault DK's audited
+// surface and must stay vault-only (its header scopes it explicitly).
+// This is the dweb's parallel use of the same primitives — AES-GCM seal,
+// AES-KW wrap — with capsule-specific lifetimes: CapK is TRANSIENT by
+// contract (minted, used for one seal/open + wrap set, dropped), never a
+// resident key like the DK.
+
+import { toBase64, fromBase64, concat } from '/shared/bundle/bytes.js';
+import { IdentityCapsuleError } from './errors.js';
+
+const CAPSULE_VERSION = 1;
+const IV_BYTES = 12;
+export const MAX_CAPSULE_B64_LENGTH = 4096;
+
+/**
+ * Mint a fresh capsule key. Extractable — SubtleCrypto.wrapKey refuses a
+ * non-extractable key, and every CapK is about to be wrapped for at
+ * least one credential. The handle is transient by contract: callers
+ * seal/wrap and drop it (same creation-time-vs-residency split the
+ * vault documents for its DK; a CapK is never resident anywhere).
+ *
+ * @returns {Promise<CryptoKey>}
+ */
+export const generateCapsuleKey = () =>
+  crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt']);
+
+/**
+ * Seal identity material into a capsule: base64(iv || AES-GCM ct) over
+ * the canonical JSON plaintext.
+ *
+ * @param {{ seed: string, pub: string }} material  base64 seed + public key
+ *        (the exact shape keypair.js stores under the vault secret)
+ * @param {CryptoKey} capsuleKey
+ * @returns {Promise<string>} the capsule ciphertext, base64
+ */
+export const sealCapsule = async ({ seed, pub }, capsuleKey) => {
+  if (typeof seed !== 'string' || typeof pub !== 'string'
+      || seed.length > 128 || pub.length > 128) {
+    throw new IdentityCapsuleError(
+      'capsule material must carry bounded base64 seed and pub',
+      'bad-material',
+    );
+  }
+  const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const plaintext = new TextEncoder().encode(
+    JSON.stringify({ v: CAPSULE_VERSION, seed, pub }),
+  );
+  try {
+    const ct = new Uint8Array(
+      await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, capsuleKey, plaintext),
+    );
+    return toBase64(concat(iv, ct));
+  } finally {
+    plaintext.fill(0);
+  }
+};
+
+/**
+ * Open a capsule. Throws on tampered ciphertext, a wrong key, or an
+ * unknown capsule version — the caller maps all three to "this record
+ * cannot be opened with this credential".
+ *
+ * @param {string} capsuleB64
+ * @param {CryptoKey} capsuleKey
+ * @returns {Promise<{ seed: string, pub: string }>}
+ */
+export const openCapsule = async (capsuleB64, capsuleKey) => {
+  if (typeof capsuleB64 !== 'string' || capsuleB64.length === 0
+      || capsuleB64.length > MAX_CAPSULE_B64_LENGTH) {
+    throw new IdentityCapsuleError('capsule ciphertext is missing or too large', 'bad-ciphertext');
+  }
+  let blob;
+  try {
+    blob = fromBase64(capsuleB64);
+  } catch (cause) {
+    throw new IdentityCapsuleError('capsule ciphertext is not base64', 'bad-ciphertext', { cause });
+  }
+  if (blob.byteLength < IV_BYTES + 16) {
+    // AES-GCM carries at least a 16-byte tag; reject malformed input with
+    // a clean message instead of an opaque OperationError.
+    throw new IdentityCapsuleError('capsule ciphertext is too short', 'bad-ciphertext');
+  }
+  const iv = blob.slice(0, IV_BYTES);
+  const ct = blob.slice(IV_BYTES);
+  let parsed;
+  /** @type {Uint8Array | null} */
+  let plaintext = null;
+  try {
+    plaintext = new Uint8Array(
+      await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, capsuleKey, ct),
+    );
+    parsed = JSON.parse(new TextDecoder().decode(plaintext));
+  } catch (cause) {
+    throw new IdentityCapsuleError('capsule could not be authenticated or decoded', 'open-failed', { cause });
+  } finally {
+    plaintext?.fill(0);
+  }
+  if (parsed?.v !== CAPSULE_VERSION || typeof parsed.seed !== 'string' || typeof parsed.pub !== 'string') {
+    throw new IdentityCapsuleError(
+      `unsupported capsule payload (v=${parsed?.v})`,
+      'unsupported-payload',
+    );
+  }
+  return { seed: parsed.seed, pub: parsed.pub };
+};

--- a/extension/peerd-distributed/identity/credential-wrapper.js
+++ b/extension/peerd-distributed/identity/credential-wrapper.js
@@ -1,0 +1,158 @@
+// @ts-check
+// peerd-distributed/identity/credential-wrapper.js — the passphrase wrapper
+// used by manual portable-identity backup and restore.
+//
+// A wrapper is ciphertext, but it is also a sensitive offline verifier:
+// AES-KW integrity tells an attacker when a guessed passphrase re-derives the
+// correct KEK. The shipped kind is Argon2id(passphrase, salt, bounded
+// parameters). Passkey PRF and hosted lookup remain design proposals until
+// their ceremonies and relying-party boundary are implemented end to end.
+//
+// why Argon2id: a carried record gives an attacker an offline correctness
+// oracle against a permanent signing root. Reuse the vault's audited,
+// vendored memory-hard implementation instead of treating this like a
+// low-value settings file.
+
+import { toBase64, fromBase64 } from '/shared/bundle/bytes.js';
+import {
+  BACKUP_ARGON2ID_PARAMS, BACKUP_ARGON2ID_SALT_BYTES,
+  deriveBackupPassphraseBytes,
+} from '/shared/backup-passphrase.js';
+import { IdentityCredentialError } from './errors.js';
+
+export const WRAPPER_KIND_PASSPHRASE = 'passphrase';
+
+const WRAPPED_KEY_BYTES = 40;
+const BASE64_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
+
+/** @param {string} message @param {string} [code] @param {unknown} [cause] */
+const credentialFailure = (message, code = 'malformed-wrapper', cause) =>
+  new IdentityCredentialError(message, code, cause === undefined ? {} : { cause });
+
+/** @param {Uint8Array} bytes  exactly 32 — imported as a non-extractable AES-KW KEK */
+const importKek = (bytes) =>
+  crypto.subtle.importKey(
+    'raw', /** @type {BufferSource} */ (bytes), { name: 'AES-KW', length: 256 }, false, ['wrapKey', 'unwrapKey'],
+  );
+
+/**
+ * @param {string} passphrase
+ * @param {Uint8Array} salt
+ * @param {{ name: string, memKiB: number, iters: number, parallelism: number }} kdf
+ */
+const kekFromPassphrase = async (passphrase, salt, kdf) => {
+  if (typeof passphrase !== 'string' || passphrase.length === 0) {
+    throw credentialFailure('passphrase required', 'passphrase-required');
+  }
+  if (!(salt instanceof Uint8Array) || salt.byteLength !== BACKUP_ARGON2ID_SALT_BYTES) {
+    throw credentialFailure('Argon2id salt must be exactly 16 bytes');
+  }
+  // Version 1 accepts exactly the parameters it emits. A future tuning uses a
+  // new wrapper version instead of letting an untrusted record choose memory or
+  // CPU work and turn import into a denial-of-service primitive.
+  if (kdf?.name !== 'Argon2id'
+      || kdf.memKiB !== BACKUP_ARGON2ID_PARAMS.memKiB
+      || kdf.iters !== BACKUP_ARGON2ID_PARAMS.iters
+      || kdf.parallelism !== BACKUP_ARGON2ID_PARAMS.parallelism) {
+    throw credentialFailure(`unsupported passphrase KDF ${kdf?.name ?? '(missing)'}`, 'unsupported-kdf');
+  }
+  const raw = await deriveBackupPassphraseBytes(passphrase, salt);
+  try {
+    return await importKek(raw);
+  } finally {
+    raw.fill(0);
+  }
+};
+
+/** @param {CryptoKey} capsuleKey @param {CryptoKey} kek */
+const wrapCapK = async (capsuleKey, kek) =>
+  toBase64(new Uint8Array(await crypto.subtle.wrapKey('raw', capsuleKey, kek, { name: 'AES-KW' })));
+
+/**
+ * Unwrap a wrapped CapK into a non-extractable AES-GCM handle — enough
+ * to open (or re-seal) the capsule, never to export the key bytes.
+ * @param {string} wrappedB64 @param {CryptoKey} kek
+ */
+const unwrapCapK = (wrappedB64, kek) => {
+  let wrapped;
+  try { wrapped = fromBase64(wrappedB64); }
+  catch (cause) { throw credentialFailure('wrapped key is not base64', 'malformed-wrapper', cause); }
+  if (wrapped.byteLength !== WRAPPED_KEY_BYTES) {
+    throw credentialFailure(`wrapped key must be exactly ${WRAPPED_KEY_BYTES} bytes`);
+  }
+  return crypto.subtle.unwrapKey(
+    'raw', /** @type {BufferSource} */ (wrapped), kek, { name: 'AES-KW' },
+    { name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt'],
+  );
+};
+
+/**
+ * A wrapper record is ciphertext but remains a sensitive offline passphrase
+ * verifier. Protect the combined recovery record.
+ * @typedef {{
+ *   kind: string,
+ *   wrappedKey: string,
+ *   kdf?: { name: string, memKiB: number, iters: number, parallelism: number, salt: string },
+ * }} CredentialWrapper
+ */
+
+/**
+ * Wrap CapK under a passphrase.
+ * @param {CryptoKey} capsuleKey @param {string} passphrase
+ * @returns {Promise<CredentialWrapper>}
+ */
+export const makePassphraseWrapper = async (capsuleKey, passphrase) => {
+  if (typeof passphrase !== 'string' || passphrase.length === 0) {
+    throw credentialFailure('passphrase required', 'passphrase-required');
+  }
+  const salt = crypto.getRandomValues(new Uint8Array(BACKUP_ARGON2ID_SALT_BYTES));
+  const kdf = {
+    name: 'Argon2id',
+    memKiB: BACKUP_ARGON2ID_PARAMS.memKiB,
+    iters: BACKUP_ARGON2ID_PARAMS.iters,
+    parallelism: BACKUP_ARGON2ID_PARAMS.parallelism,
+    salt: toBase64(salt),
+  };
+  const kek = await kekFromPassphrase(passphrase, salt, kdf);
+  return {
+    kind: WRAPPER_KIND_PASSPHRASE,
+    kdf,
+    wrappedKey: await wrapCapK(capsuleKey, kek),
+  };
+};
+
+/** @param {CredentialWrapper} wrapper @param {string} passphrase */
+export const openPassphraseWrapper = async (wrapper, passphrase) => {
+  const defect = validateCredentialWrapper(wrapper);
+  if (defect || wrapper.kind !== WRAPPER_KIND_PASSPHRASE || !wrapper.kdf) {
+    throw credentialFailure(`invalid passphrase wrapper: ${defect ?? 'wrong-kind'}`);
+  }
+  const salt = fromBase64(wrapper.kdf.salt);
+  const kek = await kekFromPassphrase(passphrase, salt, wrapper.kdf);
+  return unwrapCapK(wrapper.wrappedKey, kek);
+};
+
+/**
+ * Bound and validate one untrusted wrapper before any KDF or base64 decode.
+ * Unknown kinds remain skippable for forward compatibility, but are bounded.
+ * @param {any} wrapper
+ * @returns {string | null}
+ */
+export const validateCredentialWrapper = (wrapper) => {
+  if (!wrapper || typeof wrapper !== 'object') return 'not-an-object';
+  if (typeof wrapper.kind !== 'string' || wrapper.kind.length === 0 || wrapper.kind.length > 64) return 'bad-kind';
+  const known = wrapper.kind === WRAPPER_KIND_PASSPHRASE;
+  if (typeof wrapper.wrappedKey !== 'string' || wrapper.wrappedKey.length === 0
+      || (known ? wrapper.wrappedKey.length !== 56 : wrapper.wrappedKey.length > 4096)
+      || (known && !BASE64_PATTERN.test(wrapper.wrappedKey))) return 'bad-wrapped-key';
+  if (wrapper.kind === WRAPPER_KIND_PASSPHRASE) {
+    const kdf = wrapper.kdf;
+    if (!kdf || kdf.name !== 'Argon2id') return 'bad-kdf';
+    if (kdf.memKiB !== BACKUP_ARGON2ID_PARAMS.memKiB
+        || kdf.iters !== BACKUP_ARGON2ID_PARAMS.iters
+        || kdf.parallelism !== BACKUP_ARGON2ID_PARAMS.parallelism) return 'unsupported-kdf';
+    if (typeof kdf.salt !== 'string' || kdf.salt.length !== 24
+        || !BASE64_PATTERN.test(kdf.salt)) return 'bad-salt';
+  }
+  return null;
+};

--- a/extension/peerd-distributed/identity/did.js
+++ b/extension/peerd-distributed/identity/did.js
@@ -12,6 +12,10 @@ import { base58encode, base58decode } from '../codec/base58.js';
 // Multicodec prefix for an Ed25519 public key (unsigned varint of 0xed).
 const ED25519_PUB_PREFIX = Uint8Array.from([0xed, 0x01]);
 const DID_PREFIX = 'did:key:z';
+// Fixed multicodec bytes plus a 32-byte Ed25519 key always encode to this
+// length. Check it before base58: the decoder is intentionally tiny and its
+// repeated carry propagation is quadratic on attacker-controlled long input.
+const DID_KEY_LENGTH = 56;
 
 /** @param {Uint8Array} pubkey32 */
 export const encodeDidKey = (pubkey32) => {
@@ -26,7 +30,7 @@ export const encodeDidKey = (pubkey32) => {
 
 /** @param {string} did */
 export const decodeDidKey = (did) => {
-  if (typeof did !== 'string' || !did.startsWith(DID_PREFIX)) {
+  if (typeof did !== 'string' || did.length !== DID_KEY_LENGTH || !did.startsWith(DID_PREFIX)) {
     throw new Error('decodeDidKey: not a did:key:z… string');
   }
   const tagged = base58decode(did.slice(DID_PREFIX.length));

--- a/extension/peerd-distributed/identity/errors.js
+++ b/extension/peerd-distributed/identity/errors.js
@@ -1,0 +1,17 @@
+// @ts-check
+// Typed failures for the portable-identity boundary. Callers may collapse
+// credential and integrity failures into one user-facing refusal, while tests
+// and internal logs retain a stable machine-readable category.
+
+class PortableIdentityError extends Error {
+  /** @param {string} message @param {string} code @param {{ cause?: unknown }} [options] */
+  constructor(message, code, options = {}) {
+    super(message, options);
+    this.name = new.target.name;
+    this.code = code;
+  }
+}
+
+export class IdentityCapsuleError extends PortableIdentityError {}
+export class IdentityCredentialError extends PortableIdentityError {}
+export class IdentityRecordError extends PortableIdentityError {}

--- a/extension/peerd-distributed/identity/keypair.js
+++ b/extension/peerd-distributed/identity/keypair.js
@@ -12,10 +12,8 @@
 //                                attribution holds. IO is INJECTED (get/
 //                                setSecret) per the functional-core rule —
 //                                this file never touches the vault itself.
-// The PRF-derived seed (HKDF over the passkey PRF output) remains Phase 3
-// (NORTH-STAR D-6); the vault-random seed below is its documented fallback
-// and stores under the same secret name, so the upgrade is a derivation
-// change, not a migration.
+// Portable backup never changes derivation: it encrypts this same random seed
+// into a recovery capsule. Future passkey custody remains a design proposal.
 
 import { encodeDidKey, decodeDidKey } from './did.js';
 import { toBase64, fromBase64, concat } from '/shared/bundle/bytes.js';
@@ -66,13 +64,15 @@ const SECRET_NAME = 'distributed/identity/v1';
  */
 export const importIdentity = async ({ seed, publicKey }) => {
   if (seed.length !== 32) throw new Error('importIdentity: seed must be 32 bytes');
-  const priv = await crypto.subtle.importKey(
-    'pkcs8',
-    concat(PKCS8_ED25519_PREFIX, seed),
-    { name: 'Ed25519' },
-    false,
-    ['sign'],
-  );
+  if (publicKey.length !== 32) throw new Error('importIdentity: public key must be 32 bytes');
+  const pkcs8 = concat(PKCS8_ED25519_PREFIX, seed);
+  /** @type {CryptoKey} */
+  let priv;
+  try {
+    priv = await crypto.subtle.importKey('pkcs8', pkcs8, { name: 'Ed25519' }, false, ['sign']);
+  } finally {
+    pkcs8.fill(0);
+  }
   const did = encodeDidKey(publicKey);
   /** @param {Uint8Array} bytes */
   const sign = async (bytes) =>
@@ -104,25 +104,81 @@ export const loadIdentityMaterial = async ({ getSecret, setSecret }) => {
   const stored = await getSecret(SECRET_NAME);
   if (stored) {
     const { seed, pub } = JSON.parse(stored);
-    return { seed, pub, did: encodeDidKey(fromBase64(pub)) };
+    const did = await assertIdentityMaterial({ seed, pub });
+    return { seed, pub, did };
   }
-  // First run: generate EXTRACTABLE once to capture the seed, persist,
-  // and never export again.
+  // First run: mint once and persist. Any later backup exports it only inside
+  // the authenticated, passphrase-encrypted recovery capsule.
+  const material = await mintKeypairMaterial();
+  await setSecret(SECRET_NAME, JSON.stringify({ v: 1, seed: material.seed, pub: material.pub }));
+  return material;
+};
+
+/**
+ * Mint fresh Ed25519 material: generate EXTRACTABLE exactly once to
+ * capture the seed, then hand back base64 material for the caller to
+ * persist as the identity secret — the generated
+ * handle is dropped, and later use re-imports non-extractable.
+ *
+ * @returns {Promise<{ seed: string, pub: string, did: string }>}
+ */
+export const mintKeypairMaterial = async () => {
   const kp = await crypto.subtle.generateKey({ name: 'Ed25519' }, true, ['sign', 'verify']);
   const pkcs8 = new Uint8Array(await crypto.subtle.exportKey('pkcs8', kp.privateKey));
-  if (pkcs8.length !== 48) throw new Error(`unexpected Ed25519 PKCS#8 length: ${pkcs8.length}`);
-  const seed = pkcs8.slice(-32);
-  const publicKey = new Uint8Array(await crypto.subtle.exportKey('raw', kp.publicKey));
-  await setSecret(SECRET_NAME, JSON.stringify({ v: 1, seed: toBase64(seed), pub: toBase64(publicKey) }));
-  return { seed: toBase64(seed), pub: toBase64(publicKey), did: encodeDidKey(publicKey) };
+  /** @type {Uint8Array | null} */
+  let seed = null;
+  /** @type {Uint8Array | null} */
+  let publicKey = null;
+  try {
+    if (pkcs8.length !== 48) throw new Error(`unexpected Ed25519 PKCS#8 length: ${pkcs8.length}`);
+    seed = pkcs8.slice(-32);
+    publicKey = new Uint8Array(await crypto.subtle.exportKey('raw', kp.publicKey));
+    return { seed: toBase64(seed), pub: toBase64(publicKey), did: encodeDidKey(publicKey) };
+  } finally {
+    // Best-effort lifetime reduction on every exit, including export or
+    // encoding failures. The returned base64 owns the only required copies.
+    seed?.fill(0);
+    publicKey?.fill(0);
+    pkcs8.fill(0);
+  }
 };
 
 /**
  * Rehydrate a signing identity from stored/transferred material.
  * @param {{ seed: string, pub: string }} material
  */
-export const identityFromMaterial = ({ seed, pub }) =>
-  importIdentity({ seed: fromBase64(seed), publicKey: fromBase64(pub) });
+export const identityFromMaterial = async ({ seed, pub }) => {
+  const seedBytes = fromBase64(seed);
+  try {
+    return await importIdentity({ seed: seedBytes, publicKey: fromBase64(pub) });
+  } finally {
+    // WebCrypto copied the seed into a non-extractable handle; do not leave the
+    // decoded transfer buffer live for the rest of this turn.
+    seedBytes.fill(0);
+  }
+};
+
+const MATERIAL_PROOF = new TextEncoder().encode('peerd/identity-material-proof/v1');
+
+/**
+ * Prove that independently serialized seed/public-key fields are one Ed25519
+ * pair before the material becomes an identity. Merely deriving the advertised
+ * did from `pub` would accept a capsule whose signer can never verify under it.
+ *
+ * @param {{ seed: string, pub: string }} material
+ * @returns {Promise<string>} the verified did
+ */
+export const assertIdentityMaterial = async (material) => {
+  if (typeof material?.seed !== 'string' || typeof material?.pub !== 'string') {
+    throw new Error('identity material must contain base64 seed and pub');
+  }
+  const identity = await identityFromMaterial(material);
+  const signature = await identity.sign(MATERIAL_PROOF);
+  if (!(await verifySignature(identity.did, signature, MATERIAL_PROOF))) {
+    throw new Error('identity seed does not match public key');
+  }
+  return identity.did;
+};
 
 /**
  * Load the persistent identity, creating it on first use (the one-context

--- a/extension/peerd-distributed/identity/recovery-record.js
+++ b/extension/peerd-distributed/identity/recovery-record.js
@@ -1,0 +1,245 @@
+// @ts-check
+// peerd-distributed/identity/recovery-record.js — the portable identity
+// record: everything a fresh install needs to become this did EXCEPT the
+// credential itself (docs/design/portable-identity/ 02).
+//
+// Sensitive recovery ciphertext: the capsule is AES-GCM ciphertext and each
+// wrapper is AES-KW ciphertext under a credential-derived KEK, but a stolen
+// record still permits offline passphrase guessing. This implementation carries
+// the record only in the explicit backup file; hosted lookup and passkey
+// ceremonies remain proposals.
+//
+// This file also owns the ADOPTION decision — what an import does when a
+// record meets whatever identity the receiving install already has. The
+// rule is explicit: the same did is accepted without a write, a different did
+// is refused by default, and replacement requires an explicit user decision.
+
+import { decodeDidKey } from './did.js';
+import { assertIdentityMaterial } from './keypair.js';
+import { generateCapsuleKey, sealCapsule, openCapsule, MAX_CAPSULE_B64_LENGTH } from './capsule.js';
+import { IdentityRecordError } from './errors.js';
+import {
+  makePassphraseWrapper, openPassphraseWrapper,
+  validateCredentialWrapper,
+  WRAPPER_KIND_PASSPHRASE,
+} from './credential-wrapper.js';
+
+export const RECORD_FORMAT = 'peerd-identity-record';
+export const RECORD_VERSION = 1;
+const MAX_WRAPPERS = 8;
+
+/**
+ * @typedef {import('./credential-wrapper.js').CredentialWrapper} CredentialWrapper
+ * @typedef {{
+ *   format: string,
+ *   version: number,
+ *   did: string,
+ *   capsule: string,
+ *   wrappers: CredentialWrapper[],
+ *   updatedAt: number,
+ * }} IdentityRecord
+ */
+
+/**
+ * A wrapper spec for buildIdentityRecord — the credential material to
+ * enroll, by kind.
+ * @typedef {{ kind: 'passphrase', passphrase: string }} WrapperSpec
+ */
+
+/**
+ * Build a record around existing identity material. The material is the
+ * caller's (typically read from the vault secret keypair.js owns); this
+ * function never persists anything.
+ *
+ * @param {Object} args
+ * @param {{ seed: string, pub: string }} args.material
+ * @param {WrapperSpec[]} args.wrappers  at least one
+ * @param {number} [args.now]  injectable clock for tests
+ * @returns {Promise<IdentityRecord>}
+ */
+export const buildIdentityRecord = async ({ material, wrappers, now }) => {
+  if (!Array.isArray(wrappers) || wrappers.length === 0) {
+    throw new IdentityRecordError('at least one wrapper is required', 'no-wrappers');
+  }
+  if (wrappers.length > MAX_WRAPPERS) {
+    throw new IdentityRecordError(`at most ${MAX_WRAPPERS} wrappers are supported`, 'too-many-wrappers');
+  }
+  if (wrappers.filter((wrapper) => wrapper.kind === WRAPPER_KIND_PASSPHRASE).length > 1) {
+    throw new IdentityRecordError(
+      'version 1 supports one passphrase wrapper', 'too-many-passphrase-wrappers',
+    );
+  }
+  const did = await assertIdentityMaterial(material)
+    .catch((cause) => { throw new IdentityRecordError('identity material is not a valid keypair', 'bad-material', { cause }); });
+  const capsuleKey = await generateCapsuleKey();
+  const capsule = await sealCapsule(material, capsuleKey);
+  /** @type {CredentialWrapper[]} */
+  const built = [];
+  for (const spec of wrappers) {
+    if (spec.kind === WRAPPER_KIND_PASSPHRASE) {
+      built.push(await makePassphraseWrapper(capsuleKey, spec.passphrase));
+    } else {
+      throw new IdentityRecordError(`unknown wrapper kind ${/** @type {any} */ (spec).kind}`, 'unknown-wrapper');
+    }
+  }
+  return {
+    format: RECORD_FORMAT,
+    version: RECORD_VERSION,
+    did,
+    capsule,
+    wrappers: built,
+    updatedAt: now ?? Date.now(),
+  };
+};
+
+/**
+ * Structural validation — cheap, pure, no crypto. Returns an error
+ * string (for the import notice) or null when the record is usable.
+ *
+ * @param {any} record
+ * @returns {string | null}
+ */
+export const validateIdentityRecord = (record) => {
+  if (!record || typeof record !== 'object') return 'not-a-record';
+  if (record.format !== RECORD_FORMAT) return 'wrong-format';
+  if (record.version !== RECORD_VERSION) return `unsupported-version-${record.version}`;
+  try { decodeDidKey(record.did); } catch { return 'bad-did'; }
+  if (typeof record.capsule !== 'string' || record.capsule.length === 0) return 'missing-capsule';
+  if (record.capsule.length > MAX_CAPSULE_B64_LENGTH) return 'capsule-too-large';
+  if (!Array.isArray(record.wrappers) || record.wrappers.length === 0) return 'no-wrappers';
+  if (record.wrappers.length > MAX_WRAPPERS) return 'too-many-wrappers';
+  let passphraseWrappers = 0;
+  for (const wrapper of record.wrappers) {
+    const defect = validateCredentialWrapper(wrapper);
+    if (defect) return `bad-wrapper-${defect}`;
+    if (wrapper.kind === WRAPPER_KIND_PASSPHRASE) passphraseWrappers++;
+  }
+  if (passphraseWrappers > 1) return 'too-many-passphrase-wrappers';
+  if (!Number.isSafeInteger(record.updatedAt) || record.updatedAt < 0) return 'bad-updated-at';
+  return null;
+};
+
+/**
+ * Open a record with whatever credentials the caller holds. Tries every
+ * wrapper whose kind matches a supplied credential; unknown kinds are
+ * skipped (forward compatibility — a future record may carry wrapper
+ * kinds this build can't open, beside ones it can).
+ *
+ * why the did re-check after decryption: the did in the record is
+ * plaintext metadata anyone could edit. The capsule's AES-GCM tag
+ * already proves integrity of the MATERIAL, but binding material to the
+ * ADVERTISED did catches a swapped capsule/did pairing before the
+ * caller trusts it.
+ *
+ * @param {IdentityRecord} record
+ * @param {{ passphrase?: string }} credentials
+ * @returns {Promise<{ seed: string, pub: string, did: string }>}
+ */
+export const openIdentityRecord = async (record, { passphrase } = {}) => {
+  const invalid = validateIdentityRecord(record);
+  if (invalid) throw new IdentityRecordError(`identity record is invalid: ${invalid}`, invalid);
+  /** @type {Error | null} */
+  let lastFailure = null;
+  for (const wrapper of record.wrappers) {
+    try {
+      let capsuleKey = null;
+      if (wrapper.kind === WRAPPER_KIND_PASSPHRASE && typeof passphrase === 'string' && passphrase.length > 0) {
+        capsuleKey = await openPassphraseWrapper(wrapper, passphrase);
+      }
+      if (!capsuleKey) continue;
+      const material = await openCapsule(record.capsule, capsuleKey);
+      const did = await assertIdentityMaterial(material)
+        .catch((cause) => { throw new IdentityRecordError('capsule does not contain a valid keypair', 'bad-material', { cause }); });
+      if (did !== record.did) {
+        throw new IdentityRecordError('capsule material does not match the advertised did', 'did-mismatch');
+      }
+      return { ...material, did };
+    } catch (e) {
+      // A wrong passphrase (or a stale wrapper) fails at unwrap/decrypt;
+      // keep trying the remaining wrappers before giving up.
+      lastFailure = /** @type {Error} */ (e);
+    }
+  }
+  throw lastFailure ?? new IdentityRecordError(
+    'no wrapper matches the supplied credentials',
+    'no-matching-wrapper',
+  );
+};
+
+/**
+ * The import-side decision (see the file header for the rule).
+ *
+ * @param {Object} args
+ * @param {any} args.record  the record arriving from an export payload
+ * @param {string} [args.passphrase]
+ * @param {string | null} [args.existingMaterial]  the receiving install's
+ *        current identity secret value (JSON string), or null
+ * @param {boolean} [args.replaceExisting] explicit user-approved replacement
+ * @returns {Promise<{
+ *   adopted: boolean, did: string | null,
+ *   material: string | null, reason: string,
+ *   existingDid?: string | null, incomingDid?: string | null,
+ * }>}  material is the JSON string to store as the identity secret when
+ *      the record supplied a new identity; null when nothing changes.
+ */
+export const adoptIdentityRecord = async ({
+  record, passphrase, existingMaterial = null, replaceExisting = false,
+}) => {
+  const invalid = validateIdentityRecord(record);
+  if (invalid) return { adopted: false, did: null, material: null, reason: invalid };
+
+  let recovered;
+  try {
+    recovered = await openIdentityRecord(record, { passphrase });
+  } catch {
+    return { adopted: false, did: null, material: null, reason: 'no-openable-wrapper' };
+  }
+
+  let existingDid = null;
+  if (typeof existingMaterial === 'string' && existingMaterial.length > 0) {
+    try {
+      const existing = JSON.parse(existingMaterial);
+      existingDid = await assertIdentityMaterial(existing);
+    } catch {
+      if (!replaceExisting) {
+        return {
+          adopted: false, did: null, material: null, reason: 'invalid-local-identity',
+          existingDid: null, incomingDid: recovered.did,
+        };
+      }
+      const { seed, pub, did } = recovered;
+      return {
+        adopted: true,
+        did,
+        material: JSON.stringify({ v: 1, seed, pub }),
+        reason: 'replaced-invalid-local',
+        existingDid: null,
+        incomingDid: did,
+      };
+    }
+    if (existingDid === recovered.did) {
+      return {
+        adopted: true, did: existingDid, material: null, reason: 'already-present',
+        existingDid, incomingDid: recovered.did,
+      };
+    }
+    if (!replaceExisting) {
+      return {
+        adopted: false, did: existingDid, material: null, reason: 'did-conflict',
+        existingDid, incomingDid: recovered.did,
+      };
+    }
+  }
+
+  const { seed, pub, did } = recovered;
+  // The stored shape mirrors keypair.js's first-run write exactly, so
+  // loadIdentityMaterial reloads an adopted identity indistinguishably.
+  return {
+    adopted: true,
+    did,
+    material: JSON.stringify({ v: 1, seed, pub }),
+    reason: existingDid ? 'replaced' : 'recovered',
+    existingDid,
+    incomingDid: did,
+  };
+};

--- a/extension/peerd-egress/vault/argon2.js
+++ b/extension/peerd-egress/vault/argon2.js
@@ -1,10 +1,8 @@
 // @ts-check
-// Argon2id derivation — the thin imperative wrapper over the vendored
-// hash-wasm bundle (extension/vendor/argon2/, SHA-pinned by
-// scripts/vendor-argon2.sh).
+// Argon2id derivation — the vault-facing public-module seam over the shared
+// vendored primitive. Policy/descriptor validation remains in vault/kdf.js.
 //
-// This is the ONLY file that imports the vendor; the vault core never
-// does. The service worker injects this function as the vault's
+// The vault core never imports the vendor. The service worker injects this function as the vault's
 // `argon2` dep (functional core / imperative shell), which keeps
 // vault.js Bun-testable with a deterministic fake and keeps the
 // WASM-instantiation surface in one auditable place, beside keys.js.
@@ -16,34 +14,4 @@
 // Instantiation happens lazily on the first call, not at import — SW
 // boot pays only the ~29 KB parse.
 
-import { argon2id, VENDORED } from '/vendor/argon2/argon2.js';
-
-/**
- * Derive 32 bytes of KEK material from a passphrase under Argon2id.
- * Matches the vault's injected-`argon2` dep contract; the caller
- * (vault.js) imports the result as an AES-KW key via importRawKEK and
- * zeroes the returned buffer.
- *
- * @param {Object} args               the wrap's KDF descriptor, decoded
- * @param {string} args.passphrase
- * @param {Uint8Array} args.salt
- * @param {number} args.memKiB
- * @param {number} args.iters
- * @param {number} args.parallelism   always 1 in peerd (single-lane)
- * @returns {Promise<Uint8Array>}     exactly 32 bytes
- */
-export const deriveArgon2id = ({ passphrase, salt, memKiB, iters, parallelism }) => {
-  // why: VENDORED is the appended sentinel — a truncated or
-  // wrongly-rebuilt vendor file fails here loudly instead of at the
-  // first unlock with a confusing TypeError.
-  if (VENDORED !== true) throw new Error('argon2: vendored bundle sentinel missing');
-  return argon2id({
-    password: passphrase,
-    salt,
-    parallelism,
-    iterations: iters,
-    memorySize: memKiB,
-    hashLength: 32,          // 256-bit KEK material (AES-KW key)
-    outputType: 'binary',
-  });
-};
+export { deriveArgon2id } from '/shared/argon2id.js';

--- a/extension/peerd-runtime/index.js
+++ b/extension/peerd-runtime/index.js
@@ -325,10 +325,10 @@ export {
 // Explicit migration between installs and across channels. Pure shaping
 // + passphrase crypto; the SW injects all IO (vault, memory, hooks, kv).
 export {
-  EXPORT_VERSION, EXPORT_FORMAT,
+  EXPORT_VERSION, EXPORT_FORMAT, EXPORT_PASSPHRASE_MIN_LENGTH,
   buildExport, inspectImport, applyImport,
   encryptWithPassphrase, decryptWithPassphrase,
-  ExportPassphraseError,
+  ExportPassphraseError, isCustodySecretName,
 } from './transfer/transfer.js';
 
 // --- permissions (Plan/Act mode + confirm-actions toggle; Feature 03) ---

--- a/extension/peerd-runtime/transfer/transfer.js
+++ b/extension/peerd-runtime/transfer/transfer.js
@@ -10,7 +10,7 @@
 // and INJECTED IO (vault reads/writes, memory import, hook saves happen
 // in the SW via the `io` parameter). Pure parts are unit-testable in Bun.
 //
-// Payload shape (format: 'peerd-export', version: 1):
+// Payload shape (format: 'peerd-export', version: 2):
 //   settings           ONLY the user's explicit values (Option A: a
 //                      stored value is an intentional choice; defaults
 //                      never travel). On import, keys unknown to the
@@ -18,33 +18,62 @@
 //                      is how preview-only (dweb*) settings fall
 //                      away on a store import, by mechanism not by list.
 //   providerEndpoints  user-added provider endpoints ({ endpoints: [...] })
-//   secrets            API keys, encrypted under a passphrase the user
-//                      enters at export time (PBKDF2-SHA256 600k →
-//                      AES-GCM). Never exported in plaintext; never
+//   secrets            vault credentials, encrypted under a passphrase the user
+//                      enters at export time (fixed Argon2id → AES-GCM).
+//                      Never exported in plaintext; never
 //                      encrypted under the vault DK (the DK never leaves
 //                      the vault).
 //   memory             memory exportAll() payload (AGENTS.md docs)
 //   hooks              user hook records (exportHooks())
 //   skills             skill METADATA only — bodies reinstall from their
 //                      original sources (git/manifest origin in the meta)
-//   dweb               absent in Phase 0 (identity is ephemeral by
-//                      design — see the dweb module's identity
-//                      notes). When the persistent vault-seeded identity
-//                      lands (Phase 2), it exports here, preview-channel
-//                      only, and store imports drop it with the §10
-//                      notice. (This comment says "the dweb module"
-//                      because this file ships in store packages and the
-//                      artifact verifier greps everything.)
+//   dweb               the portable identity record ({ identityRecord }):
+//                      the did:key root sealed in an encrypted capsule
+//                      whose wrappers only the export passphrase (or an
+//                      enrolled credential) can open — built by the
+//                      channel's dweb crypto host and passed in OPAQUE,
+//                      because this file must not
+//                      touch dweb code. Preview-channel only; store
+//                      imports drop it with the §10 notice. The raw
+//                      identity/device-key secrets are structurally
+//                      excluded from the generic secrets box below —
+//                      the seed travels ONLY inside the capsule, the
+//                      device key never travels at all
+//                      (docs/design/portable-identity/ 02–03). (This
+//                      comment says "the dweb module" because this file
+//                      ships in store packages and the artifact verifier
+//                      greps everything.)
 //   durability         §12 labels for THIS file: the durability tier of
 //                      each section actually included, plus the names of
 //                      the device-bound surfaces an export structurally
-//                      cannot carry. Purely additive (older files simply
-//                      lack it), so EXPORT_VERSION is unchanged.
+//                      cannot carry. Older files may lack this additive block;
+//                      import treats absence as unlabelled durability data.
 
 import { omittedDeviceBoundStores, portableStores } from '../lifecycle/store-registry.js';
+import {
+  BACKUP_ARGON2ID_PARAMS, BACKUP_ARGON2ID_SALT_BYTES,
+  deriveBackupPassphraseBytes,
+} from '/shared/backup-passphrase.js';
 
-export const EXPORT_VERSION = 1;
+export const EXPORT_VERSION = 2;
 export const EXPORT_FORMAT = 'peerd-export';
+const LEGACY_EXPORT_VERSION = 1;
+
+export const EXPORT_PASSPHRASE_MIN_LENGTH = 16;
+
+// Secrets that never enter the generic secrets box (see the header's
+// dweb section): the identity seed travels only inside the capsule, the
+// record is carried as payload.dweb, and the device key is device-bound.
+// Enforced HERE (payload shaping), not in the route — mechanism, not
+// caller discipline. Store-safe names (kv strings, not module paths).
+const NON_EXPORTABLE_SECRET_PREFIXES = Object.freeze([
+  'distributed/identity/',
+  'distributed/device-key/',
+]);
+
+/** @param {string} name */
+export const isCustodySecretName = (name) =>
+  NON_EXPORTABLE_SECRET_PREFIXES.some((prefix) => name.startsWith(prefix));
 
 export class ExportPassphraseError extends Error {
   constructor() {
@@ -54,27 +83,56 @@ export class ExportPassphraseError extends Error {
 }
 
 // ── passphrase crypto ────────────────────────────────────────────────
-// PBKDF2-SHA256 @600k for the EXPORT FILE passphrase only (the vault
-// itself uses Argon2id; an export is an ephemeral user-carried file, a
-// different threat model) but
-// derives an AES-GCM key directly — this is file encryption under a
-// user-chosen passphrase, independent of the vault DK.
+// New exports use the same fixed memory-hard policy as the peer-identity
+// wrapper. A backup containing both sections must not give an attacker a
+// cheaper correctness oracle for their shared passphrase. PBKDF2 remains
+// import-only for backups emitted before this hardening.
 
-const PBKDF2_ITERATIONS = 600_000;
+const LEGACY_PBKDF2_ITERATIONS = 600_000;
 const IV_BYTES = 12;
-const SALT_BYTES = 16;
+const MAX_ENCRYPTED_SECRETS_B64 = 4 * 1024 * 1024;
+const MAX_SECRET_ENTRIES = 256;
+const MAX_SECRET_NAME_LENGTH = 256;
+const MAX_SECRET_VALUE_LENGTH = 1024 * 1024;
+const MAX_SETTINGS_KEYS = 512;
+const MAX_PROVIDER_ENDPOINTS = 64;
+const MAX_MEMORY_DOCS = 10_000;
+const MAX_HOOKS = 256;
+const MAX_SKILLS = 512;
+const BASE64_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
 
 /** @param {Uint8Array} bytes */
 const bytesToB64 = (bytes) => btoa(String.fromCharCode(...bytes));
 /** @param {string} b64 */
 const b64ToBytes = (b64) => Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
 
+/** @param {any} box */
+const validEncryptedSecretsBox = (box) => {
+  if (!box || typeof box !== 'object' || box.cipher !== 'AES-GCM'
+      || typeof box.salt !== 'string' || box.salt.length !== 24
+      || !BASE64_PATTERN.test(box.salt)
+      || typeof box.data !== 'string' || box.data.length === 0
+      || box.data.length > MAX_ENCRYPTED_SECRETS_B64
+      || !BASE64_PATTERN.test(box.data)) return false;
+  if (box.kdf === BACKUP_ARGON2ID_PARAMS.name) {
+    return box.memKiB === BACKUP_ARGON2ID_PARAMS.memKiB
+      && box.iters === BACKUP_ARGON2ID_PARAMS.iters
+      && box.parallelism === BACKUP_ARGON2ID_PARAMS.parallelism
+      && box.iterations === undefined;
+  }
+  return box.kdf === 'PBKDF2-SHA256'
+    && box.iterations === LEGACY_PBKDF2_ITERATIONS
+    && box.memKiB === undefined
+    && box.iters === undefined
+    && box.parallelism === undefined;
+};
+
 /**
  * @param {string} passphrase
  * @param {BufferSource} salt
  * @param {number} iterations
  */
-const deriveExportKey = async (passphrase, salt, iterations) => {
+const deriveLegacyExportKey = async (passphrase, salt, iterations) => {
   const material = await crypto.subtle.importKey(
     'raw', new TextEncoder().encode(passphrase), 'PBKDF2', false, ['deriveKey'],
   );
@@ -87,43 +145,81 @@ const deriveExportKey = async (passphrase, salt, iterations) => {
   );
 };
 
+/** @param {string} passphrase @param {Uint8Array} salt */
+const deriveExportKey = async (passphrase, salt) => {
+  const raw = await deriveBackupPassphraseBytes(passphrase, salt);
+  try {
+    return await crypto.subtle.importKey(
+      'raw', /** @type {BufferSource} */ (raw), { name: 'AES-GCM', length: 256 },
+      false, ['encrypt', 'decrypt'],
+    );
+  } finally {
+    raw.fill(0);
+  }
+};
+
 /**
  * Encrypt a JSON-able value under a passphrase → self-describing box.
  * @param {string} passphrase
  * @param {unknown} value
  */
 export const encryptWithPassphrase = async (passphrase, value) => {
-  const salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES));
+  const salt = crypto.getRandomValues(new Uint8Array(BACKUP_ARGON2ID_SALT_BYTES));
   const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
-  const key = await deriveExportKey(passphrase, salt, PBKDF2_ITERATIONS);
+  const key = await deriveExportKey(passphrase, salt);
   const plaintext = new TextEncoder().encode(JSON.stringify(value));
-  const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintext));
-  const blob = new Uint8Array(iv.length + ct.length);
-  blob.set(iv, 0);
-  blob.set(ct, iv.length);
-  return {
-    kdf: 'PBKDF2-SHA256',
-    iterations: PBKDF2_ITERATIONS,
-    salt: bytesToB64(salt),
-    cipher: 'AES-GCM',
-    data: bytesToB64(blob),
-  };
+  try {
+    const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintext));
+    const blob = new Uint8Array(iv.length + ct.length);
+    blob.set(iv, 0);
+    blob.set(ct, iv.length);
+    return {
+      kdf: BACKUP_ARGON2ID_PARAMS.name,
+      memKiB: BACKUP_ARGON2ID_PARAMS.memKiB,
+      iters: BACKUP_ARGON2ID_PARAMS.iters,
+      parallelism: BACKUP_ARGON2ID_PARAMS.parallelism,
+      salt: bytesToB64(salt),
+      cipher: 'AES-GCM',
+      data: bytesToB64(blob),
+    };
+  } finally {
+    plaintext.fill(0);
+  }
 };
 
 /**
  * Decrypt an encryptWithPassphrase box. Throws ExportPassphraseError on
  * auth failure (GCM tag mismatch = wrong passphrase or tampering).
  * @param {string} passphrase
- * @param {{ salt: string, iterations: number, data: string }} box
+ * @param {{ kdf: string, cipher: string, salt: string, data: string, iterations?: number, memKiB?: number, iters?: number, parallelism?: number }} box
  */
 export const decryptWithPassphrase = async (passphrase, box) => {
-  const blob = b64ToBytes(box.data);
-  const iv = blob.slice(0, IV_BYTES);
-  const ct = blob.slice(IV_BYTES);
-  const key = await deriveExportKey(passphrase, b64ToBytes(box.salt), box.iterations);
   try {
-    const plaintext = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ct);
-    return JSON.parse(new TextDecoder().decode(plaintext));
+    if (!validEncryptedSecretsBox(box)) {
+      throw new Error('malformed encrypted secrets box');
+    }
+    const salt = b64ToBytes(box.salt);
+    if (salt.byteLength !== BACKUP_ARGON2ID_SALT_BYTES) throw new Error('bad salt');
+    const blob = b64ToBytes(box.data);
+    if (blob.byteLength < IV_BYTES + 16) throw new Error('ciphertext too short');
+    const iv = blob.slice(0, IV_BYTES);
+    const ct = blob.slice(IV_BYTES);
+    let key;
+    if (box.kdf === BACKUP_ARGON2ID_PARAMS.name) {
+      key = await deriveExportKey(passphrase, salt);
+    } else if (box.kdf === 'PBKDF2-SHA256') {
+      key = await deriveLegacyExportKey(
+        passphrase, salt, /** @type {number} */ (box.iterations),
+      );
+    } else {
+      throw new Error('unsupported encrypted secrets KDF');
+    }
+    const plaintext = new Uint8Array(await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ct));
+    try {
+      return JSON.parse(new TextDecoder().decode(plaintext));
+    } finally {
+      plaintext.fill(0);
+    }
   } catch {
     throw new ExportPassphraseError();
   }
@@ -178,11 +274,16 @@ const durabilitySection = (payload) => {
  * @param {any} args.memory   memory exportAll() payload
  * @param {any[]} args.hooks  exportHooks() records
  * @param {any[]} args.skills skill metadata list
+ * @param {any} [args.dweb]   the portable identity section
+ *        ({ identityRecord } — already encrypted by the dweb crypto host), or null
  */
 export const buildExport = async ({
-  channel, storedSettings, providerEndpoints, secrets, passphrase, memory, hooks, skills,
+  channel, storedSettings, providerEndpoints, secrets, passphrase, memory, hooks, skills, dweb,
 }) => {
-  const secretNames = Object.keys(secrets ?? {});
+  const portableSecrets = Object.fromEntries(
+    Object.entries(secrets ?? {}).filter(([name]) => !isCustodySecretName(name)),
+  );
+  const secretNames = Object.keys(portableSecrets);
   if (secretNames.length > 0 && !passphrase) {
     throw new ExportPassphraseError();
   }
@@ -193,10 +294,13 @@ export const buildExport = async ({
     channel,
     settings: storedSettings ?? {},
     providerEndpoints: providerEndpoints ?? null,
-    secrets: secretNames.length > 0 ? await encryptWithPassphrase(passphrase, secrets) : null,
+    secrets: secretNames.length > 0 ? await encryptWithPassphrase(passphrase, portableSecrets) : null,
     memory: memory ?? null,
     hooks: hooks ?? [],
     skills: skills ?? [],
+    // Absent (not null) when there is nothing to carry — the pre-identity
+    // export shape, so old files and identity-less exports stay identical.
+    ...(dweb ? { dweb } : {}),
   };
   return { ...payload, durability: durabilitySection(payload) };
 };
@@ -210,6 +314,9 @@ export const buildExport = async ({
  * @property {string[]} settingsKeys
  * @property {string[]} settingsDropped
  * @property {boolean} hasSecrets
+ * @property {boolean} hasIdentityRecord
+ * @property {boolean} requiresPassphrase
+ * @property {string | null} identityDid
  * @property {number} memoryDocs
  * @property {number} hooks
  * @property {string[]} skills
@@ -233,18 +340,54 @@ export const inspectImport = ({ payload, channel, knownSettingKeys }) => {
   if (!payload || payload.format !== EXPORT_FORMAT) {
     return { ok: false, error: 'not-a-peerd-export' };
   }
-  if (payload.version !== EXPORT_VERSION) {
+  if (payload.version !== EXPORT_VERSION && payload.version !== LEGACY_EXPORT_VERSION) {
     return { ok: false, error: `unsupported-export-version-${payload.version}` };
+  }
+  // Bound every collection that can become work or writes before the user can
+  // approve the file. The UI already caps total bytes; these shape limits stop
+  // small adversarial JSON from expanding into unbounded route activity.
+  const settingsValid = payload.settings == null
+    || (typeof payload.settings === 'object' && !Array.isArray(payload.settings)
+      && Object.keys(payload.settings).length <= MAX_SETTINGS_KEYS);
+  const endpointsValid = payload.providerEndpoints == null
+    || (typeof payload.providerEndpoints === 'object'
+      && Array.isArray(payload.providerEndpoints.endpoints)
+      && payload.providerEndpoints.endpoints.length <= MAX_PROVIDER_ENDPOINTS
+      && payload.providerEndpoints.endpoints.every((/** @type {any} */ endpoint) =>
+        endpoint && typeof endpoint === 'object'
+        && typeof endpoint.url === 'string' && endpoint.url.length <= 4096));
+  const memoryValid = payload.memory == null
+    || (typeof payload.memory === 'object' && Array.isArray(payload.memory.docs)
+      && payload.memory.docs.length <= MAX_MEMORY_DOCS
+      && payload.memory.docs.every((/** @type {any} */ doc) => doc && typeof doc === 'object'));
+  const hooksValid = Array.isArray(payload.hooks) && payload.hooks.length <= MAX_HOOKS
+    && payload.hooks.every((/** @type {any} */ hook) => hook && typeof hook === 'object');
+  const skillsValid = Array.isArray(payload.skills) && payload.skills.length <= MAX_SKILLS
+    && payload.skills.every((/** @type {any} */ skill) => skill && typeof skill === 'object');
+  const dwebValid = payload.dweb == null
+    || (typeof payload.dweb === 'object' && !Array.isArray(payload.dweb));
+  const secretsValid = payload.secrets == null || validEncryptedSecretsBox(payload.secrets);
+  if (!settingsValid || !endpointsValid || !memoryValid || !hooksValid || !skillsValid
+      || !dwebValid || !secretsValid) {
+    return { ok: false, error: 'invalid-export-sections' };
   }
   const settings = (payload.settings && typeof payload.settings === 'object') ? payload.settings : {};
   const known = new Set(knownSettingKeys);
   const settingsDropped = Object.keys(settings).filter((k) => !known.has(k));
   const dwebPresent = payload.dweb != null;
+  const identityRecord = payload.dweb?.identityRecord;
+  const hasIdentityRecord = channel !== 'store' && identityRecord != null;
   /** @type {string[]} */
   const notices = [];
   if (channel === 'store' && dwebPresent) {
-    // The §10 notice, verbatim.
-    notices.push('Dweb state in this export is not supported in the store package and was skipped.');
+    notices.push(identityRecord != null
+      ? 'The peer identity in this preview backup cannot be restored by the store build and will be skipped.'
+      : 'Dweb state in this export is not supported in the store package and was skipped.');
+  }
+  if (hasIdentityRecord) {
+    // §10 transparency: an identity is the most consequential thing an
+    // import can carry — say so before the user confirms.
+    notices.push('This export carries a dweb identity record — if this install has no dweb identity yet, importing restores that identity (same did as the exporting install).');
   }
   if (settingsDropped.length > 0) {
     notices.push(`Settings not recognized by this build were skipped: ${settingsDropped.join(', ')}.`);
@@ -290,6 +433,9 @@ export const inspectImport = ({ payload, channel, knownSettingKeys }) => {
       settingsKeys: Object.keys(settings).filter((k) => known.has(k)),
       settingsDropped,
       hasSecrets: payload.secrets != null,
+      hasIdentityRecord,
+      requiresPassphrase: payload.secrets != null || hasIdentityRecord,
+      identityDid: typeof identityRecord?.did === 'string' ? identityRecord.did : null,
       memoryDocs: Array.isArray(payload.memory?.docs) ? payload.memory.docs.length : 0,
       hooks: Array.isArray(payload.hooks) ? payload.hooks.length : 0,
       hookIds,
@@ -321,88 +467,278 @@ export const inspectImport = ({ payload, channel, knownSettingKeys }) => {
  * @param {(name: string, value: string) => Promise<void>} args.io.setSecret
  * @param {(payload: any) => Promise<{written: number, skipped: number}>} args.io.importMemory
  * @param {(record: any) => Promise<any>} args.io.saveHook
+ * @param {(record: any, passphrase: string, options?: { replaceExisting?: boolean, prepareOnly?: boolean, expectedExistingDid?: string | null, expectedExistingRevision?: string, expectedIncomingDid?: string }) => Promise<{ adopted: boolean, did?: string | null, reason?: string, existingDid?: string | null, incomingDid?: string | null, existingUnreadable?: boolean, existingRevision?: string, runtimeRecoveryPending?: boolean }>} [args.io.adoptDwebIdentity]
+ *        preview-channel identity adoption (absent on store builds / when
+ *        the receiving build cannot host an identity)
+ * @param {boolean} [args.replaceDwebIdentity] explicit user approval to replace
+ *        a different local identity
+ * @param {string} [args.approvedExistingDwebDid] local did shown in that approval
+ * @param {string} [args.approvedExistingDwebRevision] opaque revision for an
+ *        unreadable local identity shown in that approval
+ * @param {string} [args.approvedIncomingDwebDid] backup did shown in that approval
+ * @param {boolean} [args.skipDwebIdentity] explicit user choice to keep the
+ *        local identity while importing every other section
  */
-export const applyImport = async ({ payload, passphrase, channel, knownSettingKeys, io }) => {
+export const applyImport = async ({
+  payload, passphrase, channel, knownSettingKeys, io,
+  replaceDwebIdentity = false, skipDwebIdentity = false,
+  approvedExistingDwebDid, approvedExistingDwebRevision, approvedIncomingDwebDid,
+}) => {
   const inspected = inspectImport({ payload, channel, knownSettingKeys });
   if (!inspected.ok) return inspected;
   // why: the `!ok` early-return guarantees the ok:true branch, whose
   // `summary` is always present — TS doesn't propagate that through the
   // inferred union, so assert the shape the runtime guarantees here.
   const summary = /** @type {ImportSummary} */ (inspected.summary);
-  const imported = { settings: 0, secrets: 0, memoryWritten: 0, hooks: 0 };
+  const imported = {
+    settings: 0, secrets: 0, providerEndpoints: 0,
+    memoryWritten: 0, hooks: 0, dwebIdentity: 0,
+  };
 
-  // Settings: explicit values only, filtered to keys this build knows.
-  // A preview value stricter-or-looser than this channel's default is
-  // PRESERVED — the user picked it; the channel default only applies in
-  // absence of a stored value (§11 cross-channel nuances).
-  const known = new Set(knownSettingKeys);
-  /** @type {Record<string, unknown>} */
-  const patch = {};
-  for (const [k, v] of Object.entries(payload.settings ?? {})) {
-    if (known.has(k)) patch[k] = v;
-  }
-  if (Object.keys(patch).length > 0) {
-    await io.applySettings(patch);
-    imported.settings = Object.keys(patch).length;
-  }
+  /** @type {'not-present'|'restored'|'replaced'|'already-present'|'kept-local'|'unsupported'} */
+  let identityOutcome = 'not-present';
+  let runtimeRecoveryPending = false;
 
-  if (payload.providerEndpoints?.endpoints) {
-    // R6: an imported endpoint becomes an egress target the agent sends
-    // API traffic (and headers) to. Only https (or local-loopback http for
-    // Ollama-style daemons) parses through; anything else is dropped and
-    // named. This blocks scheme smuggling; the https hosts themselves were
-    // shown to the user in the inspect summary they approved.
-    const accepted = [];
-    const dropped = [];
-    for (const endpoint of payload.providerEndpoints.endpoints) {
-      const url = (() => { try { return new URL(String(endpoint?.url ?? '')); } catch { return null; } })();
-      const localLoopback = url?.protocol === 'http:' && ['localhost', '127.0.0.1', '[::1]'].includes(url.hostname);
-      if (url && (url.protocol === 'https:' || localLoopback)) accepted.push(endpoint);
-      else dropped.push(String(endpoint?.url ?? '(unparseable)'));
-    }
-    if (accepted.length > 0) {
-      await io.setProviderEndpoints({ ...payload.providerEndpoints, endpoints: accepted });
-    }
-    if (dropped.length > 0) {
-      summary.notices.push(`Dropped ${dropped.length} provider endpoint(s) that are not https or local loopback: ${dropped.join(', ')}.`);
-    }
-  }
-
+  // Stage every credential-dependent decision before the first settings/data
+  // write. A wrong passphrase or identity conflict must leave the rest of the
+  // profile untouched.
+  /** @type {Record<string, string>} */
+  const portableSecrets = {};
   if (payload.secrets != null) {
-    // Throws ExportPassphraseError on a bad passphrase BEFORE any secret
-    // is written — secrets import is all-or-nothing.
-    const secrets = await decryptWithPassphrase(passphrase ?? '', payload.secrets);
-    for (const [name, value] of Object.entries(secrets)) {
-      if (typeof value !== 'string') continue;
-      await io.setSecret(name, value);
-      imported.secrets++;
+    const decrypted = await decryptWithPassphrase(passphrase ?? '', payload.secrets);
+    if (!decrypted || typeof decrypted !== 'object' || Array.isArray(decrypted)) {
+      throw new ExportPassphraseError();
+    }
+    const entries = Object.entries(decrypted);
+    if (entries.length > MAX_SECRET_ENTRIES) throw new ExportPassphraseError();
+    let custodySecretsSkipped = 0;
+    for (const [name, value] of entries) {
+      if (name.length === 0 || name.length > MAX_SECRET_NAME_LENGTH
+          || typeof value !== 'string' || value.length > MAX_SECRET_VALUE_LENGTH) {
+        throw new ExportPassphraseError();
+      }
+      if (isCustodySecretName(name)) { custodySecretsSkipped++; continue; }
+      portableSecrets[name] = value;
+    }
+    if (custodySecretsSkipped > 0) {
+      summary.notices.push(`${custodySecretsSkipped} protected identity/device secret(s) in the file were refused; identity custody only moves through the verified recovery record.`);
     }
   }
 
-  if (payload.memory?.docs) {
-    const res = await io.importMemory(payload.memory);
-    imported.memoryWritten = res.written;
-    if (res.written > 0) {
-      // R6: memory is injected into future prompts as trusted context — an
-      // import that repopulates it is a poisoning vector. Import stays legal
-      // (the user approved the summary), but the consequence is stated.
-      summary.notices.push(`${res.written} memory doc(s) imported — they will inform future prompts; review them via /memory if this file wasn't authored by you.`);
+  // Authenticate the identity wrapper and resolve conflicts before any write,
+  // but do not change custody yet. The final adoption happens after every
+  // fallible ordinary import write, making the permanent identity the commit.
+  let preparedIdentity = false;
+  /** @type {string | null | undefined} */
+  let preparedExistingDid;
+  /** @type {string | undefined} */
+  let preparedExistingRevision;
+  /** @type {string | undefined} */
+  let preparedIncomingDid;
+  if (channel === 'store' && payload.dweb?.identityRecord != null) {
+    identityOutcome = 'unsupported';
+  } else if (channel !== 'store' && payload.dweb?.identityRecord != null && skipDwebIdentity) {
+    identityOutcome = 'kept-local';
+    summary.notices.push('The backup\'s peer identity was skipped; this install kept its current identity.');
+  } else if (channel !== 'store' && payload.dweb?.identityRecord != null) {
+    if (!io.adoptDwebIdentity) return { ok: false, error: 'dweb-identity-unavailable' };
+    const outcome = await io.adoptDwebIdentity(
+      payload.dweb.identityRecord,
+      passphrase ?? '',
+      { replaceExisting: replaceDwebIdentity, prepareOnly: true },
+    );
+    if (replaceDwebIdentity) {
+      const unreadableLocal = outcome?.existingUnreadable === true;
+      const localApprovalPresent = unreadableLocal
+        ? typeof approvedExistingDwebRevision === 'string'
+        : typeof approvedExistingDwebDid === 'string';
+      if (!localApprovalPresent || typeof approvedIncomingDwebDid !== 'string') {
+        return { ok: false, error: 'dweb-identity-approval-required' };
+      }
+      const localApprovalMatches = unreadableLocal
+        ? outcome.existingRevision === approvedExistingDwebRevision
+        : outcome?.existingDid === approvedExistingDwebDid;
+      if (!localApprovalMatches || outcome?.incomingDid !== approvedIncomingDwebDid) {
+        return {
+          ok: false,
+          error: 'dweb-identity-conflict',
+          conflict: {
+            existingDid: outcome?.existingDid ?? outcome?.did ?? null,
+            incomingDid: outcome?.incomingDid ?? null,
+            ...(unreadableLocal ? {
+              existingUnreadable: true,
+              existingRevision: outcome?.existingRevision ?? null,
+            } : {}),
+          },
+        };
+      }
+    }
+    if (outcome?.reason === 'did-conflict') {
+      return {
+        ok: false,
+        error: 'dweb-identity-conflict',
+        conflict: {
+          existingDid: outcome.existingDid ?? outcome.did ?? null,
+          incomingDid: outcome.incomingDid ?? null,
+        },
+      };
+    }
+    if (outcome?.reason === 'identity-in-use') {
+      return {
+        ok: false,
+        error: 'dweb-identity-in-use',
+        conflict: {
+          existingDid: outcome.existingDid ?? outcome.did ?? null,
+          incomingDid: outcome.incomingDid ?? null,
+        },
+      };
+    }
+    if (outcome?.reason === 'invalid-local-identity') {
+      return {
+        ok: false,
+        error: 'dweb-identity-conflict',
+        conflict: {
+          existingDid: null,
+          incomingDid: outcome.incomingDid ?? null,
+          existingUnreadable: true,
+          existingRevision: outcome.existingRevision ?? null,
+        },
+      };
+    }
+    if (!outcome?.adopted) {
+      if (outcome?.reason === 'no-openable-wrapper') throw new ExportPassphraseError();
+      return { ok: false, error: `dweb-identity-${outcome?.reason ?? 'adopt-failed'}` };
+    }
+    if (outcome.reason === 'already-present') identityOutcome = 'already-present';
+    else {
+      preparedIdentity = true;
+      preparedExistingDid = outcome.existingDid ?? null;
+      preparedExistingRevision = outcome.existingUnreadable
+        ? outcome.existingRevision : undefined;
+      preparedIncomingDid = outcome.incomingDid ?? outcome.did ?? undefined;
     }
   }
 
-  for (const record of payload.hooks ?? []) {
-    // R6: an imported hook is CODE (or a rule) that runs against every tool
-    // call. It arrives from a file, not from this user's editor — so it
-    // lands disabled AND untrusted (a kind:'js' hook cannot even compile
-    // without trusted:true). Enabling is an explicit per-hook decision in
-    // Settings → Hooks, where the body is visible.
-    await io.saveHook({ ...record, enabled: false, trusted: false });
-    imported.hooks++;
+  try {
+    // Settings: explicit values only, filtered to keys this build knows.
+    // A preview value stricter-or-looser than this channel's default is
+    // PRESERVED — the user picked it; the channel default only applies in
+    // absence of a stored value (§11 cross-channel nuances).
+    const known = new Set(knownSettingKeys);
+    /** @type {Record<string, unknown>} */
+    const patch = {};
+    for (const [k, v] of Object.entries(payload.settings ?? {})) {
+      if (known.has(k)) patch[k] = v;
+    }
+    if (Object.keys(patch).length > 0) {
+      await io.applySettings(patch);
+      imported.settings = Object.keys(patch).length;
+    }
+
+    if (payload.providerEndpoints?.endpoints) {
+      // R6: an imported endpoint becomes an egress target the agent sends
+      // API traffic (and headers) to. Only https (or local-loopback http for
+      // Ollama-style daemons) parses through; anything else is dropped and
+      // named. This blocks scheme smuggling; the https hosts themselves were
+      // shown to the user in the inspect summary they approved.
+      const accepted = [];
+      const dropped = [];
+      for (const endpoint of payload.providerEndpoints.endpoints) {
+        const url = (() => { try { return new URL(String(endpoint?.url ?? '')); } catch { return null; } })();
+        const localLoopback = url?.protocol === 'http:' && ['localhost', '127.0.0.1', '[::1]'].includes(url.hostname);
+        if (url && (url.protocol === 'https:' || localLoopback)) accepted.push(endpoint);
+        else dropped.push(String(endpoint?.url ?? '(unparseable)'));
+      }
+      if (accepted.length > 0) {
+        await io.setProviderEndpoints({ ...payload.providerEndpoints, endpoints: accepted });
+        imported.providerEndpoints = accepted.length;
+      }
+      if (dropped.length > 0) {
+        summary.notices.push(`Dropped ${dropped.length} provider endpoint(s) that are not https or local loopback: ${dropped.join(', ')}.`);
+      }
+    }
+
+    if (payload.secrets != null) {
+      for (const [name, value] of Object.entries(portableSecrets)) {
+        await io.setSecret(name, value);
+        imported.secrets++;
+      }
+    }
+
+    if (payload.memory?.docs) {
+      const res = await io.importMemory(payload.memory);
+      imported.memoryWritten = res.written;
+      if (res.written > 0) {
+        // R6: memory is injected into future prompts as trusted context — an
+        // import that repopulates it is a poisoning vector. Import stays legal
+        // (the user approved the summary), but the consequence is stated.
+        summary.notices.push(`${res.written} memory doc(s) imported — they will inform future prompts; review them via /memory if this file wasn't authored by you.`);
+      }
+    }
+
+    for (const record of payload.hooks ?? []) {
+      // R6: an imported hook is CODE (or a rule) that runs against every tool
+      // call. It arrives from a file, not from this user's editor — so it
+      // lands disabled AND untrusted (a kind:'js' hook cannot even compile
+      // without trusted:true). Enabling is an explicit per-hook decision in
+      // Settings → Hooks, where the body is visible.
+      await io.saveHook({ ...record, enabled: false, trusted: false });
+      imported.hooks++;
+    }
+
+    if (preparedIdentity) {
+      const outcome = await io.adoptDwebIdentity?.(
+        payload.dweb.identityRecord,
+        passphrase ?? '',
+        {
+          replaceExisting: replaceDwebIdentity,
+          expectedExistingDid: preparedExistingDid,
+          ...(preparedExistingRevision
+            ? { expectedExistingRevision: preparedExistingRevision }
+            : {}),
+          expectedIncomingDid: preparedIncomingDid,
+        },
+      );
+      if (!outcome?.adopted) {
+        if (outcome?.reason === 'no-openable-wrapper') throw new ExportPassphraseError();
+        return {
+          ok: false,
+          error: `dweb-identity-${outcome?.reason ?? 'adopt-failed'}`,
+          partial: imported,
+          identityOutcome: 'not-changed',
+        };
+      }
+      if (outcome.reason === 'recovered' || outcome.reason === 'replaced'
+          || outcome.reason === 'replaced-invalid-local') {
+        imported.dwebIdentity = 1;
+        const replaced = outcome.reason === 'replaced' || outcome.reason === 'replaced-invalid-local';
+        identityOutcome = replaced ? 'replaced' : 'restored';
+        summary.notices.push(`${replaced ? 'Local peer identity replaced' : 'Peer identity restored'} from the backup${outcome.did ? ` (${outcome.did})` : ''}.`);
+      } else {
+        identityOutcome = 'already-present';
+      }
+      runtimeRecoveryPending = outcome.runtimeRecoveryPending === true;
+      if (runtimeRecoveryPending) {
+        summary.notices.push('The peer identity was stored, but the peer network is still recovering. Keep peerd open; it will retry automatically.');
+      }
+    }
+    if (identityOutcome === 'already-present') {
+      summary.notices.push('The backup carries the same peer identity already present on this install; no identity change was needed.');
+    }
+    return { ok: true, imported, identityOutcome, runtimeRecoveryPending, notices: summary.notices };
+  } catch (cause) {
+    const named = /** @type {{ name?: string, code?: string }} */ (cause);
+    const failure = cause instanceof ExportPassphraseError
+      ? 'wrong-passphrase'
+      : named?.name === 'IdentityTransferError'
+        ? `dweb-identity-${named.code ?? 'transfer-failed'}`
+        : 'write-failed';
+    return {
+      ok: false,
+      error: 'import-partial',
+      failure,
+      partial: imported,
+      identityOutcome: 'not-changed',
+    };
   }
-
-  // payload.dweb: nothing to apply in Phase 0. Store packages drop
-  // it (notice already in summary); preview packages will consume it when
-  // persistent dweb state exists (Phase 2).
-
-  return { ok: true, imported, notices: summary.notices };
 };

--- a/extension/shared/argon2id.js
+++ b/extension/shared/argon2id.js
@@ -1,0 +1,28 @@
+// @ts-check
+// Shared Argon2id execution primitive over the vendored hash-wasm bundle.
+// Vault and portable-identity policy each validate and record their own KDF
+// descriptors; this file only performs a caller-approved derivation.
+
+import { argon2id, VENDORED } from '/vendor/argon2/argon2.js';
+
+/**
+ * @param {Object} args
+ * @param {string} args.passphrase
+ * @param {Uint8Array} args.salt
+ * @param {number} args.memKiB
+ * @param {number} args.iters
+ * @param {number} args.parallelism
+ * @returns {Promise<Uint8Array>}
+ */
+export const deriveArgon2id = ({ passphrase, salt, memKiB, iters, parallelism }) => {
+  if (VENDORED !== true) throw new Error('argon2: vendored bundle sentinel missing');
+  return argon2id({
+    password: passphrase,
+    salt,
+    parallelism,
+    iterations: iters,
+    memorySize: memKiB,
+    hashLength: 32,
+    outputType: 'binary',
+  });
+};

--- a/extension/shared/backup-passphrase.js
+++ b/extension/shared/backup-passphrase.js
@@ -1,0 +1,37 @@
+// @ts-check
+// One memory-hard policy for every new passphrase-protected backup section.
+//
+// why shared: the generic credential box ships in every channel while the peer
+// identity wrapper ships only in preview. If either chooses a cheaper KDF, a
+// backup containing both gives an attacker that cheaper passphrase oracle.
+
+import { deriveArgon2id } from './argon2id.js';
+
+export const BACKUP_ARGON2ID_PARAMS = Object.freeze({
+  name: 'Argon2id',
+  memKiB: 64 * 1024,
+  iters: 3,
+  parallelism: 1,
+});
+export const BACKUP_ARGON2ID_SALT_BYTES = 16;
+
+/**
+ * @param {string} passphrase
+ * @param {Uint8Array} salt
+ * @returns {Promise<Uint8Array>}
+ */
+export const deriveBackupPassphraseBytes = async (passphrase, salt) => {
+  if (typeof passphrase !== 'string' || passphrase.length === 0) {
+    throw new TypeError('backup passphrase required');
+  }
+  if (!(salt instanceof Uint8Array) || salt.byteLength !== BACKUP_ARGON2ID_SALT_BYTES) {
+    throw new TypeError(`backup salt must be ${BACKUP_ARGON2ID_SALT_BYTES} bytes`);
+  }
+  return deriveArgon2id({
+    passphrase,
+    salt,
+    memKiB: BACKUP_ARGON2ID_PARAMS.memKiB,
+    iters: BACKUP_ARGON2ID_PARAMS.iters,
+    parallelism: BACKUP_ARGON2ID_PARAMS.parallelism,
+  });
+};

--- a/extension/shared/dweb-interface.js
+++ b/extension/shared/dweb-interface.js
@@ -36,6 +36,10 @@
  *   persistent identity material (vault IO injected — SW-side)
  * @property {((material: { seed: string, pub: string }) => Promise<any>)=} identityFromMaterial
  *   rehydrate a signing identity from material (page-side)
+ * @property {((args: { material: { seed: string, pub: string }, passphrase: string }) => Promise<any>)=} identityRecordExport
+ *   build the portable identity record (capsule + wrappers) in the dweb crypto host
+ * @property {((args: { record: any, passphrase?: string, existingMaterial?: string | null, replaceExisting?: boolean }) => Promise<any>)=} identityRecordAdopt
+ *   decide + open an imported identity record in the dweb crypto host
  * @property {((opts: any) => Promise<any>)=} installAppBundle
  *   verified bundle → engine App via an injected installer
  * @property {((io: { fetchText: (p: string) => Promise<string> }) => Promise<any>)=} loadSeedApp

--- a/extension/shared/sender-trust.js
+++ b/extension/shared/sender-trust.js
@@ -40,7 +40,7 @@
  * sibling id that merely shares a prefix. Using getURL('') rather than a
  * hardcoded scheme keeps this correct on Firefox (`moz-extension://…`).
  *
- * @param {{ id?: string, url?: string } | null | undefined} sender
+ * @param {{ id?: string, url?: string, tab?: unknown } | null | undefined} sender
  *   the second argument browser.runtime.onMessage hands to a listener
  * @param {{ runtimeId?: string, extensionOrigin?: string }} [trust]
  *   runtimeId = browser.runtime.id; extensionOrigin = browser.runtime.getURL('').
@@ -73,10 +73,11 @@ export const isFirstPartySender = (sender, { runtimeId, extensionOrigin } = {}) 
  *
  * Exact-match on the document URL, not a prefix: a prefix would also admit
  * `offscreen/offscreen.html.evil.html` or any deeper path under it. Query and
- * hash are tolerated (Chrome does not add them today, but a future
- * createDocument call might) by comparing only the part before `?` or `#`.
+ * hash are rejected because the browser-owned document is created at one exact
+ * URL. A sender with `tab` provenance is also rejected because a real offscreen
+ * document is not hosted by a user-visible tab.
  *
- * @param {{ id?: string, url?: string } | null | undefined} sender
+ * @param {{ id?: string, url?: string, tab?: unknown } | null | undefined} sender
  * @param {{ runtimeId?: string, extensionOrigin?: string, offscreenUrl?: string }} [trust]
  *   offscreenUrl = browser.runtime.getURL('offscreen/offscreen.html'). Missing or
  *   blank fails closed, so an unwired caller is "untrusted" rather than a crash.
@@ -85,6 +86,23 @@ export const isFirstPartySender = (sender, { runtimeId, extensionOrigin } = {}) 
 export const isOffscreenSender = (sender, { runtimeId, extensionOrigin, offscreenUrl } = {}) => {
   if (!isFirstPartySender(sender, { runtimeId, extensionOrigin })) return false;
   if (typeof offscreenUrl !== 'string' || offscreenUrl.length === 0) return false;
-  const url = /** @type {string} */ (sender?.url).split('?')[0].split('#')[0];
-  return url === offscreenUrl;
+  if (sender && typeof sender === 'object' && 'tab' in sender) return false;
+  return sender?.url === offscreenUrl;
+};
+
+/**
+ * Is this sender the full-tab options page that owns backup and restore?
+ * Hash routes are part of the trusted page URL. Queries and sibling paths are
+ * not, and open_in_tab means legitimate callers carry tab provenance.
+ * @param {{ id?: string, url?: string, tab?: { id?: number } } | null | undefined} sender
+ * @param {{ runtimeId?: string, extensionOrigin?: string, optionsUrl?: string }} [trust]
+ */
+export const isOptionsSender = (sender, { runtimeId, extensionOrigin, optionsUrl } = {}) => {
+  if (!isFirstPartySender(sender, { runtimeId, extensionOrigin })) return false;
+  if (typeof optionsUrl !== 'string' || optionsUrl.length === 0) return false;
+  if (typeof sender?.tab?.id !== 'number') return false;
+  const url = /** @type {string} */ (sender.url);
+  const hashAt = url.indexOf('#');
+  const documentUrl = hashAt === -1 ? url : url.slice(0, hashAt);
+  return !documentUrl.includes('?') && documentUrl === optionsUrl;
 };

--- a/extension/tests/index.js
+++ b/extension/tests/index.js
@@ -112,6 +112,7 @@ import './unit/sidepanel/learned-origins-view.test.js';
 import './unit/options/activity-origin-events.test.js';
 import './unit/options/behavior-rows.test.js';
 import './unit/options/activity-tool-failed.test.js';
+import './unit/options/transfer-identity.test.js';
 
 // --- home (chassis): the full-tab Library page ---
 import './unit/home/library-section.test.js';

--- a/extension/tests/unit/options/transfer-identity.test.js
+++ b/extension/tests/unit/options/transfer-identity.test.js
@@ -1,0 +1,318 @@
+// @ts-check
+// Options → Backup/restore: the identity-only path must still ask for the file
+// passphrase, and a different local did requires an explicit keep/replace choice.
+
+import m from '/vendor/mithril/mithril.js';
+import { describe, it, expect } from '../../framework.js';
+import { TransferSection } from '/options/sections/transfer.js';
+
+const RECORD = { did: 'did:key:zIncomingPortable' };
+const SUMMARY = Object.freeze({
+  settingsKeys: [], hasSecrets: false, hasIdentityRecord: true,
+  requiresPassphrase: true, identityDid: RECORD.did,
+  memoryDocs: 0, hooks: 0, skills: [], notices: [], sourceChannel: 'preview',
+});
+
+const flush = async () => { await new Promise((resolve) => setTimeout(resolve, 0)); m.redraw.sync(); };
+
+/**
+ * @param {(msg: any, calls: any[]) => any} importReply
+ * @param {(msg: any, calls: any[]) => any} [inspectReply]
+ * @param {Record<string, any>} [stateOverrides]
+ */
+const mount = async (importReply, inspectReply, stateOverrides = {}) => {
+  const calls = /** @type {any[]} */ ([]);
+  const send = async (/** @type {any} */ msg) => {
+    calls.push(msg);
+    if (msg.type === 'transfer/import') return importReply(msg, calls);
+    if (msg.type === 'transfer/inspectImport' && inspectReply) return inspectReply(msg, calls);
+    return { ok: true };
+  };
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  const state = {
+    exportPass: '', exportConfirm: '', exportBusy: false, exportMsg: null,
+    importPayload: { dweb: { identityRecord: RECORD } }, importSummary: SUMMARY,
+    importPass: '', importBusy: false, importInspectBusy: false, importMsg: null, importNotices: [],
+    identityConflict: null, replacementPending: false, importFileInput: null,
+    importInspectGeneration: 0, restoreFocusToReview: false, focusImportFileOnUpdate: false,
+    focusImportStatusOnUpdate: false,
+    artifactEnvelope: null, artifactSummary: null, artifactBusy: false, artifactMsg: null,
+    debugSessions: [], debugSessionId: '', debugBusy: false, debugMsg: null,
+    ...stateOverrides,
+  };
+  m.mount(root, { view: () => TransferSection.view({ attrs: { send }, state }) });
+  await flush();
+  return { root, calls, unmount: () => { m.mount(root, null); root.remove(); } };
+};
+
+describe('options.transfer — portable identity restore', () => {
+  it('asks for a passphrase even when the backup carries no API keys', async () => {
+    const { root, unmount } = await mount(() => ({ ok: false, error: 'unused' }));
+    try {
+      expect(root.textContent).toContain('Peer identity');
+      expect(root.querySelector('#imppass')).toBeTruthy();
+      expect(root.textContent).toContain('restoring it may replace an identity');
+    } finally { unmount(); }
+  });
+
+  it('shows complete long setting values inside a compact disclosure', async () => {
+    const value = { fallbacks: Array.from({ length: 40 }, (_, index) => `model-${index}`) };
+    const { root, unmount } = await mount(() => ({ ok: false }), undefined, {
+      importPayload: { settings: { providerFallbacks: value }, dweb: { identityRecord: RECORD } },
+      importSummary: { ...SUMMARY, settingsKeys: ['providerFallbacks'] },
+    });
+    try {
+      const details = root.querySelector('details.import-setting-values');
+      expect(details).toBeTruthy();
+      expect(details?.textContent).toContain(JSON.stringify(value));
+      expect(details?.textContent).toContain('model-39');
+    } finally { unmount(); }
+  });
+
+  it('stops on a conflict and keeps the local identity only after explicit choice', async () => {
+    const { root, calls, unmount } = await mount((msg) => msg.skipDwebIdentity
+      ? { ok: true, imported: { settings: 0, secrets: 0, memoryWritten: 0, hooks: 0, dwebIdentity: 0 }, identityOutcome: 'kept-local', notices: [] }
+      : {
+          ok: false, error: 'dweb-identity-conflict',
+          conflict: { existingDid: 'did:key:zExistingLocal', incomingDid: RECORD.did },
+        });
+    try {
+      const passphrase = /** @type {HTMLInputElement} */ (root.querySelector('#imppass'));
+      passphrase.value = 'backup-passphrase';
+      passphrase.dispatchEvent(new Event('input'));
+      await flush();
+      const apply = /** @type {HTMLButtonElement} */ ([...root.querySelectorAll('button')]
+        .find((button) => button.textContent === 'Apply import'));
+      apply.click();
+      await flush();
+      expect(root.querySelector('#identity-conflict')?.textContent).toContain('Identity conflict');
+      expect(root.querySelector('#identity-conflict')?.getAttribute('role')).toBe('alert');
+      expect(root.textContent).toContain('did:key:zExistingLocal');
+      expect(root.textContent).toContain(RECORD.did);
+      expect(root.textContent).toContain('Keep current identity & import rest');
+      expect(root.textContent).toContain('Review identity replacement');
+
+      const keep = /** @type {HTMLButtonElement} */ ([...root.querySelectorAll('button')]
+        .find((button) => button.textContent === 'Keep current identity & import rest'));
+      keep.click();
+      await flush();
+      const imports = calls.filter((call) => call.type === 'transfer/import');
+      expect(imports[1].skipDwebIdentity).toBe(true);
+      expect(imports[1].replaceDwebIdentity).toBe(false);
+      expect(root.querySelector('[role=status]')?.textContent).toContain('local peer identity was kept');
+    } finally { unmount(); }
+  });
+
+  it('requires a second destructive confirmation before replacement', async () => {
+    const { root, calls, unmount } = await mount(() => ({
+      ok: false, error: 'dweb-identity-conflict',
+      conflict: { existingDid: 'did:key:zExistingLocal', incomingDid: RECORD.did },
+    }));
+    try {
+      const passphrase = /** @type {HTMLInputElement} */ (root.querySelector('#imppass'));
+      passphrase.value = 'backup-passphrase';
+      passphrase.dispatchEvent(new Event('input'));
+      await flush();
+      /** @type {HTMLButtonElement} */ ([...root.querySelectorAll('button')]
+        .find((button) => button.textContent === 'Apply import')).click();
+      await flush();
+      /** @type {HTMLButtonElement} */ ([...root.querySelectorAll('button')]
+        .find((button) => button.textContent === 'Review identity replacement')).click();
+      await flush();
+      expect(root.querySelector('#identity-replace-confirmation')?.textContent).toContain('Existing peers will see a new identity');
+      expect(root.textContent).toContain('Permanently replace identity');
+      expect(root.querySelector('button.danger')).toBeTruthy();
+      /** @type {HTMLButtonElement} */ ([...root.querySelectorAll('button')]
+        .find((button) => button.textContent === 'Permanently replace identity')).click();
+      await flush();
+      const replacement = calls.filter((/** @type {any} */ call) => call.type === 'transfer/import').at(-1);
+      expect(replacement.approvedExistingDwebDid).toBe('did:key:zExistingLocal');
+      expect(replacement.approvedIncomingDwebDid).toBe(RECORD.did);
+    } finally { unmount(); }
+  });
+
+  it('recovers from a rejected extension message instead of wedging controls', async () => {
+    const { root, unmount } = await mount(() => Promise.reject(new Error('worker restarted')));
+    try {
+      const passphrase = /** @type {HTMLInputElement} */ (root.querySelector('#imppass'));
+      passphrase.value = 'backup-passphrase';
+      passphrase.dispatchEvent(new Event('input'));
+      await flush();
+      const apply = /** @type {HTMLButtonElement} */ ([...root.querySelectorAll('button')]
+        .find((button) => button.textContent === 'Apply import'));
+      apply.click();
+      await flush();
+      expect(root.textContent).toContain('final state is unknown');
+      expect(root.querySelector('#restore-summary')).toBeFalsy();
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      expect(root.querySelector('#peerd-backup-file')).toBe(document.activeElement);
+    } finally { unmount(); }
+  });
+
+  it('discards an older inspection reply when a newer file was selected', async () => {
+    /** @type {(value: any) => void} */ let resolveA = () => {};
+    /** @type {(value: any) => void} */ let resolveB = () => {};
+    const replyA = new Promise((resolve) => { resolveA = resolve; });
+    const replyB = new Promise((resolve) => { resolveB = resolve; });
+    const { root, unmount } = await mount(() => ({ ok: false }), (msg) =>
+      msg.payload.id === 'A' ? replyA : replyB);
+    try {
+      const input = /** @type {HTMLInputElement} */ (root.querySelector('#peerd-backup-file'));
+      const select = (/** @type {string} */ id) => {
+        Object.defineProperty(input, 'files', {
+          configurable: true,
+          value: [{ size: 10, text: async () => JSON.stringify({ id }) }],
+        });
+        input.dispatchEvent(new Event('change'));
+      };
+      select('A');
+      await flush();
+      select('B');
+      await flush();
+      resolveB({ ok: true, summary: { ...SUMMARY, identityDid: 'did:key:zNewestBackup' } });
+      await flush();
+      resolveA({ ok: true, summary: { ...SUMMARY, identityDid: 'did:key:zStaleBackup' } });
+      await flush();
+      expect(root.textContent).toContain('did:key:zNewestBackup');
+      expect(root.textContent?.includes('did:key:zStaleBackup')).toBe(false);
+    } finally { unmount(); }
+  });
+
+  it('lets the user cancel a stalled inspection and ignores its late reply', async () => {
+    /** @type {(value: any) => void} */ let resolveInspect = () => {};
+    const inspect = new Promise((resolve) => { resolveInspect = resolve; });
+    const { root, unmount } = await mount(() => ({ ok: false }), () => inspect);
+    try {
+      const input = /** @type {HTMLInputElement} */ (root.querySelector('#peerd-backup-file'));
+      Object.defineProperty(input, 'files', {
+        configurable: true,
+        value: [{ size: 10, text: async () => JSON.stringify({ id: 'slow' }) }],
+      });
+      input.dispatchEvent(new Event('change'));
+      await flush();
+      expect(root.querySelector('[role=status]')?.textContent).toContain('Inspecting backup');
+      const cancel = /** @type {HTMLButtonElement} */ ([...root.querySelectorAll('button')]
+        .find((button) => button.textContent === 'Cancel inspection'));
+      cancel.click();
+      await flush();
+      expect(root.textContent?.includes('Inspecting backup')).toBe(false);
+      expect(document.activeElement?.id).toBe('peerd-backup-file');
+      resolveInspect({ ok: true, summary: SUMMARY });
+      await flush();
+      expect(root.querySelector('#restore-summary')).toBeFalsy();
+    } finally { unmount(); }
+  });
+
+  it('reports completed section counts when final identity adoption fails', async () => {
+    const { root, unmount } = await mount(() => ({
+      ok: false,
+      error: 'import-partial',
+      failure: 'dweb-identity-stop-failed',
+      partial: { settings: 2, secrets: 1, memoryWritten: 3, hooks: 4, dwebIdentity: 0 },
+      identityOutcome: 'not-changed',
+    }));
+    try {
+      const passphrase = /** @type {HTMLInputElement} */ (root.querySelector('#imppass'));
+      passphrase.value = 'backup-passphrase';
+      passphrase.dispatchEvent(new Event('input'));
+      await flush();
+      /** @type {HTMLButtonElement} */ ([...root.querySelectorAll('button')]
+        .find((button) => button.textContent === 'Apply import')).click();
+      await flush();
+      expect(root.textContent).toContain('2 setting(s), 1 stored credential(s), 0 provider endpoint(s), 3 memory doc(s), and 4 hook(s)');
+      expect(root.textContent).toContain('peer identity was not changed');
+      expect(root.textContent).toContain('peer network could not be paused safely');
+      expect(root.querySelector('#restore-summary')).toBeFalsy();
+    } finally { unmount(); }
+  });
+
+  it('restores focus to the replacement review action after going back', async () => {
+    const { root, unmount } = await mount(() => ({
+      ok: false, error: 'dweb-identity-conflict',
+      conflict: { existingDid: 'did:key:zExistingLocal', incomingDid: RECORD.did },
+    }));
+    try {
+      const passphrase = /** @type {HTMLInputElement} */ (root.querySelector('#imppass'));
+      passphrase.value = 'backup-passphrase';
+      passphrase.dispatchEvent(new Event('input'));
+      await flush();
+      /** @type {HTMLButtonElement} */ ([...root.querySelectorAll('button')]
+        .find((button) => button.textContent === 'Apply import')).click();
+      await flush();
+      /** @type {HTMLButtonElement} */ ([...root.querySelectorAll('button')]
+        .find((button) => button.textContent === 'Review identity replacement')).click();
+      await flush();
+      /** @type {HTMLButtonElement} */ ([...root.querySelectorAll('button')]
+        .find((button) => button.textContent === 'Go back')).click();
+      await flush();
+      expect(document.activeElement?.textContent).toBe('Review identity replacement');
+    } finally { unmount(); }
+  });
+
+  it('moves focus to the result after a successful restore', async () => {
+    const { root, unmount } = await mount(() => ({
+      ok: true,
+      imported: { settings: 0, secrets: 0, providerEndpoints: 0, memoryWritten: 0, hooks: 0, dwebIdentity: 1 },
+      identityOutcome: 'restored', notices: [],
+    }));
+    try {
+      const passphrase = /** @type {HTMLInputElement} */ (root.querySelector('#imppass'));
+      passphrase.value = 'backup-passphrase';
+      passphrase.dispatchEvent(new Event('input'));
+      await flush();
+      /** @type {HTMLButtonElement} */ ([...root.querySelectorAll('button')]
+        .find((button) => button.textContent === 'Apply import')).click();
+      await flush();
+      expect(document.activeElement?.id).toBe('transfer-import-status');
+      expect(root.querySelector('[role=status]')?.textContent).toContain('peer identity was restored');
+    } finally { unmount(); }
+  });
+
+  it('binds repair of an unreadable local identity to its reviewed revision', async () => {
+    const { root, calls, unmount } = await mount(() => ({
+      ok: false, error: 'dweb-identity-conflict',
+      conflict: {
+        existingDid: null, incomingDid: RECORD.did,
+        existingUnreadable: true, existingRevision: 'revision-a',
+      },
+    }));
+    try {
+      const passphrase = /** @type {HTMLInputElement} */ (root.querySelector('#imppass'));
+      passphrase.value = 'backup-passphrase';
+      passphrase.dispatchEvent(new Event('input'));
+      await flush();
+      /** @type {HTMLButtonElement} */ ([...root.querySelectorAll('button')]
+        .find((button) => button.textContent === 'Apply import')).click();
+      await flush();
+      expect(root.textContent).toContain('local peer identity is unreadable');
+      /** @type {HTMLButtonElement} */ ([...root.querySelectorAll('button')]
+        .find((button) => button.textContent === 'Review identity replacement')).click();
+      await flush();
+      const confirm = /** @type {HTMLButtonElement} */ ([...root.querySelectorAll('button')]
+        .find((button) => button.textContent === 'Discard damaged identity and restore'));
+      expect(confirm).toBeTruthy();
+      confirm.click();
+      await flush();
+      expect(calls.filter((call) => call.type === 'transfer/import').at(-1)
+        .approvedExistingDwebRevision).toBe('revision-a');
+    } finally { unmount(); }
+  });
+
+  it('turns expected internal failures into recovery guidance', async () => {
+    const { root, unmount } = await mount(() => ({
+      ok: false, error: 'dweb-identity-identity-changed',
+    }));
+    try {
+      const passphrase = /** @type {HTMLInputElement} */ (root.querySelector('#imppass'));
+      passphrase.value = 'backup-passphrase';
+      passphrase.dispatchEvent(new Event('input'));
+      await flush();
+      /** @type {HTMLButtonElement} */ ([...root.querySelectorAll('button')]
+        .find((button) => button.textContent === 'Apply import')).click();
+      await flush();
+      expect(root.textContent).toContain('identity changed after review');
+      expect(root.textContent?.includes('dweb-identity-identity-changed')).toBe(false);
+    } finally { unmount(); }
+  });
+});

--- a/manifests/preview.patch.json
+++ b/manifests/preview.patch.json
@@ -5,7 +5,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "peerd-preview@peerd.ai",
-      "strict_min_version": "121.0",
+      "strict_min_version": "129.0",
       "update_url": "https://peerd.ai/updates/firefox-preview.json"
     }
   },

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -128,7 +128,19 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // outcomes), write-guard.js (§11.5 enforcement), engine-liveness.js (§9
 // ledger); all carry // @ts-check.
 // 618 → 619: the actors-in-code SW route extracted for issue #324.
-const COVERED_FLOOR = 619;
+// 619 → 624: the initial portable-identity capsule/record implementation.
+// 624 → 628: custody hardening added the shared crypto/host boundaries,
+// rendered restore-flow test, and tested offscreen lifecycle barrier while
+// centralizing identity-bound sharing and removing unused device-key files.
+// 628 → 629: targeted dweb-custody port client (raw roots and passphrases
+// never ride extension-wide broadcast messaging).
+// 629 → 630: permanent identity reads and first-mint writes moved from generic
+// runtime routes into the verified custody port.
+// 630 → 631: one shared memory-hard KDF policy now protects every new backup
+// password oracle.
+// 631 → 633: the exact-options transfer Port and its client keep backup
+// passwords off extension-wide runtime messages.
+const COVERED_FLOOR = 633;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/packaging/security-baseline.json
+++ b/packaging/security-baseline.json
@@ -238,7 +238,7 @@
       "browser_specific_settings": {
         "gecko": {
           "id": "peerd-preview@peerd.ai",
-          "strict_min_version": "121.0",
+          "strict_min_version": "129.0",
           "update_url": "https://peerd.ai/updates/firefox-preview.json",
           "data_collection_permissions": {
             "required": [

--- a/scripts/cdp/states.mjs
+++ b/scripts/cdp/states.mjs
@@ -39,6 +39,18 @@ const probe = (ctx) => evalIn(ctx.page, `(() => {
 })()`);
 
 const SMOKE_TEXT = 'e2e-smoke-ok';
+const TRANSFER_EXPORT_VERSION = 2;
+
+// Transfer routes require the exact options-page Port. Keep the live E2E on
+// that production boundary instead of calling the generic dispatcher.
+const privateTransferRpc = (page, message) => evalIn(page, `(async () => {
+  const browser = (await import('/vendor/browser-polyfill.js')).default;
+  const { makePrivateTransferClient } = await import('/options/private-transfer-client.js');
+  globalThis.__peerdE2eTransferClient ??= makePrivateTransferClient({
+    connect: () => browser.runtime.connect({ name: 'private-transfer' }),
+  });
+  return globalThis.__peerdE2eTransferClient.call(${JSON.stringify(message)});
+})()`, true);
 
 // The local-first personal-data agent, end to end through the REAL stack: the
 // faked model calls script, the sealed worker builds an on-device index in OPFS
@@ -184,6 +196,240 @@ export const STATES = [
       rec.check('assistant turn renders the streamed text', out.assistantText === SMOKE_TEXT, JSON.stringify(out.assistantText));
       rec.check('turn reaches a terminal/idle state', out.busy === false);
       await rec.shot('final');
+    },
+  },
+
+  // --- functional: portable identity through the live SW + offscreen host ---
+  {
+    name: 'portable-identity', kind: 'functional', phase: 'post-unlock',
+    responder: null,
+    async run(ctx, rec) {
+      const transferPage = await openWidePage(ctx, 'options/options.html#!/transfer', { ready: '#exppass' });
+      let exported = await privateTransferRpc(transferPage, { type: 'transfer/export', passphrase: PASSPHRASE });
+      if (!exported?.payload?.dweb?.identityRecord) {
+        // The harness initializes a new vault but does not perform the later
+        // unlock wake that normally starts the base network and mints its root.
+        // Seed through the shipped encrypted restore surface. No raw root uses
+        // the generic runtime-message dispatcher.
+        const bootstrap = await evalIn(ctx.page, `(async () => {
+          const dweb = await import('/peerd-distributed/index.js');
+          let value = null;
+          await dweb.createPersistentIdentity({
+            getSecret: async () => null,
+            setSecret: async (_name, next) => { value = next; },
+          });
+          const material = JSON.parse(value);
+          return dweb.createDwebClient().identityRecordExport({
+            material, passphrase: ${JSON.stringify(PASSPHRASE)},
+          });
+        })()`, true);
+        const seeded = await privateTransferRpc(transferPage, {
+          type: 'transfer/import', passphrase: PASSPHRASE,
+          payload: {
+            format: 'peerd-export', version: TRANSFER_EXPORT_VERSION, exportedAt: new Date(0).toISOString(), channel: 'preview',
+            settings: {}, providerEndpoints: null, secrets: null, memory: null,
+            hooks: [], skills: [], dweb: { identityRecord: bootstrap },
+          },
+        });
+        rec.check('test fixture restores only through the encrypted transfer surface',
+          seeded?.ok === true && seeded?.imported?.dwebIdentity === 1, JSON.stringify(seeded));
+        exported = await privateTransferRpc(transferPage, { type: 'transfer/export', passphrase: PASSPHRASE });
+      }
+      const record = exported?.payload?.dweb?.identityRecord;
+      const beforeDid = record?.did ?? null;
+      rec.check('preview identity exists in the unlocked vault',
+        typeof beforeDid === 'string' && beforeDid.startsWith('did:key:'), JSON.stringify(beforeDid));
+      rec.check('live export includes an encrypted identity record',
+        exported?.ok === true && typeof record?.capsule === 'string' && record?.did?.startsWith('did:key:'),
+        JSON.stringify({ ok: exported?.ok, error: exported?.error, did: record?.did }));
+
+      const inspected = await privateTransferRpc(transferPage, { type: 'transfer/inspectImport', payload: exported?.payload });
+      rec.check('pre-flight names the identity and requires its passphrase',
+        inspected?.ok === true && inspected.summary?.hasIdentityRecord === true
+          && inspected.summary?.requiresPassphrase === true && inspected.summary?.identityDid === record?.did,
+        JSON.stringify(inspected?.summary));
+
+      const wrong = await privateTransferRpc(transferPage, {
+        type: 'transfer/import', payload: exported?.payload, passphrase: `${PASSPHRASE}-wrong`,
+      });
+      rec.check('wrong identity passphrase fails closed',
+        wrong?.ok === false && wrong?.error === 'wrong-passphrase', JSON.stringify(wrong));
+
+      const restored = await privateTransferRpc(transferPage, {
+        type: 'transfer/import', payload: exported?.payload, passphrase: PASSPHRASE,
+      });
+      const after = await privateTransferRpc(transferPage, { type: 'transfer/export', passphrase: PASSPHRASE });
+      const afterDid = after?.payload?.dweb?.identityRecord?.did ?? null;
+      rec.check('same-did restore authenticates without replacing the local root',
+        restored?.ok === true && restored.imported?.dwebIdentity === 0
+          && afterDid === beforeDid,
+        JSON.stringify({ restored, beforeDid, afterDid }));
+
+      const incoming = await evalIn(ctx.page, `(async () => {
+        const dweb = await import('/peerd-distributed/index.js');
+        let value = null;
+        await dweb.createPersistentIdentity({
+          getSecret: async () => null,
+          setSecret: async (_name, next) => { value = next; },
+        });
+        const material = JSON.parse(value);
+        const record = await dweb.createDwebClient().identityRecordExport({
+          material, passphrase: ${JSON.stringify(PASSPHRASE)},
+        });
+        return { record, did: record.did };
+      })()`, true);
+      const replacementPayload = {
+        ...exported.payload,
+        settings: {}, providerEndpoints: null, secrets: null,
+        memory: null, hooks: [], skills: [],
+        dweb: { identityRecord: incoming.record },
+      };
+      const conflict = await privateTransferRpc(transferPage, {
+        type: 'transfer/import', payload: replacementPayload, passphrase: PASSPHRASE,
+      });
+      rec.check('a different live identity stops for explicit approval',
+        conflict?.ok === false && conflict?.error === 'dweb-identity-conflict'
+          && conflict.conflict?.existingDid === record.did
+          && conflict.conflict?.incomingDid === incoming.did,
+        JSON.stringify(conflict));
+
+      const replaced = await privateTransferRpc(transferPage, {
+        type: 'transfer/import', payload: replacementPayload, passphrase: PASSPHRASE,
+        replaceDwebIdentity: true,
+        approvedExistingDwebDid: conflict?.conflict?.existingDid,
+        approvedIncomingDwebDid: conflict?.conflict?.incomingDid,
+      });
+      const exportedAfterReplace = await privateTransferRpc(transferPage, {
+        type: 'transfer/export', passphrase: PASSPHRASE,
+      });
+      const storedDid = exportedAfterReplace?.payload?.dweb?.identityRecord?.did ?? null;
+      rec.check('approved replacement commits the incoming permanent identity',
+        replaced?.ok === true && replaced.identityOutcome === 'replaced'
+          && replaced.imported?.dwebIdentity === 1 && storedDid === incoming.did,
+        JSON.stringify({ replaced, storedDid, incomingDid: incoming.did }));
+
+      const restarted = await rpc(ctx.page, { type: 'dweb/base-host/start' });
+      rec.check('the peer host starts under the restored identity after lease release',
+        restarted?.ok === true && restarted?.running === true && restarted?.did === incoming.did,
+        JSON.stringify(restarted));
+      await rec.shot('final');
+      try { transferPage.close(); } catch { /* */ }
+    },
+  },
+
+  // --- visual: portable identity backup + destructive restore conflict ------
+  {
+    name: 'options-transfer', kind: 'visual', phase: 'post-unlock',
+    responder: () => ({ sse: sseText('noted') }),
+    async run(ctx, rec) {
+      const page = await openWidePage(ctx, 'options/options.html#!/transfer');
+      try {
+        await waitFor(() => evalIn(page, `!!document.querySelector('#exppass')`),
+          { budgetMs: 15_000, pollMs: 80 }).catch(() => {});
+        await rec.visualPage('options-transfer', page);
+      } finally { try { page.close(); } catch { /* */ } }
+    },
+  },
+  {
+    name: 'options-transfer-conflict', kind: 'visual', phase: 'post-unlock',
+    responder: () => ({ sse: sseText('noted') }),
+    async run(ctx, rec) {
+      const seedPage = await openWidePage(ctx, 'options/options.html#!/transfer', { ready: '#exppass' });
+      const localExport = await privateTransferRpc(seedPage, { type: 'transfer/export', passphrase: PASSPHRASE });
+      let localReady = !!localExport?.payload?.dweb?.identityRecord;
+      if (!localReady) {
+        const record = await evalIn(ctx.page, `(async () => {
+          const dweb = await import('/peerd-distributed/index.js');
+          let value = null;
+          await dweb.createPersistentIdentity({ getSecret: async () => null, setSecret: async (_name, next) => { value = next; } });
+          return dweb.createDwebClient().identityRecordExport({
+            material: JSON.parse(value), passphrase: ${JSON.stringify(PASSPHRASE)},
+          });
+        })()`, true);
+        await privateTransferRpc(seedPage, {
+          type: 'transfer/import', passphrase: PASSPHRASE,
+          payload: {
+            format: 'peerd-export', version: TRANSFER_EXPORT_VERSION, exportedAt: new Date(0).toISOString(), channel: 'preview',
+            settings: {}, providerEndpoints: null, secrets: null, memory: null,
+            hooks: [], skills: [], dweb: { identityRecord: record },
+          },
+        });
+        const postBootstrap = await privateTransferRpc(seedPage, {
+          type: 'transfer/export', passphrase: PASSPHRASE,
+        });
+        localReady = !!postBootstrap?.payload?.dweb?.identityRecord;
+      }
+      try { seedPage.close(); } catch { /* */ }
+      const incoming = await evalIn(ctx.page, `(async () => {
+        const dweb = await import('/peerd-distributed/index.js');
+        let value = null;
+        await dweb.createPersistentIdentity({ getSecret: async () => null, setSecret: async (_name, next) => { value = next; } });
+        const material = JSON.parse(value);
+        const record = await dweb.createDwebClient().identityRecordExport({
+          material, passphrase: ${JSON.stringify(PASSPHRASE)},
+        });
+        return { material, record };
+      })()`, true);
+      const payload = {
+        format: 'peerd-export', version: TRANSFER_EXPORT_VERSION, exportedAt: new Date(0).toISOString(), channel: 'preview',
+        // why: keep the complete-value disclosure in the same visual contract
+        // as the destructive conflict. A long recognized array catches both
+        // accidental truncation and wrapping regressions before the user acts.
+        settings: {
+          openrouterModels: [
+            'review/complete-setting-value-that-must-remain-visible-without-ellipsis-or-clipping-0123456789',
+            'review/second-model-preserves-the-array-shape-and-confirms-every-value-is-inspectable',
+          ],
+        },
+        providerEndpoints: null, secrets: null, memory: null, hooks: [], skills: [],
+        dweb: { identityRecord: incoming?.record },
+      };
+      const page = await openWidePage(ctx, 'options/options.html#!/transfer', { ready: '#peerd-backup-file' });
+      try {
+        await evalIn(page, `(() => {
+          const file = new File([${JSON.stringify(JSON.stringify(payload))}], 'identity-backup.json', { type: 'application/json' });
+          const transfer = new DataTransfer();
+          transfer.items.add(file);
+          const input = document.querySelector('#peerd-backup-file');
+          input.files = transfer.files;
+          input.dispatchEvent(new Event('change', { bubbles: true }));
+        })()`);
+        await waitFor(() => evalIn(page, `!!document.querySelector('#imppass')`),
+          { budgetMs: 15_000, pollMs: 80 });
+        await evalIn(page, `(() => {
+          const input = document.querySelector('#imppass');
+          input.value = ${JSON.stringify(PASSPHRASE)};
+          input.dispatchEvent(new Event('input', { bubbles: true }));
+        })()`);
+        await waitFor(() => evalIn(page, `[...document.querySelectorAll('button')].some((button) => button.textContent === 'Apply import' && !button.disabled)`),
+          { budgetMs: 5_000, pollMs: 50 });
+        await evalIn(page, `[...document.querySelectorAll('button')].find((button) => button.textContent === 'Apply import')?.click()`);
+        await waitFor(() => evalIn(page, `!!document.querySelector('#identity-conflict')`),
+          { budgetMs: 20_000, pollMs: 80 });
+        await evalIn(page, `[...document.querySelectorAll('button')].find((button) => button.textContent === 'Review identity replacement')?.click()`);
+        await waitFor(() => evalIn(page, `!!document.querySelector('#identity-replace-confirmation')`),
+          { budgetMs: 5_000, pollMs: 80 });
+        await evalIn(page, `document.querySelector('.import-setting-values > summary')?.click()`);
+        await waitFor(() => evalIn(page, `(() => {
+          const disclosure = document.querySelector('.import-setting-values');
+          const value = disclosure?.querySelector('code')?.textContent ?? '';
+          return disclosure?.open === true
+            && value.includes('complete-setting-value-that-must-remain-visible')
+            && value.includes('second-model-preserves-the-array-shape');
+        })()`), { budgetMs: 5_000, pollMs: 80 });
+        const state = await evalIn(page, `(() => ({
+          conflict: document.querySelector('#identity-conflict')?.textContent,
+          confirmation: document.querySelector('#identity-replace-confirmation')?.textContent,
+          danger: !!document.querySelector('button.danger'),
+          settingsDisclosureOpen: document.querySelector('.import-setting-values')?.open === true,
+        }))()`);
+        rec.check('destructive identity replacement requires a second confirmation',
+          state?.danger === true && state?.settingsDisclosureOpen === true
+            && /Existing peers will see a new identity/.test(state?.confirmation ?? ''),
+          JSON.stringify({ local: localReady, incoming: !!incoming?.record, state }));
+        await evalIn(page, `document.querySelector('#identity-replace-confirmation')?.scrollIntoView({ block: 'center' })`);
+        await rec.visualPage('options-transfer-conflict', page);
+      } finally { try { page.close(); } catch { /* */ } }
     },
   },
 
@@ -954,7 +1200,6 @@ export const STATES = [
       } finally { try { page.close(); } catch { /* */ } }
     },
   },
-
   // --- visual: the STANDALONE TAB PAGES ---------------------------------------
   //
   // Coverage audit finding: every visual baseline photographed the side panel,

--- a/tests/background/dweb-custody-client.test.ts
+++ b/tests/background/dweb-custody-client.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  makeDwebCustodyClient, makeRetryableCustodyReset,
+} from '../../extension/background/dweb-custody-client.js';
+
+const makeEvent = () => {
+  const listeners: Array<(message?: any) => void> = [];
+  return {
+    addListener: (listener: (message?: any) => void) => { listeners.push(listener); },
+    emit: (message?: any) => { for (const listener of listeners) listener(message); },
+  };
+};
+
+const makePort = () => {
+  const onMessage = makeEvent();
+  const onDisconnect = makeEvent();
+  const sent: any[] = [];
+  return {
+    port: {
+      onMessage,
+      onDisconnect,
+      postMessage: (message: any) => { sent.push(message); },
+      disconnect: () => onDisconnect.emit(),
+    } as any,
+    sent,
+    reply: (message: any) => onMessage.emit(message),
+    disconnect: () => onDisconnect.emit(),
+  };
+};
+
+const nextTask = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('dweb custody port client', () => {
+  test('carries a custody request and response only on the attached port', async () => {
+    let ensured = 0;
+    const host = makePort();
+    const client = makeDwebCustodyClient({
+      ensureOffscreen: async () => { ensured++; },
+      handleSecretRequest: async () => ({ ok: false }),
+      timeoutMs: 100,
+      newRequestId: () => 'req-1',
+    });
+    client.attach(host.port);
+    const result = client.call('export', { passphrase: 'secret', material: { seed: 'root' } });
+    await nextTask();
+    expect(host.sent).toEqual([{
+      type: 'custody/request', requestId: 'req-1', operation: 'export',
+      args: { passphrase: 'secret', material: { seed: 'root' } },
+    }]);
+    host.reply({ type: 'custody/response', requestId: 'req-1', ok: true, result: { did: 'did:key:zA' } });
+    expect(await result).toEqual({ did: 'did:key:zA' });
+    expect(ensured).toBe(0);
+  });
+
+  test('waits for the verified host port after ensuring the offscreen document', async () => {
+    const host = makePort();
+    const client = makeDwebCustodyClient({
+      ensureOffscreen: async () => {},
+      handleSecretRequest: async () => ({ ok: false }),
+      timeoutMs: 100,
+      newRequestId: () => 'req-2',
+    });
+    const result = client.call('reset');
+    await nextTask();
+    client.attach(host.port);
+    await nextTask();
+    expect(host.sent[0]).toMatchObject({ operation: 'reset', requestId: 'req-2' });
+    host.reply({ type: 'custody/response', requestId: 'req-2', ok: true, result: { reset: true } });
+    await expect(result).resolves.toEqual({ reset: true });
+  });
+
+  test('rejects in-flight custody work when the exact port disconnects', async () => {
+    const host = makePort();
+    const client = makeDwebCustodyClient({
+      ensureOffscreen: async () => {}, handleSecretRequest: async () => ({ ok: false }),
+      timeoutMs: 100, newRequestId: () => 'req-3',
+    });
+    client.attach(host.port);
+    const result = client.call('adopt', {});
+    await nextTask();
+    host.disconnect();
+    await expect(result).rejects.toMatchObject({
+      name: 'DwebCustodyPortError', code: 'port-disconnected',
+    });
+  });
+
+  test('retries cleanly after the initial port wait times out and a host reconnects', async () => {
+    const ids = ['timed-out', 'after-reconnect'];
+    const host = makePort();
+    const client = makeDwebCustodyClient({
+      ensureOffscreen: async () => {}, handleSecretRequest: async () => ({ ok: false }),
+      timeoutMs: 5, newRequestId: () => ids.shift() ?? 'extra',
+    });
+    await expect(client.call('reset')).rejects.toMatchObject({ code: 'port-timeout' });
+    client.attach(host.port);
+    const retried = client.call('reset');
+    await nextTask();
+    expect(host.sent[0]).toMatchObject({ requestId: 'timed-out', operation: 'reset' });
+    host.reply({
+      type: 'custody/response', requestId: 'timed-out', ok: true,
+      result: { reset: true },
+    });
+    await expect(retried).resolves.toEqual({ reset: true });
+  });
+
+  test('serves identity reads and writes only through the attached verified port', async () => {
+    const host = makePort();
+    const handled: any[] = [];
+    const client = makeDwebCustodyClient({
+      ensureOffscreen: async () => {},
+      handleSecretRequest: async (operation, args) => {
+        handled.push({ operation, args });
+        return operation === 'get' ? { ok: true, value: 'root' } : { ok: true };
+      },
+      timeoutMs: 100,
+    });
+    client.attach(host.port);
+    host.reply({
+      type: 'custody/secret-request', requestId: 'secret-1', operation: 'get', args: {},
+    });
+    await nextTask();
+    expect(handled).toEqual([{ operation: 'get', args: {} }]);
+    expect(host.sent).toContainEqual({
+      type: 'custody/secret-response', requestId: 'secret-1', ok: true,
+      result: { ok: true, value: 'root' },
+    });
+  });
+
+  test('a failed boot reset is retryable and concurrent callers share one attempt', async () => {
+    let attempts = 0;
+    let release = () => {};
+    const reset = makeRetryableCustodyReset({
+      enabled: true,
+      hostAvailable: true,
+      reset: async () => {
+        attempts++;
+        if (attempts === 1) throw new Error('port-timeout');
+        await new Promise<void>((resolve) => { release = resolve; });
+      },
+    });
+    await expect(reset.ensure()).rejects.toThrow('port-timeout');
+    const first = reset.ensure();
+    const second = reset.ensure();
+    await nextTask();
+    expect(attempts).toBe(2);
+    release();
+    await Promise.all([first, second]);
+    await reset.ensure();
+    expect(attempts).toBe(2);
+  });
+
+  test('does not contact the custody host when dweb or the host is unavailable', async () => {
+    let attempts = 0;
+    const reset = async () => { attempts++; };
+    const disabled = makeRetryableCustodyReset({
+      enabled: false, hostAvailable: true, reset,
+    });
+    const hostless = makeRetryableCustodyReset({
+      enabled: true, hostAvailable: false, reset,
+    });
+    await disabled.ensure();
+    await hostless.ensure();
+    expect(attempts).toBe(0);
+  });
+});

--- a/tests/background/dweb-identity-custody.test.ts
+++ b/tests/background/dweb-identity-custody.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  identityChangeBlockedByApps, makeDwebIdentityCustody,
+} from '../../extension/background/dweb-identity-custody.js';
+
+const makeFixture = (overrides: any = {}) => {
+  let stored: string | null = overrides.stored ?? null;
+  let writes = 0;
+  const audits: any[] = [];
+  const custody = makeDwebIdentityCustody({
+    enabled: true,
+    active: () => true,
+    vault: {
+      isLocked: () => false,
+      getSecret: async () => stored,
+      setSecret: async (_name: string, value: string) => { stored = value; writes++; },
+      ...overrides.vault,
+    },
+    auditLog: {
+      append: async (entry: any) => { audits.push(entry); },
+      ...overrides.auditLog,
+    },
+    identitySecretName: 'distributed/identity/v1',
+    withIdentityMutation: async (operation: () => Promise<any>) => operation(),
+    canChangeIdentity: async () => true,
+    ...overrides.deps,
+  });
+  return { custody, audits, get stored() { return stored; }, get writes() { return writes; } };
+};
+
+describe('dweb identity custody', () => {
+  test('recognizes current and legacy local publisher bindings only', () => {
+    expect(identityChangeBlockedByApps([{ shared: true }])).toBe(true);
+    expect(identityChangeBlockedByApps([{
+      shared: false, dweb: { local: true, publisher: 'did:key:zLegacy' },
+    }])).toBe(true);
+    expect(identityChangeBlockedByApps([{
+      shared: false, dweb: { local: true, publisher: null },
+    }])).toBe(false);
+    expect(identityChangeBlockedByApps([{
+      shared: false, dweb: { local: false, publisher: 'did:key:zPeer' },
+    }])).toBe(false);
+  });
+
+  test('reads and first-mints the root inside the custody handler', async () => {
+    const fixture = makeFixture();
+    expect(await fixture.custody.handle('get')).toEqual({ ok: true, value: null });
+    expect(await fixture.custody.handle('set', { value: 'root' })).toEqual({ ok: true });
+    expect(fixture.stored).toBe('root');
+    expect(fixture.audits).toEqual([{ type: 'dweb_identity_issued', details: {} }]);
+  });
+
+  test('fails closed when disabled, locked, or given a non-string root', async () => {
+    const disabled = makeFixture({ deps: { enabled: false } });
+    expect(await disabled.custody.handle('get')).toEqual({ ok: false, error: 'dweb-disabled' });
+    const locked = makeFixture({ vault: { isLocked: () => true } });
+    expect(await locked.custody.handle('get')).toEqual({ ok: false, error: 'vault-locked' });
+    const fixture = makeFixture();
+    expect(await fixture.custody.handle('set', { value: 3 })).toEqual({ ok: false, error: 'value-required' });
+  });
+
+  test('rechecks inside the mutation lane and never overwrites a recovered root', async () => {
+    const fixture = makeFixture({ stored: 'recovered-root' });
+    expect(await fixture.custody.handle('set', { value: 'stale-mint' }))
+      .toEqual({ ok: false, error: 'identity-already-exists' });
+    expect(fixture.writes).toBe(0);
+  });
+
+  test('blocks first mint while a local shared app still depends on the missing root', async () => {
+    const fixture = makeFixture({
+      deps: { canChangeIdentity: async () => false },
+    });
+    expect(await fixture.custody.handle('set', { value: 'replacement-root' }))
+      .toEqual({ ok: false, error: 'identity-in-use' });
+    expect(fixture.writes).toBe(0);
+  });
+
+  test('does not report a durable mint as failed when audit append fails', async () => {
+    const fixture = makeFixture({
+      auditLog: { append: async () => { throw new Error('audit unavailable'); } },
+    });
+    expect(await fixture.custody.handle('set', { value: 'root' })).toEqual({ ok: true });
+    expect(fixture.stored).toBe('root');
+  });
+});

--- a/tests/background/dweb-share.test.ts
+++ b/tests/background/dweb-share.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from 'bun:test';
+import { makeDwebShare } from '../../extension/background/dweb-share.js';
+
+const makeLane = () => {
+  let tail = Promise.resolve();
+  return <T>(operation: () => Promise<T>) => {
+    const result = tail.then(operation, operation);
+    tail = result.then(() => undefined, () => undefined);
+    return result;
+  };
+};
+
+describe('identity-bound dweb share', () => {
+  test('publish and complete identity metadata persistence stay in the custody lane', async () => {
+    const events: string[] = [];
+    const lane = makeLane();
+    let releasePublish!: () => void;
+    const publishGate = new Promise<void>((resolve) => { releasePublish = resolve; });
+    let publishStarted!: () => void;
+    const published = new Promise<void>((resolve) => { publishStarted = resolve; });
+    let persisted: any;
+    const share = makeDwebShare({
+      enabled: true, active: () => true, withIdentityMutation: lane,
+      appRegistry: {
+        get: async () => ({ name: 'App', entryFile: 'index.html', dweb: {} }),
+        update: async (_id, patch) => { events.push('persist'); persisted = patch; return { id: 'app-1' }; },
+      },
+      opfsHelpers: () => ({ list: async () => [{ path: '/index.html' }], read: async () => '<h1>App</h1>' }),
+      prepareRuntime: async () => ({ ok: true }),
+      sendMessage: async () => {
+        events.push('publish');
+        publishStarted();
+        await publishGate;
+        return { ok: true, uri: 'peerd://bundle', publisher: 'did:key:zOld', hash: 'hash', slug: 'app', dwapp_id: 'dwapp', seq: 7 };
+      },
+    });
+
+    const sharing = share('app-1', 'app');
+    await published;
+    const replacing = lane(async () => { events.push('replace'); });
+    expect(events).toEqual(['publish']);
+    releasePublish();
+    await Promise.all([sharing, replacing]);
+    expect(events).toEqual(['publish', 'persist', 'replace']);
+    expect(persisted).toEqual({
+      shared: true,
+      dweb: {
+        uri: 'peerd://bundle', publisher: 'did:key:zOld', hash: 'hash', version_id: 'hash',
+        slug: 'app', dwapp_id: 'dwapp', seq: 7, local: true,
+      },
+    });
+  });
+
+  test('metadata failure rolls back the published share and reports failure', async () => {
+    const messages: any[] = [];
+    const share = makeDwebShare({
+      enabled: true, active: () => true, withIdentityMutation: makeLane(),
+      appRegistry: {
+        get: async () => ({ name: 'App', entryFile: 'index.html', dweb: {} }),
+        update: async () => { throw new Error('disk'); },
+      },
+      opfsHelpers: () => ({ list: async () => [], read: async () => '' }),
+      prepareRuntime: async () => ({ ok: true }),
+      sendMessage: async (message) => {
+        messages.push(message);
+        return message.type.endsWith('unshare-app')
+          ? { ok: true }
+          : { ok: true, publisher: 'did:key:zOld', hash: 'hash', slug: 'custom-slug' };
+      },
+    });
+    expect(await share('app-1', undefined)).toMatchObject({ ok: false, error: 'share-metadata-store-failed' });
+    expect(messages.map((message) => message.type)).toEqual([
+      'dweb/base-host/share-app', 'dweb/base-host/unshare-app',
+    ]);
+    expect(messages[1].slug).toBe('custom-slug');
+  });
+
+  test('cold runtime preparation completes before the share takes the custody lane', async () => {
+    const events: string[] = [];
+    const lane = makeLane();
+    const share = makeDwebShare({
+      enabled: true, active: () => true, withIdentityMutation: lane,
+      appRegistry: {
+        get: async () => ({ name: 'App', entryFile: 'index.html', dweb: { local: false } }),
+        update: async (_id, patch) => { events.push('persist'); return { id: 'app-1', ...patch }; },
+      },
+      opfsHelpers: () => ({ list: async () => [], read: async () => '' }),
+      prepareRuntime: () => lane(async () => { events.push('mint'); return { ok: true }; }),
+      sendMessage: async () => {
+        events.push('publish');
+        return { ok: true, uri: 'peerd://bundle', publisher: 'did:key:zLocal', hash: 'hash', slug: 'app', dwapp_id: 'dwapp', seq: 1 };
+      },
+    });
+    expect(await share('app-1', undefined)).toMatchObject({ ok: true });
+    expect(events).toEqual(['mint', 'publish', 'persist']);
+  });
+
+  test('a concurrent deletion is a persistence failure and rolls back', async () => {
+    const messages: any[] = [];
+    const share = makeDwebShare({
+      enabled: true, active: () => true, withIdentityMutation: makeLane(),
+      appRegistry: {
+        get: async () => ({ name: 'App', entryFile: 'index.html', dweb: {} }),
+        update: async () => null,
+      },
+      opfsHelpers: () => ({ list: async () => [], read: async () => '' }),
+      prepareRuntime: async () => ({ ok: true }),
+      sendMessage: async (message) => {
+        messages.push(message);
+        return message.type.endsWith('unshare-app')
+          ? { ok: true }
+          : { ok: true, publisher: 'did:key:zOld', hash: 'hash', slug: 'app' };
+      },
+    });
+    expect(await share('app-1', undefined)).toMatchObject({
+      ok: false, error: 'share-metadata-store-failed',
+    });
+    expect(messages.at(-1)).toMatchObject({
+      type: 'dweb/base-host/unshare-app', slug: 'app',
+    });
+  });
+});

--- a/tests/background/dweb-transfer.test.ts
+++ b/tests/background/dweb-transfer.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  IdentityTransferError,
+  makeDwebTransfer,
+} from '../../extension/background/dweb-transfer.js';
+
+const material = JSON.stringify({ v: 1, seed: 'seed', pub: 'pub' });
+
+const makeLane = () => {
+  let tail = Promise.resolve();
+  return <T>(operation: () => Promise<T>): Promise<T> => {
+    const result = tail.then(operation, operation);
+    tail = result.then(() => undefined, () => undefined);
+    return result;
+  };
+};
+
+const baseDeps = (over: Record<string, any> = {}) => ({
+  enabled: true,
+  offscreenAvailable: true,
+  vault: {
+    isLocked: () => false,
+    getSecret: async () => material,
+    setSecret: async () => {},
+  },
+  identitySecretName: 'distributed/identity/v1',
+  runCustodyOperation: async (operation: string) => operation === 'export'
+    ? { did: 'did:key:zPortable' }
+    : { adopted: true, material, did: 'did:key:zPortable', reason: 'already-present' },
+  loadDweb: async () => ({ available: false }),
+  withIdentityMutation: makeLane(),
+  canReplaceIdentity: async () => true,
+  stopIdentityRuntime: async () => {},
+  startIdentityRuntime: async () => {},
+  audit: async () => {},
+  ...over,
+});
+
+describe('dweb transfer host selection', () => {
+  test('Chrome uses the offscreen host and fails loudly on a bad reply', async () => {
+    const messages: any[] = [];
+    const transfer = makeDwebTransfer(baseDeps({
+      runCustodyOperation: async (operation: string, args: any) => {
+        messages.push({ operation, args });
+        throw Object.assign(new Error('worker crashed'), { code: 'worker-crashed' });
+      },
+    }));
+    await expect(transfer.exportRecord('backup-passphrase'))
+      .rejects.toMatchObject({ name: 'IdentityTransferError', code: 'worker-crashed' });
+    expect(messages[0]).toMatchObject({
+      operation: 'export',
+      args: { material: { v: 1, seed: 'seed', pub: 'pub' }, passphrase: 'backup-passphrase' },
+    });
+  });
+
+  test('Firefox runs the same crypto through the direct preview client', async () => {
+    const calls: any[] = [];
+    const transfer = makeDwebTransfer(baseDeps({
+      offscreenAvailable: false,
+      runCustodyOperation: async () => { throw new Error('offscreen relay must not run'); },
+      loadDweb: async () => ({
+        available: true,
+        identityRecordExport: async (args: any) => {
+          calls.push(args);
+          return { did: 'did:key:zFirefox' };
+        },
+      }),
+    }));
+    expect(await transfer.exportRecord('backup-passphrase')).toEqual({
+      identityRecord: { did: 'did:key:zFirefox' },
+    });
+    expect(calls).toEqual([{
+      material: { v: 1, seed: 'seed', pub: 'pub' },
+      passphrase: 'backup-passphrase',
+    }]);
+  });
+
+  test('an install without an identity exports no identity section', async () => {
+    let hosted = false;
+    const transfer = makeDwebTransfer(baseDeps({
+      vault: { isLocked: () => false, getSecret: async () => null, setSecret: async () => {} },
+      runCustodyOperation: async () => { hosted = true; return null; },
+    }));
+    expect(await transfer.exportRecord('backup-passphrase')).toBeNull();
+    expect(hosted).toBe(false);
+  });
+});
+
+describe('dweb transfer adoption shell', () => {
+  test('replacement stops the old runtime before the vault write, audits, then restarts', async () => {
+    const events: string[] = [];
+    const transfer = makeDwebTransfer(baseDeps({
+      runCustodyOperation: async () => ({
+        adopted: true,
+        material: JSON.stringify({ v: 1, seed: 'new', pub: 'new' }),
+        did: 'did:key:zNew',
+        existingDid: 'did:key:zOld',
+        reason: 'replaced',
+      }),
+      vault: {
+        isLocked: () => false,
+        getSecret: async () => material,
+        setSecret: async () => { events.push('write'); },
+      },
+      stopIdentityRuntime: async () => { events.push('stop'); },
+      startIdentityRuntime: () => { events.push('start'); },
+      audit: async () => { events.push('audit'); },
+    }));
+    const outcome = await transfer.adoptRecord({}, 'backup-passphrase', { replaceExisting: true });
+    expect(outcome.reason).toBe('replaced');
+    expect(events).toEqual(['stop', 'write', 'audit', 'start']);
+  });
+
+  test('a stop failure prevents the custody write', async () => {
+    let writes = 0;
+    const transfer = makeDwebTransfer(baseDeps({
+      runCustodyOperation: async () => ({ adopted: true, material, reason: 'replaced' }),
+      stopIdentityRuntime: async () => { throw new IdentityTransferError('stop failed', 'stop-failed'); },
+      vault: {
+        isLocked: () => false,
+        getSecret: async () => material,
+        setSecret: async () => { writes++; },
+      },
+    }));
+    await expect(transfer.adoptRecord({}, 'backup-passphrase', { replaceExisting: true }))
+      .rejects.toMatchObject({ code: 'stop-failed' });
+    expect(writes).toBe(0);
+  });
+
+  test('the injected custody lane serializes concurrent adoptions', async () => {
+    let concurrent = 0;
+    let peak = 0;
+    const transfer = makeDwebTransfer(baseDeps({
+      runCustodyOperation: async () => {
+        concurrent++;
+        peak = Math.max(peak, concurrent);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        concurrent--;
+        return { adopted: false, material: null, reason: 'did-conflict' };
+      },
+    }));
+    await Promise.all([
+      transfer.adoptRecord({}, 'one'),
+      transfer.adoptRecord({}, 'two'),
+    ]);
+    expect(peak).toBe(1);
+  });
+
+  test('backup export shares the custody lane with replacement', async () => {
+    let concurrent = 0;
+    let peak = 0;
+    const transfer = makeDwebTransfer(baseDeps({
+      runCustodyOperation: async (operation: string) => {
+        concurrent++;
+        peak = Math.max(peak, concurrent);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        concurrent--;
+        return operation === 'export'
+          ? { did: 'did:key:zPortable' }
+          : { adopted: false, reason: 'did-conflict' };
+      },
+    }));
+    await Promise.all([
+      transfer.exportRecord('backup-passphrase'),
+      transfer.adoptRecord({}, 'backup-passphrase'),
+    ]);
+    expect(peak).toBe(1);
+  });
+
+  test('replacement is refused while local shares are identity-bound', async () => {
+    let stops = 0;
+    let starts = 0;
+    let writes = 0;
+    const transfer = makeDwebTransfer(baseDeps({
+      canReplaceIdentity: async () => false,
+      runCustodyOperation: async () => ({
+        adopted: true, material: JSON.stringify({ v: 1, seed: 'new', pub: 'new' }),
+        existingDid: 'did:key:zOld', incomingDid: 'did:key:zNew', reason: 'replaced',
+      }),
+      stopIdentityRuntime: async () => { stops++; },
+      startIdentityRuntime: async () => { starts++; },
+      vault: {
+        isLocked: () => false,
+        getSecret: async () => material,
+        setSecret: async () => { writes++; },
+      },
+    }));
+    expect(await transfer.adoptRecord({}, 'backup-passphrase', { replaceExisting: true }))
+      .toMatchObject({ adopted: false, reason: 'identity-in-use' });
+    expect({ stops, starts, writes }).toEqual({ stops: 1, starts: 1, writes: 0 });
+  });
+
+  test('commit refuses when the prepared local did changed before adoption', async () => {
+    let writes = 0;
+    const transfer = makeDwebTransfer(baseDeps({
+      runCustodyOperation: async () => ({
+        adopted: true, material: JSON.stringify({ v: 1, seed: 'new', pub: 'new' }),
+        existingDid: 'did:key:zUnexpected', incomingDid: 'did:key:zIncoming', reason: 'replaced',
+      }),
+      vault: {
+        isLocked: () => false,
+        getSecret: async () => material,
+        setSecret: async () => { writes++; },
+      },
+    }));
+    expect(await transfer.adoptRecord({}, 'backup-passphrase', {
+      replaceExisting: true,
+      expectedExistingDid: 'did:key:zApproved',
+      expectedIncomingDid: 'did:key:zIncoming',
+    })).toMatchObject({ adopted: false, reason: 'identity-changed' });
+    expect(writes).toBe(0);
+  });
+
+  test('fresh recovery suspends before entering the custody lane, then resumes', async () => {
+    const events: string[] = [];
+    const transfer = makeDwebTransfer(baseDeps({
+      withIdentityMutation: async (operation: () => Promise<any>) => {
+        events.push('lane');
+        return operation();
+      },
+      stopIdentityRuntime: async () => { events.push('suspend'); },
+      startIdentityRuntime: async () => { events.push('resume'); },
+      runCustodyOperation: async () => ({
+        adopted: true,
+        material: JSON.stringify({ v: 1, seed: 'new', pub: 'new' }),
+        did: 'did:key:zIncoming', existingDid: null, incomingDid: 'did:key:zIncoming', reason: 'recovered',
+      }),
+      vault: {
+        isLocked: () => false,
+        getSecret: async () => null,
+        setSecret: async () => { events.push('write'); },
+      },
+    }));
+    expect(await transfer.adoptRecord({}, 'backup-passphrase', {
+      expectedExistingDid: null, expectedIncomingDid: 'did:key:zIncoming',
+    })).toMatchObject({ adopted: true, reason: 'recovered' });
+    expect(events).toEqual(['suspend', 'lane', 'write', 'resume']);
+  });
+
+  test('a committed identity reports runtime recovery when lease release is retrying', async () => {
+    const transfer = makeDwebTransfer(baseDeps({
+      runCustodyOperation: async () => ({
+        adopted: true,
+        material: JSON.stringify({ v: 1, seed: 'new', pub: 'new' }),
+        did: 'did:key:zIncoming', existingDid: null,
+        incomingDid: 'did:key:zIncoming', reason: 'recovered',
+      }),
+      vault: {
+        isLocked: () => false,
+        getSecret: async () => null,
+        setSecret: async () => {},
+      },
+      startIdentityRuntime: async () => { throw new Error('lost acknowledgement'); },
+    }));
+    expect(await transfer.adoptRecord({}, 'backup-passphrase', {
+      expectedExistingDid: null, expectedIncomingDid: 'did:key:zIncoming',
+    })).toMatchObject({
+      adopted: true, reason: 'recovered', runtimeRecoveryPending: true,
+    });
+  });
+
+  test('fresh recovery is blocked when local shares still bind the old publisher', async () => {
+    let writes = 0;
+    const transfer = makeDwebTransfer(baseDeps({
+      canReplaceIdentity: async () => false,
+      runCustodyOperation: async () => ({
+        adopted: true,
+        material: JSON.stringify({ v: 1, seed: 'new', pub: 'new' }),
+        did: 'did:key:zIncoming', existingDid: null,
+        incomingDid: 'did:key:zIncoming', reason: 'recovered',
+      }),
+      vault: {
+        isLocked: () => false,
+        getSecret: async () => null,
+        setSecret: async () => { writes++; },
+      },
+    }));
+    expect(await transfer.prepareRecord({}, 'backup-passphrase'))
+      .toMatchObject({ adopted: false, reason: 'identity-in-use' });
+    expect(writes).toBe(0);
+  });
+
+  test('repair approval is bound to the exact unreadable local value', async () => {
+    let stored = '{broken-a';
+    let writes = 0;
+    const transfer = makeDwebTransfer(baseDeps({
+      runCustodyOperation: async (_operation: string, args: any) => args.replaceExisting
+        ? {
+            adopted: true,
+            material: JSON.stringify({ v: 1, seed: 'new', pub: 'new' }),
+            did: 'did:key:zIncoming', existingDid: null,
+            incomingDid: 'did:key:zIncoming', reason: 'replaced-invalid-local',
+          }
+        : {
+            adopted: false, material: null, did: null, existingDid: null,
+            incomingDid: 'did:key:zIncoming', reason: 'invalid-local-identity',
+          },
+      vault: {
+        isLocked: () => false,
+        getSecret: async () => stored,
+        setSecret: async () => { writes++; },
+      },
+    }));
+    const prepared = await transfer.prepareRecord({}, 'backup-passphrase');
+    expect(prepared).toMatchObject({
+      reason: 'invalid-local-identity', existingUnreadable: true,
+      incomingDid: 'did:key:zIncoming',
+    });
+    stored = '{broken-b';
+    expect(await transfer.adoptRecord({}, 'backup-passphrase', {
+      replaceExisting: true,
+      expectedExistingDid: null,
+      expectedExistingRevision: prepared.existingRevision,
+      expectedIncomingDid: 'did:key:zIncoming',
+    })).toMatchObject({ adopted: false, reason: 'identity-changed' });
+    expect(writes).toBe(0);
+  });
+});

--- a/tests/background/private-transfer-port.test.ts
+++ b/tests/background/private-transfer-port.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test';
+import { makePrivateTransferPort } from '../../extension/background/private-transfer-port.js';
+import { makePrivateTransferClient } from '../../extension/options/private-transfer-client.js';
+
+const makeEvent = () => {
+  const listeners: Array<(message?: any) => void> = [];
+  return {
+    addListener: (listener: (message?: any) => void) => { listeners.push(listener); },
+    emit: (message?: any) => { for (const listener of listeners) listener(message); },
+  };
+};
+
+const makePortPair = () => {
+  const clientMessage = makeEvent();
+  const serverMessage = makeEvent();
+  const disconnect = makeEvent();
+  return {
+    client: {
+      onMessage: clientMessage, onDisconnect: disconnect,
+      postMessage: (message: any) => serverMessage.emit(message),
+    } as any,
+    server: {
+      onMessage: serverMessage, onDisconnect: disconnect,
+      postMessage: (message: any) => clientMessage.emit(message),
+    } as any,
+    disconnect: () => disconnect.emit(),
+  };
+};
+
+const nextTask = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('private transfer Port', () => {
+  test('carries the password only to the attached handler with an unforgeable capability', async () => {
+    const pair = makePortPair();
+    const authorization = Symbol('transfer');
+    const received: any[] = [];
+    const server = makePrivateTransferPort({
+      authorization,
+      handlers: {
+        'transfer/export': async (message) => {
+          received.push(message);
+          return { ok: true, payload: { version: 2 } };
+        },
+      },
+    });
+    server.attach(pair.server);
+    const client = makePrivateTransferClient({
+      connect: () => pair.client, newRequestId: () => 'request-1', timeoutMs: 100,
+    });
+    await expect(client.call({ type: 'transfer/export', passphrase: 'private password' }))
+      .resolves.toEqual({ ok: true, payload: { version: 2 } });
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({
+      type: 'transfer/export', passphrase: 'private password',
+      privateTransferAuthorization: authorization,
+    });
+  });
+
+  test('ignores non-transfer operations and rejects pending work on disconnect', async () => {
+    const pair = makePortPair();
+    const server = makePrivateTransferPort({ authorization: Symbol(), handlers: {} });
+    server.attach(pair.server);
+    const client = makePrivateTransferClient({
+      connect: () => pair.client, newRequestId: () => 'request-2', timeoutMs: 100,
+    });
+    const pending = client.call({ type: 'vault/export', passphrase: 'nope' });
+    await nextTask();
+    pair.disconnect();
+    await expect(pending).rejects.toMatchObject({ code: 'port-disconnected' });
+  });
+});

--- a/tests/background/routes-dweb.test.ts
+++ b/tests/background/routes-dweb.test.ts
@@ -13,11 +13,12 @@ const baseDeps = (over: any = {}) => {
     appRegistry: { get: async () => ({ id: 'a1', name: 'A', entryFile: 'i.html' }), list: async () => [], update: async (_i: any, p: any) => ({ id: 'a1', ...p }) },
     appClient: { create: async (r: any) => ({ id: 'new', ...r }), opfsForApp: () => ({ list: async () => [], read: async () => '', write: async () => {}, delete: async () => {} }) },
     appTabTracker: { ensureTab: async () => {}, reloadTab: async () => {} },
-    opfsHelpers: () => ({ list: async () => [], read: async () => '' }),
+    shareLocalApp: async (appId: string, slug?: string) => ({ ok: true, appId, slug }),
     settingsStore: { get: () => ({ dwebEnabled: true }) },
     DWEB_ENABLED: true,
     DWEB_IDENTITY_SECRET: 'distributed/identity/v1',
     APP_TAB_GROUP_TITLE: 'peerd apps',
+    withDwebIdentityMutation: async (operation: () => Promise<any>) => operation(),
     ...over,
   };
   return { deps, sent, audits };
@@ -27,7 +28,6 @@ describe('dweb gate (build flag + setting)', () => {
   test('disabled when the build flag is off', async () => {
     const { deps } = baseDeps({ DWEB_ENABLED: false });
     expect(await makeDwebRoutes(deps)['dweb/base/start']()).toEqual({ ok: false, error: 'dweb-disabled' });
-    expect(await makeDwebRoutes(deps)['dweb/identity-get']()).toEqual({ ok: false, error: 'dweb-disabled' });
   });
   test('disabled when the user setting is off', async () => {
     const { deps } = baseDeps({ settingsStore: { get: () => ({ dwebEnabled: false }) } });
@@ -35,26 +35,15 @@ describe('dweb gate (build flag + setting)', () => {
   });
   test('enabled when both on', async () => {
     const { deps, sent } = baseDeps();
-    expect(await makeDwebRoutes(deps)['dweb/base/start']()).toEqual({ ok: true });
+    const routes = makeDwebRoutes(deps);
+    expect(await routes['dweb/base/start']()).toEqual({ ok: true });
     expect(sent[0]).toEqual({ type: 'dweb/base-host/start' });
+    expect(routes['dweb/identity-get']).toBeUndefined();
+    expect(routes['dweb/identity-set']).toBeUndefined();
   });
 });
 
-describe('dweb identity + audit', () => {
-  test('identity-get returns the vaulted secret', async () => {
-    const { deps } = baseDeps();
-    expect(await makeDwebRoutes(deps)['dweb/identity-get']()).toEqual({ ok: true, value: 'id-secret' });
-  });
-  test('identity-get refused when vault locked', async () => {
-    const { deps } = baseDeps({ vault: { isLocked: () => true } });
-    expect(await makeDwebRoutes(deps)['dweb/identity-get']()).toEqual({ ok: false, error: 'vault-locked' });
-  });
-  test('identity-set requires a string + audits issuance', async () => {
-    const { deps, audits } = baseDeps();
-    expect(await makeDwebRoutes(deps)['dweb/identity-set']({ value: 5 })).toEqual({ ok: false, error: 'value-required' });
-    expect(await makeDwebRoutes(deps)['dweb/identity-set']({ value: 'k' })).toEqual({ ok: true });
-    expect(audits.at(-1)).toEqual({ type: 'dweb_identity_issued', details: {} });
-  });
+describe('dweb audit', () => {
   test('dweb/audit gates only on the build flag (not the setting) + dweb_ prefix', async () => {
     // setting off but build on → still accepted (matches the original inline gate)
     const { deps, audits } = baseDeps({ settingsStore: { get: () => ({ dwebEnabled: false }) } });
@@ -72,13 +61,12 @@ describe('dweb app store', () => {
     expect(audits.at(-1)).toMatchObject({ type: 'dweb_app_installed', details: { uri: 'u', publisher: 'p' } });
   });
   test('share-app persists the version slot on success', async () => {
-    let updated: any = null;
+    const shared: any[] = [];
     const { deps } = baseDeps({
-      _reply: { ok: true, uri: 'u2', publisher: 'pub', hash: 'h', slug: 's', dwapp_id: 'd', seq: 2 },
-      appRegistry: { get: async () => ({ id: 'a1', name: 'A', entryFile: 'i.html', dweb: {} }), update: async (_i: any, p: any) => { updated = p; return p; } },
+      shareLocalApp: async (appId: string, slug?: string) => { shared.push({ appId, slug }); return { ok: true }; },
     });
     await makeDwebRoutes(deps)['dweb/base/share-app']({ appId: 'a1', slug: 's' });
-    expect(updated).toMatchObject({ shared: true, dweb: { uri: 'u2', version_id: 'h', slug: 's', dwapp_id: 'd', seq: 2 } });
+    expect(shared).toEqual([{ appId: 'a1', slug: 's' }]);
   });
   test('updates flags an installed app when a higher-seq different version is heard', async () => {
     const { deps } = baseDeps({

--- a/tests/background/routes-engine.test.ts
+++ b/tests/background/routes-engine.test.ts
@@ -149,12 +149,12 @@ describe('apps/delete', () => {
     const r = makeEngineRoutes(baseDeps({
       DWEB_ENABLED: true,
       settingsStore: { get: () => ({ dwebEnabled: true }) },
-      appRegistry: { get: async () => ({ id: 'a1', name: 'A', shared: true, dweb: { publisher: 'pub', hash: 'h' } }) },
+      appRegistry: { get: async () => ({ id: 'a1', name: 'A', shared: true, dweb: { publisher: 'pub', hash: 'h', slug: 'custom-a' } }) },
       appClient: { delete: async () => true },
       browser: { runtime: { sendMessage: async (m: any) => { msg = m; } } },
     }));
     expect(await r['apps/delete']({ appId: 'a1' })).toEqual({ ok: true });
-    expect(msg).toEqual({ type: 'dweb/base-host/unshare-app', name: 'A', publisher: 'pub', hash: 'h' });
+    expect(msg).toEqual({ type: 'dweb/base-host/unshare-app', name: 'A', slug: 'custom-a', publisher: 'pub', hash: 'h' });
   });
   test('does NOT unshare a purely-local app even with dweb fully on', async () => {
     let sent = false;

--- a/tests/background/routes-settings.test.ts
+++ b/tests/background/routes-settings.test.ts
@@ -1,18 +1,23 @@
 import { describe, test, expect } from 'bun:test';
 import { makeSettingsRoutes } from '../../extension/background/routes/settings.js';
 
+const PRIVATE_TRANSFER_AUTHORIZATION = Symbol('test-transfer');
+const authorized = (message: Record<string, unknown> = {}) => ({
+  ...message, privateTransferAuthorization: PRIVATE_TRANSFER_AUTHORIZATION,
+});
+
 // settings/update + settings/reset + transfer/export, now over settingsStore.
 // Pin: patch normalization is delegated, the vault auto-lock side effect fires,
 // reset filters to known keys, and export gates on a passphrase when secrets exist.
 
 const baseDeps = (over: any = {}) => {
-  const calls: any = { autoLock: [], updated: [], reset: [] };
+  const calls: any = { autoLock: [], updated: [], reset: [], getSecret: [], identityExport: [] };
   const deps = {
     vault: {
       setAutoLockMs: (v: number) => { calls.autoLock.push(v); },
       isLocked: () => false,
       listSecretNames: async () => ['anthropic.key'],
-      getSecret: async () => 'sk-secret',
+      getSecret: async (name: string) => { calls.getSecret.push(name); return 'sk-secret'; },
     },
     auditLog: { append: async () => {} },
     pushState: () => {},
@@ -33,9 +38,16 @@ const baseDeps = (over: any = {}) => {
     DWEB_ENABLED: false,
     DEFAULT_SETTINGS: { providerModel: '', spendLimitUsd: 0 },
     buildExport: async (a: any) => ({ payload: 'X', channel: a.channel, stored: a.storedSettings }),
+    dwebTransfer: {
+      exportRecord: async (passphrase: string) => { calls.identityExport.push(passphrase); return null; },
+    },
+    EXPORT_PASSPHRASE_MIN_LENGTH: 16,
+    isCustodySecretName: (name: string) => name.startsWith('distributed/identity/')
+      || name.startsWith('distributed/device-key/'),
     CHANNEL: 'preview',
     exportHooks: () => [],
     skillRegistry: { list: async () => [] },
+    privateTransferAuthorization: PRIVATE_TRANSFER_AUTHORIZATION,
     ...over,
   };
   return { deps, calls };
@@ -80,23 +92,61 @@ describe('settings/reset', () => {
 });
 
 describe('transfer/export', () => {
+  test('requires the private transfer capability', async () => {
+    const { deps } = baseDeps();
+    expect(await makeSettingsRoutes(deps)['transfer/export']({ passphrase: 'long-enough-for-backup' }))
+      .toEqual({ ok: false, error: 'private-transfer-required' });
+  });
   test('refused when vault locked', async () => {
     const { deps } = baseDeps({ vault: { isLocked: () => true } });
-    expect(await makeSettingsRoutes(deps)['transfer/export']({})).toEqual({ ok: false, error: 'vault-locked' });
+    expect(await makeSettingsRoutes(deps)['transfer/export'](authorized())).toEqual({ ok: false, error: 'vault-locked' });
   });
   test('requires a passphrase when secrets exist', async () => {
     const { deps } = baseDeps();
-    expect(await makeSettingsRoutes(deps)['transfer/export']({ passphrase: 'short' })).toEqual({ ok: false, error: 'passphrase-required' });
+    expect(await makeSettingsRoutes(deps)['transfer/export'](authorized({ passphrase: 'short' }))).toEqual({ ok: false, error: 'passphrase-required' });
   });
   test('builds an export from settingsStore.stored() when authorized', async () => {
     const { deps } = baseDeps();
-    const res = await makeSettingsRoutes(deps)['transfer/export']({ passphrase: 'longenough' });
+    const res = await makeSettingsRoutes(deps)['transfer/export'](authorized({ passphrase: 'long-enough-for-backup' }));
     expect(res.ok).toBe(true);
     expect(res.payload.stored).toEqual({ providerModel: 'm' });
   });
   test('no secrets → no passphrase required', async () => {
     const { deps } = baseDeps({ vault: { isLocked: () => false, listSecretNames: async () => [], getSecret: async () => null } });
-    const res = await makeSettingsRoutes(deps)['transfer/export']({});
+    const res = await makeSettingsRoutes(deps)['transfer/export'](authorized());
     expect(res.ok).toBe(true);
+  });
+
+  test('custody secrets are never decrypted and the portable identity is reported', async () => {
+    const identityRecord = { did: 'did:key:zPortable' };
+    const decrypted: string[] = [];
+    const identityExports: string[] = [];
+    const { deps } = baseDeps({
+      vault: {
+        isLocked: () => false,
+        listSecretNames: async () => ['anthropic.key', 'distributed/identity/v1'],
+        getSecret: async (name: string) => { decrypted.push(name); return 'secret'; },
+      },
+      dwebTransfer: {
+        exportRecord: async (passphrase: string) => {
+          identityExports.push(passphrase);
+          return { identityRecord };
+        },
+      },
+    });
+    const res = await makeSettingsRoutes(deps)['transfer/export'](authorized({ passphrase: 'long-enough-for-backup' }));
+    expect(res.ok).toBe(true);
+    expect(decrypted).toEqual(['anthropic.key']);
+    expect(identityExports).toEqual(['long-enough-for-backup']);
+    expect(res.identityIncluded).toBe(true);
+    expect(res.identityDid).toBe(identityRecord.did);
+  });
+
+  test('fails loudly when a local identity cannot be included', async () => {
+    const { deps } = baseDeps({
+      dwebTransfer: { exportRecord: async () => { throw new Error('offscreen failed'); } },
+    });
+    expect(await makeSettingsRoutes(deps)['transfer/export'](authorized({ passphrase: 'long-enough-for-backup' })))
+      .toEqual({ ok: false, error: 'identity-export-failed' });
   });
 });

--- a/tests/background/routes-system.test.ts
+++ b/tests/background/routes-system.test.ts
@@ -3,6 +3,11 @@ import { makeSystemRoutes } from '../../extension/background/routes/system.js';
 
 class ExportPassphraseError extends Error {}
 
+const PRIVATE_TRANSFER_AUTHORIZATION = Symbol('test-transfer');
+const authorized = (message: Record<string, unknown> = {}) => ({
+  ...message, privateTransferAuthorization: PRIVATE_TRANSFER_AUTHORIZATION,
+});
+
 const baseDeps = (over: any = {}) => ({
   vault: { isLocked: () => false, setSecret: async () => {} },
   auditLog: { append: async () => {}, list: async () => [{ id: 1 }, { id: 2 }, { id: 3 }] },
@@ -23,9 +28,11 @@ const baseDeps = (over: any = {}) => ({
   applyImport: async (_a: any) => ({ ok: true, imported: { secrets: 1 } }),
   settingsStore: { update: async () => {} },
   saveUserHook: async () => {},
+  dwebTransfer: { adoptRecord: async () => ({ adopted: true, reason: 'recovered' }) },
   CHANNEL: 'preview',
   DEFAULT_SETTINGS: { a: 1, b: 2 },
   ExportPassphraseError,
+  privateTransferAuthorization: PRIVATE_TRANSFER_AUTHORIZATION,
   ...over,
 });
 
@@ -79,13 +86,25 @@ describe('surfaces + sidepanel', () => {
 });
 
 describe('transfer import', () => {
+  test('requires the private transfer capability', async () => {
+    const r = makeSystemRoutes(baseDeps());
+    expect(await r['transfer/inspectImport']({ payload: {} }))
+      .toEqual({ ok: false, error: 'private-transfer-required' });
+    expect(await r['transfer/import']({ payload: {} }))
+      .toEqual({ ok: false, error: 'private-transfer-required' });
+  });
   test('inspectImport passes channel + known keys', async () => {
     const r = makeSystemRoutes(baseDeps());
-    expect(await r['transfer/inspectImport']({ payload: {} })).toEqual({ ok: true, channel: 'preview', keys: ['a', 'b'] });
+    expect(await r['transfer/inspectImport'](authorized({ payload: {} }))).toEqual({ ok: true, channel: 'preview', keys: ['a', 'b'] });
   });
   test('import with secrets refused when vault locked', async () => {
     const r = makeSystemRoutes(baseDeps({ vault: { isLocked: () => true } }));
-    expect(await r['transfer/import']({ payload: { secrets: {} } })).toEqual({ ok: false, error: 'vault-locked' });
+    expect(await r['transfer/import'](authorized({ payload: { secrets: {} } }))).toEqual({ ok: false, error: 'vault-locked' });
+  });
+  test('identity-only import is also refused when vault locked', async () => {
+    const r = makeSystemRoutes(baseDeps({ vault: { isLocked: () => true } }));
+    expect(await r['transfer/import'](authorized({ payload: { dweb: { identityRecord: {} } } })))
+      .toEqual({ ok: false, error: 'vault-locked' });
   });
   test('import audits + pushes on success', async () => {
     let pushed = false; let audited = false;
@@ -93,16 +112,57 @@ describe('transfer import', () => {
       pushState: () => { pushed = true; },
       auditLog: { append: async () => { audited = true; }, list: async () => [] },
     }));
-    expect(await r['transfer/import']({ payload: {} })).toEqual({ ok: true, imported: { secrets: 1 } });
+    expect(await r['transfer/import'](authorized({ payload: {} }))).toEqual({ ok: true, imported: { secrets: 1 } });
     expect(pushed).toBe(true);
     expect(audited).toBe(true);
   });
+  test('partial import audits committed counts and refreshes visible state', async () => {
+    let pushed = false; let event: any;
+    const partial = { settings: 2, secrets: 1, memoryWritten: 0, hooks: 0, dwebIdentity: 0 };
+    const r = makeSystemRoutes(baseDeps({
+      applyImport: async () => ({ ok: false, error: 'import-partial', failure: 'dweb-identity-stop-failed', partial }),
+      pushState: () => { pushed = true; },
+      auditLog: { append: async (value: any) => { event = value; }, list: async () => [] },
+    }));
+    expect(await r['transfer/import'](authorized({ payload: {} }))).toMatchObject({ ok: false, partial });
+    expect(event).toEqual({
+      type: 'settings_import_partial', counts: partial,
+      details: { failure: 'dweb-identity-stop-failed' },
+    });
+    expect(pushed).toBe(true);
+  });
   test('wrong export passphrase mapped', async () => {
     const r = makeSystemRoutes(baseDeps({ applyImport: async () => { throw new ExportPassphraseError(); } }));
-    expect(await r['transfer/import']({ payload: {} })).toEqual({ ok: false, error: 'wrong-passphrase' });
+    expect(await r['transfer/import'](authorized({ payload: {} }))).toEqual({ ok: false, error: 'wrong-passphrase' });
+  });
+  test('passes explicit identity conflict choices to the import core', async () => {
+    let received: any;
+    const r = makeSystemRoutes(baseDeps({
+      applyImport: async (args: any) => { received = args; return { ok: false, error: 'dweb-identity-conflict' }; },
+    }));
+    await r['transfer/import'](authorized({
+      payload: { dweb: { identityRecord: {} } },
+      replaceDwebIdentity: true,
+      skipDwebIdentity: false,
+      approvedExistingDwebDid: 'did:key:zOld',
+      approvedIncomingDwebDid: 'did:key:zNew',
+    }));
+    expect(received.replaceDwebIdentity).toBe(true);
+    expect(received.skipDwebIdentity).toBe(false);
+    expect(received.approvedExistingDwebDid).toBe('did:key:zOld');
+    expect(received.approvedIncomingDwebDid).toBe('did:key:zNew');
+    expect(received.io.adoptDwebIdentity).toBeFunction();
+  });
+  test('identity transfer infrastructure errors are mapped', async () => {
+    const error = Object.assign(new Error('offscreen unavailable'), {
+      name: 'IdentityTransferError', code: 'host-unavailable',
+    });
+    const r = makeSystemRoutes(baseDeps({ applyImport: async () => { throw error; } }));
+    expect(await r['transfer/import'](authorized({ payload: {} })))
+      .toEqual({ ok: false, error: 'dweb-identity-host-unavailable' });
   });
   test('unexpected import error rethrown', async () => {
     const r = makeSystemRoutes(baseDeps({ applyImport: async () => { throw new Error('disk'); } }));
-    await expect(r['transfer/import']({ payload: {} })).rejects.toThrow('disk');
+    await expect(r['transfer/import'](authorized({ payload: {} }))).rejects.toThrow('disk');
   });
 });

--- a/tests/meta/runtime-connect-exclusivity.test.ts
+++ b/tests/meta/runtime-connect-exclusivity.test.ts
@@ -1,0 +1,40 @@
+// Confidential extension Ports rely on one shipped runtime.onConnect receiver.
+// Chrome permits multiple receivers, so adding a listener anywhere outside the
+// service worker would turn offscreen or options-originated messages into a
+// broadcast. Keep that architectural boundary fail-closed in CI.
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { EXTENSION_DIR } from '../../packaging/lib.ts';
+
+const filesUnder = (directory: string): string[] => readdirSync(directory)
+  .flatMap((name) => {
+    const path = join(directory, name);
+    return statSync(path).isDirectory() ? filesUnder(path) : [path];
+  });
+
+const stripComments = (source: string) => source
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/\/\/[^\n]*/g, '');
+
+describe('runtime Port receiver exclusivity', () => {
+  test('only the service worker registers runtime.onConnect', () => {
+    const registrations = filesUnder(EXTENSION_DIR)
+      .filter((path) => path.endsWith('.js') || path.endsWith('.mjs'))
+      .flatMap((path) => {
+        const source = stripComments(readFileSync(path, 'utf8'));
+        const count = [...source.matchAll(/\bruntime\.onConnect\.addListener\s*\(/g)].length;
+        return Array.from({ length: count }, () => relative(EXTENSION_DIR, path));
+      });
+    expect(registrations).toEqual(['background/service-worker.js']);
+  });
+
+  test('no source aliases onConnect outside the guarded registration', () => {
+    const offenders = filesUnder(EXTENSION_DIR)
+      .filter((path) => path.endsWith('.js') || path.endsWith('.mjs'))
+      .filter((path) => relative(EXTENSION_DIR, path) !== 'background/service-worker.js')
+      .filter((path) => /\bonConnect\b/.test(stripComments(readFileSync(path, 'utf8'))));
+    expect(offenders.map((path) => relative(EXTENSION_DIR, path))).toEqual([]);
+  });
+});

--- a/tests/meta/sw-routes-wiring.test.ts
+++ b/tests/meta/sw-routes-wiring.test.ts
@@ -47,7 +47,7 @@ const factoryNames = (src: string): string[] =>
 
 /** Inner text of the object literal passed at the `...makeFooRoutes({ ... })` call site. */
 const callSiteSpan = (factory: string): string | null => {
-  const open = SW.indexOf(`...${factory}({`);
+  const open = SW.indexOf(`${factory}({`);
   if (open === -1) return null;
   // Walk from the first `{` matching braces to find the object-literal span.
   const braceStart = SW.indexOf('{', open);

--- a/tests/offscreen/start-stop-barrier.test.ts
+++ b/tests/offscreen/start-stop-barrier.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  HostStopFailedError,
+  HostSuspendedError,
+  makeStartStopBarrier,
+} from '../../extension/offscreen/start-stop-barrier.js';
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => { resolve = done; });
+  return { promise, resolve };
+};
+
+describe('offscreen host start/stop barrier', () => {
+  test('stop waits for and closes a candidate that finishes starting late', async () => {
+    const created = deferred<{ id: string }>();
+    let active: { id: string } | null = null;
+    const closed: string[] = [];
+    const barrier = makeStartStopBarrier({
+      getActive: () => active,
+      create: () => created.promise,
+      activate: (candidate) => { active = candidate; },
+      close: (candidate) => { closed.push(candidate.id); if (active === candidate) active = null; },
+    });
+
+    const starting = barrier.start();
+    const stopping = barrier.stop();
+    let stopped = false;
+    void stopping.then(() => { stopped = true; });
+    await Promise.resolve();
+    expect(stopped).toBe(false);
+
+    created.resolve({ id: 'old-identity' });
+    await expect(starting).rejects.toMatchObject({ name: 'HostStartCancelledError' });
+    await stopping;
+    expect(active).toBeNull();
+    expect(closed).toEqual(['old-identity']);
+  });
+
+  test('a fresh start succeeds after an in-flight start was cancelled', async () => {
+    const first = deferred<{ id: string }>();
+    let next = 0;
+    let active: { id: string } | null = null;
+    const barrier = makeStartStopBarrier({
+      getActive: () => active,
+      create: () => next++ === 0 ? first.promise : Promise.resolve({ id: 'new-identity' }),
+      activate: (candidate) => { active = candidate; },
+      close: (candidate) => { if (active === candidate) active = null; },
+    });
+    const oldStart = barrier.start();
+    const stop = barrier.stop();
+    first.resolve({ id: 'old-identity' });
+    await expect(oldStart).rejects.toMatchObject({ name: 'HostStartCancelledError' });
+    await stop;
+    expect(await barrier.start()).toEqual({ id: 'new-identity' });
+  });
+
+  test('a failed close rejects stop and preserves the active handle', async () => {
+    const candidate = { id: 'old-identity' };
+    let active: typeof candidate | null = candidate;
+    const barrier = makeStartStopBarrier({
+      getActive: () => active,
+      create: async () => candidate,
+      activate: (value) => { active = value; },
+      close: () => { throw new Error('close failed'); },
+    });
+
+    await expect(barrier.stop()).rejects.toBeInstanceOf(HostStopFailedError);
+    expect(active).toBe(candidate);
+  });
+
+  test('suspend rejects starts throughout the custody-write gap until resume', async () => {
+    let creates = 0;
+    let active: { id: string } | null = null;
+    const barrier = makeStartStopBarrier({
+      getActive: () => active,
+      create: async () => ({ id: `identity-${++creates}` }),
+      activate: (candidate) => { active = candidate; },
+      close: (candidate) => { if (active === candidate) active = null; },
+    });
+
+    expect(await barrier.start()).toEqual({ id: 'identity-1' });
+    await barrier.stop({ suspensionOwner: 'rotation-a' });
+    await expect(barrier.start()).rejects.toBeInstanceOf(HostSuspendedError);
+    expect(creates).toBe(1);
+
+    // This models the complete interval after stop returns and before the
+    // caller commits its new identity material.
+    await Promise.resolve();
+    await expect(barrier.start()).rejects.toBeInstanceOf(HostSuspendedError);
+    expect(creates).toBe(1);
+
+    expect(barrier.resume('unrelated-operation')).toBe(false);
+    await expect(barrier.start()).rejects.toBeInstanceOf(HostSuspendedError);
+    expect(barrier.resume('rotation-a')).toBe(true);
+    expect(await barrier.start()).toEqual({ id: 'identity-2' });
+  });
+
+  test('a second owner cannot steal a live suspension lease', async () => {
+    const barrier = makeStartStopBarrier({
+      getActive: () => null,
+      create: async () => ({ id: 'identity' }),
+      activate: () => {},
+      close: () => {},
+    });
+    await barrier.stop({ suspensionOwner: 'rotation-a' });
+    await expect(barrier.stop({ suspensionOwner: 'rotation-b' }))
+      .rejects.toBeInstanceOf(HostSuspendedError);
+    expect(barrier.resume('rotation-b')).toBe(false);
+    await expect(barrier.start()).rejects.toBeInstanceOf(HostSuspendedError);
+  });
+
+  test('normal stop rejects a retry that arrives while an old start settles', async () => {
+    const first = deferred<{ id: string }>();
+    let creates = 0;
+    let active: { id: string } | null = null;
+    const barrier = makeStartStopBarrier({
+      getActive: () => active,
+      create: () => ++creates === 1 ? first.promise : Promise.resolve({ id: 'retry' }),
+      activate: (candidate) => { active = candidate; },
+      close: (candidate) => { if (active === candidate) active = null; },
+    });
+    const oldStart = barrier.start();
+    const retry = oldStart.catch(() => barrier.start());
+    const stop = barrier.stop();
+    first.resolve({ id: 'old' });
+
+    await expect(retry).rejects.toBeInstanceOf(HostSuspendedError);
+    await stop;
+    expect(creates).toBe(1);
+    expect(active).toBeNull();
+  });
+});

--- a/tests/peerd-distributed/identity-capsule.test.ts
+++ b/tests/peerd-distributed/identity-capsule.test.ts
@@ -1,0 +1,61 @@
+// The identity capsule + credential wrappers (docs/design/
+// portable-identity/ 01): seal/open round-trips, per-credential unlock,
+// tamper and wrong-passphrase failure. Pure WebCrypto — Bun territory.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  generateCapsuleKey, sealCapsule, openCapsule,
+} from '../../extension/peerd-distributed/identity/capsule.js';
+import {
+  makePassphraseWrapper, openPassphraseWrapper,
+} from '../../extension/peerd-distributed/identity/credential-wrapper.js';
+import { mintKeypairMaterial } from '../../extension/peerd-distributed/identity/keypair.js';
+
+describe('capsule', () => {
+  test('seals and opens the same material', async () => {
+    const material = await mintKeypairMaterial();
+    const capK = await generateCapsuleKey();
+    const capsule = await sealCapsule(material, capK);
+    const back = await openCapsule(capsule, capK);
+    expect(back.seed).toBe(material.seed);
+    expect(back.pub).toBe(material.pub);
+  });
+
+  test('a wrong key or tampered ciphertext fails closed', async () => {
+    const material = await mintKeypairMaterial();
+    const capK = await generateCapsuleKey();
+    const capsule = await sealCapsule(material, capK);
+    expect(openCapsule(capsule, await generateCapsuleKey())).rejects.toThrow();
+    const tampered = `${capsule.slice(0, -4)}AAAA`;
+    expect(openCapsule(tampered, capK)).rejects.toThrow();
+  });
+});
+
+describe('credential wrappers', () => {
+  test('passphrase wrapper round-trips CapK and reopens the capsule', async () => {
+    const material = await mintKeypairMaterial();
+    const capK = await generateCapsuleKey();
+    const capsule = await sealCapsule(material, capK);
+    const wrapper = await makePassphraseWrapper(capK, 'correct horse battery');
+    expect(wrapper.kind).toBe('passphrase');
+    expect(wrapper.kdf?.name).toBe('Argon2id');
+    const reopened = await openCapsule(capsule, await openPassphraseWrapper(wrapper, 'correct horse battery'));
+    expect(reopened.pub).toBe(material.pub);
+  });
+
+  test('wrong passphrase fails at unwrap, not with garbage output', async () => {
+    const capK = await generateCapsuleKey();
+    const wrapper = await makePassphraseWrapper(capK, 'right');
+    // AES-KW integrity check rejects a wrong KEK deterministically.
+    expect(openPassphraseWrapper(wrapper, 'wrong')).rejects.toThrow();
+  });
+
+  test('untrusted KDF work factors are refused before crypto', async () => {
+    const capK = await generateCapsuleKey();
+    const wrapper = await makePassphraseWrapper(capK, 'right');
+    expect(openPassphraseWrapper({
+      ...wrapper,
+      kdf: { ...wrapper.kdf!, iters: 999_999_999 },
+    }, 'right')).rejects.toThrow(/unsupported-kdf/);
+  });
+});

--- a/tests/peerd-distributed/recovery-record.test.ts
+++ b/tests/peerd-distributed/recovery-record.test.ts
@@ -1,0 +1,202 @@
+// The portable identity record (docs/design/portable-identity/ 02):
+// build → open across independent credentials, structural validation,
+// the did-binding tamper check, and the adoption decision table an
+// import runs (existing did wins; same did merges; no credential → no
+// identity). This is the Phase-1 exit proof at the values level: the
+// SAME did comes out on the other side.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  buildIdentityRecord, openIdentityRecord, adoptIdentityRecord, validateIdentityRecord,
+  RECORD_FORMAT, RECORD_VERSION,
+} from '../../extension/peerd-distributed/identity/recovery-record.js';
+import { mintKeypairMaterial, identityFromMaterial, verifySignature } from '../../extension/peerd-distributed/identity/keypair.js';
+import { generateCapsuleKey, sealCapsule } from '../../extension/peerd-distributed/identity/capsule.js';
+import { makePassphraseWrapper } from '../../extension/peerd-distributed/identity/credential-wrapper.js';
+
+describe('buildIdentityRecord / openIdentityRecord', () => {
+  test('round-trips the SAME did through a passphrase wrapper', async () => {
+    const material = await mintKeypairMaterial();
+    const record = await buildIdentityRecord({
+      material, wrappers: [{ kind: 'passphrase', passphrase: 'export-pass-123' }], now: 1000,
+    });
+    expect(record.format).toBe(RECORD_FORMAT);
+    expect(record.version).toBe(RECORD_VERSION);
+    expect(record.did).toBe(material.did);
+    expect(record.updatedAt).toBe(1000);
+    const back = await openIdentityRecord(record, { passphrase: 'export-pass-123' });
+    expect(back.did).toBe(material.did);
+    expect(back.seed).toBe(material.seed);
+  });
+
+  test('a recovered identity SIGNS verifiably under the original did', async () => {
+    const material = await mintKeypairMaterial();
+    const record = await buildIdentityRecord({
+      material, wrappers: [{ kind: 'passphrase', passphrase: 'pw-pw-pw' }],
+    });
+    const recovered = await openIdentityRecord(record, { passphrase: 'pw-pw-pw' });
+    const identity = await identityFromMaterial(recovered);
+    const bytes = new TextEncoder().encode('hello from the new install');
+    const sig = await identity.sign(bytes);
+    expect(await verifySignature(material.did, sig, bytes)).toBe(true);
+  });
+
+  test('a swapped did (capsule/did mismatch) is refused after decryption', async () => {
+    const material = await mintKeypairMaterial();
+    const other = await mintKeypairMaterial();
+    const record = await buildIdentityRecord({
+      material, wrappers: [{ kind: 'passphrase', passphrase: 'pw' }],
+    });
+    const forged = { ...record, did: other.did };
+    expect(openIdentityRecord(forged, { passphrase: 'pw' })).rejects.toThrow(/does not match/);
+  });
+
+  test('a seed paired with another public key is refused before adoption', async () => {
+    const a = await mintKeypairMaterial();
+    const b = await mintKeypairMaterial();
+    const capsuleKey = await generateCapsuleKey();
+    const record = {
+      format: RECORD_FORMAT,
+      version: RECORD_VERSION,
+      did: b.did,
+      capsule: await sealCapsule({ seed: a.seed, pub: b.pub }, capsuleKey),
+      wrappers: [await makePassphraseWrapper(capsuleKey, 'pw')],
+      updatedAt: 1,
+    };
+    expect(openIdentityRecord(record, { passphrase: 'pw' })).rejects.toThrow(/valid keypair/);
+  });
+
+  test('unknown wrapper kinds are skipped, not fatal (forward compat)', async () => {
+    const material = await mintKeypairMaterial();
+    const record = await buildIdentityRecord({
+      material, wrappers: [{ kind: 'passphrase', passphrase: 'pw' }],
+    });
+    const future = { ...record, wrappers: [{ kind: 'post-quantum-lattice', wrappedKey: 'AAAA' }, ...record.wrappers] };
+    const back = await openIdentityRecord(future, { passphrase: 'pw' });
+    expect(back.did).toBe(material.did);
+  });
+
+  test('version 1 refuses more than one passphrase wrapper', async () => {
+    const material = await mintKeypairMaterial();
+    await expect(buildIdentityRecord({
+      material,
+      wrappers: [
+        { kind: 'passphrase', passphrase: 'one' },
+        { kind: 'passphrase', passphrase: 'two' },
+      ],
+    })).rejects.toMatchObject({ code: 'too-many-passphrase-wrappers' });
+  });
+});
+
+describe('validateIdentityRecord', () => {
+  test('names the defect instead of throwing', async () => {
+    expect(validateIdentityRecord(null)).toBe('not-a-record');
+    expect(validateIdentityRecord({ format: 'nope' })).toBe('wrong-format');
+    expect(validateIdentityRecord({ format: RECORD_FORMAT, version: 99 })).toBe('unsupported-version-99');
+    const material = await mintKeypairMaterial();
+    const good = await buildIdentityRecord({ material, wrappers: [{ kind: 'passphrase', passphrase: 'pw' }] });
+    expect(validateIdentityRecord(good)).toBeNull();
+    expect(validateIdentityRecord({ ...good, wrappers: Array(9).fill(good.wrappers[0]) })).toBe('too-many-wrappers');
+    expect(validateIdentityRecord({ ...good, wrappers: [good.wrappers[0], good.wrappers[0]] }))
+      .toBe('too-many-passphrase-wrappers');
+    expect(validateIdentityRecord({ ...good, did: `did:key:z${'1'.repeat(1_000_000)}` }))
+      .toBe('bad-did');
+    expect(validateIdentityRecord({
+      ...good,
+      wrappers: [{ ...good.wrappers[0], kdf: { ...good.wrappers[0].kdf, iters: 999_999_999 } }],
+    })).toBe('bad-wrapper-unsupported-kdf');
+  });
+});
+
+describe('adoptIdentityRecord — the import decision', () => {
+  test('fresh install + right passphrase → recovered, material matches keypair.js layout', async () => {
+    const material = await mintKeypairMaterial();
+    const record = await buildIdentityRecord({ material, wrappers: [{ kind: 'passphrase', passphrase: 'pw123456' }] });
+    const outcome = await adoptIdentityRecord({ record, passphrase: 'pw123456', existingMaterial: null });
+    expect(outcome.adopted).toBe(true);
+    expect(outcome.reason).toBe('recovered');
+    expect(outcome.did).toBe(material.did);
+    const stored = JSON.parse(outcome.material as string);
+    expect(stored).toEqual({ v: 1, seed: material.seed, pub: material.pub });
+  });
+
+  test('existing identity with the SAME did → keep local seed, no material write', async () => {
+    const material = await mintKeypairMaterial();
+    const record = await buildIdentityRecord({ material, wrappers: [{ kind: 'passphrase', passphrase: 'pw' }] });
+    const existing = JSON.stringify({ v: 1, seed: material.seed, pub: material.pub });
+    const outcome = await adoptIdentityRecord({ record, passphrase: 'pw', existingMaterial: existing });
+    expect(outcome.adopted).toBe(true);
+    expect(outcome.reason).toBe('already-present');
+    expect(outcome.material).toBeNull();
+  });
+
+  test('same-did metadata is not enough: the wrapper must authenticate', async () => {
+    const material = await mintKeypairMaterial();
+    const record = await buildIdentityRecord({ material, wrappers: [{ kind: 'passphrase', passphrase: 'right' }] });
+    const existing = JSON.stringify({ v: 1, seed: material.seed, pub: material.pub });
+    const outcome = await adoptIdentityRecord({ record, passphrase: 'wrong', existingMaterial: existing });
+    expect(outcome.adopted).toBe(false);
+    expect(outcome.reason).toBe('no-openable-wrapper');
+  });
+
+  test('existing identity with a DIFFERENT did → refused (the did invariant beats the import)', async () => {
+    const material = await mintKeypairMaterial();
+    const local = await mintKeypairMaterial();
+    const record = await buildIdentityRecord({ material, wrappers: [{ kind: 'passphrase', passphrase: 'pw' }] });
+    const existing = JSON.stringify({ v: 1, seed: local.seed, pub: local.pub });
+    const outcome = await adoptIdentityRecord({ record, passphrase: 'pw', existingMaterial: existing });
+    expect(outcome.adopted).toBe(false);
+    expect(outcome.reason).toBe('did-conflict');
+    expect(outcome.did).toBe(local.did);
+    expect(outcome.existingDid).toBe(local.did);
+    expect(outcome.incomingDid).toBe(material.did);
+  });
+
+  test('a different identity is replaced only with explicit approval', async () => {
+    const material = await mintKeypairMaterial();
+    const local = await mintKeypairMaterial();
+    const record = await buildIdentityRecord({ material, wrappers: [{ kind: 'passphrase', passphrase: 'pw' }] });
+    const existing = JSON.stringify({ v: 1, seed: local.seed, pub: local.pub });
+    const outcome = await adoptIdentityRecord({
+      record, passphrase: 'pw', existingMaterial: existing, replaceExisting: true,
+    });
+    expect(outcome.adopted).toBe(true);
+    expect(outcome.reason).toBe('replaced');
+    expect(outcome.did).toBe(material.did);
+    expect(JSON.parse(outcome.material as string).pub).toBe(material.pub);
+  });
+
+  test('an unreadable local identity requires explicit replacement', async () => {
+    const material = await mintKeypairMaterial();
+    const record = await buildIdentityRecord({
+      material, wrappers: [{ kind: 'passphrase', passphrase: 'pw' }],
+    });
+    const conflict = await adoptIdentityRecord({
+      record, passphrase: 'pw', existingMaterial: '{broken',
+    });
+    expect(conflict).toMatchObject({
+      adopted: false, reason: 'invalid-local-identity', incomingDid: material.did,
+    });
+    const repaired = await adoptIdentityRecord({
+      record, passphrase: 'pw', existingMaterial: '{broken', replaceExisting: true,
+    });
+    expect(repaired).toMatchObject({
+      adopted: true, reason: 'replaced-invalid-local', did: material.did,
+    });
+  });
+
+  test('no openable wrapper (wrong passphrase) → not adopted, no leak of why per-wrapper', async () => {
+    const material = await mintKeypairMaterial();
+    const record = await buildIdentityRecord({ material, wrappers: [{ kind: 'passphrase', passphrase: 'right' }] });
+    const outcome = await adoptIdentityRecord({ record, passphrase: 'wrong', existingMaterial: null });
+    expect(outcome.adopted).toBe(false);
+    expect(outcome.reason).toBe('no-openable-wrapper');
+    expect(outcome.material).toBeNull();
+  });
+
+  test('structurally invalid record → named refusal', async () => {
+    const outcome = await adoptIdentityRecord({ record: { format: 'junk' }, passphrase: 'pw' });
+    expect(outcome.adopted).toBe(false);
+    expect(outcome.reason).toBe('wrong-format');
+  });
+});

--- a/tests/peerd-runtime/lifecycle/historical-fixtures.test.ts
+++ b/tests/peerd-runtime/lifecycle/historical-fixtures.test.ts
@@ -67,7 +67,7 @@ import {
 import { normalizeToolManifest } from '/peerd-runtime/tools/manifests.js';
 import { compileUserHook } from '/peerd-runtime/tools/hooks/compile.js';
 import { orderAlwaysLoaded, assembleAlwaysLoaded } from '/peerd-runtime/memory/memory.js';
-import { inspectImport, EXPORT_FORMAT, EXPORT_VERSION } from '/peerd-runtime/transfer/transfer.js';
+import { inspectImport, EXPORT_FORMAT } from '/peerd-runtime/transfer/transfer.js';
 import { runMigration, guardStore } from '/peerd-runtime/lifecycle/store-version.js';
 import { checkStores, storeEntry, STORE_REGISTRY } from '/peerd-runtime/lifecycle/store-registry.js';
 import { CHANNEL_DEFAULTS } from '/shared/channel-config.js';
@@ -350,9 +350,9 @@ const KNOWN_SETTING_KEYS = Object.keys(CHANNEL_DEFAULTS);
 describe.each(FIXTURES)('$name — the export envelope this release wrote', ({ data }) => {
   const envelope = () => data.exportEnvelope;
 
-  test('the format/version this build still speaks', () => {
+  test('the historical format/version remains intact', () => {
     expect(envelope().format).toBe(EXPORT_FORMAT);
-    expect(envelope().version).toBe(EXPORT_VERSION);
+    expect(envelope().version).toBe(1);
   });
 
   test('inspectImport accepts it and the summary is sane', () => {
@@ -885,9 +885,9 @@ describe('the new fixtures — permission normalization over non-default values'
 describe.each(NEW_FIXTURES)('$name — inspectImport over the export envelope', ({ data }) => {
   const envelope = () => data.exportEnvelope;
 
-  test('the format/version this build still speaks', () => {
+  test('the historical format/version remains intact', () => {
     expect(envelope().format).toBe(EXPORT_FORMAT);
-    expect(envelope().version).toBe(EXPORT_VERSION);
+    expect(envelope().version).toBe(1);
   });
 
   test('inspectImport accepts it and the summary is sane', () => {

--- a/tests/peerd-runtime/transfer/transfer.test.ts
+++ b/tests/peerd-runtime/transfer/transfer.test.ts
@@ -13,6 +13,29 @@ import {
 
 const KNOWN_KEYS = ['devMode', 'reasoningEnabled', 'providerName', 'spendLimitUsd'];
 
+const bytesToB64 = (bytes: Uint8Array) => btoa(String.fromCharCode(...bytes));
+const makeLegacySecretsBox = async (passphrase: string, value: unknown) => {
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const material = await crypto.subtle.importKey(
+    'raw', new TextEncoder().encode(passphrase), 'PBKDF2', false, ['deriveKey'],
+  );
+  const key = await crypto.subtle.deriveKey(
+    { name: 'PBKDF2', hash: 'SHA-256', salt, iterations: 600_000 },
+    material, { name: 'AES-GCM', length: 256 }, false, ['encrypt'],
+  );
+  const ciphertext = new Uint8Array(await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv }, key, new TextEncoder().encode(JSON.stringify(value)),
+  ));
+  const data = new Uint8Array(iv.length + ciphertext.length);
+  data.set(iv);
+  data.set(ciphertext, iv.length);
+  return {
+    kdf: 'PBKDF2-SHA256', iterations: 600_000, salt: bytesToB64(salt),
+    cipher: 'AES-GCM', data: bytesToB64(data),
+  };
+};
+
 const makePayload = (over: Record<string, unknown> = {}) => ({
   format: EXPORT_FORMAT,
   version: EXPORT_VERSION,
@@ -31,7 +54,9 @@ describe('passphrase crypto', () => {
   test('round-trips JSON values', async () => {
     const box = await encryptWithPassphrase('correct horse', { anthropic: 'sk-ant-xyz' });
     expect(box.cipher).toBe('AES-GCM');
-    expect(box.kdf).toBe('PBKDF2-SHA256');
+    expect(box).toMatchObject({
+      kdf: 'Argon2id', memKiB: 64 * 1024, iters: 3, parallelism: 1,
+    });
     const back = await decryptWithPassphrase('correct horse', box);
     expect(back).toEqual({ anthropic: 'sk-ant-xyz' });
   });
@@ -39,6 +64,23 @@ describe('passphrase crypto', () => {
   test('wrong passphrase throws ExportPassphraseError', async () => {
     const box = await encryptWithPassphrase('right', { k: 'v' });
     expect(decryptWithPassphrase('wrong', box)).rejects.toBeInstanceOf(ExportPassphraseError);
+  });
+
+  test('rejects attacker-controlled KDF parameters before doing crypto', async () => {
+    const box = await encryptWithPassphrase('right', { k: 'v' });
+    await expect(decryptWithPassphrase('right', { ...box, memKiB: Number.MAX_SAFE_INTEGER }))
+      .rejects.toBeInstanceOf(ExportPassphraseError);
+    await expect(decryptWithPassphrase('right', { ...box, iterations: 600_000 }))
+      .rejects.toBeInstanceOf(ExportPassphraseError);
+  });
+
+  test('imports legacy PBKDF2 backups without emitting new PBKDF2 boxes', async () => {
+    const legacy = await makeLegacySecretsBox('old backup passphrase', { anthropic: 'sk-old' });
+    await expect(decryptWithPassphrase('old backup passphrase', legacy))
+      .resolves.toEqual({ anthropic: 'sk-old' });
+    const current = await encryptWithPassphrase('new backup passphrase', { anthropic: 'sk-new' });
+    expect(JSON.stringify(current)).not.toContain('PBKDF2');
+    expect(current.kdf).toBe('Argon2id');
   });
 });
 
@@ -58,6 +100,8 @@ describe('buildExport', () => {
     expect(payload.channel).toBe('preview');
     expect(payload.settings).toEqual({ devMode: false });
     expect(payload.secrets?.data).toBeString();
+    expect(payload.secrets?.kdf).toBe('Argon2id');
+    expect(JSON.stringify(payload.secrets)).not.toContain('PBKDF2');
     expect(JSON.stringify(payload)).not.toContain('sk-1'); // never plaintext
   });
 
@@ -68,7 +112,7 @@ describe('buildExport', () => {
     })).rejects.toBeInstanceOf(ExportPassphraseError);
   });
 
-  test('no dweb field in Phase 0 exports', async () => {
+  test('no dweb field in identity-less exports', async () => {
     const payload = await buildExport({
       channel: 'preview', storedSettings: {}, providerEndpoints: null,
       secrets: {}, passphrase: '', memory: null, hooks: [], skills: [],
@@ -81,8 +125,25 @@ describe('inspectImport', () => {
   test('rejects non-exports and unknown versions', () => {
     expect(inspectImport({ payload: { hi: 1 }, channel: 'store', knownSettingKeys: KNOWN_KEYS }).ok).toBe(false);
     expect(inspectImport({
+      payload: makePayload({ version: 1 }), channel: 'store', knownSettingKeys: KNOWN_KEYS,
+    }).ok).toBe(true);
+    expect(inspectImport({
       payload: makePayload({ version: 99 }), channel: 'store', knownSettingKeys: KNOWN_KEYS,
     }).error).toBe('unsupported-export-version-99');
+  });
+
+  test('rejects malformed write-bearing sections during pre-flight', () => {
+    for (const malformed of [
+      { hooks: { id: 'not-an-array' } },
+      { providerEndpoints: { endpoints: {} } },
+      { memory: { docs: [null] } },
+      { dweb: [] },
+      { secrets: { kdf: 'Argon2id', memKiB: Number.MAX_SAFE_INTEGER } },
+    ]) {
+      expect(inspectImport({
+        payload: makePayload(malformed), channel: 'preview', knownSettingKeys: KNOWN_KEYS,
+      })).toEqual({ ok: false, error: 'invalid-export-sections' });
+    }
   });
 
   test('drops unknown settings keys with a notice (dweb* on store)', () => {
@@ -146,7 +207,10 @@ describe('applyImport', () => {
     // devMode: true travels even though the store default is false — the
     // user's explicit choice wins (§11 cross-channel nuances).
     expect(calls.applySettings).toEqual([{ devMode: true }]);
-    expect(res.imported).toEqual({ settings: 1, secrets: 0, memoryWritten: 1, hooks: 1 });
+    expect(res.imported).toEqual({
+      settings: 1, secrets: 0, providerEndpoints: 0,
+      memoryWritten: 1, hooks: 1, dwebIdentity: 0,
+    });
   });
 
   test('secrets import is all-or-nothing on a bad passphrase', async () => {
@@ -244,5 +308,333 @@ describe('R6 import gates', () => {
     });
     if (!res.ok || !('notices' in res)) throw new Error('expected notices');
     expect((res.notices as string[]).some((n) => n.includes('memory doc'))).toBe(true);
+  });
+});
+
+// The portable-identity section (docs/design/portable-identity/ 02): the
+// did travels ONLY as the capsule record in payload.dweb — never as a raw
+// seed in the secrets box — and the import side routes the dweb-side
+// adoption decision into user-visible notices.
+describe('dweb identity section', () => {
+  const record = { format: 'peerd-identity-record', version: 1, did: 'did:key:zTest', capsule: 'AAAA', wrappers: [{ kind: 'passphrase', wrappedKey: 'BBBB' }], updatedAt: 1 };
+
+  test('buildExport carries the record and structurally excludes custody secrets', async () => {
+    const payload = await buildExport({
+      channel: 'preview',
+      storedSettings: {},
+      providerEndpoints: null,
+      secrets: {
+        anthropic: 'sk-1',
+        'distributed/identity/v1': '{"v":1}',
+        'distributed/identity/record/v1': '{}',
+        'distributed/device-key/v1': '{"v":1}',
+      },
+      passphrase: 'pw123456',
+      memory: null, hooks: [], skills: [],
+      dweb: { identityRecord: record },
+    });
+    expect(payload.dweb).toEqual({ identityRecord: record });
+    const secrets = await decryptWithPassphrase('pw123456', payload.secrets as any);
+    expect(Object.keys(secrets)).toEqual(['anthropic']); // seed/device key filtered by mechanism
+  });
+
+  test('inspectImport: store drops with the §10 notice; preview names the identity restore', () => {
+    const store = inspectImport({ payload: makePayload({ dweb: { identityRecord: record } }), channel: 'store', knownSettingKeys: KNOWN_KEYS });
+    if (!store.ok || !store.summary) throw new Error('expected summary');
+    expect(store.summary.dwebDropped).toBe(true);
+    expect(store.summary.notices[0]).toBe(
+      'The peer identity in this preview backup cannot be restored by the store build and will be skipped.',
+    );
+    const preview = inspectImport({ payload: makePayload({ dweb: { identityRecord: record } }), channel: 'preview', knownSettingKeys: KNOWN_KEYS });
+    if (!preview.ok || !preview.summary) throw new Error('expected summary');
+    expect(preview.summary.dwebDropped).toBe(false);
+    expect(preview.summary.hasIdentityRecord).toBe(true);
+    expect(preview.summary.requiresPassphrase).toBe(true);
+    expect(preview.summary.identityDid).toBe(record.did);
+    expect(preview.summary.notices.join(' ')).toContain('identity record');
+  });
+
+  test('applyImport adopts on preview via injected IO, passing the file passphrase through', async () => {
+    const adoptions: any[] = [];
+    const io = {
+      applySettings: async () => {}, setProviderEndpoints: async () => {},
+      setSecret: async () => {}, importMemory: async () => ({ written: 0, skipped: 0 }),
+      saveHook: async () => {},
+      adoptDwebIdentity: async (r: any, pass: string, options: any) => { adoptions.push([r, pass, options]); return { adopted: true, did: r.did, reason: 'recovered' }; },
+    };
+    const res = await applyImport({
+      payload: makePayload({ memory: null, hooks: [], dweb: { identityRecord: record } }),
+      passphrase: 'pw123456', channel: 'preview', knownSettingKeys: KNOWN_KEYS, io,
+    });
+    if (!res.ok || !('imported' in res)) throw new Error('expected applied result');
+    expect(adoptions).toEqual([
+      [record, 'pw123456', { replaceExisting: false, prepareOnly: true }],
+      [record, 'pw123456', {
+        replaceExisting: false,
+        expectedExistingDid: null,
+        expectedIncomingDid: record.did,
+      }],
+    ]);
+    expect((res.imported as any).dwebIdentity).toBe(1);
+    expect((res.notices as string[]).join(' ')).toContain('restored');
+  });
+
+  test('store never calls the adopter; preview conflicts stop before any other writes', async () => {
+    const adoptions: any[] = [];
+    const baseIo = {
+      applySettings: async () => {}, setProviderEndpoints: async () => {},
+      setSecret: async () => {}, importMemory: async () => ({ written: 0, skipped: 0 }),
+      saveHook: async () => {},
+    };
+    const storeRes = await applyImport({
+      payload: makePayload({ memory: null, hooks: [], dweb: { identityRecord: record } }),
+      channel: 'store', knownSettingKeys: KNOWN_KEYS,
+      io: { ...baseIo, adoptDwebIdentity: async (r: any) => { adoptions.push(r); return { adopted: true, reason: 'recovered' }; } },
+    });
+    expect(storeRes.ok).toBe(true);
+    expect(adoptions).toEqual([]);
+
+    const conflict = await applyImport({
+      payload: makePayload({ memory: null, hooks: [], dweb: { identityRecord: record } }),
+      channel: 'preview', knownSettingKeys: KNOWN_KEYS,
+      io: { ...baseIo, adoptDwebIdentity: async () => ({
+        adopted: false,
+        reason: 'did-conflict',
+        existingDid: 'did:key:zOther',
+        incomingDid: record.did,
+      }) },
+    });
+    expect(conflict).toEqual({
+      ok: false,
+      error: 'dweb-identity-conflict',
+      conflict: { existingDid: 'did:key:zOther', incomingDid: record.did },
+    });
+
+    await expect(applyImport({
+      payload: makePayload({ memory: null, hooks: [], dweb: { identityRecord: record } }),
+      channel: 'preview', knownSettingKeys: KNOWN_KEYS,
+      io: { ...baseIo, adoptDwebIdentity: async () => ({ adopted: false, reason: 'no-openable-wrapper' }) },
+    })).rejects.toBeInstanceOf(ExportPassphraseError);
+  });
+
+  test('explicit keep and replace choices are passed through', async () => {
+    const adopted: any[] = [];
+    const baseIo = {
+      applySettings: async () => {}, setProviderEndpoints: async () => {},
+      setSecret: async () => {}, importMemory: async () => ({ written: 0, skipped: 0 }),
+      saveHook: async () => {},
+      adoptDwebIdentity: async (_record: any, _pass: string, options: any) => {
+        adopted.push(options);
+        return {
+          adopted: true, reason: 'replaced', did: record.did,
+          existingDid: 'did:key:zOld', incomingDid: record.did,
+        };
+      },
+    };
+    const skipped = await applyImport({
+      payload: makePayload({ memory: null, hooks: [], dweb: { identityRecord: record } }),
+      channel: 'preview', knownSettingKeys: KNOWN_KEYS, io: baseIo,
+      skipDwebIdentity: true,
+    });
+    expect(skipped.ok).toBe(true);
+    expect(adopted).toEqual([]);
+
+    const replaced = await applyImport({
+      payload: makePayload({ memory: null, hooks: [], dweb: { identityRecord: record } }),
+      passphrase: 'pw123456', channel: 'preview', knownSettingKeys: KNOWN_KEYS,
+      io: baseIo, replaceDwebIdentity: true,
+      approvedExistingDwebDid: 'did:key:zOld', approvedIncomingDwebDid: record.did,
+    });
+    expect(replaced.ok).toBe(true);
+    expect(adopted).toEqual([
+      { replaceExisting: true, prepareOnly: true },
+      { replaceExisting: true, expectedExistingDid: 'did:key:zOld', expectedIncomingDid: record.did },
+    ]);
+  });
+
+  test('replacement approval is bound to the exact did pair the user reviewed', async () => {
+    let writes = 0;
+    const result = await applyImport({
+      payload: makePayload({
+        settings: { devMode: true }, memory: null, hooks: [],
+        providerEndpoints: { endpoints: [{ url: 'https://api.example.test/v1' }] },
+        dweb: { identityRecord: record },
+      }),
+      passphrase: 'pw123456', channel: 'preview', knownSettingKeys: KNOWN_KEYS,
+      replaceDwebIdentity: true,
+      approvedExistingDwebDid: 'did:key:zApprovedOld', approvedIncomingDwebDid: record.did,
+      io: {
+        applySettings: async () => { writes++; }, setProviderEndpoints: async () => {},
+        setSecret: async () => {}, importMemory: async () => ({ written: 0, skipped: 0 }),
+        saveHook: async () => {},
+        adoptDwebIdentity: async () => ({
+          adopted: true, reason: 'replaced', did: record.did,
+          existingDid: 'did:key:zChangedWhileDialogOpen', incomingDid: record.did,
+        }),
+      },
+    });
+    expect(result).toEqual({
+      ok: false, error: 'dweb-identity-conflict',
+      conflict: { existingDid: 'did:key:zChangedWhileDialogOpen', incomingDid: record.did },
+    });
+    expect(writes).toBe(0);
+  });
+
+  test('an unreadable local identity becomes a bound destructive conflict', async () => {
+    const calls: any[] = [];
+    const baseIo = {
+      applySettings: async () => {}, setProviderEndpoints: async () => {},
+      setSecret: async () => {}, importMemory: async () => ({ written: 0, skipped: 0 }),
+      saveHook: async () => {},
+      adoptDwebIdentity: async (_record: any, _pass: string, options: any) => {
+        calls.push(options);
+        return options.replaceExisting
+          ? {
+              adopted: true, reason: 'replaced-invalid-local', did: record.did,
+              existingDid: null, incomingDid: record.did,
+              existingUnreadable: true, existingRevision: 'revision-a',
+            }
+          : {
+              adopted: false, reason: 'invalid-local-identity', existingDid: null,
+              incomingDid: record.did, existingUnreadable: true, existingRevision: 'revision-a',
+            };
+      },
+    };
+    const first = await applyImport({
+      payload: makePayload({ memory: null, hooks: [], dweb: { identityRecord: record } }),
+      passphrase: 'pw123456', channel: 'preview', knownSettingKeys: KNOWN_KEYS, io: baseIo,
+    });
+    expect(first).toEqual({
+      ok: false, error: 'dweb-identity-conflict',
+      conflict: {
+        existingDid: null, incomingDid: record.did,
+        existingUnreadable: true, existingRevision: 'revision-a',
+      },
+    });
+
+    const repaired = await applyImport({
+      payload: makePayload({ memory: null, hooks: [], dweb: { identityRecord: record } }),
+      passphrase: 'pw123456', channel: 'preview', knownSettingKeys: KNOWN_KEYS, io: baseIo,
+      replaceDwebIdentity: true,
+      approvedExistingDwebRevision: 'revision-a', approvedIncomingDwebDid: record.did,
+    });
+    expect(repaired).toMatchObject({ ok: true, identityOutcome: 'replaced' });
+    expect(calls.at(-1)).toEqual({
+      replaceExisting: true,
+      expectedExistingDid: null,
+      expectedExistingRevision: 'revision-a',
+      expectedIncomingDid: record.did,
+    });
+  });
+
+  test('identity is authenticated first but committed only after all ordinary writes succeed', async () => {
+    const events: string[] = [];
+    const io = {
+      applySettings: async () => { events.push('settings'); throw new Error('disk full'); },
+      setProviderEndpoints: async () => {}, setSecret: async () => {},
+      importMemory: async () => ({ written: 0, skipped: 0 }), saveHook: async () => {},
+      adoptDwebIdentity: async (_record: any, _pass: string, options: any) => {
+        events.push(options.prepareOnly ? 'identity-authenticated' : 'identity-committed');
+        return {
+          adopted: true, reason: 'replaced', did: record.did,
+          existingDid: 'did:key:zOld', incomingDid: record.did,
+        };
+      },
+    };
+    const result = await applyImport({
+      payload: makePayload({
+        settings: { devMode: true }, memory: null, hooks: [],
+        providerEndpoints: { endpoints: [{ url: 'https://api.example.test/v1' }] },
+        dweb: { identityRecord: record },
+      }),
+      passphrase: 'pw123456', channel: 'preview', knownSettingKeys: KNOWN_KEYS,
+      io, replaceDwebIdentity: true,
+      approvedExistingDwebDid: 'did:key:zOld', approvedIncomingDwebDid: record.did,
+    });
+    expect(result).toMatchObject({
+      ok: false, error: 'import-partial', failure: 'write-failed',
+      partial: { settings: 0, dwebIdentity: 0 }, identityOutcome: 'not-changed',
+    });
+    expect(events).toEqual(['identity-authenticated', 'settings']);
+  });
+
+  test('final identity failure reports every ordinary section already committed', async () => {
+    let identityCalls = 0;
+    const io = {
+      applySettings: async () => {}, setProviderEndpoints: async () => {},
+      setSecret: async () => {}, importMemory: async () => ({ written: 0, skipped: 0 }),
+      saveHook: async () => {},
+      adoptDwebIdentity: async () => {
+        identityCalls++;
+        if (identityCalls === 1) {
+          return { adopted: true, reason: 'replaced', did: record.did, existingDid: 'did:key:zOld', incomingDid: record.did };
+        }
+        throw Object.assign(new Error('host stopped'), { name: 'IdentityTransferError', code: 'stop-failed' });
+      },
+    };
+    const result = await applyImport({
+      payload: makePayload({
+        settings: { devMode: true }, memory: null, hooks: [],
+        providerEndpoints: { endpoints: [{ url: 'https://api.example.test/v1' }] },
+        dweb: { identityRecord: record },
+      }),
+      passphrase: 'pw123456', channel: 'preview', knownSettingKeys: KNOWN_KEYS,
+      io, replaceDwebIdentity: true,
+      approvedExistingDwebDid: 'did:key:zOld', approvedIncomingDwebDid: record.did,
+    });
+    expect(result).toMatchObject({
+      ok: false, error: 'import-partial', failure: 'dweb-identity-stop-failed',
+      partial: { settings: 1, providerEndpoints: 1, dwebIdentity: 0 }, identityOutcome: 'not-changed',
+    });
+  });
+
+  test('a committed identity with runtime recovery pending returns success and a notice', async () => {
+    let identityCalls = 0;
+    const result = await applyImport({
+      payload: makePayload({ memory: null, hooks: [], dweb: { identityRecord: record } }),
+      passphrase: 'pw123456', channel: 'preview', knownSettingKeys: KNOWN_KEYS,
+      io: {
+        applySettings: async () => {}, setProviderEndpoints: async () => {},
+        setSecret: async () => {}, importMemory: async () => ({ written: 0, skipped: 0 }),
+        saveHook: async () => {},
+        adoptDwebIdentity: async () => {
+          identityCalls++;
+          return identityCalls === 1
+            ? { adopted: true, reason: 'recovered', did: record.did, existingDid: null, incomingDid: record.did }
+            : {
+                adopted: true, reason: 'recovered', did: record.did,
+                existingDid: null, incomingDid: record.did, runtimeRecoveryPending: true,
+              };
+        },
+      },
+    });
+    expect(result).toMatchObject({
+      ok: true, identityOutcome: 'restored', runtimeRecoveryPending: true,
+    });
+    if (!result.ok || !('notices' in result)) throw new Error('expected notices');
+    expect((result.notices ?? []).join(' ')).toContain('peer network is still recovering');
+  });
+
+  test('crafted generic secrets cannot overwrite identity custody records', async () => {
+    const writes: any[] = [];
+    const secrets = await encryptWithPassphrase('right', {
+      anthropic: 'sk-safe',
+      'distributed/identity/v1': 'forged-root',
+      'distributed/identity/v2': 'future-forged-root',
+      'distributed/device-key/v99': 'forged-device',
+    });
+    const res = await applyImport({
+      payload: makePayload({ memory: null, hooks: [], secrets }),
+      passphrase: 'right', channel: 'preview', knownSettingKeys: KNOWN_KEYS,
+      io: {
+        applySettings: async () => {}, setProviderEndpoints: async () => {},
+        setSecret: async (name: string, value: string) => { writes.push([name, value]); },
+        importMemory: async () => ({ written: 0, skipped: 0 }), saveHook: async () => {},
+      },
+    });
+    expect(res.ok).toBe(true);
+    expect(writes).toEqual([['anthropic', 'sk-safe']]);
+    if (!res.ok || !('notices' in res)) throw new Error('expected notices');
+    expect((res.notices as string[]).join(' ')).toContain('protected identity/device');
   });
 });

--- a/tests/shared/sender-trust.test.ts
+++ b/tests/shared/sender-trust.test.ts
@@ -5,7 +5,9 @@
 // future-content-script cases the guard exists to reject.
 
 import { describe, it, expect } from 'bun:test';
-import { isFirstPartySender } from '../../extension/shared/sender-trust.js';
+import {
+  isFirstPartySender, isOffscreenSender, isOptionsSender,
+} from '../../extension/shared/sender-trust.js';
 
 const ID = 'abcdefghijklmnopabcdefghijklmnop';
 const ORIGIN = `chrome-extension://${ID}/`;
@@ -84,5 +86,60 @@ describe('isFirstPartySender', () => {
     const fxOrigin = `moz-extension://11111111-2222-3333-4444-555555555555/`;
     const fx = { runtimeId: ID, extensionOrigin: fxOrigin };
     expect(isFirstPartySender({ id: ID, url: `${fxOrigin}sidepanel/sidepanel.html` }, fx)).toBe(true);
+  });
+});
+
+describe('isOffscreenSender', () => {
+  const offscreenUrl = `${ORIGIN}offscreen/offscreen.html`;
+  const offscreenTrust = { ...trust, offscreenUrl };
+
+  it('accepts only the exact browser-owned offscreen document', () => {
+    expect(isOffscreenSender({ id: ID, url: offscreenUrl }, offscreenTrust)).toBe(true);
+  });
+
+  it('rejects query and hash variants', () => {
+    expect(isOffscreenSender({ id: ID, url: `${offscreenUrl}?copy=1` }, offscreenTrust)).toBe(false);
+    expect(isOffscreenSender({ id: ID, url: `${offscreenUrl}#frame` }, offscreenTrust)).toBe(false);
+  });
+
+  it('rejects a tab-hosted copy of the offscreen page', () => {
+    expect(isOffscreenSender(
+      { id: ID, url: offscreenUrl, tab: { id: 9 } }, offscreenTrust,
+    )).toBe(false);
+  });
+
+  it('rejects prefix variants and missing trust data', () => {
+    expect(isOffscreenSender(
+      { id: ID, url: `${offscreenUrl}.evil.html` }, offscreenTrust,
+    )).toBe(false);
+    expect(isOffscreenSender({ id: ID, url: offscreenUrl }, trust as any)).toBe(false);
+  });
+});
+
+describe('isOptionsSender', () => {
+  const optionsUrl = `${ORIGIN}options/options.html`;
+  const optionsTrust = { ...trust, optionsUrl };
+
+  it('accepts the exact full-tab options page and its hash routes', () => {
+    expect(isOptionsSender(
+      { id: ID, url: optionsUrl, tab: { id: 11 } }, optionsTrust,
+    )).toBe(true);
+    expect(isOptionsSender(
+      { id: ID, url: `${optionsUrl}#!/transfer`, tab: { id: 11 } }, optionsTrust,
+    )).toBe(true);
+  });
+
+  it('rejects no-tab, query, sibling-path, and wrong-origin senders', () => {
+    expect(isOptionsSender({ id: ID, url: optionsUrl }, optionsTrust)).toBe(false);
+    expect(isOptionsSender(
+      { id: ID, url: `${optionsUrl}?mode=transfer`, tab: { id: 11 } }, optionsTrust,
+    )).toBe(false);
+    expect(isOptionsSender(
+      { id: ID, url: `${optionsUrl}.evil`, tab: { id: 11 } }, optionsTrust,
+    )).toBe(false);
+    expect(isOptionsSender(
+      { id: ID, url: 'https://evil.example/options/options.html', tab: { id: 11 } },
+      optionsTrust,
+    )).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Adds password-protected backup and restore for preview peer identities.
- Keeps the permanent identity seed out of generic secret export.
- Requires explicit review before replacing a different or unreadable local identity.
- Keeps backup passwords off broadcast messaging with exact-sender Ports.
- Keeps store builds free of dweb code.

## Safety

- Uses one fixed Argon2id policy for every new password-protected backup section.
- Accepts legacy PBKDF2 credential boxes on import only.
- Proves the recovered seed and public key against the advertised DID.
- Serializes identity writes and binds each commit to the state the user reviewed.
- Blocks identity changes while local shared apps still depend on the current publisher.
- Suspends the peer host for custody writes and reports restart recovery honestly.
- Enforces a single runtime Port receiver in CI.

## User and model UX

- Shows complete peer identities and keeps them selectable.
- Makes keeping the current identity the safe primary action.
- Requires a second confirmation for permanent replacement.
- Announces inspection, conflict, progress, completion, and recovery states.
- Reports committed state as success even when peer-network restart is still retrying.
- Uses neutral, accessible success text and 44-pixel transfer controls.

## Verification

- `bun run preflight`
- 4,686 Bun tests
- 730 in-browser tests
- 21 visual E2E states, with light and dark transfer screens inspected
- Live encrypted restore, wrong-password rejection, same-identity authentication, conflict handling, approved replacement, and peer-host restart
- Three independent adversarial reviews covering security, correctness, user UX, accessibility, and model UX