### PR TITLE
ci: deploy peerd.ai feeds after releases

### DIFF
--- a/.github/workflows/package-and-release.yml
+++ b/.github/workflows/package-and-release.yml
@@ -19,6 +19,8 @@
 #                     same key forever, or every preview install breaks)
 #   AMO_JWT_ISSUER    addons.mozilla.org API credentials used by
 #   AMO_JWT_SECRET    `web-ext sign` for the Firefox preview package
+#   PEERD_SITE_DISPATCH_TOKEN  fine-grained token scoped only to the private
+#                     NotASithLord/peerd-site repo with Contents:write
 
 name: package-and-release
 
@@ -779,6 +781,19 @@ jobs:
               --notes-file "$RUNNER_TEMP/release-notes.md" \
               "${ASSETS[@]}"
           fi
+
+      - name: Trigger peerd.ai feed deployment
+        env:
+          GH_TOKEN: ${{ secrets.PEERD_SITE_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          [ -n "$GH_TOKEN" ] || {
+            echo "::error::PEERD_SITE_DISPATCH_TOKEN is not set"
+            exit 1
+          }
+          gh api --method POST repos/NotASithLord/peerd-site/dispatches \
+            -f event_type=peerd-release \
+            -F "client_payload[tag]=$GITHUB_REF_NAME"
 
       # The feeds are committed so the repo (and the peerd.ai site deploy,
       # which serves update-feeds/ at /updates/) always reflects the

--- a/.github/workflows/package-and-release.yml
+++ b/.github/workflows/package-and-release.yml
@@ -787,10 +787,10 @@ jobs:
           GH_TOKEN: ${{ secrets.PEERD_SITE_DISPATCH_TOKEN }}
         run: |
           set -euo pipefail
-          [ -n "$GH_TOKEN" ] || {
-            echo "::error::PEERD_SITE_DISPATCH_TOKEN is not set"
-            exit 1
-          }
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::PEERD_SITE_DISPATCH_TOKEN is not set; peerd-site's scheduled sync remains the fallback"
+            exit 0
+          fi
           gh api --method POST repos/NotASithLord/peerd-site/dispatches \
             -f event_type=peerd-release \
             -F "client_payload[tag]=$GITHUB_REF_NAME"


### PR DESCRIPTION
Dispatches the private peerd-site feed workflow immediately after release assets are published, passing the exact tag. Requires `PEERD_SITE_DISPATCH_TOKEN`, scoped only to NotASithLord/peerd-site with Contents:write.