### PR TITLE
feat(actor): delegate from trusted actor code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and storage formats may move until the surface stabilizes.
 
 ## [Unreleased]
 
+### Changed
+- **Trusted spawned actors can orchestrate delegations in JavaScript.** When a
+  spawned actor is explicitly granted both `script` and `message_actor`, its
+  code can fan out, chain replies, and handle retries through the `actors`
+  client's awaited `ask` plus roster-only `list` surface. The earlier
+  `actors.send` code method is retired pending a genuine no-reply `cast`
+  design; the direct `message_actor` tool remains the asynchronous path.
+  Every delegation still crosses the original lineage, grant, manifest, rate,
+  audit, fencing, and Stop gates; bound environment actors remain pinned and
+  non-delegating.
+
 ## [0.5.0] - 2026-08-06
 
 ### Added

--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -266,8 +266,9 @@ spawned by an inbound or injected turn is tainted for its whole subtree. Forged,
 severed, foreign-rooted, and cyclic lineages fail closed. A poisoned mesh op (bad
 method or args) is rejected, and signing as the user requires per-target consent. The
 wall covers EVERY door to delegation, not only the direct `message_actor` tool: the
-`script` tool's `actors.send`/`actors.ask` surface reaches the same `messageActor`, so
-it is refused mint on an inbound turn (`tools/defs/script.js` gates `actorsOn` on
+`script` tool's awaited `actors.ask` surface reaches the same `messageActor`
+(while `actors.list` only reads the roster), so delegation is refused mint on
+an inbound turn (`tools/defs/script.js` gates `actorsOn` on
 `ctx.inbound !== true` — the trusted turn signal folded SW-side; the untrusted worker
 never echoes it).
 Code: `peerd-runtime/actor/delegation-lineage.js` (`mayMessageActor`,

--- a/extension/background/offscreen-js-client.js
+++ b/extension/background/offscreen-js-client.js
@@ -14,9 +14,10 @@
 export const makeOffscreenJsClient = ({ ensureOffscreen, sendMessage }) => ({
   /**
    * @param {string} code
-   * @param {{ timeoutMs?: number, a2a?: boolean, actors?: boolean, siteFetch?: string, toolbox?: boolean, caps?: { page?: boolean, egress?: boolean, subagent?: boolean, opfs?: boolean, provider?: boolean }, ownerSessionId?: string, ownerToolUseId?: string, runId?: string, workspaceSessionId?: string }} [opts]
+   * @param {{ timeoutMs?: number, a2a?: boolean, actors?: boolean, siteFetch?: string, toolbox?: boolean, caps?: { page?: boolean, egress?: boolean, subagent?: boolean, opfs?: boolean, provider?: boolean }, ownerSessionId?: string, ownerToolUseId?: string, runId?: string, workspaceSessionId?: string, signal?: AbortSignal }} [opts]
    *   a2a: expose the `mesh` agent-to-agent client; actors: expose the `actors`
-   *   delegation client (the script surface). caps: capability profile for the
+   *   delegation client (the script surface for chat or a granted spawned actor).
+   *   caps: capability profile for the
    *   sealed worker (default = the historical js_run surface); caps.page also
    *   needs ownerSessionId — the actor session the page bridge dispatches FOR,
    *   set only from a trusted ctx (PR #119). ownerSessionId / ownerToolUseId /
@@ -28,8 +29,14 @@ export const makeOffscreenJsClient = ({ ensureOffscreen, sendMessage }) => ({
    *   worker can never name its own root).
    * @returns {Promise<{ value: unknown, consoleOutput: {level:string,text:string}[], durationMs: number, error: string|null, usedEgress?: boolean, usedActors?: boolean, usedWorkspace?: boolean, workspaceOverBudget?: boolean, actorsTrace?: Array<{ seq: number, method: string, to?: string, goal?: string, ok: boolean, ms: number, error?: string }>, usedProvider?: boolean, providerCalls?: number, providerTokens?: number }>}
    */
-  execHeadless: async (code, { timeoutMs, a2a, ownerSessionId, actors, ownerToolUseId, runId, caps, siteFetch, toolbox, workspaceSessionId } = {}) => {
+  execHeadless: async (code, { timeoutMs, a2a, ownerSessionId, actors, ownerToolUseId, runId, caps, siteFetch, toolbox, workspaceSessionId, signal } = {}) => {
     await ensureOffscreen();
+    // why: Stop may arrive while the offscreen document is still being
+    // created. In that window job/abort has nowhere to leave its early-abort
+    // tombstone, so launching after ensureOffscreen would orphan the worker
+    // until its wall-clock. The signal is local-only (never cloned into the
+    // message); there is no await between this check and dispatch.
+    if (signal?.aborted) throw new Error('headless job aborted before dispatch');
     const reply = await sendMessage({
       type: 'job/run', code, timeoutMs,
       ...(a2a ? { a2a: true, ownerSessionId } : {}),

--- a/extension/background/routes/actors.js
+++ b/extension/background/routes/actors.js
@@ -1,0 +1,158 @@
+// @ts-check
+// background/routes/actors.js — the `script` tool's actors-in-code relay.
+//
+// A sealed headless worker can choreograph local actors with actors.list/ask.
+// This route translates each call back into the EXISTING actor machinery; it does
+// not create a second authority path. The live run, owner, narrowed tool grant,
+// sender lineage, rate caps, dedupe, audit, and Stop signal are all re-checked
+// SW-side on every operation.
+
+/**
+ * @param {Record<string, any>} deps
+ * @returns {Record<string, (msg?: any, sender?: unknown) => Promise<any>>}
+ */
+export const makeActorsRoutes = (deps) => {
+  const {
+    sessions, uiPorts, buildToolContext, dispatchToolCall, actorMessaging,
+    scriptRuns, actorsCallToOp, shapeActorsResult, askOutcome,
+    ACTORS_ASK_DEFAULT_TIMEOUT_MS, resolveManifestAllow, isOffscreenSender,
+  } = deps;
+
+  /**
+   * The code bridge must never widen the caller's model-facing tool surface.
+   * A spawned actor's persisted grant is already the manifest-intersected,
+   * narrowed source of truth; a chat session resolves its manifest directly.
+   * null means the chat has no manifest and keeps the historical full surface.
+   * @param {Record<string, any>} owner
+   * @returns {Set<string> | null}
+   */
+  const ownerAllow = (owner) => owner.kind === 'spawned'
+    ? new Set(Array.isArray(owner.grantedTools) ? owner.grantedTools : [])
+    : resolveManifestAllow(owner.toolManifest);
+
+  return {
+    'actors/call': async (msg = {}, sender = undefined) => {
+      const pushOp = (/** @type {string} */ phase, /** @type {object} */ extra = {}) => {
+        try {
+          uiPorts.broadcast({
+            type: 'script/op',
+            sessionId: msg.ownerSessionId, toolUseId: msg.ownerToolUseId ?? null,
+            seq: msg.seq ?? 0, method: msg.method ?? '?', phase, ...extra,
+          });
+        } catch { /* panel closed — the trace in the result still records it */ }
+      };
+
+      try {
+        // why exact provenance, not merely makeDispatcher's first-party wall:
+        // runtime.sendMessage broadcasts the SW-minted job params to every
+        // extension page. This route carries the owning session's actor
+        // authority, so only the offscreen job host may redeem a live run.
+        if (!isOffscreenSender(sender)) {
+          return { ok: false, error: 'actors: unauthorized relay' };
+        }
+        // Reject a dead, foreign, non-actors, or already-Stopped run before an
+        // IDB session read. A worker past its operation limit cannot turn this
+        // route into an unbounded storage-read relay either.
+        if (typeof msg.runId !== 'string'
+          || scriptRuns.ownerFor(msg.runId) !== msg.ownerSessionId
+          || scriptRuns.allows?.(msg.runId, 'actors') !== true) {
+          return { ok: false, error: 'actors: unknown, finished, or foreign script run' };
+        }
+        const owner = msg.ownerSessionId ? await sessions.get(msg.ownerSessionId) : null;
+        // Bound environment actors remain intentionally non-delegating: their
+        // authority is one pinned environment. A spawned actor is different —
+        // trusted-lineage message_actor already admits it, so code gets parity
+        // only when that exact tool survived its narrowed persisted grant.
+        if (!owner || owner.kind === 'actor') {
+          return { ok: false, error: 'actors: only a chat session or a granted spawned actor holds the script delegation surface' };
+        }
+        const { op, args } = actorsCallToOp({ method: msg.method, args: msg.args });
+        const requiredTool = op === 'list' ? 'actor_list' : 'message_actor';
+        const allow = ownerAllow(owner);
+        if (allow instanceof Set && !allow.has(requiredTool)) {
+          return { ok: false, error: `actors.${op}: '${requiredTool}' is not granted to this session` };
+        }
+        if (scriptRuns.admitActorOp?.(msg.runId) !== true) {
+          return { ok: false, error: 'actors: this script run reached its delegation-operation limit' };
+        }
+
+        if (op === 'list') {
+          // The roster still runs through the normal dispatcher/gates. The
+          // explicit allow check above is the spawned-grant wall that a generic
+          // buildToolContext does not reconstruct on its own.
+          const listCtx = await buildToolContext({ exposure: 'main', sessionId: msg.ownerSessionId });
+          const result = await dispatchToolCall({
+            id: `${msg.runId}-list-${msg.seq ?? 0}`, name: 'actor_list', args: {},
+          }, listCtx);
+          return result?.ok
+            ? { ok: true, value: shapeActorsResult('list', { ok: true, roster: result.content }) }
+            : { ok: false, error: result?.error ?? 'actor_list failed' };
+        }
+
+        const target = /** @type {{ to: string, goal: string, timeoutMs?: number, oneShot?: boolean }} */ (args);
+        // A chained goal can carry actor/web-derived bytes. The UI renders plain
+        // text, but keep the live preview one-line + capped so it cannot shape UI.
+        const goalPreview = target.goal.replace(/\s+/g, ' ').slice(0, 60);
+        pushOp('sent', { to: target.to, goalPreview });
+        const mirror = (/** @type {Record<string, unknown>} */ opRecord) => {
+          scriptRuns.recordOp(msg.runId, {
+            seq: msg.seq ?? 0, method: msg.method, to: target.to, ...opRecord,
+          });
+        };
+
+        // ask — awaitReply, raced against the per-ask timeout AND the run's Stop
+        // signal. The same signal cancels the underlying actor turn.
+        const askTimeoutMs = target.timeoutMs ?? ACTORS_ASK_DEFAULT_TIMEOUT_MS;
+        const runSignal = scriptRuns.signalFor(msg.runId);
+        const askController = new AbortController();
+        let timedOut = false;
+        const timer = setTimeout(() => { timedOut = true; askController.abort(); }, askTimeoutMs);
+        const onRunAbort = () => askController.abort();
+        if (runSignal) {
+          if (runSignal.aborted) askController.abort();
+          else runSignal.addEventListener('abort', onRunAbort, { once: true });
+        }
+        try {
+          const startedAt = Date.now();
+          const result = await actorMessaging.messageActor({
+            to: target.to, message: target.goal, senderSessionId: msg.ownerSessionId,
+            toolUseId: msg.ownerToolUseId, oneShot: target.oneShot === true, via: 'script',
+            // Keep the reply's untrusted-content envelope intact when it
+            // resolves into code and code feeds
+            // it into another actor. Fencing only the final script result would
+            // let page/instance text become an authoritative chained goal.
+            awaitReply: true, awaitSignal: askController.signal,
+          });
+          const ms = Date.now() - startedAt;
+          const outcome = askOutcome(result, {
+            timedOut, aborted: !timedOut && askController.signal.aborted,
+            timeoutMs: askTimeoutMs, to: target.to,
+          });
+          if (!outcome.ok) {
+            pushOp('failed', { ms, error: timedOut ? 'timeout' : 'refused' });
+            mirror({ ok: false, ms, error: outcome.error });
+            return { ok: false, error: outcome.error };
+          }
+          pushOp('replied', { ms, ...(outcome.failed ? { failed: true } : {}) });
+          mirror({ ok: true, ms, ...(outcome.failed ? { actorFailed: true } : {}) });
+          return {
+            ok: true,
+            value: shapeActorsResult('ask', {
+              ok: true, reply: outcome.reply, failed: outcome.failed,
+            }),
+          };
+        } finally {
+          clearTimeout(timer);
+          if (runSignal) {
+            try { runSignal.removeEventListener?.('abort', onRunAbort); } catch { /* stub */ }
+          }
+        }
+      } catch (e) {
+        // A throw after the sent phase must settle the live line instead of
+        // leaving it pulsing forever.
+        pushOp('failed', { error: 'error' });
+        return { ok: false, error: /** @type {{ message?: string }} */ (e)?.message ?? String(e) };
+      }
+    },
+  };
+};

--- a/extension/background/script-runs.js
+++ b/extension/background/script-runs.js
@@ -1,25 +1,25 @@
 // @ts-check
-// background/script-runs.js — the live registry of delegating script runs:
-// actors-enabled AND provider-enabled (design 5 — a provider run registers
-// here with no actors at all, for the owner binding the script/model-call
-// relay checks and the per-run sub-model quota counters below).
+// background/script-runs.js — the live registry of session-owned script runs.
+// Every run registers so Stop can terminate its worker. Actors/provider flags
+// are explicit capabilities: a run id alone buys no relay authority.
 //
-// why it exists: a `script` run that delegates holds real work in flight —
-// pending actors.ask calls are LIVE ACTOR TURNS. When the user hits Stop (or
-// the turn aborts for any reason), those turns must die with the run, and the
-// worker itself should be terminated instead of running to its wall-clock.
+// why it exists: a `script` run holds real work in flight — compute, egress,
+// workspace writes, and possibly LIVE ACTOR/MODEL TURNS. When the user hits
+// Stop (or the turn aborts for any reason), that work must die with the run
+// instead of continuing to its wall-clock.
 // The tool execute registers each run here with the dispatch abort signal;
 // the SW actors/call route derives every pending ask's awaitSignal from the
 // run's controller, so one abort() unwinds the whole delegation fan.
 //
-// Pure factory (values + injected clock only) — bun-tested without a browser.
+// Pure factory (values + injected limits only) — bun-tested without a browser.
 
 /**
  * @typedef {{ aborted: boolean, addEventListener: (t: string, fn: () => void, opts?: object) => void, removeEventListener?: (t: string, fn: () => void) => void }} AbortSignalLike
  */
 
-export const createScriptRunRegistry = () => {
-  /** @type {Map<string, { controller: AbortController, onOuterAbort?: () => void, outer?: AbortSignalLike, ops: Array<Record<string, unknown>>, owner?: string, providerCalls: number, providerOutputTokens: number }>} */
+/** @param {{ actorOpLimit?: number }} [options] */
+export const createScriptRunRegistry = ({ actorOpLimit = 50 } = {}) => {
+  /** @type {Map<string, { controller: AbortController, onOuterAbort?: () => void, outer?: AbortSignalLike, ops: Array<Record<string, unknown>>, owner?: string, capabilities: { actors: boolean, provider: boolean }, actorOps: number, providerCalls: number, providerOutputTokens: number }>} */
   const runs = new Map();
   let seq = 0;
 
@@ -41,11 +41,23 @@ export const createScriptRunRegistry = () => {
      * refuses a runId whose registered owner doesn't match the trusted job
      * param (design 5 — a dead or foreign run buys nothing).
      * @param {string} runId @param {AbortSignalLike} [outerSignal] @param {string} [owner]
+     * @param {{ actors?: boolean, provider?: boolean }} [capabilities]
      */
-    register: (runId, outerSignal, owner) => {
+    register: (runId, outerSignal, owner, capabilities = {}) => {
       const controller = new AbortController();
-      /** @type {{ controller: AbortController, onOuterAbort?: () => void, outer?: AbortSignalLike, ops: Array<Record<string, unknown>>, owner?: string, providerCalls: number, providerOutputTokens: number }} */
-      const entry = { controller, ops: [], ...(owner ? { owner } : {}), providerCalls: 0, providerOutputTokens: 0 };
+      /** @type {{ controller: AbortController, onOuterAbort?: () => void, outer?: AbortSignalLike, ops: Array<Record<string, unknown>>, owner?: string, capabilities: { actors: boolean, provider: boolean }, actorOps: number, providerCalls: number, providerOutputTokens: number }} */
+      const entry = {
+        controller,
+        ops: [],
+        ...(owner ? { owner } : {}),
+        capabilities: {
+          actors: capabilities.actors === true,
+          provider: capabilities.provider === true,
+        },
+        actorOps: 0,
+        providerCalls: 0,
+        providerOutputTokens: 0,
+      };
       if (outerSignal) {
         const onOuterAbort = () => controller.abort();
         if (outerSignal.aborted) controller.abort();
@@ -66,7 +78,7 @@ export const createScriptRunRegistry = () => {
     recordOp: (runId, op) => {
       const entry = runs.get(runId);
       if (!entry) return;
-      if (entry.ops.length >= 50) entry.ops.shift();
+      if (entry.ops.length >= actorOpLimit) entry.ops.shift();
       entry.ops.push(op);
     },
 
@@ -78,6 +90,25 @@ export const createScriptRunRegistry = () => {
 
     /** The session a live run was registered FOR, or null. @param {string} runId */
     ownerFor: (runId) => runs.get(runId)?.owner ?? null,
+
+    /** A live run may redeem only the capability minted for its job lane.
+     * @param {string} runId @param {'actors'|'provider'} capability */
+    allows: (runId, capability) => {
+      const entry = runs.get(runId);
+      return entry?.controller.signal.aborted !== true
+        && entry?.capabilities[capability] === true;
+    },
+
+    /** Atomically admit one actors op against the run-wide ceiling. Counting
+     * happens before any await, so Promise.all fan-out cannot oversubscribe it.
+     * @param {string} runId */
+    admitActorOp: (runId) => {
+      const entry = runs.get(runId);
+      if (!entry || entry.controller.signal.aborted
+        || !entry.capabilities.actors || entry.actorOps >= actorOpLimit) return false;
+      entry.actorOps += 1;
+      return true;
+    },
 
     // ── design 5: the per-run sub-model quota counters ────────────────────
     // SW-side ON PURPOSE (never worker state): the realm being metered must

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -29,7 +29,7 @@
 
 import browser from '/vendor/browser-polyfill.js';
 import { makeDispatcher, isTrustedSender } from '/shared/messaging.js';
-import { isOffscreenSender } from '/shared/sender-trust.js';
+import { isOffscreenSender as senderIsOffscreen } from '/shared/sender-trust.js';
 import { CHANNEL_DEFAULTS, CHANNEL, DWEB_ENABLED } from '/shared/channel-config.js';
 import { REMOTE_SKILL_INSTALL } from '/shared/flags.js';
 
@@ -286,6 +286,7 @@ import {
   // helpers the actor tool context is built from (keyless strip + kind scope).
   makeActorMessaging, restrictCtxCapabilities, actorAllowedToolsFor, EXPOSURE_ACTOR, EXPOSURE_REVIEW, pinActorCall, actorDescriptors, buildAncestry,
   actorsCallToOp, shapeActorsResult, askOutcome, ACTORS_ASK_DEFAULT_TIMEOUT_MS,
+  ACTORS_RUN_MAX_OPS,
   // Design 5 — the pure core the script/model-call route runs: text-only arg
   // validation, per-run quota arithmetic, and the provider-event fold.
   validateProviderCallArgs, providerQuotaError, foldProviderEvents,
@@ -393,6 +394,7 @@ import { makeSessionMutationRoutes } from './routes/session-mutations.js';
 import { makeLocalModelRoutes } from './routes/local-model.js';
 import { makeDwebRoutes } from './routes/dweb.js';
 import { makeToolboxRoutes } from './routes/toolbox.js';
+import { makeActorsRoutes } from './routes/actors.js';
 
 // ---- §11.5 universal write guard -------------------------------------------
 // EVERY store this file constructs gets its storage through these wrapped
@@ -2612,7 +2614,15 @@ const jsOffscreenClient = offscreenAvailable ? makeOffscreenJsClient({
 // Live actors-enabled script runs (background/script-runs.js): Stop → abort
 // pending asks + terminate the worker. Declared here (before buildToolContext
 // consumers run) and read by the actors/call route below.
-const scriptRuns = createScriptRunRegistry();
+const scriptRuns = createScriptRunRegistry({ actorOpLimit: ACTORS_RUN_MAX_OPS });
+
+// Relays that redeem an offscreen worker's authority need an exact host
+// predicate, not the dispatcher's broader "one of our extension pages" check.
+const isOffscreenSender = (/** @type {any} */ sender) => senderIsOffscreen(sender, {
+  runtimeId: browser.runtime?.id,
+  extensionOrigin: browser.runtime?.getURL?.('') ?? '',
+  offscreenUrl: browser.runtime?.getURL?.(OFFSCREEN_URL) ?? '',
+});
 
 // The context inspector's capture ring — "what did the model see" per
 // session, SW-memory only. Fed from the two seams that together cover
@@ -2688,11 +2698,7 @@ const actorClient = offscreenAvailable ? makeOffscreenActorClient({
   // three relay routes to the offscreen document is therefore what actually
   // keeps another first-party page from dispatching as an actor; the token
   // carries run identity and liveness on top of it.
-  isOffscreenSender: (/** @type {any} */ sender) => isOffscreenSender(sender, {
-    runtimeId: browser.runtime?.id,
-    extensionOrigin: browser.runtime?.getURL?.('') ?? '',
-    offscreenUrl: browser.runtime?.getURL?.(OFFSCREEN_URL) ?? '',
-  }),
+  isOffscreenSender,
   // Spend-limit preflight for the actor lane. Two tallies, because they fail in
   // different directions and each alone leaves a hole:
   //
@@ -4469,119 +4475,6 @@ const resolveReplyConsent = async (/** @type {string} */ convId, /** @type {stri
   return granted;
 };
 
-// The actors/call route — invoked by the offscreen relay for each `actors.*`
-// call an actors-enabled `script` run makes. ownerSessionId / ownerToolUseId /
-// runId are TRUSTED (job params, minted by the script tool SW-side); the
-// worker's own words buy nothing. Every delegation runs the FULL messageActor
-// gate chain (sender gate, rate caps, duplicate-intent, oneShot sandbox-only,
-// audit) — this route adds only translation, the per-ask timeout, the Stop
-// chain, and the live per-op feed the side panel renders on the script card.
-const actorsCallRoute = async (/** @type {{ method?: string, args?: any, ownerSessionId?: string, ownerToolUseId?: string, runId?: string, seq?: number }} */ msg) => {
-  const pushOp = (/** @type {string} */ phase, /** @type {object} */ extra = {}) => {
-    try {
-      uiPorts.broadcast({
-        type: 'script/op',
-        sessionId: msg.ownerSessionId, toolUseId: msg.ownerToolUseId ?? null,
-        seq: msg.seq ?? 0, method: msg.method ?? '?', phase, ...extra,
-      });
-    } catch { /* panel closed — the trace in the result still records it */ }
-  };
-  try {
-    const owner = msg.ownerSessionId ? await sessions.get(msg.ownerSessionId) : null;
-    // v1 is the ORCHESTRATOR's surface only: a top-level chat session. An
-    // actor must never delegate (the recursion rule message_actor already
-    // enforces), and an actor's channel is its own message_actor grant.
-    if (!owner || owner.kind === 'actor' || owner.kind === 'spawned') {
-      return { ok: false, error: 'actors: only a chat session holds the script delegation surface' };
-    }
-    // why no inbound re-check HERE: the inbound (untrusted-origin) wall for this
-    // path is enforced at the trusted MINT — script.js refuses to expose the
-    // `actors` surface at all when ctx.inbound === true (folded SW-side by the
-    // turn driver), so an inbound turn never reaches this route with an actors
-    // op. inbound is a per-TURN property the untrusted worker cannot be trusted
-    // to echo, so the mint is the only sound enforcement point; do NOT accept an
-    // inbound flag off the relay message here.
-    const { op, args } = actorsCallToOp({ method: msg.method, args: msg.args });
-    if (op === 'list') {
-      // The roster through the normal tool gates — actor_list with the owner's
-      // main ctx, so exposure/manifest rules apply exactly as a direct call.
-      const listCtx = await buildToolContext({ exposure: 'main', sessionId: msg.ownerSessionId });
-      const r = await dispatchToolCall({ id: `${msg.runId ?? 'script'}-list-${msg.seq ?? 0}`, name: 'actor_list', args: {} }, /** @type {any} */ (listCtx));
-      return r?.ok
-        ? { ok: true, value: shapeActorsResult('list', { ok: true, roster: /** @type {any} */ (r).content }) }
-        : { ok: false, error: /** @type {any} */ (r)?.error ?? 'actor_list failed' };
-    }
-    const target = /** @type {{ to: string, goal: string, timeoutMs?: number, oneShot?: boolean }} */ (args);
-    // The UI preview: a chained goal can carry actor/web-derived bytes, so
-    // collapse whitespace (no line-shaping) and cap — it renders as plain
-    // text (Mithril escapes), same posture as the sanitized actor names.
-    const goalPreview = target.goal.replace(/\s+/g, ' ').slice(0, 60);
-    pushOp('sent', { to: target.to, goalPreview });
-    // The SW-side op mirror: survives an offscreen crash, so the script tool's
-    // failure path can still show the chain of events (script-runs.js).
-    const mirror = (/** @type {Record<string, unknown>} */ opRecord) => {
-      if (typeof msg.runId === 'string') scriptRuns.recordOp(msg.runId, { seq: msg.seq ?? 0, method: msg.method, to: target.to, ...opRecord });
-    };
-    if (op === 'send') {
-      const r = await actorMessaging.messageActor({
-        to: target.to, message: target.goal, senderSessionId: msg.ownerSessionId,
-        toolUseId: msg.ownerToolUseId, oneShot: target.oneShot === true, via: 'script',
-      });
-      pushOp(r.ok ? 'handed-off' : 'failed', r.ok ? {} : { error: 'refused' });
-      mirror({ ok: r.ok === true, ms: 0, ...(r.ok ? {} : { error: r.error }) });
-      return r.ok
-        ? { ok: true, value: shapeActorsResult('send', { ok: true }) }
-        : { ok: false, error: r.error ?? 'send failed' };
-    }
-    // ask — awaitReply, raced against the per-ask timeout AND the run's Stop
-    // signal (script-runs.js). Either abort cancels the underlying actor turn.
-    const askTimeoutMs = target.timeoutMs ?? ACTORS_ASK_DEFAULT_TIMEOUT_MS;
-    const runSignal = typeof msg.runId === 'string' ? scriptRuns.signalFor(msg.runId) : null;
-    const askController = new AbortController();
-    let timedOut = false;
-    const timer = setTimeout(() => { timedOut = true; askController.abort(); }, askTimeoutMs);
-    const onRunAbort = () => askController.abort();
-    if (runSignal) {
-      if (runSignal.aborted) askController.abort();
-      else runSignal.addEventListener('abort', onRunAbort, { once: true });
-    }
-    try {
-      const t0 = Date.now();
-      const r = await actorMessaging.messageActor({
-        to: target.to, message: target.goal, senderSessionId: msg.ownerSessionId,
-        toolUseId: msg.ownerToolUseId, oneShot: target.oneShot === true, via: 'script',
-        // bareReply: the reply resolves into CODE — the fence is re-applied at
-        // the script-result boundary (the one model-facing seam), so the raw
-        // body is what plumbing composes with (no fence markup in goals).
-        awaitReply: true, bareReply: true, awaitSignal: askController.signal,
-      });
-      const ms = Date.now() - t0;
-      // The timeout / Stop-abort / system-refusal / actor-failure fork is the
-      // pure askOutcome (actors-api.js) — provable without this route.
-      const outcome = askOutcome(/** @type {any} */ (r), {
-        timedOut, aborted: !timedOut && askController.signal.aborted,
-        timeoutMs: askTimeoutMs, to: target.to,
-      });
-      if (!outcome.ok) {
-        pushOp('failed', { ms, error: timedOut ? 'timeout' : 'refused' });
-        mirror({ ok: false, ms, error: outcome.error });
-        return { ok: false, error: outcome.error };
-      }
-      pushOp('replied', { ms, ...(outcome.failed ? { failed: true } : {}) });
-      mirror({ ok: true, ms, ...(outcome.failed ? { actorFailed: true } : {}) });
-      return { ok: true, value: shapeActorsResult('ask', { ok: true, reply: outcome.reply, failed: outcome.failed }) };
-    } finally {
-      clearTimeout(timer);
-      if (runSignal) { try { runSignal.removeEventListener?.('abort', onRunAbort); } catch { /* stub */ } }
-    }
-  } catch (e) {
-    // A throw after pushOp('sent') would otherwise leave the live-feed line
-    // pulsing 'working…' forever — settle it, then report.
-    pushOp('failed', { error: 'error' });
-    return { ok: false, error: /** @type {{ message?: string }} */ (e)?.message ?? String(e) };
-  }
-};
-
 // Design 5's session cost fold, SERIALIZED per session. why a chain: the
 // sub-call route below is the first caller that is concurrent with ITSELF by
 // design (a script can Promise.all its provider.call fan-out), and a bare
@@ -4611,8 +4504,14 @@ const foldSessionCost = (/** @type {string} */ sessionId, /** @type {any} */ usa
 // owner check, text-only arg validation, the per-run quota, the session
 // provider PIN + model gate, the spend-limit preflight, the cost fold, and the
 // Stop chain (the run's abort signal cancels an in-flight provider fetch).
-const scriptModelCallRoute = async (/** @type {{ ownerSessionId?: string, runId?: string, args?: unknown }} */ msg) => {
+const scriptModelCallRoute = async (
+  /** @type {{ ownerSessionId?: string, runId?: string, args?: unknown }} */ msg,
+  /** @type {unknown} */ sender,
+) => {
   try {
+    if (!isOffscreenSender(sender)) {
+      return { ok: false, error: 'provider: unauthorized relay' };
+    }
     const owner = msg.ownerSessionId ? await sessions.get(msg.ownerSessionId) : null;
     // Same posture as actors/call: v1 is the ORCHESTRATOR's surface only. An
     // actor or spawned owner is refused even if a job param leaked — the
@@ -4623,7 +4522,9 @@ const scriptModelCallRoute = async (/** @type {{ ownerSessionId?: string, runId?
     // The LIVE-RUN check: the runId must be registered (script-runs.js) and
     // bound to this owner — a call from a dead or foreign run is refused.
     const runId = typeof msg.runId === 'string' ? msg.runId : '';
-    if (!runId || scriptRuns.ownerFor(runId) !== msg.ownerSessionId) {
+    if (!runId
+      || scriptRuns.ownerFor(runId) !== msg.ownerSessionId
+      || scriptRuns.allows(runId, 'provider') !== true) {
       return { ok: false, error: 'provider: unknown or finished run' };
     }
     /** @type {ReturnType<typeof validateProviderCallArgs>} */
@@ -5540,17 +5441,21 @@ browser.runtime.onMessage.addListener(/** @type {any} */ (makeDispatcher({
   // reasoning child never exercises tool-dispatch. actorClient is defined above (after
   // ensureOffscreen), before this dispatcher literal — safe to spread.
   ...(actorClient?.routes ?? {}),
+  // The script tool's actors-in-code relay: live-run/owner/grant verified,
+  // then every ask re-enters the existing messageActor gate chain.
+  ...makeActorsRoutes({
+    sessions, uiPorts, buildToolContext, dispatchToolCall, actorMessaging,
+    scriptRuns, actorsCallToOp, shapeActorsResult, askOutcome,
+    ACTORS_ASK_DEFAULT_TIMEOUT_MS, resolveManifestAllow, isOffscreenSender,
+  }),
   // A2A: the sealed a2a_run worker's mesh calls relay here (owner-verified,
   // consent-gated, dispatched on the peerd-agent room).
   'a2a/call': (/** @type {any} */ msg) => a2aCallRoute(msg),
-  // actors: the script tool's delegation surface — each actors.* call an
-  // actors-enabled headless run makes relays here (owner-verified, fully
-  // re-gated through messageActor).
-  'actors/call': (/** @type {any} */ msg) => actorsCallRoute(msg),
   // provider (design 5): the script tool's sub-model surface — each
   // peerd.provider.call a provider-enabled headless run makes relays here
   // (owner/run-verified, quota-capped, the key added SW-side).
-  'script/model-call': (/** @type {any} */ msg) => scriptModelCallRoute(msg),
+  'script/model-call': (/** @type {any} */ msg, /** @type {any} */ sender) =>
+    scriptModelCallRoute(msg, sender),
   ...makeVaultRoutes({
     vault, auditLog, kv, idb, base64ToBytes, ensureOffscreen, maybeStartBaseNetwork,
     pushState, purgeVaultBlob, confirmCoordinator, sessionCache, maybeAutoResume, resumeGoalRuns,

--- a/extension/engine-tabs/notebook-tab/worker-source.js
+++ b/extension/engine-tabs/notebook-tab/worker-source.js
@@ -309,8 +309,8 @@ const __mesh = {
 globalThis.mesh = __mesh;
 ` : ''}
 
-// --- actors.* (the orchestrator's OWN actors) proxy — capability-gated ---
-// The script tool's delegation client: ask/send hand a GOAL to a local actor
+// --- actors.* (the trusted caller's actors) proxy — capability-gated ---
+// The script tool's delegation client: ask hands a GOAL to a local actor
 // (vm/notebook/app instance, "web", an API origin) through the SW actors/call
 // route — the full message_actor gate chain runs per call. The guard value is
 // INTERPOLATED from the timeout tower (actors-api.js): it sits above the
@@ -321,7 +321,6 @@ const actorsCall = (method, args) => actorsRelay({ method, args });
 const __actors = {
   list: () => actorsCall('list', {}),
   ask:  (to, goal, opts) => actorsCall('ask', { to, goal, timeoutMs: opts && opts.timeoutMs, oneShot: opts && opts.oneShot }),
-  send: (to, goal, opts) => actorsCall('send', { to, goal, oneShot: opts && opts.oneShot }),
 };
 globalThis.actors = __actors;
 ` : ''}

--- a/extension/offscreen/job-runner.js
+++ b/extension/offscreen/job-runner.js
@@ -27,7 +27,7 @@
 
 import { opfsHelpers, buildModule, makeFetchRemote, TOOLBOX_SPECIFIER_PREFIX } from '/peerd-engine/index.js';
 import { buildWorkerSource, mapWorkerError, NOTEBOOK_BUILTINS, DEFAULT_WORKER_CAPS } from '/engine-tabs/notebook-tab/worker-source.js';
-import { ACTORS_BRIDGE_GUARD_MS, MAX_FILE_CONTENT_CHARS } from '/peerd-runtime/index.js';
+import { ACTORS_BRIDGE_GUARD_MS, ACTORS_RUN_MAX_OPS, MAX_FILE_CONTENT_CHARS } from '/peerd-runtime/index.js';
 import { applyFetchExtract } from '/shared/fetch-extract.js';
 
 // The workspace's total-size SOFT budget: over it the run still executes but
@@ -40,8 +40,8 @@ const WORKSPACE_BUDGET_BYTES = 200 * 1024 * 1024;
 let jobSeq = 0;
 
 // Live jobs by the SW-minted runId, so a Stop can TERMINATE the worker instead
-// of letting an abandoned script run to its wall-clock. Registered only for
-// runs that carry a runId (the actors-enabled script path mints one).
+// of letting an abandoned script run to its wall-clock. Every session-owned
+// `script` invocation carries one; other headless lanes may omit it.
 /** @type {Map<string, { kill: () => void, owner?: string }>} */
 const liveJobs = new Map();
 // An abort that arrives BEFORE the job registers (Stop racing job startup —
@@ -347,6 +347,13 @@ const _runJob = async ({ code, timeoutMs = 30000, a2a = false, actors = false, s
           }
           usedActors = true;   // actor replies are untrusted content → fence the run's output
           const seq = ++actorsSeq;
+          if (seq > ACTORS_RUN_MAX_OPS) {
+            worker.postMessage({
+              type: 'actors-response', rid: m.rid,
+              error: 'actors: this script run reached its delegation-operation limit',
+            });
+            return;
+          }
           const goalRaw = m?.args?.goal;
           /** @type {{ seq: number, method: string, to?: string, goal?: string, ok: boolean, ms: number, error?: string, settled?: boolean, actorFailed?: boolean }} */
           const entry = {
@@ -358,6 +365,7 @@ const _runJob = async ({ code, timeoutMs = 30000, a2a = false, actors = false, s
             // reports this op as IN FLIGHT, never as an instant failure.
             ok: false, ms: 0, settled: false,
           };
+          if (actorsTrace.length >= ACTORS_RUN_MAX_OPS) actorsTrace.shift();
           actorsTrace.push(entry);
           const t0 = performance.now();
           try {

--- a/extension/peerd-provider/system-prompt.txt
+++ b/extension/peerd-provider/system-prompt.txt
@@ -103,7 +103,8 @@ Delegation is async BY DEFAULT: message_actor hands the actor a goal and returns
 once; its summary arrives on a LATER turn as a fenced note you handle then ("complete
 the checkout and report the order number"). Nothing is polled: fire the message(s),
 keep working or end your turn, react to each reply when it lands. Prefer this — it is
-the only shape that fans out, and it never parks the user waiting on you.
+the simplest shape for one result that can arrive later, and it never parks the user
+waiting on you.
 
 The ONE exception is await:true, and the test is narrow: you need the actor's value to
 write THIS turn's answer, and deferring would make you end on "I'll report back" with
@@ -117,8 +118,8 @@ turn as usual, so nothing is ever lost.
 FAN-OUT IN CODE — the script tool's `actors` client. When a task needs SEVERAL
 delegations, or one actor's output feeds another, write ONE script instead of
 choreographing tool calls across turns: `await actors.ask(to, goal)` delegates
-and returns { reply, failed }; `actors.send(to, goal)` hands off without
-waiting; `await actors.list()` is the roster. Intermediate results flow
+and returns { reply, failed }; `await actors.list()` is the roster. Use
+Promise.all for independent fan-out. Intermediate results flow
 between actors as variables — they never transit your context — and you get
 retry/timeout/race in real code. Each delegation is still individually gated,
 audited, and shown live in the chat, and the result carries a [DELEGATIONS]

--- a/extension/peerd-runtime/actor/actor-messaging.js
+++ b/extension/peerd-runtime/actor/actor-messaging.js
@@ -337,9 +337,8 @@ export const makeActorMessaging = (deps) => {
     // `synthetic` alone can't carry this — it also marks truncation/resume
     // nudges, which must stay hidden. name is sanitized the same way replyText's
     // lead is (it renders un-fenced in the bubble's attribution line). `via`
-    // marks a delegation a SCRIPT fired (actors.send): its reply can land
-    // minutes later mid-unrelated-conversation, and an unattributed bubble
-    // would be unexplainable to a user who never saw the fan-out.
+    // attributes a mediated delegation if a future async code surface routes
+    // its reply here; without that, a late bubble would be unexplainable.
     const safeName = name ? escapeAttr(name.replace(/\s+/g, ' ').trim().slice(0, 80)) : undefined;
     const actorReply = { kind, instanceId, ...(safeName ? { name: safeName } : {}), failed, ...(via ? { via } : {}) };
     turnSlots.runWhenIdle(senderSessionId, () => {

--- a/extension/peerd-runtime/actor/actors-api.js
+++ b/extension/peerd-runtime/actor/actors-api.js
@@ -1,6 +1,6 @@
 // @ts-check
-// actors-api.js — the PURE translation core for the ORCHESTRATOR's code
-// surface over its own actors: `peerd.actors.*` inside the `script` tool.
+// actors-api.js — the PURE translation core for a trusted delegator's code
+// surface over its actors: `actors.*` inside the `script` tool.
 //
 // The inverse of a2a-api.js (its direct twin): a2a said "a peer's agent is an
 // actor whose heap is remote"; this says "an actor is a peer whose heap is
@@ -11,11 +11,11 @@
 // machinery (sender gate, rate caps, dedupe, audit — nothing new is trusted).
 //
 // What script code gets ON PURPOSE and what it doesn't:
-//   • list / ask / send — DELEGATION only. The script can ask an actor to do
+//   • list / ask — DELEGATION only. The script can ask an actor to do
 //     work and await the reply; it can never name a raw tool, spawn an actor,
 //     or reach another capability through this bridge (the job host denies
 //     everything undeclared, same posture as a2a).
-//   • ask/send address SANDBOX + WEB actors alike — authority is unchanged
+//   • ask addresses SANDBOX + WEB actors alike — authority is unchanged
 //     because every op runs the full messageActor gate chain per call; oneShot
 //     rides through and stays sandbox-only (enforced there, not re-implemented
 //     here).
@@ -36,6 +36,13 @@ const nonEmptyString = (v, what) => {
   return v;
 };
 
+/** Actor lists render numeric tab ids; normalize those handles at the code edge.
+ * @param {unknown} v @param {string} what */
+const actorAddress = (v, what) => {
+  if (typeof v === 'number' && Number.isInteger(v) && v >= 0) return String(v);
+  return nonEmptyString(v, what);
+};
+
 // The timeout TOWER, defined once so it cannot drift apart (the nesting
 // job wall-clock > worker bridge guard > per-ask cap is what makes a stuck
 // actor turn fail as an ask timeout the script can handle, not a mid-run
@@ -43,6 +50,9 @@ const nonEmptyString = (v, what) => {
 // DERIVES from the ask ceiling: bump it and the tower moves together.
 export const ACTORS_ASK_MAX_TIMEOUT_MS = 240_000;
 export const ACTORS_ASK_DEFAULT_TIMEOUT_MS = 120_000;
+// One run may compose many calls, but it is not an unbounded actor-message
+// pump. Shared by the SW admission meter and the offscreen trace ring.
+export const ACTORS_RUN_MAX_OPS = 50;
 // The worker-side bridge guard — sits ABOVE the ask cap so the SW's timeout
 // (a handleable rejection) always fires before the bridge gives up.
 export const ACTORS_BRIDGE_GUARD_MS = ACTORS_ASK_MAX_TIMEOUT_MS + 10_000;
@@ -55,13 +65,13 @@ export const ACTORS_JOB_MAX_TIMEOUT_MS = ACTORS_BRIDGE_GUARD_MS + 50_000;
  */
 
 // The method table. `delegates:true` marks an op that hands a GOAL to an actor
-// (ask/send) — the SW route runs those through messageActor's full gate chain
+// (ask) — the SW route runs it through messageActor's full gate chain
 // (sender gate, runaway caps, duplicate-intent, audit). `list` is the read-only
 // roster (the actor_list catalog, dispatched through the normal tool gates).
 /** @type {Record<string, ActorsMethodSpec>} */
 const ACTORS_METHODS = {
   // Everything addressable right now — instances, open tabs, integrations —
-  // with the handle to pass as ask/send's `to`. Read.
+  // with the handle to pass as ask's `to`. Read.
   list: {
     op: 'list',
     toArgs: () => ({}),
@@ -73,7 +83,7 @@ const ACTORS_METHODS = {
   ask: {
     op: 'ask',
     toArgs: (a) => {
-      const to = nonEmptyString(a?.to, 'actors.ask(to, goal): to');
+      const to = actorAddress(a?.to, 'actors.ask(to, goal): to');
       const goal = nonEmptyString(a?.goal, 'actors.ask(to, goal): goal');
       const timeoutMs = typeof a?.timeoutMs === 'number' && a.timeoutMs > 0
         ? Math.min(a.timeoutMs, ACTORS_ASK_MAX_TIMEOUT_MS) : undefined;
@@ -81,19 +91,6 @@ const ACTORS_METHODS = {
       return { to, goal, ...(timeoutMs ? { timeoutMs } : {}), ...(oneShot ? { oneShot } : {}) };
     },
     shape: (c) => ({ reply: c?.reply ?? null, failed: c?.failed === true }),
-    delegates: true,
-  },
-  // TELL — fire-and-forget: hand the goal off and keep running. The actor's
-  // reply routes to the CHAT as a normal fenced actor note on a later turn
-  // (attributed to this script's tool call), not into this run.
-  send: {
-    op: 'send',
-    toArgs: (a) => ({
-      to: nonEmptyString(a?.to, 'actors.send(to, goal): to'),
-      goal: nonEmptyString(a?.goal, 'actors.send(to, goal): goal'),
-      ...(a?.oneShot === true ? { oneShot: true } : {}),
-    }),
-    shape: (c) => ({ sent: c?.ok === true }),
     delegates: true,
   },
 };

--- a/extension/peerd-runtime/index.js
+++ b/extension/peerd-runtime/index.js
@@ -123,6 +123,7 @@ export { meshCallToOp, shapeMeshResult } from './actor/a2a-api.js';
 export {
   actorsCallToOp, shapeActorsResult, renderTraceLines, traceErrorDetails,
   askOutcome, ACTORS_ASK_DEFAULT_TIMEOUT_MS, ACTORS_BRIDGE_GUARD_MS,
+  ACTORS_RUN_MAX_OPS,
 } from './actor/actors-api.js';
 export { makeMeshDispatch } from './actor/a2a-dispatch.js';
 // Design 5 — peerd.provider.call: the pure core (text-only arg validation,

--- a/extension/peerd-runtime/tools/defs/script.js
+++ b/extension/peerd-runtime/tools/defs/script.js
@@ -62,8 +62,7 @@ export const scriptTool = {
     'markdown — res.extracted says whether it ran);',
     '(3) ORCHESTRATION — the `actors` client drives your OWN actors in code:',
     'await actors.ask(to, goal, {timeoutMs, oneShot}) delegates and returns',
-    '{ reply, failed }; actors.send(to, goal) hands off without waiting (the',
-    'reply lands in chat later); await actors.list() is the roster. Fan out to',
+    '{ reply, failed }; await actors.list() is the roster. Fan out to',
     'several actors, feed one\'s output to the next as a variable, retry/timeout',
     'in code. `to` is anything message_actor accepts; a failed ask returns',
     'failed:true (actor-level) or throws (refusal/timeout — the message says',
@@ -105,7 +104,7 @@ export const scriptTool = {
     }
     // why: jsOffscreenClient/scriptRuns/messageActor ride the opaque ctx
     // contract (not on ToolContext); narrow to what this tool touches.
-    const c = /** @type {{ jsOffscreenClient?: { execHeadless?: (code: string, opts: object) => Promise<RunResult>, abortHeadless?: (runId: string) => Promise<void> }, scriptRuns?: { mintRunId: (sid: string) => string, register: (runId: string, signal?: any, owner?: string) => void, abort: (runId: string) => void, release: (runId: string) => void, opsFor?: (runId: string) => Array<any> }, runCache?: { put?: (record: object) => Promise<void> }, messageActor?: unknown, inbound?: boolean, abortSignal?: { aborted: boolean, addEventListener: Function, removeEventListener?: Function }, toolUseId?: string }} */ (
+    const c = /** @type {{ jsOffscreenClient?: { execHeadless?: (code: string, opts: object) => Promise<RunResult>, abortHeadless?: (runId: string, ownerSessionId?: string) => Promise<void> }, scriptRuns?: { mintRunId: (sid: string) => string, register: (runId: string, signal?: any, owner?: string, capabilities?: { actors?: boolean, provider?: boolean }) => void, abort: (runId: string) => void, release: (runId: string) => void, opsFor?: (runId: string) => Array<any> }, runCache?: { put?: (record: object) => Promise<void> }, messageActor?: unknown, toolAllow?: Set<string> | null, inbound?: boolean, abortSignal?: AbortSignal, toolUseId?: string }} */ (
       /** @type {unknown} */ (ctx));
     const jsOffscreenClient = c.jsOffscreenClient;
     if (!jsOffscreenClient || typeof jsOffscreenClient.execHeadless !== 'function') {
@@ -117,9 +116,11 @@ export const scriptTool = {
     //   • the ctx carries the messageActor capability + the run registry (a
     //     chat's main turn — an actor's keyless narrowing strips it, a child
     //     without the message_actor grant loses the closure);
-    //   • the SESSION is a top-level chat (the actors/call route refuses
-    //     actor/actor owners — minting the stub for them would advertise a
-    //     surface every op then refuses);
+    //   • a bound environment actor is refused (its authority stays pinned to
+    //     one environment), while a spawned actor gets parity with its existing
+    //     direct message_actor grant — no grant, no closure, no client;
+    //   • a chat manifest that removed message_actor cannot recover it through
+    //     script (spawned grants are already manifest-intersected);
     //   • the CODE references `actors` at all (any use requires the
     //     identifier, aliasing included) — a pure-compute script must keep the
     //     30s compute wall-clock, not inherit the ~5-minute delegation one.
@@ -129,15 +130,17 @@ export const scriptTool = {
     // async-actor reintegration wake or the dweb agent's trickle-up, both fenced
     // attacker-derived bytes — is refused a DIRECT message_actor by the sender
     // gate's Wall 1 (mayMessageActor: inbound === true → false). The script tool's
-    // actors.send/ask reach the SAME messageActor through the actors/call relay,
+    // actors.ask reaches the SAME messageActor through the actors/call relay,
     // so minting that surface on an inbound turn would be a SECOND, ungated door
     // through the inbound wall (the relay never carried the flag). Fail closed at
     // the mint — no surface advertised — and thread the flag to the SW route below
     // (defense-in-depth: the route re-checks, consistent with "SW re-verifies
     // every op"). Direct message_actor already gates on c.inbound the same way.
     const inbound = c.inbound === true;
+    const messageActorAllowed = !(c.toolAllow instanceof Set) || c.toolAllow.has('message_actor');
     const actorsOn = typeof c.messageActor === 'function' && !!c.scriptRuns && !!sid
-      && sessionKind !== 'spawned' && sessionKind !== 'actor'
+      && sessionKind !== 'actor'
+      && messageActorAllowed
       && !inbound
       && /\bactors\b/.test(args.code);
     // The durable workspace is a CHAT-SESSION surface: a spawned/actor child's
@@ -173,29 +176,36 @@ export const scriptTool = {
     /** @type {(() => void) | undefined} */
     let onAbort;
     try {
-      /** @type {{ timeoutMs: number, toolbox: boolean, actors?: boolean, ownerSessionId?: string, ownerToolUseId?: string, runId?: string, workspaceSessionId?: string, caps?: { provider?: boolean } }} */
+      /** @type {{ timeoutMs: number, toolbox: boolean, actors?: boolean, ownerSessionId?: string, ownerToolUseId?: string, runId?: string, workspaceSessionId?: string, caps?: { provider?: boolean, subagent?: boolean }, signal?: AbortSignal }} */
       // toolbox: the script lane resolves peerd:toolbox modules (design 06) —
       // a trusted job param, not a worker choice; the other headless lanes
       // (a2a/site-client/page_code) never set it.
-      const opts = { timeoutMs, toolbox: true };
+      // `script` is compute/orchestration, never a hidden second actor_create.
+      // The default worker also supports embedded artifacts that call
+      // peerd.runtime.runAgent, but here that would bypass the session manifest
+      // and the caller's narrowed grant. Explicit actor_create remains the only
+      // subtask authority; Notebook/App runtimes keep their separate profile.
+      const opts = { timeoutMs, toolbox: true, caps: { subagent: false }, signal: c.abortSignal };
       // The durable workspace mount — the SESSION id rides as a TRUSTED job
       // param (invariant: the worker never names its own root; the SW-side tool
       // is the only place the owning session is resolved).
       if (workspaceOn) opts.workspaceSessionId = sid;
-      if ((actorsOn || workspaceOn || providerOn) && c.scriptRuns) {
+      if (sid && c.scriptRuns) {
         runId = c.scriptRuns.mintRunId(sid);
         // Stop plumbing: register the run under the dispatch abort signal so a
         // Stop (a) aborts every pending actors.ask AND in-flight sub-model
         // fetches (both race the run's signal SW-side) and (b) terminates the
-        // worker instead of letting it run to its cap. Workspace runs register
-        // too, actors or not: their writes are DURABLE, so a zombie run
-        // outliving Stop would keep mutating an archived session's workspace —
-        // runId forwards on any lane (#153). The owner binds the runId to this
-        // session for the script/model-call relay's check.
-        c.scriptRuns.register(runId, c.abortSignal, sid);
+        // worker instead of letting compute, egress, or workspace writes run to
+        // their cap. Every session-owned lane registers; the capability flags
+        // still decide what its run id may redeem at a relay. The owner binds
+        // the runId to this session for those checks.
+        c.scriptRuns.register(runId, c.abortSignal, sid, {
+          actors: actorsOn,
+          provider: providerOn,
+        });
         if (c.abortSignal && jsOffscreenClient.abortHeadless) {
           const rid = runId;
-          onAbort = () => { jsOffscreenClient.abortHeadless?.(rid); };
+          onAbort = () => { jsOffscreenClient.abortHeadless?.(rid, sid); };
           if (c.abortSignal.aborted) onAbort();
           else c.abortSignal.addEventListener('abort', onAbort, { once: true });
         }
@@ -206,7 +216,10 @@ export const scriptTool = {
         // ownerSessionId binds the run to this session for the SW
         // script/model-call route's owner check (set here for a providerOn run
         // that isn't also an actors run, which already set it above).
-        if (providerOn) Object.assign(opts, { ownerSessionId: sid, caps: { provider: true } });
+        if (providerOn) Object.assign(opts, {
+          ownerSessionId: sid,
+          caps: { ...(opts.caps ?? {}), provider: true },
+        });
       }
       const result = await jsOffscreenClient.execHeadless(args.code, opts);
       // Value spill (run cache): when the serialized [VALUE] overflows its cap,

--- a/extension/tests/unit/background/script-model-call.test.js
+++ b/extension/tests/unit/background/script-model-call.test.js
@@ -2,18 +2,14 @@
 // 'script/model-call' — the design-5 sub-model relay, exercised at the WIRE
 // against the REAL service worker (the state-get pattern: runner.html is a
 // first-party page, so runtime.sendMessage crosses the real dispatcher). The
-// route's refusal matrix is custody-critical — a dead/foreign run, a
-// non-chat owner, or bad args must never reach a key-bearing model call —
+// Exact offscreen provenance is the outer custody wall: this runner page must
+// never reach owner/run validation or a key-bearing model call —
 // and scriptModelCallRoute is a deliberate closure over the SW's module
 // singletons (sessions, scriptRuns, settings), not an importable unit, so
 // the contract is pinned here at the wire.
 //
-// Scope (deliberate): only the refusal paths reachable WITHOUT a live model
-// or an unlocked vault run unconditionally; the foreign-runId check for a
-// REAL chat session additionally needs session/list (vault-gated), so that
-// test soft-skips on a locked profile. The happy-path round-trip and the
-// mid-stream Stop race ride the E2E verify loop (model wire faked over CDP),
-// not this tier.
+// Deeper owner/capability behavior is covered by pure registry/tool tests; the
+// happy path and Stop race ride the E2E verify loop.
 
 import { describe, it, expect } from '../../framework.js';
 import browser from '/vendor/browser-polyfill.js';
@@ -35,35 +31,19 @@ describe('background/script-model-call — the sub-model relay refusal matrix', 
 
   if (!HAVE_LIVE_SW) return;
 
-  it('refuses an unknown owner session — no key-bearing call without a real chat owner', async () => {
+  it('refuses the runner page before owner/run validation', async () => {
     const reply = await send({
       type: 'script/model-call',
       ownerSessionId: 'no-such-session', runId: 'run-x',
       args: { prompt: 'hi' },
     });
     expect(reply?.ok).toBe(false);
-    expect(String(reply?.error)).toContain('only a chat session');
+    expect(String(reply?.error)).toContain('unauthorized relay');
   });
 
-  it('refuses a missing owner entirely (fail closed on absent job params)', async () => {
+  it('refuses missing job params at the same provenance wall', async () => {
     const reply = await send({ type: 'script/model-call', args: { prompt: 'hi' } });
     expect(reply?.ok).toBe(false);
-    expect(String(reply?.error)).toContain('only a chat session');
-  });
-
-  it('refuses a foreign/dead runId for a REAL chat session (owner check passes, run check refuses)', async () => {
-    // Needs a real chat session id — session/list is vault-gated, so a locked
-    // profile (the headless CDP default) soft-skips rather than false-fails.
-    const list = await send({ type: 'session/list' });
-    if (!list?.ok) { expect(String(list?.error)).toBe('locked'); return; }
-    const sid = /** @type {any} */ (list).sessions?.[0]?.sessionId;
-    if (!sid) return;   // fresh profile, no chats yet — nothing to pin against
-    const reply = await send({
-      type: 'script/model-call',
-      ownerSessionId: sid, runId: 'never-registered-run',
-      args: { prompt: 'hi' },
-    });
-    expect(reply?.ok).toBe(false);
-    expect(String(reply?.error)).toContain('unknown or finished run');
+    expect(String(reply?.error)).toContain('unauthorized relay');
   });
 });

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -127,7 +127,8 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // 615 → 618: the lifecycle hardening batch — failure-taxonomy.js (typed
 // outcomes), write-guard.js (§11.5 enforcement), engine-liveness.js (§9
 // ledger); all carry // @ts-check.
-const COVERED_FLOOR = 618;
+// 618 → 619: the actors-in-code SW route extracted for issue #324.
+const COVERED_FLOOR = 619;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/scripts/cdp/states.mjs
+++ b/scripts/cdp/states.mjs
@@ -78,6 +78,10 @@ let a2aState = { delegates: 0, actorCalls: 0 };
 let reasoningState = { spawned: 0, childCalls: 0 };
 // heap-split phase 4: the offscreen TOOL-BEARING actor state.
 let actorToolsState = { spawned: 0, childCalls: 0 };
+// issue #324: an offscreen actor delegating FROM its granted script surface.
+let actorCodeDelegatesState = {
+  spawned: 0, childCalls: 0, webCalls: 0, sawComposedResult: false,
+};
 // heap-split phase 4: an offscreen actor DELEGATING to its own web actor.
 let actorDelegatesState = { spawned: 0, childCalls: 0, webCalls: 0 };
 // heap-split phase 4: an offscreen actor BUILDING an app (create + delegate).
@@ -1075,11 +1079,12 @@ export const STATES = [
       scriptFanState.seen.push({
         isActor,
         isWebActor: body.includes("You are peerd's web actor"),
-        // why GOT: (not '[DELEGATIONS]'): the prompt lore itself mentions the
-        // trace header now, so every request body contains it — the round-trip
-        // VALUE marker (built by the script FROM the actor's reply) is the
-        // discriminator that proves the reply entered the script's realm.
-        hasScriptResult: body.includes('GOT:WIDGET_PRICE_777'),
+        // why all three: GOT proves the script shaped the value, the price
+        // proves the actor reply entered the realm, and the fence proves code
+        // could not launder that reply back into authoritative prompt text.
+        hasScriptResult: body.includes('GOT:')
+          && body.includes('WIDGET_PRICE_777')
+          && body.includes('<untrusted_web_content'),
       });
       // WEB ACTOR turn (spawned by the script's ask): answer in plain text.
       // why delayMs: the live-feed check below observes the PENDING script
@@ -1090,7 +1095,9 @@ export const STATES = [
       if (isActor) return { sse: sseText('WIDGET_PRICE_777'), delayMs: 1500 };
       // ORCHESTRATOR sees the script result (value derived from the reply) →
       // final answer.
-      if (body.includes('GOT:WIDGET_PRICE_777')) return { sse: sseText('SCRIPT-FAN-DONE') };
+      if (body.includes('GOT:')
+        && body.includes('WIDGET_PRICE_777')
+        && body.includes('<untrusted_web_content')) return { sse: sseText('SCRIPT-FAN-DONE') };
       // ORCHESTRATOR first step: ONE script that asks the web actor and
       // returns a value computed FROM the reply (proves the reply entered
       // the script's realm, not just the chat).
@@ -1470,6 +1477,72 @@ export const STATES = [
       rec.check('script actually executed via the SW-gated relay (tool_executed audit)', jsRan === true, `jsRan=${jsRan}`);
       rec.check('it did NOT fall back to the in-SW loop', fellBack === false);
       rec.check('the child result round-tripped into the orchestrator final answer', (out.bubbles || []).includes('FINAL-WITH-CHILD'));
+      rec.check('the turn settles idle', out.busy === false);
+      await rec.shot('final');
+    },
+  },
+
+  // --- functional: a trusted spawned actor delegates FROM CODE (#324) -------
+  // Direct message_actor already admitted this trusted lineage. This state proves
+  // the code hand has exact parity: actor heap -> script worker -> actors.ask relay
+  // -> web-actor heap -> reply back into code -> child -> orchestrator.
+  {
+    name: 'actor-code-delegates-offscreen', kind: 'functional', phase: 'post-unlock',
+    responder: (callIndex, request) => {
+      const body = (request && request.postData) || '';
+      if (body.includes("You are peerd's web actor")) {
+        actorCodeDelegatesState.webCalls += 1;
+        return { sse: sseText('WEB-CODE-PRICE-101') };
+      }
+      if (body.includes('You are an EPHEMERAL ACTOR')) {
+        actorCodeDelegatesState.childCalls += 1;
+        if (body.includes('CODE:')
+          && body.includes('WEB-CODE-PRICE-101')
+          && body.includes('untrusted')) {
+          actorCodeDelegatesState.sawComposedResult = true;
+        }
+        if (actorCodeDelegatesState.childCalls === 1) {
+          return { sse: sseToolCall('script', {
+            code: "const r = await actors.ask('web', 'get the code-path price'); return 'CODE:' + r.reply;",
+          }) };
+        }
+        return { sse: sseText('CHILD-CODE-GOT-WEB') };
+      }
+      if (actorCodeDelegatesState.spawned === 0) {
+        actorCodeDelegatesState.spawned += 1;
+        return { sse: sseToolCall('actor_create', {
+          task: 'use one script to ask the web actor for the price and report it',
+          tools: ['script', 'message_actor'], sync: true,
+        }) };
+      }
+      return { sse: sseText('FINAL-VIA-ACTOR-CODE') };
+    },
+    async run(ctx, rec) {
+      actorCodeDelegatesState = {
+        spawned: 0, childCalls: 0, webCalls: 0, sawComposedResult: false,
+      };
+      const sent = await rpc(ctx.page, { type: 'agent/send', text: 'use an actor script to ask the web actor for the price' });
+      rec.check('agent/send accepted', !!sent?.ok, JSON.stringify(sent));
+      let out = {};
+      await waitFor(async () => {
+        out = await evalIn(ctx.page, `(() => {
+          const bubbles = [...document.querySelectorAll('.message-assistant .bubble')].map((b) => b.textContent.trim());
+          const busy = !!document.querySelector('form.input-bar button.stop');
+          return { bubbles, busy };
+        })()`) || {};
+        return (out.bubbles || []).includes('FINAL-VIA-ACTOR-CODE') && !out.busy;
+      }, { budgetMs: 45_000 });
+
+      const audit = await rpc(ctx.page, { type: 'audit/list', limit: 800 });
+      const entries = (audit && audit.entries) || [];
+      const ranOffscreen = entries.some((e) => e.type === 'actor_ran_offscreen');
+      const fellBack = entries.some((e) => e.type === 'actor_offscreen_fallback');
+      const jsRan = entries.some((e) => e.type === 'tool_executed' && e.details && e.details.tool === 'script');
+      rec.check('the actor script ran through the SW-gated relay', jsRan === true, `jsRan=${jsRan}`);
+      rec.check('the actor looped after code received the web reply', actorCodeDelegatesState.childCalls >= 2 && actorCodeDelegatesState.sawComposedResult, `childCalls=${actorCodeDelegatesState.childCalls} composed=${actorCodeDelegatesState.sawComposedResult}`);
+      rec.check('actors.ask reached a real web-actor heap', actorCodeDelegatesState.webCalls >= 1, `webCalls=${actorCodeDelegatesState.webCalls}`);
+      rec.check('the actor stayed in its isolated offscreen heap', ranOffscreen === true && fellBack === false, `offscreen=${ranOffscreen} fellBack=${fellBack}`);
+      rec.check('the composed result reached the orchestrator', (out.bubbles || []).includes('FINAL-VIA-ACTOR-CODE'));
       rec.check('the turn settles idle', out.busy === false);
       await rec.shot('final');
     },

--- a/tests/background/offscreen-js-client.test.ts
+++ b/tests/background/offscreen-js-client.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import { makeOffscreenJsClient } from '../../extension/background/offscreen-js-client.js';
+
+describe('offscreen JS client', () => {
+  test('Stop during offscreen startup prevents the job from being dispatched', async () => {
+    let finishStartup = () => {};
+    const startup = new Promise<void>((resolve) => { finishStartup = resolve; });
+    const sent: object[] = [];
+    const controller = new AbortController();
+    const client = makeOffscreenJsClient({
+      ensureOffscreen: () => startup,
+      sendMessage: async (message: object) => {
+        sent.push(message);
+        return { ok: true, result: {} };
+      },
+    });
+
+    const pending = client.execHeadless('return 1', {
+      runId: 'run-1',
+      signal: controller.signal,
+    });
+    controller.abort();
+    finishStartup();
+
+    await expect(pending).rejects.toThrow('headless job aborted before dispatch');
+    expect(sent).toEqual([]);
+  });
+});

--- a/tests/background/routes-actors.test.ts
+++ b/tests/background/routes-actors.test.ts
@@ -1,0 +1,217 @@
+// The actors-in-code route is the authority bridge behind script's actors.*
+// client. Prove the full caller classes here: chat manifests, persisted spawned
+// grants, bound-actor refusal, live-run owner binding, sender-gate propagation,
+// actor_list narrowing, and Stop cancellation.
+
+import { describe, test, expect } from 'bun:test';
+import { makeActorsRoutes } from '../../extension/background/routes/actors.js';
+import {
+  actorsCallToOp, shapeActorsResult, askOutcome, ACTORS_ASK_DEFAULT_TIMEOUT_MS,
+} from '../../extension/peerd-runtime/actor/actors-api.js';
+import { resolveManifestAllow } from '../../extension/peerd-runtime/tools/manifests.js';
+
+type Owner = {
+  sessionId: string;
+  kind?: string;
+  grantedTools?: string[];
+  toolManifest?: unknown;
+};
+
+const OFFSCREEN = { id: 'peerd', url: 'chrome-extension://peerd/offscreen/offscreen.html' };
+const ENGINE_TAB = { id: 'peerd', url: 'chrome-extension://peerd/engine-tabs/notebook-tab/index.html' };
+
+const makeHarness = ({
+  owner = { sessionId: 'chat-1' },
+  runOwner,
+  actorsAllowed = true,
+  actorOpAllowed = true,
+  messageActor,
+}: {
+  owner?: Owner | null;
+  runOwner?: string | null;
+  actorsAllowed?: boolean;
+  actorOpAllowed?: boolean;
+  messageActor?: (req: any) => Promise<any>;
+} = {}) => {
+  const resolvedRunOwner = runOwner === undefined ? owner?.sessionId ?? null : runOwner;
+  const calls: any[] = [];
+  const broadcasts: any[] = [];
+  const mirrored: any[] = [];
+  const runController = new AbortController();
+  const route = makeActorsRoutes({
+    sessions: { get: async (id: string) => owner?.sessionId === id ? owner : null },
+    uiPorts: { broadcast: (event: any) => broadcasts.push(event) },
+    buildToolContext: async (args: any) => ({ builtFor: args }),
+    dispatchToolCall: async (call: any, ctx: any) => {
+      calls.push({ kind: 'dispatch', call, ctx });
+      return { ok: true, content: 'ROSTER' };
+    },
+    actorMessaging: {
+      messageActor: async (req: any) => {
+        calls.push({ kind: 'message', req });
+        return messageActor ? messageActor(req) : { ok: true, content: 'done' };
+      },
+    },
+    scriptRuns: {
+      ownerFor: (runId: string) => runId === 'run-1' ? resolvedRunOwner : null,
+      allows: (runId: string, capability: string) => runId === 'run-1'
+        && capability === 'actors' && actorsAllowed,
+      admitActorOp: (runId: string) => runId === 'run-1' && actorOpAllowed,
+      signalFor: (runId: string) => runId === 'run-1' ? runController.signal : null,
+      recordOp: (_runId: string, op: any) => mirrored.push(op),
+    },
+    actorsCallToOp,
+    shapeActorsResult,
+    askOutcome,
+    ACTORS_ASK_DEFAULT_TIMEOUT_MS,
+    resolveManifestAllow,
+    isOffscreenSender: (sender: unknown) => sender === OFFSCREEN,
+  })['actors/call'];
+  const callFrom = (sender: unknown, method: string, args: any = {}) => route({
+    method, args, ownerSessionId: owner?.sessionId ?? 'missing',
+    ownerToolUseId: 'tu-1', runId: 'run-1', seq: 1,
+  }, sender);
+  const call = (method: string, args: any = {}) => callFrom(OFFSCREEN, method, args);
+  return { call, callFrom, calls, broadcasts, mirrored, runController };
+};
+
+describe('actors/call — owner and grant walls', () => {
+  test('a chat with no manifest keeps the historical delegation surface', async () => {
+    const h = makeHarness();
+    expect(await h.call('ask', { to: 'web', goal: 'find it' }))
+      .toEqual({ ok: true, value: { reply: 'done', failed: false } });
+    expect(h.calls[0].req.senderSessionId).toBe('chat-1');
+    expect(h.calls[0].req.via).toBe('script');
+  });
+
+  test('a chat manifest cannot be bypassed through script', async () => {
+    const h = makeHarness({
+      owner: { sessionId: 'chat-1', toolManifest: { allow: ['script'] } },
+    });
+    const result = await h.call('ask', { to: 'web', goal: 'find it' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("'message_actor' is not granted");
+    expect(h.calls).toEqual([]);
+  });
+
+  test('a spawned actor with script + message_actor gets exact direct-call parity', async () => {
+    const h = makeHarness({
+      owner: {
+        sessionId: 'spawn-1', kind: 'spawned',
+        grantedTools: ['script', 'message_actor'],
+      },
+    });
+    expect(await h.call('ask', { to: 'vm-1', goal: 'run tests' }))
+      .toEqual({ ok: true, value: { reply: 'done', failed: false } });
+    const req = h.calls[0].req;
+    expect(req.senderSessionId).toBe('spawn-1');
+    expect(req.awaitReply).toBe(true);
+    // Chained actor-derived bytes keep messageActor's untrusted envelope.
+    expect(req.bareReply).toBeUndefined();
+  });
+
+  test('a spawned actor without message_actor is refused before the sender gate', async () => {
+    const h = makeHarness({
+      owner: { sessionId: 'spawn-1', kind: 'spawned', grantedTools: ['script'] },
+    });
+    const result = await h.call('ask', { to: 'vm-1', goal: 'run tests' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("'message_actor' is not granted");
+    expect(h.calls).toEqual([]);
+  });
+
+  test('a bound environment actor remains unable to cross-delegate', async () => {
+    const h = makeHarness({
+      owner: { sessionId: 'bound-1', kind: 'actor', grantedTools: ['script', 'message_actor'] },
+    });
+    const result = await h.call('ask', { to: 'web', goal: 'escape the pin' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('chat session or a granted spawned actor');
+    expect(h.calls).toEqual([]);
+  });
+
+  test('a missing, finished, or foreign run id buys no delegation', async () => {
+    const h = makeHarness({ runOwner: 'other-session' });
+    const result = await h.call('ask', { to: 'web', goal: 'find it' });
+    expect(result).toEqual({ ok: false, error: 'actors: unknown, finished, or foreign script run' });
+    expect(h.calls).toEqual([]);
+  });
+
+  test('only the offscreen job host may redeem a live actors run', async () => {
+    const h = makeHarness();
+    expect(await h.callFrom(ENGINE_TAB, 'ask', { to: 'web', goal: 'find it' }))
+      .toEqual({ ok: false, error: 'actors: unauthorized relay' });
+    expect(await h.callFrom(undefined, 'ask', { to: 'web', goal: 'find it' }))
+      .toEqual({ ok: false, error: 'actors: unauthorized relay' });
+    expect(h.calls).toEqual([]);
+  });
+
+  test('an owner-bound non-actors run id buys no delegation', async () => {
+    const h = makeHarness({ actorsAllowed: false });
+    expect(await h.call('ask', { to: 'web', goal: 'find it' }))
+      .toEqual({ ok: false, error: 'actors: unknown, finished, or foreign script run' });
+    expect(h.calls).toEqual([]);
+  });
+});
+
+describe('actors/call — per-operation authority', () => {
+  test('the SW-side run ceiling refuses work before dispatch', async () => {
+    const h = makeHarness({ actorOpAllowed: false });
+    expect(await h.call('ask', { to: 'web', goal: 'find it' }))
+      .toEqual({ ok: false, error: 'actors: this script run reached its delegation-operation limit' });
+    expect(h.calls).toEqual([]);
+  });
+
+  test('actors.list requires actor_list in a spawned actor grant', async () => {
+    const refused = makeHarness({
+      owner: {
+        sessionId: 'spawn-1', kind: 'spawned',
+        grantedTools: ['script', 'message_actor'],
+      },
+    });
+    expect((await refused.call('list')).error).toContain("'actor_list' is not granted");
+    expect(refused.calls).toEqual([]);
+
+    const allowed = makeHarness({
+      owner: {
+        sessionId: 'spawn-1', kind: 'spawned',
+        grantedTools: ['script', 'message_actor', 'actor_list'],
+      },
+    });
+    expect(await allowed.call('list')).toEqual({ ok: true, value: 'ROSTER' });
+    expect(allowed.calls[0].call.name).toBe('actor_list');
+  });
+
+  test('the existing sender-gate refusal propagates unchanged', async () => {
+    const refusal = 'message_actor: only the active foreground chat or a trusted-lineage actor may message an actor';
+    const h = makeHarness({
+      owner: {
+        sessionId: 'spawn-1', kind: 'spawned',
+        grantedTools: ['script', 'message_actor'],
+      },
+      messageActor: async () => ({ ok: false, error: refusal }),
+    });
+    expect(await h.call('ask', { to: 'web', goal: 'find it' }))
+      .toEqual({ ok: false, error: refusal });
+  });
+
+  test('Stop aborts an awaited actors.ask through the live run signal', async () => {
+    const h = makeHarness({
+      owner: {
+        sessionId: 'spawn-1', kind: 'spawned',
+        grantedTools: ['script', 'message_actor'],
+      },
+      messageActor: (req: any) => new Promise((resolve) => {
+        const settle = () => resolve({ ok: false, error: 'the request was aborted before the actor replied' });
+        if (req.awaitSignal.aborted) settle();
+        else req.awaitSignal.addEventListener('abort', settle, { once: true });
+      }),
+    });
+    const pending = h.call('ask', { to: 'vm-1', goal: 'long task', timeoutMs: 5_000 });
+    h.runController.abort();
+    expect(await pending).toEqual({
+      ok: false,
+      error: "actors.ask: aborted (Stop) while awaiting 'vm-1'",
+    });
+  });
+});

--- a/tests/background/script-runs.test.ts
+++ b/tests/background/script-runs.test.ts
@@ -60,6 +60,21 @@ describe('createScriptRunRegistry', () => {
     r.release('run-4');
     expect(outer._count()).toBe(0);
   });
+
+  test('actors capability and the run-wide operation ceiling are admitted atomically', () => {
+    const r = createScriptRunRegistry({ actorOpLimit: 3 });
+    r.register('run-a', undefined, 'chat-1', { actors: true });
+    r.register('run-p', undefined, 'chat-1', { provider: true });
+    expect(r.allows('run-a', 'actors')).toBe(true);
+    expect(r.allows('run-a', 'provider')).toBe(false);
+    expect(r.allows('run-p', 'actors')).toBe(false);
+    expect(r.admitActorOp('run-p')).toBe(false);
+    for (let i = 0; i < 3; i++) expect(r.admitActorOp('run-a')).toBe(true);
+    expect(r.admitActorOp('run-a')).toBe(false);
+    r.abort('run-p');
+    expect(r.allows('run-p', 'provider')).toBe(false);
+    expect(r.admitActorOp('run-p')).toBe(false);
+  });
 });
 
 // Design 5 — the sub-model lane's SW-side state: the owner binding the

--- a/tests/peerd-runtime/actors-api.test.ts
+++ b/tests/peerd-runtime/actors-api.test.ts
@@ -1,6 +1,6 @@
 // The pure translation core for the orchestrator's `peerd.actors.*` code
 // surface (script tool) — the local twin of a2a-api.test.ts. Proves the
-// method table (validation, the ask/send split, oneShot passthrough), the
+// method table (validation + oneShot passthrough), the
 // result shaping (system failures REJECT), and the ops-trace helpers that
 // carry the observability contract (fence-safe lines vs fenced error details).
 
@@ -13,10 +13,9 @@ import {
 } from '../../extension/peerd-runtime/actor/actors-api.js';
 
 describe('the method table', () => {
-  test('exposes exactly list / ask / send — delegation only, no raw tools', () => {
-    expect([...ACTORS_API_METHODS].sort()).toEqual(['ask', 'list', 'send']);
+  test('exposes exactly list / ask — delegation only, no raw tools or fake cast', () => {
+    expect([...ACTORS_API_METHODS].sort()).toEqual(['ask', 'list']);
     expect(actorsMethodDelegates('ask')).toBe(true);
-    expect(actorsMethodDelegates('send')).toBe(true);
     expect(actorsMethodDelegates('list')).toBe(false);
   });
 
@@ -39,10 +38,9 @@ describe('actorsCallToOp — validation', () => {
     expect(r.args).toEqual({ to: 'web', goal: 'find the price' });
   });
 
-  test('send requires to + goal; oneShot rides through', () => {
-    expect(actorsCallToOp({ method: 'send', args: { to: 'nb-1', goal: 'chart it', oneShot: true } }).args)
-      .toEqual({ to: 'nb-1', goal: 'chart it', oneShot: true });
-    expect(() => actorsCallToOp({ method: 'send', args: { to: 'nb-1' } })).toThrow(ActorsApiError);
+  test('numeric tab handles from actors.list normalize to message_actor addresses', () => {
+    expect(actorsCallToOp({ method: 'ask', args: { to: 42, goal: 'inspect it' } }).args.to)
+      .toBe('42');
   });
 
   test('list takes no args', () => {
@@ -54,7 +52,6 @@ describe('shapeActorsResult — system failures reject, actor failures return', 
   test('a failed op (gate refusal / rate cap / timeout) THROWS with the system reason', () => {
     expect(() => shapeActorsResult('ask', { ok: false, error: 'message_actor: 4 actor messages already in flight…' }))
       .toThrow(/in flight/);
-    expect(() => shapeActorsResult('send', { ok: false })).toThrow(/actors.send failed/);
   });
 
   test('ask shapes { reply, failed } — an actor-level failure RETURNS (script decides)', () => {
@@ -66,8 +63,7 @@ describe('shapeActorsResult — system failures reject, actor failures return', 
       .toEqual({ reply: 'the vm actor failed: …', failed: true });
   });
 
-  test('send shapes { sent }; list shapes the roster string', () => {
-    expect(shapeActorsResult('send', { ok: true })).toEqual({ sent: true });
+  test('list shapes the roster string', () => {
     expect(shapeActorsResult('list', { ok: true, roster: '{"tabs_columns":…}' })).toBe('{"tabs_columns":…}');
   });
 });

--- a/tests/peerd-runtime/tools/script-format.test.ts
+++ b/tests/peerd-runtime/tools/script-format.test.ts
@@ -128,10 +128,47 @@ describe('scriptTool.execute — workspace opt + value spill', () => {
     expect(released).toEqual(['scriptrun-chat-1-1']);  // the finally path unwinds it
   });
 
-  test('an ephemeral run without actors mints NO runId (unchanged fast path)', async () => {
-    const { ctx, seen } = ctxWith({ scriptRuns: { mintRunId: () => 'x', register: () => {}, abort: () => {}, release: () => {}, opsFor: () => [] } });
+  test('a pure-compute run gets a runId so Stop can terminate its worker', async () => {
+    const registered: unknown[][] = [];
+    const released: string[] = [];
+    const { ctx, seen } = ctxWith({
+      scriptRuns: {
+        mintRunId: () => 'x',
+        register: (...args: unknown[]) => { registered.push(args); },
+        abort: () => {},
+        release: (runId: string) => { released.push(runId); },
+        opsFor: () => [],
+      },
+    });
     await scriptTool.execute({ code: 'return 1' }, ctx as any);
-    expect(seen.opts.runId).toBeUndefined();
+    expect(seen.opts.runId).toBe('x');
+    expect(seen.opts.caps).toEqual({ subagent: false });
+    expect(registered[0]?.[3]).toEqual({ actors: false, provider: false });
+    expect(released).toEqual(['x']);
+  });
+
+  test('Stop aborts a pure-compute worker, not just actor/provider runs', async () => {
+    const controller = new AbortController();
+    const aborted: string[] = [];
+    let finish: (value: any) => void = () => {};
+    const scriptRuns = {
+      mintRunId: () => 'pure-run', register: () => {}, abort: () => {},
+      release: () => {}, opsFor: () => [],
+    };
+    const { ctx } = ctxWith({
+      abortSignal: controller.signal,
+      scriptRuns,
+      jsOffscreenClient: {
+        execHeadless: () => new Promise((resolve) => { finish = resolve; }),
+        abortHeadless: async (runId: string) => { aborted.push(runId); },
+      },
+    });
+    const pending = scriptTool.execute({ code: 'for (;;) {}' }, ctx as any);
+    await Promise.resolve();
+    controller.abort();
+    expect(aborted).toEqual(['pure-run']);
+    finish({ durationMs: 1, value: undefined, error: 'job aborted (Stop)' });
+    await pending;
   });
 
   test('an overflowing value spills to runCache stamped with session + fence state, and the result carries the footer', async () => {

--- a/tests/peerd-runtime/tools/script-provider.test.ts
+++ b/tests/peerd-runtime/tools/script-provider.test.ts
@@ -43,7 +43,7 @@ describe('script — the caps.provider mint (design 5)', () => {
   test('code referencing peerd.provider mints the cap, an owner-bound runId, and the delegation wall-clock', async () => {
     const { result, opts, scriptRuns } = await run('const r = await peerd.provider.call({ prompt: "x" }); return r.text;');
     expect(result.ok).toBe(true);
-    expect(opts?.caps).toEqual({ provider: true });
+    expect(opts?.caps).toEqual({ subagent: false, provider: true });
     expect(opts?.ownerSessionId).toBe('s1');
     expect(opts?.runId).toBe('run-s1');
     expect(opts?.timeoutMs).toBe(ACTORS_JOB_DEFAULT_TIMEOUT_MS);
@@ -55,12 +55,14 @@ describe('script — the caps.provider mint (design 5)', () => {
     expect(opts?.actors).toBeUndefined();
   });
 
-  test('a pure-compute run mints NOTHING and keeps the short compute wall-clock', async () => {
+  test('a pure-compute run is Stop-bound but mints no actor/provider capability', async () => {
     const { opts, scriptRuns } = await run('return 6 * 7;');
-    expect(opts?.caps).toBeUndefined();
-    expect(opts?.runId).toBeUndefined();
+    expect(opts?.caps).toEqual({ subagent: false });
+    expect(opts?.runId).toBe('run-s1');
     expect(opts?.timeoutMs).toBe(30_000);
-    expect(scriptRuns.calls.length).toBe(0);
+    const reg = scriptRuns.calls.find((c) => c.fn === 'register');
+    expect(reg?.args[3]).toEqual({ actors: false, provider: false });
+    expect(scriptRuns.calls.some((c) => c.fn === 'release')).toBe(true);
   });
 
   test('an actor/spawned session cannot mint the cap (the SW route refuses it anyway)', async () => {
@@ -69,8 +71,8 @@ describe('script — the caps.provider mint (design 5)', () => {
         'return peerd.provider;',
         { session: { sessionId: 's1', kind } },
       );
-      expect(opts?.caps).toBeUndefined();
-      expect(opts?.runId).toBeUndefined();
+      expect(opts?.caps).toEqual({ subagent: false });
+      expect(opts?.runId).toBe('run-s1');
     }
   });
 });
@@ -79,9 +81,56 @@ describe('script — the actors mint is refused on an inbound (untrusted) turn (
   const actorsCtx = () => ({ messageActor: () => {} });
 
   test('baseline: a chat turn referencing `actors` mints the delegation surface', async () => {
-    const { opts } = await run('await actors.send({ to: "web", goal: "x" });', actorsCtx());
+    const { opts } = await run('await actors.ask("web", "x");', actorsCtx());
     expect(opts?.actors).toBe(true);
     expect(opts?.ownerSessionId).toBe('s1');
+  });
+
+  test('a trusted spawned actor gets code parity when message_actor survived narrowing', async () => {
+    const { opts, scriptRuns } = await run('return (await actors.ask("vm-1", "run tests")).reply;', {
+      ...actorsCtx(),
+      session: { sessionId: 'spawn-1', kind: 'spawned' },
+      toolAllow: new Set(['script', 'message_actor']),
+    });
+    expect(opts?.actors).toBe(true);
+    expect(opts?.ownerSessionId).toBe('spawn-1');
+    expect(opts?.runId).toBe('run-spawn-1');
+    expect(opts?.caps).toEqual({ subagent: false });
+    const reg = scriptRuns.calls.find((c) => c.fn === 'register');
+    expect(reg?.args[3]).toEqual({ actors: true, provider: false });
+  });
+
+  test('every script disables hidden peerd.runtime.runAgent, even without actors code', async () => {
+    const { opts } = await run('return peerd.runtime.runAgent({ task: "escape" });', {
+      session: { sessionId: 'spawn-1', kind: 'spawned' },
+      toolAllow: new Set(['script']),
+    });
+    expect(opts?.caps).toEqual({ subagent: false });
+    expect(opts?.runId).toBe('run-spawn-1');
+  });
+
+  test('a spawned actor without message_actor cannot recover delegation through script', async () => {
+    const { opts, scriptRuns } = await run('return await actors.list();', {
+      session: { sessionId: 'spawn-1', kind: 'spawned' },
+      toolAllow: new Set(['script']),
+    });
+    expect(opts?.actors).toBeUndefined();
+    const reg = scriptRuns.calls.find((c) => c.fn === 'register');
+    expect(reg?.args[3]).toEqual({ actors: false, provider: false });
+  });
+
+  test('a chat manifest that removes message_actor cannot recover it through script', async () => {
+    const { opts } = await run('await actors.ask("web", "x");', {
+      ...actorsCtx(), toolAllow: new Set(['script']),
+    });
+    expect(opts?.actors).toBeUndefined();
+  });
+
+  test('a bound environment actor remains non-delegating even if a malformed ctx carries the closure', async () => {
+    const { opts } = await run('await actors.ask("web", "x");', {
+      ...actorsCtx(), session: { sessionId: 'actor-1', kind: 'actor' },
+    });
+    expect(opts?.actors).toBeUndefined();
   });
 
   test('an INBOUND turn does NOT mint the actors surface — the second door through the inbound wall is closed', async () => {
@@ -89,12 +138,13 @@ describe('script — the actors mint is refused on an inbound (untrusted) turn (
     // script tool must not hand that same delegation reach through a relay that
     // never carried the flag. ctx.inbound is folded SW-side (trusted); the fix
     // fails closed at the mint so no surface is ever advertised.
-    const { opts, scriptRuns } = await run('await actors.send({ to: "site:https://mail.example.com", goal: "x" });', {
+    const { opts, scriptRuns } = await run('await actors.ask("site:https://mail.example.com", "x");', {
       ...actorsCtx(), inbound: true,
     });
     expect(opts?.actors).toBeUndefined();
-    // and with no other cap referenced, the run mints nothing at all
-    expect(scriptRuns.calls.some((c) => c.fn === 'mintRunId')).toBe(false);
+    // It still gets a Stop-bound run, with no delegation authority.
+    const reg = scriptRuns.calls.find((c) => c.fn === 'register');
+    expect(reg?.args[3]).toEqual({ actors: false, provider: false });
   });
 });
 


### PR DESCRIPTION
## Summary

- give a trusted spawned actor the `script` tool's `actors.list/ask` client only when its persisted, manifest-intersected grant contains `script` plus `message_actor`; `list` additionally requires `actor_list`
- keep bound environment actors and inbound/untrusted turns non-delegating
- route every awaited ask back through the existing lineage, rate, dedupe, audit, and Stop machinery, with the reply's untrusted fence preserved before code can chain it
- bind each relay redemption to the exact offscreen host plus a live run, owner, explicit capability, and atomically enforced operation ceiling
- disable hidden `peerd.runtime.runAgent` in every `script` worker, and Stop-bind every session-owned script run, including pure compute and the offscreen-startup window
- keep the model-facing contract lean: `actors.ask` + `actors.list` for compound orchestration; direct `message_actor` for the simple asynchronous one-call path
- add a real Chrome state proving actor heap → script worker → `actors.ask` → web-actor heap → fenced reply composed in code → parent

## Why

Direct `message_actor` already allowed trusted-lineage spawned actors, but the same caller was categorically blocked when delegating from JavaScript. Compound fan-out/chaining therefore cost extra model/tool turns and the code surface was inconsistent.

The adversarial review also found that the initial relay trusted too much ambient state: a leaked owner id, a non-offscreen first-party sender, a capability-free run id, or the worker's default subagent surface could cross boundaries the direct tool already enforced. The final implementation closes those paths rather than introducing a second authority model.

## Messaging contract

- code exposes exactly awaited `actors.ask(address, message, options)` and roster-only `actors.list()`
- the earlier `actors.send` experiment is removed; it was not a true Elixir-style cast because its late reply could re-enter a session
- a future `actors.cast` must be genuinely no-reply/no-late-wake; `actors.call` vs `actors.ask` naming remains an evaluation-backed follow-up in #326
- `message_actor` remains for scalar asynchronous delivery until the A/B matrix in #326 shows code should replace it

## Security and lifecycle invariants

- spawned callers need explicit `script` plus `message_actor`; `actors.list` additionally needs `actor_list`
- each operation is exact-offscreen, owner-, live-run-, capability-, grant-, manifest-, and operation-cap checked
- actor replies retain their untrusted envelope inside code, so chained goals cannot launder page/instance content into trusted instructions
- every `script` worker has `subagent:false`; explicit `actor_create` is the only subtask authority
- every session-owned script run is Stop-bound; an abort during offscreen creation prevents `job/run` dispatch
- provider sub-calls use the same exact-sender/live-owner/capability custody

## Verification

- `bun test ./tests` — 4,601 passed
- in-browser suite — 718 passed
- `bun run typecheck`
- `bun run lint`
- `bun run check:tscheck`
- `bun run check:boundary`
- `bun run check:invariants`
- `bun run check:imports` — all channel × browser packages resolve
- `bun run e2e:verify --only=actor-code-delegates-offscreen` — 7/7; result JSON and final screenshot inspected
- `bun run test:e2e:all` — 22 functional states, 140/140 checks; the existing script-fanout state now explicitly proves the chained reply stays fenced
- three-agent adversarial swarm: security, concurrency/lifecycle, and messaging/API reviewers all returned **MERGE** after remediation

Broader capability-derived code surfaces, actor prompt-size/drift gates, structured roster handles, code-web parity, true call/cast naming, and the `message_actor` A/B decision remain tracked in #326.

Closes #324
