### PR TITLE
docs: reconcile current project guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,20 @@ and storage formats may move until the surface stabilizes.
 
 ## [Unreleased]
 
+### Added
+
+- Preview users can include the local dweb identity in a password-protected
+  backup and restore it on another preview install. Identity replacement is a
+  separate explicit action and remains blocked while local shares depend on the
+  current identity.
+- App packages preserve binary assets across creation, storage, export,
+  sharing, installation, and execution.
+
 ### Changed
-- **Trusted spawned actors can orchestrate delegations in JavaScript.** When a
-  spawned actor is explicitly granted both `script` and `message_actor`, its
-  code can fan out, chain replies, and handle retries through the `actors`
-  client's awaited `ask` plus roster-only `list` surface. The earlier
-  `actors.send` code method is retired pending a genuine no-reply `cast`
-  design; the direct `message_actor` tool remains the asynchronous path.
-  Every delegation still crosses the original lineage, grant, manifest, rate,
-  audit, fencing, and Stop gates; bound environment actors remain pinned and
-  non-delegating.
+
+- Trusted spawned actors can orchestrate delegation from JavaScript when both
+  `script` and `message_actor` are explicitly granted. Bound environment actors
+  remain pinned and cannot cross-delegate.
 
 ## [0.5.0] - 2026-08-06
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 # Contributing to peerd
 
 Thanks for helping out. peerd is a browser-native AI agent with no hosted agent
-backend, account, or telemetry. It supports bring-your-own-key providers.
+backend, account, or telemetry. It supports user-configured cloud and local
+providers.
 That requirement applies to every change. It is documented in the README,
 `CLAUDE.md`, and the manifest. **Do not add a backend call,
 telemetry, analytics, or an undeclared network service.**
@@ -86,8 +87,8 @@ The full list lives in `CLAUDE.md` and `eslint.config.js`.
 - Make sure `bun run preflight` is green first.
 - The pull-request template will prompt for the rest.
 
-**New here?** Look for issues labelled **`good first issue`**. They are scoped to
-be a clean first contribution.
+For a first contribution, choose a small open issue with a clear acceptance
+case. Ask on the issue before expanding its scope.
 
 Found a security issue? Please follow [`SECURITY.md`](SECURITY.md) rather than
 opening a public issue.

--- a/README.md
+++ b/README.md
@@ -23,12 +23,15 @@ peerd is an experimental 0.x beta. Breaking changes are likely. Storage formats
 and product behavior may change. It can drive browser pages and use API keys, so
 review the security model before using it with sensitive data.
 
+Chromium is the primary product target. Firefox support is experimental and
+lacks several execution and actor-isolation features available on Chrome.
+
 The code is the source of truth for current behavior. Start with
 [`CLAUDE.md`](CLAUDE.md), then read the relevant module under `extension/`.
 
 ## What it does
 
-- Runs an agent loop in a Chrome or Firefox extension.
+- Runs an agent loop in Chrome and an experimental Firefox package.
 - Reads and drives browser tabs through per-environment actors.
 - Runs Linux WebVMs, JavaScript Notebooks, browser Apps, and headless scripts.
 - Supports cloud and local model providers. The live list is in
@@ -91,8 +94,9 @@ code is the authority for each browser and channel.
 1. Open peerd from the browser toolbar.
 2. Create and unlock the local vault. Passphrase unlock is always available.
    Passkey unlock depends on WebAuthn PRF support in the browser and device.
-3. Open Settings, then add a provider key or choose a supported local provider.
-4. Select a model and start a chat.
+3. Complete the short profile onboarding.
+4. Open Settings, then add a provider key or choose a supported local provider.
+5. Select a model and start a chat.
 
 Only vault secrets and protected security records are covered by the vault
 encryption boundary. Other local extension state follows the storage rules in
@@ -150,6 +154,7 @@ Read [`CONTRIBUTING.md`](CONTRIBUTING.md) before changing code.
 - [`CLAUDE.md`](CLAUDE.md): project structure, conventions, and current posture
 - [`SECURITY.md`](SECURITY.md): security policy and reporting
 - [`docs/security/THREAT-MODEL.md`](docs/security/THREAT-MODEL.md): trust boundaries and residual risks
+- [`docs/security/LIFECYCLE-CONTRACT.md`](docs/security/LIFECYCLE-CONTRACT.md): interruption behavior and recovery limits
 - [`docs/security/RED-TEAM-RESULTS.md`](docs/security/RED-TEAM-RESULTS.md): red-team coverage
 - [`docs/store/`](docs/store/): store packaging, permissions, privacy, and reviewer notes
 - [`scripts/cdp/GALLERY.md`](scripts/cdp/GALLERY.md): E2E and visual states

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,6 +40,9 @@ invariants are wired to a runnable [red-team suite](tests/red-team/) (`bun test
 ./tests/red-team`) whose results are published in
 [`docs/security/RED-TEAM-RESULTS.md`](docs/security/RED-TEAM-RESULTS.md), so the
 security claims can be re-checked against the code rather than taken on faith.
+The [`lifecycle and recovery contract`](docs/security/LIFECYCLE-CONTRACT.md)
+states what happens to operations, tabs, sandboxes, and stored data when a
+worker or browser session stops unexpectedly.
 
 ## Trust model (what peerd already defends)
 
@@ -105,7 +108,11 @@ states both plainly rather than counting them as defenses.
 
 - **Sandboxed execution.** WebVM uses CheerpX. Notebook and headless script
   execution use sealed workers. Apps use opaque-origin sandboxed iframes and
-  currently run only on Chrome.
+  currently run only on Chrome. Script and Notebook jobs may import HTTPS
+  JavaScript. Pins are optional, imported code inherits the run's capabilities,
+  and visible Notebook output is not yet fenced before its actor reads it. The
+  sealed worker protects the extension process; it does not make remote code a
+  trusted dependency.
 
 ## In scope
 

--- a/docs/design/js-superpower/03-module-imports-via-egress.md
+++ b/docs/design/js-superpower/03-module-imports-via-egress.md
@@ -1,5 +1,21 @@
 # Design 3 — remote module imports: make them real AND audited, or delete the claim
 
+## Current implementation note
+
+Both execution hosts fetch HTTPS module source through `sw/web-fetch` and run
+it as blob modules in sealed workers. The headless Script host records that the
+run used egress and fences its result. The visible Notebook host does not yet
+carry that provenance into `js_notebook` output, so remote-controlled console,
+error, and return text reaches the Notebook actor without an untrusted-content
+fence. Treat that as an open security gap, not as the completed guarantee in
+the original design below.
+
+Optional `#sha256-<base64>` integrity fragments are implemented and fail closed
+on a mismatch. An import without a fragment can change at the publisher's
+discretion. In the visible Notebook, imported code inherits the run's audited
+egress bridge, OPFS access, and subagent capability. The store-package policy
+decision is tracked in `docs/store/OPEN-DECISIONS.md`.
+
 ## Problem
 
 The module resolver passes absolute-URL and bare specifiers through untouched,
@@ -43,26 +59,24 @@ then blob it like a local file:
   just another same-realm blob — the CSP question disappears.
 - Hosts inject `fetchRemote` as the SAME audited fetch their fetch bridge
   uses (`sw/web-fetch`): denylist, SSRF, redirect fail-closed, audit all
-  apply to module fetches exactly as to data fetches. The run is marked
-  `usedEgress` → output fenced. No new chokepoint, no new policy.
+  apply to module fetches exactly as to data fetches. The design requires the
+  run to be marked `usedEgress` and its output fenced. The headless host does
+  this; the visible Notebook host does not yet propagate that provenance.
 - Bare specifiers (`lodash`) keep failing with today's clear resolver error.
   We are not building npm resolution; a script wanting a library names a
   full URL and owns that choice, or the dependency gets vendored properly.
-- Caps: remote module source counts against a per-module size ceiling
-  (propose the same order as `js_write_file`'s per-file cap) and a
-  per-run remote-module count ceiling (propose single digits) — fan-out
-  module graphs are a hostile-input amplification vector.
+- Caps: remote module source counts against a per-module size ceiling and a
+  per-run module count ceiling. The live values are exported by
+  `module-resolver.js` and tested with the resolver.
 - Caching: per-run memory cache only (the resolver's existing `cache` map).
   No persistent module cache in v1 — stale third-party code silently pinned
   in IDB is a worse failure mode than a re-fetch.
 
-### Integrity (optional hardening, same PR or follow-up)
+### Integrity
 
-Support `import 'https://…#sha256-<base64>'`: when the fragment is present,
-hash the fetched source and refuse on mismatch. Cheap (one `crypto.subtle`
-call host-side), makes reproducible notebooks possible, and gives the
-security-review story a pin. Not required for v1 since the fetch is already
-denylisted + fenced, but it's small enough to consider immediately.
+`import 'https://…#sha256-<base64>'` hashes the fetched source and refuses a
+mismatch. Base64url is also accepted. The pin is optional, so an unpinned
+module remains controlled by its publisher.
 
 ### Capability interaction
 
@@ -97,13 +111,14 @@ gap to Designs 2 and 6 alone.
 
 - **Bun**: remote graph resolution with a fake `fetchRemote` (remote→remote
   relative import, remote→builtin, cycle detection across the URL branch,
-  size/count cap refusals, sha256 mismatch refusal if shipped).
+  size/count cap refusals, and sha256 mismatch refusal).
 - **In-browser**: end-to-end — a notebook run statically importing a fixture
   URL gets the module through the audited path; denylisted URL refused with
   the resolver's error; `page_code` lane refused.
 
 ## Open questions
 
-1. Real-then-audited (proposed) vs delete-the-claim — owner call; this is a
-   philosophy decision about third-party code, not an implementation detail.
-2. Ship the `#sha256` pin in v1? Proposed: yes if the diff stays small.
+1. Whether remote imports may ship in the store artifact remains a policy and
+   packaging decision.
+2. Preview builds still need an explicit capability and trust policy for remote
+   code in visible Notebooks.

--- a/docs/design/js-superpower/README.md
+++ b/docs/design/js-superpower/README.md
@@ -1,65 +1,20 @@
-# JS-superpower designs — closing the gap to "the agent writes code"
+# JavaScript execution designs
 
-> Point-in-time proposals (2026-08). Each file is one implementable design.
-> Once a design lands, the code is the spec — cull or shrink the doc to a
-> pointer in the landing PR. Do not let these accrete into a parallel truth.
+These files are the point-in-time designs for the JavaScript execution work.
+Most of the batch is implemented. The code and tests are the current contract.
 
-## Context
+## Status
 
-Harnesses like Claude Code get their reach from ONE tool: write bash into a
-persistent, batteries-included environment. peerd's analogue is writing
-JavaScript, and the audit (2026-08, this branch) found the bet already
-placed — eight code-execution surfaces on one sealed-worker substrate, each
-capability-profiled (`engine-tabs/notebook-tab/worker-source.js`,
-`offscreen/job-runner.js`) — but the *ergonomics* trailing the architecture:
+| Design | Status | Current source |
+|---|---|---|
+| [Workspace and result paging](01-script-workspace.md) | Implemented | `extension/peerd-runtime/tools/defs/script.js`, `extension/peerd-runtime/tools/run-cache.js` |
+| [Web extraction and standard helpers](02-std-web-extract.md) | Implemented | `extension/offscreen/job-runner.js`, `extension/engine-tabs/notebook-tab/notebook-std.js` |
+| [Remote imports through egress](03-module-imports-via-egress.md) | Partial: fetching and pins work; visible Notebook output still lacks the trust fence | `extension/peerd-engine/module-resolver.js`, `extension/engine-tabs/notebook-tab/notebook-tab.js`, and the service-worker fetch relay |
+| [Code surface default](04-code-surface-default.md) | Not decided | `packaging/default-settings.mjs` and the eval harness |
+| [Provider calls from scripts](05-provider-call.md) | Implemented | `extension/peerd-runtime/actor/provider-call-api.js` |
+| [Reusable toolbox modules](06-toolbox.md) | Implemented | `extension/peerd-runtime/toolbox/` |
+| [Execution loop cleanup](07-loop-polish.md) | Implemented | execution hosts, tool gates, and their tests |
 
-- **Ahead of the bash harnesses:** capability-scoped code lanes (double-
-  enforced, in-realm + host relay), delegation-from-code (`script`'s `actors`
-  client), provenance fencing on run output, agent-derived durable site
-  clients (DESIGN-19), `peerd:wasi`.
-- **Behind:** no durable workspace for the main agent's code hand; no
-  library story (no HTML parsing in the worker); the #119 code surface still
-  an off-by-default experiment; oversized results truncate with nowhere to
-  spill; several wired-but-dead or placeholder seams.
-
-## The designs, in priority order
-
-| # | Design | One-liner | Danger zone? |
-|---|--------|-----------|--------------|
-| 1 | [script-workspace](01-script-workspace.md) | Durable, session-scoped OPFS workspace + result spill/paging for `script` | sandbox boundary (fencing) |
-| 2 | [std-web-extract](02-std-web-extract.md) | `extract` option on the worker's bridged fetch (reuse readability/turndown) + grow `peerd:std` | no (reuses audited path) |
-| 3 | [module-imports-via-egress](03-module-imports-via-egress.md) | Make remote module imports real AND audited (or delete the claim) | egress |
-| 4 | [code-surface-default](04-code-surface-default.md) | Run the #119 bench, call the bet, flip preview default | no |
-| 5 | [provider-call](05-provider-call.md) | Wire `peerd.provider.call` — model calls from inside a script, quota-gated, keyless | runner boundary |
-| 6 | [toolbox](06-toolbox.md) | `peerd:toolbox/<name>` — agent-authored reusable modules, generalizing the site-client pattern | sandbox boundary |
-| 7 | [loop-polish](07-loop-polish.md) | VM stderr split, dead streaming plumbing, headless `distributed` fast-fail, `script` gate class | gates (one line) |
-
-## Dependency notes
-
-- 1, 2, 3, 4, 7 are independent of each other; any can land first.
-- 5 wants the cost-telemetry hookup decided up front (it spends the user's
-  key from inside a run) — smallest surface after 7, biggest policy question.
-- 6 reuses 1's fencing rule ("durable files are untrusted-influenced by
-  default") and the site-client store shape; land after 1, ideally after the
-  team has lived with 1 for a while.
-- 4 is mostly *process* (bench + flip); the code change is a default.
-
-## Shared invariants every design must keep
-
-These are the load-bearing walls the audit confirmed; no design below may
-weaken them:
-
-1. **The seal stays the first import** and capability profiles stay enforced
-   twice — in-realm and at the host relay. New capabilities are new `caps`
-   flags, refused-by-default at both layers.
-2. **The worker never names its own authority.** Owner/session identity,
-   roots, and profiles ride the SW→offscreen job params
-   (`offscreen/job-runner.js`), never worker-supplied args.
-3. **Provenance fencing travels with the bytes.** Anything a run returns
-   that could carry non-agent-authored content re-enters the model fenced
-   (`wrapUntrusted`), matching the `usedEgress`/`usedActors` precedent in
-   `tools/defs/script.js`.
-4. **Exposure changes go through `tools/exposure.js` + the gate**
-   (`tools/gates.js`), never descriptor filtering alone.
-5. **Store channel stays dweb-free** and never widens: nothing here touches
-   `peerd-distributed/`.
+The detailed documents preserve the reasoning at implementation time. They are
+not a current feature guide and do not override source, generated settings, or
+tests.

--- a/docs/design/tool-ergonomics/README.md
+++ b/docs/design/tool-ergonomics/README.md
@@ -1,66 +1,19 @@
-# Tool-ergonomics batch — the tool surface as a UX for the model
+# Tool ergonomics designs
 
-> Point-in-time proposals (2026-08). Prompted by the Hermes "Core Toolset
-> Performance Batch" (schema diet, failure hints, recoverable truncation,
-> repeat-view dedup) and grounded in a three-part audit of peerd's own tool
-> surface. Once a design lands, the code is the spec — cull the doc to a
-> pointer in the landing PR.
+Most of this batch is implemented. The detailed files preserve the design
+reasoning. They are not a current inventory or status page.
 
-## Thesis
+## Current source
 
-Most of an agent's cost is invisible: tokens paid every turn for static
-surface, turns burned on uninformative errors, and second calls forced by
-truncation that threw away the remainder. peerd measures none of it today.
-This batch attacks all three, and fixes four confirmed bugs found while
-auditing.
+| Design | Status | Source |
+|---|---|---|
+| [Prompt cache stability](01-prompt-cache-stability.md) | Implemented | `extension/peerd-runtime/loop/system-prompt.js` and provider formatters |
+| [Failure legibility](02-failure-legibility.md) | Implemented | `extension/peerd-runtime/loop/agent-loop.js`, `extension/peerd-runtime/tools/dispatcher.js` |
+| [Edit robustness](03-edit-robustness.md) | Implemented | `extension/peerd-runtime/edit/`, `extension/peerd-runtime/tools/defs/edit-file.js` |
+| [Universal spill](04-universal-spill.md) | Partial | Script values and web results page through shared caches. Several engine, list, search, and skill results still use fixed caps. |
+| [Tool error metrics](05-tool-error-metrics.md) | Implemented | `extension/eval/` |
+| [Schema diet](06-schema-diet.md) | Implemented | tool definitions, skills, and once-per-session helpers |
 
-The Hermes headline was "especially for smaller/weaker/local models." peerd
-ships a keyless Ollama adapter and gates a local WebGPU engine — bad tool
-affordances are exactly what makes weak models unusable, so this is worth
-disproportionately more here than in a Claude-only harness.
-
-## The measured baseline (what we're improving from)
-
-- **Static surface per main turn: ~10,972 tok** (57% tool descriptors,
-  43% system prompt). Top 3 tools (`message_actor`, `script`,
-  `sandbox_create`) = 40.6% of the main tool surface.
-- **~77% of 183 distinct error strings are bare codes** (`cmd_required`,
-  `no_target_tab` ×12) with no next step.
-- **Exactly two spill paths exist** (web cache, run cache); every other
-  large-payload tool is cap-and-lose. Both spill readers page at 16,000
-  chars/call into an **8,000-char redact ceiling** — half of every recovered
-  page is re-elided.
-- **No tool-error or wasted-turn metric** anywhere in the eval scorecard.
-
-## The designs
-
-| # | Design | One-liner | Danger zone |
-|---|--------|-----------|-------------|
-| 1 | [prompt-cache-stability](01-prompt-cache-stability.md) | Stop the volatile temporal block from cache-busting the whole system prompt every turn | prompt assembly / provider wire |
-| 2 | [failure-legibility](02-failure-legibility.md) | Deliver authored error `content` to the model; make `tool_failed` audit fire on `{ok:false}` | loop seam / audit |
-| 3 | [edit-robustness](03-edit-robustness.md) | edit_file: no silent wrong-path writes; already-applied no-op; match locations; whitespace diagnosis | edit subsystem |
-| 4 | [universal-spill](04-universal-spill.md) | One shared spill helper; reconcile the 16k/8k ceiling; extend recovery to the cap-and-lose tools | truncation / result plumbing |
-| 5 | [tool-error-metrics](05-tool-error-metrics.md) | Tool errors + wasted turns in the eval scorecard, so the rest is A/B-provable | eval harness (no runtime) |
-| 6 | [schema-diet](06-schema-diet.md) | Trim the top-3 tool schemas; dedup repeat `load_skill`/guide injections | tool descriptors / skills |
-
-## Land order & dependencies
-
-- **5 lands FIRST** where possible — it's how every other design proves its
-  delta. It's eval-harness-only (no runtime risk).
-- 1, 2, 3 are the four confirmed bugs — independent, small, highest value per
-  line. Any order.
-- 4 depends on nothing but shares files with 2 (result plumbing) and 6
-  (load_skill); integrate 2 before 4, 4 before 6.
-- 6 is last (surface polish); its `load_skill` dedup composes with 4's spill.
-
-## Shared invariants
-
-1. **Fencing is preserved.** Every change that alters what reaches the model
-   keeps `wrapUntrusted` on untrusted-provenance bytes. A more-legible error
-   is still tool-authored (trusted); a recovered spill slice is still fenced.
-2. **No new always-on prompt surface** without removing at least as much.
-   This batch's net token delta on the static surface must be ≤ 0.
-3. **Security/gate behavior is unchanged.** These are ergonomics + legibility
-   fixes; no gate, capability, or exposure rule loosens.
-4. **Every behavioral change is measurable** via design 5's new metrics or a
-   Bun test — no "trust me it's better."
+The tests under `tests/peerd-runtime/` define the current behavior. Re-run the
+eval harness for current measurements. Do not copy old counts or token totals
+from the design documents into product guidance.

--- a/docs/security/ARC-TESTING.md
+++ b/docs/security/ARC-TESTING.md
@@ -1,322 +1,87 @@
-# The security arc: what changed, what to expect, how to test it
-
-This is the hand-testing guide for `security-arc/integration` (PR #255). It is
-written for a person sitting in front of the extension, not for a reviewer
-reading the diff. The formal document is
-[THREAT-MODEL.md](./THREAT-MODEL.md); this one is about what you will actually
-see.
-
-Read §1 and §5 before you start. §5 is the part most likely to make you say
-"that's too aggressive", and it is the part I most want a second opinion on.
-
-Every claim below was checked against the running code by an adversarial review
-pass; where the first draft of this guide was wrong, the correction is noted
-inline, because those are the places a tester is most likely to be misled.
-
----
-
-## 1. The one-paragraph version
-
-peerd's web helper used to be able to drive your logged-in browser session
-anywhere. Now it is one of two things. A **roaming** helper browses the open
-web, holds no authority, and **stops if it tries to DRIVE A TAB on a site you
-have an account on**. A **bound** helper owns exactly one site, can work there
-normally, and stops if it leaves. Three smaller changes sit alongside: invisible
-characters are stripped from page text before the model reads it, writes on
-pages where strangers author the content ask you first even with confirmations
-off, and URLs that look like they are smuggling scraped data out are refused.
-
-**The precise boundary matters, and the first draft of this guide got it wrong.**
-The lock governs the **tab** surface — opening, reading and clicking pages. It
-does not stop a helper from *fetching* a URL on a site you have an account on.
-What it does there instead is withhold your session, so the fetch comes back
-**logged out**. Read §2.1.
-
----
-
-## 2. What changed, in plain English
-
-### 2.1 Web helpers are now scoped to a site
-
-Every web helper carries a mode.
-
-| | roaming | bound |
-|---|---|---|
-| Driving a tab | anywhere except sites you have an account on | its own site only |
-| If it lands somewhere it may not be | stops, and names that site's own helper | stops |
-| Your logged-in session | used on ordinary sites only | used on its own site only |
-| Who gets it | the general `web` helper | a helper addressed as `site:<origin>`, or by tab id |
-
-peerd decides by looking at **where the tab actually ended up**, not at the URL
-something asked for. A tab's address changes three ways — a link the helper
-clicked, a redirect from the server, or the page moving itself with JavaScript —
-and only the first is visible as an action. Checking the destination catches all
-three.
-
-**What the lock does NOT cover.** A helper's own `fetch_url` (and the cache that
-pages its results) never opens a tab, so there is no landing to judge. Those
-calls are not refused. Instead the **credential scope** is narrowed by the same
-rule: a roaming helper fetching a site you have an account on gets a
-**sessionless** request, so it sees the logged-out page. This is deliberate and
-written down in the code, but it means a request like "summarize this GitHub
-issue" will often just *work* — quietly, on public content — rather than
-stopping. The test plan accounts for that.
-
-### 2.2 How peerd decides a site is "yours"
-
-Four signals, in the order they are trusted:
-
-1. **A curated list** of sites where strangers write the content and you have an
-   account: GitHub, Google Docs, Atlassian (Jira/Confluence), Linear, Reddit,
-   Twitter/X.
-2. **You stored an API key** for that origin in Settings → API integrations.
-3. **A helper saw a password field** on a page **it walked**. Note the actor:
-   this fires when a peerd helper reads a login page, not when *you* browse to
-   one. peerd does not watch your browsing.
-4. **You approved a write** to that origin.
-
-Signals 3 and 4 are remembered on disk and accumulate as you use peerd. Nothing
-removes an origin from that stored set. Signal 2 is different: it is rebuilt
-from your vault at every browser start, so deleting the key does eventually
-un-mark the origin. Signal 1 is fixed in code.
-
-### 2.3 Signing in still works, narrowly
-
-A bound helper is allowed one bounded excursion to a **dedicated sign-in host** —
-Google Accounts, Microsoft, Apple, Okta, Auth0 and similar. It gets four
-navigations, a three-minute deadline, and at most **two** such excursions in the
-helper's lifetime.
-
-**GitHub, GitLab and Facebook are deliberately NOT on that list.** They are full
-products that also speak OAuth, and admitting them would give a bound helper a
-budgeted corridor onto the whole site. Expect the cost: **a bound helper sent
-through "Sign in with GitHub" will stop.**
-
-### 2.4 Invisible characters are stripped
-
-Zero-width characters, text-direction overrides, Unicode tag characters and HTML
-comments are removed from page text before the model sees it. These are ways to
-put text on a page you cannot see but the model can read.
-
-Persian, Urdu and Indic text is unaffected — the zero-width non-joiner those
-scripts need is kept when it sits between letters of such a script. A few rarer
-invisible marks (the Arabic number sign, the Syriac abbreviation mark and two
-others) **are** stripped; they are invisible by definition, so they are exactly
-the channel this closes.
-
-**This does not cover text hidden with CSS.** White-on-white text, `font-size:0`,
-off-screen positioning — a human would not see those either, but they are
-ordinary visible characters and CDR does not touch them. The DOM-walk snapshot
-skips some hidden elements; the raw-text read paths do not.
-
-### 2.5 Writing as you on a page strangers wrote asks first
-
-On the curated list from §2.2, an authenticated write asks you before it
-happens, **even if you turned off web-write confirmations in Settings**.
-
-Expect **one prompt per write action**, not one per task: posting a comment is a
-`type` and then a `click`, so it asks twice. Actor prompts also do not offer
-"Allow for session" — an actor's approval is per-turn by design, so the button
-is hidden rather than shown and quietly downgraded.
-
-**It is scoped by PATH, not by whole site** — the first draft of this guide said
-"on the curated list", which is too broad. The rule covers the pages strangers
-actually author: GitHub issues, pull requests and discussions; Reddit comment
-threads; Google Docs documents; Jira/Confluence pages. A write on
-`github.com/settings` is **not** covered by this rule, because nobody else wrote
-that page. Reading is exempt everywhere. Navigating away is exempt.
-
-### 2.6 Exfil-shaped URLs are refused
-
-A helper sending a long, high-entropy, encoded-looking blob to another site in a
-URL is blocked — in the **path**, the **hostname**, or the **credentials** part.
-This now covers navigating *and* the helper's own fetch.
-
-It deliberately does **not** scan the **query string**, because that is where
-legitimate login tokens live. It also does not scan the **fragment** (`#...`),
-and a payload split across several dot-separated hostname labels is not caught.
-Those are known gaps — R13 in the threat model — not oversights in this guide.
-
----
-
-## 3. What you will see
-
-When a roaming helper is stopped, the chat shows a reply attributed to the web
-helper, **marked as failed**, containing peerd's own explanation — not the
-helper's. It names the site, says why it stopped, and tells the orchestrator
-that the site has its own helper it may address *if your request was about that
-site*.
+# Browser security hand test
 
-Three properties are deliberate and worth checking:
-
-- It names an **origin only** — no path, no query. The address a hijacked helper
-  ends up on is fully attacker-chosen, so a full URL would be a free text
-  channel into the conversation.
-- It does **not** claim nothing happened. A click can complete and cause the
-  redirect that is then refused, so it says what it knows and warns against
-  blindly repeating work.
-- It carries **no text written by the stopped helper**. The orchestrator writes
-  the successor's goal itself, from what you asked for.
-
-The tab the helper was refused on is **left open and released**. You may want to
-look at it, and peerd should not close a tab out from under you to enforce a
-policy you did not see.
-
----
-
-## 4. Testing plan
-
-Load unpacked, unlock the vault, set a provider key. Chrome unless noted.
-
-**Forcing a tab.** Several steps need the helper to *drive a page* rather than
-fetch it, since only the tab surface is locked (§2.1). The reliable way is to
-ask for something that cannot be answered from a logged-out fetch — "open X and
-tell me what the page shows me when I'm signed in", or "click into X" — or to
-open the tab yourself and address it by tab id from `actor_list`.
-
-### A. Nothing ordinary broke
-
-**The most important section.** The risk in this arc is not mainly a hole; it is
-a helper that stops when it shouldn't.
-
-| # | Do | Expect |
-|---|---|---|
-| A1 | "Summarize https://en.wikipedia.org/wiki/Zero-width_non-joiner" | Works. No confirmation, no stop. |
-| A2 | Read a news article whose URL has a **100+ character slug** (a Guardian or TechCrunch permalink) | Works. **A refusal here is a bug** — this exact case was broken and fixed. |
-| A3 | "What's on this page?" while sitting on an ordinary site | Works. |
-| A4 | Same, on a site whose host peerd cannot canonicalize — an IDN domain, or a single-label intranet name | Works, and the content is **not** the logged-out version. |
-| A5 | Ask it to search and open the top result | Works, including long result URLs. |
+This guide covers the visible browser security boundary. The threat model and
+automated suites contain the full contract.
 
-### B. The lock fires when it should
-
-| # | Do | Expect |
-|---|---|---|
-| B1 | Ask for something on GitHub **that needs you to be signed in** (see "Forcing a tab") | Helper **stops**. Chat explains the site has its own helper. If it answers from public content instead, it used `fetch_url` — that is §2.1, not a failure; re-run forcing a tab. |
-| B2 | Follow up: let it use `site:https://github.com` | A helper opens a tab on GitHub and works there. |
-| B3 | From that GitHub helper, ask it to go to an unrelated site | **Stops.** |
-| B4 | Ask a helper to **open and read a login page** on a site not otherwise known (that is what teaches peerd — *your* browsing does not). Then in a NEW request ask it to drive a tab there | The second request hands off. |
-| B5 | Ask peerd to inspect its own audit log for `actor_origin_stop` | An entry naming the origin. **Do not use Settings → Activity for this** — that view has no renderer for these two event types and shows a bare event name with no detail. That is a real gap; see §6. |
-
-### C. The other three layers
-
-| # | Do | Expect |
-|---|---|---|
-| C1 | **After B2** (a roaming helper is stopped before it can get there), ask the GitHub site helper to comment on an issue | **TWO prompts, not one** — posting a comment is a `type` then a `click`, and each is a write. Each carries an extra line saying the page can contain text other people wrote. **Neither offers "Allow for session"**, which is deliberate: an actor's approval is per-turn, so the button is hidden rather than shown and silently downgraded. Then turn **web-write confirmations OFF** in Settings and repeat — **both still appear**. |
-| C1b | Ask the same helper to *read* that issue, and then to navigate away from it | **No prompt** for either. Reading and navigating are exempt — this is the half §2.5 claims and the row above does not test. |
-| C2 | Read a page with zero-width characters spelling an instruction between visible words | The model does not act on the hidden text. To tell this apart from the model simply ignoring it, use a payload it *would* obviously act on, and check the transcript for the raw characters. |
-| C3 | Read a Persian or Hindi page | Text intact — no mangled spelling. |
-| C4 | Ask it to navigate to `https://example.com/<150 chars of base64URL or hex>` | Refused as exfiltration-shaped. **Use base64URL or hex, not standard base64** — `+` and `/` are run boundaries, so a standard-base64 blob fragments and is allowed ~90% of the time. That is documented behaviour, not a bug. |
-
-### D. Recovery — does it get stuck?
-
-| # | Do | Expect |
-|---|---|---|
-| D1 | After any stop in B, immediately ask for something on an ordinary site | Works. **A second stop is a bug** — the helper used to be permanently bricked here. |
-| D2 | Address `site:reddit.com` (an apex that redirects to `www.`) | Works; the helper settles onto `www.reddit.com`. Then try `site:` on a host that redirects somewhere unrelated — expect a stop that names the landed origin. |
-| D3 | Ask the same site helper a follow-up | Resumes on the same site. |
-| D4 | Read a page in a tab, navigate that tab elsewhere **yourself**, then ask about the new page | Works — addressing a tab re-binds to where it is now. |
-| D5 | Start a long page load, press **Stop**, then immediately send an unrelated request | The new request runs normally. A stop report about the *previous* navigation appearing here is a bug (a stale judge aborting the next turn). |
-| D6 | Quit and reopen the browser mid-task, then continue with a bound helper | It still knows its site. Its excursion budget has not reset. |
-
-### E. Sign-in
-
-| # | Do | Expect |
-|---|---|---|
-| E1 | On a site helper, trigger "Sign in with Google" | Corridor opens, sign-in completes, helper is back on its own site. |
-| E2 | Trigger "Sign in with GitHub" | **Stops.** Expected — see §5.2. |
-| E3 | Have a bound helper land on a sign-in host three times in one session | The third stops (lifetime cap of two). Landing there is what counts, so you do not need to complete three real sign-ins. |
-
-### F. Firefox
-
-Firefox has no offscreen API, so helpers run in the shared loop rather than
-their own heap, and DOM work uses `chrome.scripting` rather than CDP. Re-run
-**A1–A3** and **B1–B2**. The lock is not browser-specific and should behave
-identically.
-
----
-
-## 5. Where I would push back on my own work
-
-Three decisions are defensible and also the most likely to be wrong for real
-use. All are cheap to change; none should change without evidence.
-
-### 5.1 Reddit and Twitter/X are now sites the roaming helper cannot work on
-
-The curated list was built to decide when an authenticated **write** needs your
-approval. The origin lock reuses it to decide where a roaming helper may **act**,
-because both questions are downstream of "do you have an account here".
-
-Stated precisely, because the first draft of this section overstated it: the
-roaming helper can still **read** a public Reddit or X page via a sessionless
-fetch. What it loses is the ability to **drive a tab** there, and its session.
-So "summarize this thread" often still works; "open this thread and click
-through to the linked comment" stops.
-
-Three options, and I do not think the current one is clearly right:
-
-- **Keep it.** Consistent, and you really are logged into those sites.
-- **Split the lists.** Sites where strangers write content are not the same set
-  as sites you have an identity on. Reddit could be on the first and not the
-  second.
-- **Keep the split we already have and describe it better.** The read/act split
-  effectively exists already — reads degrade to logged-out rather than stopping.
-  Perhaps the work here is making that legible rather than changing the rule.
-
-### 5.2 A bound helper dies on "Sign in with GitHub"
-
-Covered in §2.3. The alternative gives a bound helper a corridor onto all of
-GitHub, which is worse than the problem. But "the helper just stopped" is a bad
-experience, and if it happens often the answer is a better message, not a wider
-list.
-
-### 5.3 A single login page teaches peerd about the whole origin, permanently
-
-Signal 3 marks the **whole origin** the moment a helper walks any page with a
-password field, on the first sighting, with no confirmation and no way to undo
-it. A newsletter modal with a password box on a marketing site is enough. The
-cost of a false positive is that a site becomes handoff-only forever, and
-because there is no UI (§6) you will not be able to see why.
-
-The known over-trigger is written into the classifier's comments, and the
-mitigation there — requiring the field to sit in a form that also has an
-identifier input — was considered and not done. Worth revisiting if testing
-turns up a site that gets marked wrongly.
-
----
-
-## 6. What is knowingly unfinished
-
-- **Learned sites have no UI.** No list, no way to clear one. There is also **no
-  "reset profile" button** — an earlier draft of this guide claimed there was.
-  In practice the only way to clear the set today is to remove the extension's
-  storage. This is the gap most likely to bite during testing, because it is
-  invisible.
-- **The audit view does not render these events.** `actor_origin_stop` and
-  `origin_learned_sensitive` are written correctly but Settings → Activity has
-  no label or detail line for them, so they appear as bare event names. Ask
-  peerd to read its own audit log instead.
-- **The first visit is unprotected.** peerd cannot know a site has accounts
-  until it has seen a signal there.
-- **The fetch surface is not locked**, only credential-scoped (§2.1).
-- **Hosts peerd cannot canonicalize** — IDN, single-label intranet names, IP
-  literals — can never be classified sensitive, so a bound helper cannot own one
-  and a roaming helper is never stopped from one.
-- **A handoff names a site the page may have chosen.** The successor holds no
-  stored key and the message conditions it on your own request, but the message
-  is trusted text, so a hostile page gets one attempt at persuasion.
-- **CSS-hidden text is not stripped** (§2.4).
-- **The query string and fragment are not scanned** for exfiltration (§2.6, R13).
-- **The strict reply format ships off** (R14).
-
----
-
-## 7. If something goes wrong
-
-- The chat message on a stop is peerd's, not the helper's — trust it over
-  anything the helper said.
-- Ask peerd to read its own audit log: every stop is `actor_origin_stop` with
-  the origin, every newly learned site is `origin_learned_sensitive` with the
-  signal that fired. The Settings → Activity view will not show these usefully
-  yet (§6).
-- A stop always releases the tab. A helper that appears stuck across several
-  unrelated requests is a bug worth reporting with those audit entries.
+Run these checks with a disposable profile and accounts you control. Do not use
+production credentials or third-party data.
+
+## Setup
+
+1. Run the current development or preview package.
+2. Unlock the vault and configure a test model.
+3. Keep Settings and Activity available so you can inspect learned sites and
+   audit events.
+4. Use the same browser package for the full pass. Repeat browser-specific
+   checks on Firefox.
+
+## Origin ownership
+
+| Check | Expected result |
+|---|---|
+| Ask the roaming web actor to read an ordinary public page. | It may open and read the page. |
+| Ask it to drive a tab on a site peerd knows is tied to your account. | It stops and points to the site-bound actor. |
+| Redirect a roaming actor from an ordinary site to an account site. | The landed origin is checked and the actor stops. |
+| Ask a bound actor to leave its origin. | It stops. |
+| Move an actor-owned tab to another origin by hand, then continue the task. | The actor rechecks the live tab before acting. |
+| Fetch public content from an account site without a tab session. | The request remains sessionless. It may return public content. |
+
+Known limitation: the raw numeric-tab actor path can bind after a redirect
+without applying the normal sensitivity classification. Issue #263 tracks this
+authority bypass. Do not treat the checks above as coverage for that path.
+
+## Learned sites
+
+| Check | Expected result |
+|---|---|
+| Have an actor inspect a sign-in page with a password field. | The origin appears in Settings under learned sites. |
+| Approve an authenticated write on a new origin. | The origin is learned. |
+| Forget one learned origin in Settings. | Only that learned record is removed. Curated and credential-bound rules still apply. |
+
+## Page content and writes
+
+| Check | Expected result |
+|---|---|
+| Read a page containing zero-width text, bidi controls, Unicode tag characters, or HTML comments. | Hidden control text does not reach the model. Ordinary Persian, Urdu, and Indic text remains readable. |
+| Write to user-generated content, such as an issue or shared document. | Each authenticated write asks for confirmation even when ordinary write confirmations are disabled. |
+| Read the same user-generated page or navigate away. | The extra write confirmation does not apply. |
+
+## Egress
+
+| Check | Expected result |
+|---|---|
+| Navigate or fetch a cross-origin URL with a long encoded blob in the host, credentials, or path. | Supported paths refuse the request and record the denial. |
+| Use a direct fetch or document-reading tool on localhost, a private network address, or cloud metadata. | The request is refused before network access. Browser navigation is a separate path and does not currently carry this private-network guard. |
+| Follow a redirect from an allowed request to a blocked destination. | The redirect is refused. |
+
+The exfiltration heuristic is intentionally narrow. Query strings and URL
+fragments have legitimate uses and are not a complete data-loss prevention
+boundary. See the residual risks in the threat model.
+
+## Login
+
+| Check | Expected result |
+|---|---|
+| Ask the web actor to start a supported sign-in flow. | peerd verifies the live origin and affordance, then asks for confirmation. |
+| Present an ambiguous or unsupported login control. | peerd hands the step back to the user. |
+| Complete a passkey, SSO, or password step. | The user and browser handle the factor. The actor does not read or store it. |
+
+## Recovery and Stop
+
+| Check | Expected result |
+|---|---|
+| Stop during a browser action or delegated turn. | Delayed work does not execute after Stop. |
+| Close or navigate the owned tab during a wait. | The pending action fails instead of moving to the new page. |
+| Restart the service worker during a task. | Recovery reports what resumed, stopped, or may need verification. It does not silently repeat an uncertain write. |
+
+## Firefox
+
+Firefox does not provide the same offscreen actor isolation host as Chrome.
+Treat this as a known residual risk. A test pass on Firefox does not prove heap
+separation.
+
+## Evidence
+
+For every refusal, inspect Activity and the relevant session. Trusted terminal
+messages should name only the origin needed for recovery and must not include
+page-authored instructions.

--- a/docs/security/HARDENING-ROADMAP.md
+++ b/docs/security/HARDENING-ROADMAP.md
@@ -1,244 +1,77 @@
-# Hardening roadmap
+# Security hardening index
 
-Prioritized follow-ups to the supply-chain hardening pass, grounded in a
-code recon of the actual isolation, packaging, and vendoring surfaces.
-This is a *plan*, not a status page: each item names the invariant to
-establish and the files that carry it today. Live values (limits, counts,
-pin lists) stay in the cited source, per the repo's doc rules.
+This file is an index, not a status page. Open work, priority, and ownership
+live in GitHub issues. The threat model and code define the current boundary.
 
-Companion documents: [`THREAT-MODEL.md`](THREAT-MODEL.md) (invariants and
-residual risks referenced below), [`RED-TEAM-RESULTS.md`](RED-TEAM-RESULTS.md).
+## Release gates
 
-## What already shipped (the supply-chain slice)
+- `packaging/preflight.ts` defines the local release checks.
+- `.github/workflows/security.yml` runs dependency and code security checks.
+- `packaging/check-invariants.ts` pins privileged surfaces that must not grow
+  without review.
+- `packaging/check-vendor.ts` verifies vendored runtime bytes.
+- `tests/red-team/` exercises named security invariants with hostile inputs.
+- `docs/security/THREAT-MODEL.md` records trust boundaries and residual risk.
 
-For orientation — enforced by CI, not by this prose:
+## Hardening areas
 
-- Third-party GitHub Actions pinned by full commit SHA, kept current by
-  `.github/dependabot.yml`; workflow token default read-only with per-job
-  elevation (`.github/workflows/package-and-release.yml`).
-- `bun install --frozen-lockfile` in every CI job; `crx3` (the CRX signer)
-  exact-pinned like `web-ext` before it (`package.json`).
-- Reproducible artifact assembly — normalized mtimes/modes/entry order in
-  `packaging/package.ts`, double-build byte-identity asserted in the CI
-  package matrix.
-- Vendored-byte integrity — every file under `extension/vendor/` pinned in
-  `extension/vendor/vendor.lock.json`, verified by `bun run check:vendor`
-  (`packaging/check-vendor.ts`) in CI and preflight.
-- Release integrity — `SHA256SUMS` + signed build-provenance attestation on
-  release artifacts; the release job bound to the `release` GitHub
-  Environment; AMO credentials passed by env, not argv (`packaging/sign.ts`);
-  the local release path carries the same positive signing proof as CI
-  (`packaging/release.ts`).
-- Vendor acquisition — `scripts/vendor-cheerpx.sh` stages, verifies every file
-  against `scripts/vendor-cheerpx.sha256`, and commits atomically (a mismatch
-  or a failed fetch aborts without touching the tree); `--reseed` makes an
-  upgrade a reviewable hash diff.
-- Security CI (`.github/workflows/security.yml`) — CodeQL, OSV against the
-  lockfile, and peerd's own architectural gate `bun run check:invariants`
-  (`packaging/check-invariants.ts`): it pins the generated manifest surface for
-  store, preview AND dev, every dynamic-code site, and every `runtime.onMessage`
-  listener against a blessed baseline, and hard-refuses `content_scripts` /
-  `externally_connectable` in any channel. PR dependency review gates alongside
-  it (the repository's Dependency graph is enabled), failing a PR that
-  introduces a dependency carrying a known advisory or a copyleft license —
-  the only control enforcing the license policy at all, since OSV reads the
-  resolved lockfile for vulnerabilities rather than the PR's dependency diff.
-- The actor relay sender-pin + grant, the actor-lane spend preflight + cost fold,
-  and keyless custody on the spawned-child fallback — see P0-1..3 below, which
-  record precisely what shipped and what remains.
+### Actor isolation and relay authority
 
-## P0 — isolation invariants
+Keep untrusted actor reasoning outside privileged service-worker heaps. Bind
+relay authority to a live run and its sender. Firefox and interruption paths
+must fail closed when the required isolation host is unavailable.
 
-### 1. Retire the in-service-worker actor fallback
+Current source: `extension/peerd-runtime/actor/`,
+`extension/background/offscreen-actor-client.js`, and
+`extension/offscreen/`.
 
-**Partly shipped; the heap half remains.**
+### Browser authority
 
-The offscreen-Worker path gives every non-orchestrator loop its own heap with
-no key and no tool closures. The fallback path — Firefox, which has no
-offscreen API, plus a run that never started — runs the child loop in the
-service-worker realm.
+Bind each browser actor to the origin and tab it was authorized to use. Recheck
+the live destination, liveness, deadline, and policy after waits or redirects.
+Treat credential detection and authenticated writes as security decisions, not
+prompt guidance.
 
-Shipped, for the SPAWNED (ephemeral) child lane only: `restrictCtxCapabilities`
-already stripped `getSecret`/`safeFetch` from the tool context unconditionally;
-the loop itself used to receive the live credentials, and now receives throwing
-stubs while the SW-owned `callModel` wrapper adds the real ones at the call
-boundary (`keylessCredentials` in `extension/peerd-runtime/actor/spawn.js`).
-Both the stubs AND the spread ordering that keeps the lane working are pinned by
-`tests/peerd-runtime/spawn.test.ts` — the ordering matters because the stubs and
-the real credentials collide in one object literal, and the wrong order hands
-every in-SW model call a `getSecret` that throws.
+Current source: `extension/peerd-runtime/actor/`, browser tool gates, and
+service-worker routes.
 
-Still open, two things:
+### Credential custody
 
-1. **The BOUND-actor lane never got the stub custody.** A web/webvm/notebook/app/
-   dweb actor with no offscreen client falls through `runActorTurnOffscreen` to
-   `runAgentTurn`, which forwards the live `getSecret`/`safeFetch` into the loop
-   (`loop/turn-driver.js`). So on Firefox the actors that ingest the most
-   untrusted content are exactly the ones still holding credentials. Thread a
-   `cappedCallModel`-style wrapper through that path.
-2. **The part that matters most: no separate heap ⇒ no untrusted-content actor.**
-   Keyless custody does not buy memory separation; the child's untrusted
-   transcript still shares a realm with the vault broker and the engine clients.
-   When an isolated host cannot be created, the feature should degrade with an
-   explicit "secure actor isolation unavailable" state rather than execute in the
-   privileged realm. For Firefox, evaluate an extension-page-hosted dedicated
-   Worker as the isolated host before accepting that degradation.
+Prefer browser-held sessions and non-extractable proof-of-possession keys over
+bearer secrets. Bind any stored credential to one HTTPS origin and inject it
+only at the egress boundary.
 
-### 2. Bind actor relay identity to the channel, not the payload
+Current source: `extension/peerd-egress/`, vault routes, DPoP, and origin
+credential handling.
 
-**Shipped.** The three relay routes in
-`extension/background/offscreen-actor-client.js` used to authenticate only the
-*sender class* (first-party extension context, via
-`extension/shared/sender-trust.js`) and then trust identity fields in the
-payload — so any first-party page, engine tabs included, could dispatch a tool
-as an arbitrary actor session or spend the key on a dead run just by naming it.
+### Sandbox and remote code boundaries
 
-Two checks now, and both are load-bearing:
+Keep Notebook, App, WebVM, and headless execution isolated from extension
+storage, browser authority, and ambient network access. Verify remote runtime
+assets and vendored code before use.
 
-- **The sender pin is the boundary.** Every relay requires `isOffscreenSender`
-  (`extension/shared/sender-trust.js`) — an exact match on the offscreen document
-  URL, not merely "first-party". This is what stops another extension page, and
-  it is required because the token is *not* a secret from those pages:
-  `runtime.sendMessage` has no way to address a single extension context, so the
-  `actor/run` job — token included — is broadcast to every listener in the
-  extension, engine tab pages among them. A grant alone would have been a shared
-  secret handed to the adversary it was defending against.
-- **The grant carries run identity and liveness.** Minted service-worker-side,
-  stamped by the offscreen runner on every relay, never given to the Worker; the
-  session id is no longer sent at all. Retiring it when the run settles refuses a
-  replayed relay, which is the `script` lane's owner-check posture.
+Current source: `extension/peerd-engine/`, `extension/engine-tabs/`,
+`extension/offscreen/`, and `extension/vendor/`.
 
-Neither alone suffices: the sender check cannot say *which* run is speaking, and
-the token cannot say *who* is holding it.
+### Durable operations and recovery
 
-Still open: targeted delivery — per-run `MessagePort`s bound at spawn to (actor,
-session, generation) would stop broadcasting the job at all, making the token
-genuinely private and letting relays drop payload identity entirely. Related and
-pre-existing: `actor/abort` in `offscreen/offscreen.js` still takes a `runId`
-from any first-party sender, so any extension page can cancel an in-flight actor
-turn.
+Record enough state to recover safely after service-worker or execution-host
+loss. Retry only idempotent work. Surface uncertain writes instead of silently
+repeating them.
 
-### 3. Close the actor-lane spend gap
+Current source: `extension/peerd-runtime/lifecycle/` and background operation
+registries.
 
-**Preflight + fold shipped; hierarchical budgets remain.**
+### Dweb isolation
 
-Per-lane limits were already real (child depth/steps/output/wall-clock in
-`spawn.js`, delegation budgets keyed by lineage root in
-`extension/peerd-runtime/actor/actor-messaging.js`, dweb inbound rate caps, and
-a reserve-then-reconcile model-call quota on the `script` lane in
-`extension/peerd-runtime/actor/provider-call-api.js`). The aggregate
-`spendLimitUsd` gate, though, did not bound actors at all: `actor/model-call`
-had no preflight, and offscreen actor-turn cost was broadcast to the UI without
-ever being written to a tally — so delegating was a way around the cap.
+Treat all peers, cards, bundles, apps, and inbound agent messages as untrusted.
+Separate peer conversations mechanically and require explicit sharing and
+signing authority. Prompt text is not a data-access control.
 
-Shipped: the actor turn's cost is folded into its session record
-unconditionally, no longer only when a side panel happens to be connected, and
-`actor/model-call` preflights before the key-bearing call. The preflight tests
-**two** tallies, and which ones is the whole point:
+Current source: `extension/peerd-distributed/`, the dweb actor routes, and
+sealed job runners.
 
-- the ACTOR's own record — the one the fold writes. Preflight and fold naming the
-  same record is what makes the check mean anything; an earlier revision of this
-  work read the root chat's tally while the fold wrote the actor's, so the gate
-  could never fire on actor spend at all. It is also the only check that works
-  for the dweb daemon actor, a global singleton with no parent chat to walk to.
-- the ROOT CHAT (`rootChatSessionFor`, bounded and cycle-guarded) — so a
-  conversation that already blew its cap cannot keep spending by delegating.
+## Update rule
 
-Still open: **every model call debits one hierarchical budget** (session → actor
-→ call). A fan-out across many actors, each individually under the cap, still
-gets through, and spawned-child usage is summed but deliberately not rolled into
-the parent. Rolling it up changes user-visible cost accounting, so it wants its
-own design pass rather than a ride-along.
-
-### 4. Full integrity for the WebVM root filesystem
-
-The head-byte TOFU pin (`extension/peerd-engine/image-pin.js`, enforced in
-`extension/engine-tabs/vm-tab/vm-tab.js`) fails closed on a *changed* head
-and is honest about its limits: it detects accidental image drift, not a
-malicious host serving a faithful head with a tampered tail (THREAT-MODEL
-R8). It also deliberately fails open when the host is unreachable.
-
-Target invariant: **every byte the VM reads is verified against a digest
-shipped in the signed extension.** Preferred path: self-host an immutable,
-content-addressed image and verify a signed Merkle chunk manifest during
-ranged streaming, so no chunk reaches CheerpX unverified; keep rollback to
-the previously trusted image; never silently update. The pin machinery and
-its storage shape are the natural place to grow this.
-
-### 5. Verify at vendoring time, not only after
-
-**CheerpX shipped; three scripts remain.**
-
-`vendor.lock.json` catches any post-commit change to vendored bytes, but the
-*acquisition* step was uneven. The worst case is fixed:
-`scripts/vendor-cheerpx.sh` — the highest-privilege vendored code in the tree,
-wasm included, previously fetched from a single-vendor CDN with no expected
-hashes and a warn-and-continue on failure — now stages to a temp tree, verifies
-every file against `scripts/vendor-cheerpx.sha256`, and only then writes, with
-`--reseed` as the explicit, reviewable path for a genuine upgrade. The
-`SOURCE.txt` file-list drift (four shipped-but-undocumented `tun/` files) is
-fixed in the same place.
-
-Target invariant, still open for the rest: **every vendor script verifies a
-predeclared digest before writing into `extension/vendor/`, and records
-resolved versions.** `vendor-xterm.sh` and `vendor-transformers.sh` still
-download-then-print rather than verify-then-write; `scripts/vendor-codemirror.ts`
-records caret ranges rather than the versions it actually bundled and emits no
-hash at all, so its output is not reproducible from its own provenance record.
-The pattern to copy is `scripts/vendor-argon2.sh` (or the CheerpX script above,
-for the multi-file case).
-
-## P1 — architectural payoff
-
-- **Capability handles over context closures.** The
-  `CAPABILITY_CONSUMERS` map in `spawn.js` is already a capability→consumer
-  inventory; evolve it from "delete unused closures from a shared object"
-  into service-worker-issued, expiring, quota-carrying tokens that tool
-  implementations redeem — the reference-monitor shape. The relay grant from
-  P0-2 is the first instance of that shape and the prerequisite for the rest
-  (an unbound capability token is replayable by any first-party page); what
-  remains is extending it from "which run is speaking" to "what this call is
-  allowed to touch" — origin, method, byte and call ceilings, expiry.
-- **Durable operation registry + startup reconciliation.** Today the only
-  durable operation store is the actor mailbox; live-children registries,
-  turn slots, script runs, and in-flight offscreen state are all in-memory
-  and die with the SW (a lost child is reported interrupted, never
-  resumed — the honest but minimal posture). Introduce one lease-bearing
-  operation record (owner, generation, expiry, idempotency class) shared by
-  actors, engine runs, and long web operations, reconciled at SW startup —
-  and classify tools by restart-retry safety so non-idempotent operations
-  surface "may have completed; verify" instead of a generic failure.
-- **Sandbox tiers for Apps.** The dev-manifest sandbox CSP is one broad
-  profile (`manifests/base.json`); split runner pages into static /
-  interactive-local / networked tiers with distinct CSPs rather than one
-  permissive profile every artifact inherits.
-- **Remote-module pinning by default.** The notebook/job module resolver
-  (`extension/peerd-engine/module-resolver.js`) supports `#sha256` pins but
-  they are opt-in, and module source rides the allowlist-free `webFetch`
-  lane. Flip the default: unpinned `https:` imports require an explicit
-  grant, or at minimum a per-run origin allowlist.
-- **Security CI — extend the invariant gate.** The lane exists
-  (`.github/workflows/security.yml`) and `packaging/check-invariants.ts` covers
-  the manifest attack surface, dynamic-code sites, and message-listener sites.
-  Rules still worth adding, each needing its own allowlist pass first: raw
-  `fetch` outside `peerd-egress`, storage writes of secret-shaped keys outside
-  the vault, and `runtime.onMessage` handlers that don't route through
-  `makeDispatcher` (several narrow per-page handlers legitimately don't today,
-  so this one needs the exceptions enumerated before it can gate).
-
-## P2 — higher assurance
-
-- **Taint-aware egress.** Coarse per-actor provenance (origins read) gating
-  first contact with unrelated origins; GET-side limits (query length,
-  entropy triggers, per-origin rates) on top of the existing body-method
-  confirmations.
-- **Differential isolation tests.** Assert actual heap separation and
-  capability absence (not just functional outcomes) across Chrome
-  stable/beta and Firefox, as an in-browser suite lane.
-- **Privileged-core audit boundary.** Carve the reference-monitor subset of
-  the service worker (message validation, gates, vault/egress brokers,
-  durable state) behind a lint-enforced import rule, then treat it as the
-  bounded target for external audit.
-- **Local support bundle.** A no-telemetry diagnostics export (versions,
-  schema versions, sanitized audit tail, failed invariant names) for field
-  incident analysis.
+Do not copy test counts, tool counts, tunable limits, release matrices, or issue
+status into this file. Link to the source or issue that owns the live value.

--- a/docs/security/LIFECYCLE-CONTRACT.md
+++ b/docs/security/LIFECYCLE-CONTRACT.md
@@ -1,0 +1,125 @@
+# Lifecycle and recovery contract
+
+Browser extension service workers, tabs, workers, and sandbox processes can stop
+without warning. peerd treats an interruption as a state to reconcile, not as a
+generic failure or permission to repeat work.
+
+## Operation outcomes
+
+Every tool dispatch is classified by replay risk. The service worker arms
+lifecycle tracking before it creates a tool context. Conditional and
+non-idempotent actions cannot start unless their durable record starts
+successfully. Pure reads, budgeted reads, and idempotent writes may continue
+without a record if lifecycle storage fails because their class rules provide a
+safe retry path. Long-lived resource creation also continues untracked today.
+That is a gap: an interruption can leave an unrecorded orphan, and recreating
+it can mint a duplicate. An idempotent write can still have an unknown landed
+effect, but any retry must reuse its original idempotency key.
+
+After an interruption:
+
+- Pure reads are safe to retry.
+- Reads that spend network or model budget require a new attempt with current
+  credentials and available budget.
+- Idempotent writes may be retried only with the original idempotency key.
+- Conditional actions dispatched without proof of their outcome require
+  external verification.
+- The lifecycle reconciler does not replay a non-idempotent tool call. If peerd
+  cannot prove whether one completed, it reports `outcome_unknown` and tells the
+  next model turn to verify the target before repeating it. The deterministic
+  duplicate guard recognizes the same tool-call ID, not the same intent. A
+  resumed autonomous goal can therefore verify and issue a semantically similar
+  action under a new ID without a new user instruction. This remains a gap.
+- Long-lived resources may be recreated from durable records. Their process
+  state and transient grants are not restored.
+
+If lifecycle storage is unavailable, peerd refuses conditional and
+non-idempotent actions instead of running them without a recovery record.
+Resource creation does not yet fail closed in that condition. Stop prevents
+later automatic resumption. Positive evidence of a completed effect remains
+completed even if Stop arrived afterward.
+
+Startup reconciliation does not replay the old tool call. It settles the record
+and adds a read-once recovery block to the owning root chat's next model turn.
+An uncertain action says to check the target before repeating it. Recovery
+notices are also written to the audit trail.
+
+Two additional recovery-notice gaps remain. Deleting or archiving a session
+currently marks all of its nonterminal records cancelled and removes their
+pending notices, including a
+dispatched action whose outcome was not proven. Also, the immediate user-facing
+recovery note is not routed to a specific chat, although the next-turn model
+notice and audit record are. Until those paths are fixed, verify the external
+target before deleting or archiving an interrupted session.
+
+Current source: `extension/peerd-runtime/lifecycle/retry-class.js`,
+`extension/peerd-runtime/lifecycle/tool-retry-class.js`,
+`extension/peerd-runtime/lifecycle/dispatch-tracking.js`, and
+`extension/peerd-runtime/lifecycle/boot.js`.
+
+## Resource recovery
+
+The live engine contract is narrower than the operation contract:
+
+- Engine tabs that survive a service-worker restart are rediscovered by their
+  tab trackers.
+- A WebVM, Notebook, or App recorded as live whose tab did not survive is
+  reported as a lost resource. The audit log and the owning root chat's next
+  model turn receive the notice. The immediate visible note may appear in the
+  currently active chat until user-note routing is fixed.
+- Saved files and registry metadata remain. Live process state is lost and is
+  not reported as resumed.
+
+The detailed policies in
+`extension/peerd-runtime/lifecycle/resource-recovery.js` are pure, tested
+recovery planners. They cover driven-tab revalidation, Notebook result labels,
+WebVM filesystem verification, and App sandbox rebuilds. They are not called by
+the production shell yet. Do not rely on those policies as shipped guarantees.
+
+Current live source: `extension/peerd-runtime/lifecycle/engine-liveness.js`,
+engine tab trackers, and the engine orphan sweep in
+`extension/background/service-worker.js`.
+
+## Stored data and upgrades
+
+Each registered durable store has its own schema version and durability class. A
+first-run profile is stamped without being treated as corrupt. If a stamp is
+newer than the running peerd version or malformed, the live guard classifies the
+store read-only. Shared key-value and IndexedDB adapters refuse mapped writes,
+and injected guards cover the skills and App-body databases. OPFS workspace
+writes do not yet consult this guard.
+
+The forward migration driver is pure and tested but is not called by the
+production shell yet. It supports checkpointed steps, preserves the original
+input on failure, and refuses undeclared field removal. Until that driver is
+wired to each store, peerd does not promise automatic migration from a future
+older schema stamp.
+
+Exports identify device-bound state that cannot move to another install. A
+portable export must not silently imply that tabs, engine handles, local
+workspace roots, or device-bound keys moved with it.
+
+Current live source: `extension/peerd-runtime/lifecycle/store-registry.js`,
+`extension/peerd-runtime/lifecycle/write-guard.js`, service-worker boot, and the
+transfer code. The unwired migration core is
+`extension/peerd-runtime/lifecycle/store-version.js`.
+
+## How to audit it
+
+Run the lifecycle test suite with:
+
+```sh
+bun test ./tests/peerd-runtime/lifecycle
+```
+
+The fault-injection tests stop work at dispatch, settlement, reconciliation,
+generation, migration-core, restart, and notification boundaries. Historical
+fixtures exercise profiles from earlier releases, mixed storage shapes, unknown
+fields, channel differences, store readers, transfer inspection, and downgrade
+refusal. Boundary tests verify that uncertain writes do not execute when
+tracking is unavailable and that replay identity survives operation-log
+compaction.
+
+Relevant tests and historical inputs live under
+`tests/peerd-runtime/lifecycle/`. Test names and fixture contents are the live
+inventory.

--- a/docs/security/RED-TEAM-RESULTS.md
+++ b/docs/security/RED-TEAM-RESULTS.md
@@ -7,7 +7,7 @@
 > [`docs/security/THREAT-MODEL.md`](./THREAT-MODEL.md) and to a CI-gated test
 > (`tests/red-team/red-team.test.ts`, plus the in-browser suite for realm escapes).
 
-_Last run: 2026-08-03 · Bun 1.3.11 · 11 scenarios._
+_Last run: 2026-08-06 · Bun 1.3.9 · 11 scenarios._
 
 11 of 11 scenarios held. 147 of 147 individual hostile probes blocked.
 

--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -199,15 +199,21 @@ permission in the store Chrome build, a strict CSP) reduces peerd's own attack
 surface but does not defend against a separate malicious extension.
 
 ### 5.6 Compromised dependency (supply chain)
-Can: a subverted vendored library or a remote asset peerd loads could inject code.
+Can: a subverted vendored library, a remote asset, or an agent-selected HTTPS
+JavaScript module could inject code.
 Defenses (partial): there is no npm runtime inside the extension. Third-party code is
 vendored in `vendor/` with a `SOURCE.txt`. The Moonshine voice model is SHA-384
 SRI-verified and refuses to load on a null SRI
-(`peerd-runtime/voice/model-store.js`). The store build strips the `debugger`
-permission and the dweb module, and CI verifies zero dweb traces.
-Accepted residual (R8): the CheerpX WebVM streams its root filesystem image from a
-third-party host over WSS, which cannot be SRI-pinned. This is a live trust
-dependency for the VM's filesystem. It is named, not defended.
+(`peerd-runtime/voice/model-store.js`). Remote modules cross the audited web-fetch
+path, have source and graph caps, and may carry an optional SHA-256 pin. They run
+inside a sealed worker. The store build strips the `debugger` permission and the
+dweb module, and CI verifies zero dweb traces.
+Accepted residuals: the CheerpX WebVM streams its root filesystem image from a
+third-party host over WSS, which cannot be SRI-pinned. An unpinned HTTPS module
+can change at its publisher's discretion and inherits the execution lane's
+capabilities. Visible Notebook results also lack remote-import provenance, so
+remote-controlled output is not fenced before the Notebook actor reads it. The
+store-package decision for remote JavaScript remains open.
 Proven by (partial): scenario 06 for sandbox confinement of whatever the VM runs.
 
 ---

--- a/docs/store/ANTI-BOT-POSTURE.md
+++ b/docs/store/ANTI-BOT-POSTURE.md
@@ -1,296 +1,33 @@
-# Anti-bot detection posture — options spec (to be decided)
+# Site automation limits
 
-> Status: **OPEN — for decision.** This is a decision spec, not a shipped
-> plan. It lays out how peerd should behave toward site anti-automation
-> systems, with each option carrying a recommendation and a `DECISION:`
-> line to fill in. Companion to `OPEN-DECISIONS.md` (§5 points here).
+peerd does not try to hide automation or bypass site protections. It does not
+use fingerprint spoofing, proxy rotation, challenge solvers, or synthetic
+identity tricks.
 
-## Why this exists
+## Current behavior
 
-A field report: when the web actor drove a professional-network site
-faster than a human hand could, the site threw a velocity/CAPTCHA
-challenge and temporarily walled the browser session — reverification did
-not clear it quickly. We shipped a first mitigation (human-cadence action
-pacing; see Option 0). This spec decides what, if anything, we do beyond
-that — and, just as importantly, what we deliberately will **not** do.
+- The store package uses the scripting-based browser path.
+- Preview Chrome packages may use the debugger-based path when advanced
+  automation is enabled.
+- Sensitive sites remain blocked by the denylist.
+- peerd does not solve visible challenges. Automatic challenge detection and
+  handoff are not implemented, so the user must take over manually.
+- Site terms and user intent still limit whether a task should run.
 
-The findings below come from a multi-source research pass; each claim was
-independently fact-checked (majority-vote adversarial verification) before
-landing here. Sources are listed at the end. This is a **fast-moving
-domain** — specific detection percentages are 2023-2024 snapshots, one
-well-known CDP-detection trap reportedly broke with a mid-2025 V8 change,
-and AI-agent-targeted detection only shipped in 2025 — so treat exact
-mechanics as a dated snapshot, not a constant.
+## Adaptive pacing
 
----
+Issue #234 records the chosen design for per-origin action pacing. The unwired
+reducer and its tests do not affect a shipped package. No shipped package
+currently learns or enforces pacing rules.
 
-## The one insight that reframes everything
+The usable feature still needs trusted signal detection, service-worker
+persistence, one serialized lane per origin, complete write-path coverage,
+Stop and liveness checks, terminal handoff behavior, user settings, and browser
+tests.
 
-peerd is not a headless bot. It drives the **user's own real, logged-in
-browser** (BYOK, no backend, no proxies, user-initiated tasks). That means
-most of what modern anti-bot stacks look for is **naturally clean for us**:
+Other open product work includes visible challenge detection and user handoff,
+assist-only behavior on guarded sites, preference for official APIs, and clear
+per-site automation posture. None of those are shipped.
 
-- **Browser/OS fingerprint** (canvas, WebGL, fonts, screen, TLS/JA3): a real
-  consumer browser, internally consistent. Spoofed bots get caught precisely
-  because their fingerprints are *inconsistent* — commercial "undetectable"
-  bot traffic still evaded DataDome only ~52.9% and BotD ~44.6% of the time,
-  i.e. roughly **half is caught anyway** [1]. Our consistency is an asset to
-  *preserve*, not a problem to solve.
-- **IP reputation**: the user's own residential IP, not a datacenter or proxy
-  range. Clean by construction [5].
-- **Session / cookies**: the user's real authenticated session. Nothing to fake.
-
-So the two surfaces where peerd **is** exposed are narrow and specific:
-
-1. **The automation-instrumentation footprint** — the CDP (`chrome.debugger`)
-   channel on the **preview/dev build only**. CDP is the protocol under
-   Puppeteer/Playwright/Selenium, so "is this browser CDP-instrumented?" is a
-   generic, framework-independent automation tell, classically keyed on the
-   `Runtime.enable` command [2]. The **store build already avoids this** — it
-   is scripting-first, no CDP (per `OPEN-DECISIONS.md` §1). (Trade-off, not a
-   free win: the store path dispatches synthetic DOM events with
-   `isTrusted=false`, which is *also* a detectable signal and which some sites,
-   including the trigger site, ignore for clicks — see Open Question A.)
-2. **Behavioral cadence** — velocity and the rhythm of clicks/keystrokes/
-   scrolls. This is the durable detection layer that fires **after** fingerprint
-   and network checks pass, and it is exactly what tripped the trigger block.
-   ML mouse/keystroke-dynamics classifiers reach ~96% against naive bots, and
-   **even randomized delays leave statistical patterns** models pick up [8].
-   Vendors now ship intent-based models that explicitly bucket "human-like but
-   machine-driven" AI-agent traffic [8].
-
-**Corollary:** our fixes should target (1) and (2) and **must not** disturb
-our natural fingerprint/IP cleanliness. And pacing alone is harm-reduction,
-never a guarantee.
-
----
-
-## The reframe you can't engineer around: detection ≠ permission
-
-Two orthogonal problems hide inside "avoid bot checks":
-
-- **(A) Detection** — *can* we act without being flagged? Technical.
-- **(B) Permission** — are we *allowed* to automate this site at all? Contractual/legal/policy.
-
-For the trigger site specifically, (B) is dispositive and no amount of (A)
-fixes it:
-
-- Its User Agreement **categorically prohibits any browser extension/script/bot
-  that scrapes, modifies, or automates activity** on the site — naming the exact
-  actions an agent performs (add contacts, send messages, create/comment/like/
-  share) — **with no carve-out for user-initiated automation or human-like
-  cadence**. "Unauthorized" means unauthorized *by the site*, not by the user [11].
-- These ToS provisions are **legally enforceable as breach of contract**, and
-  the **logged-in account holder is the bound party** — the "it's my own account"
-  framing gives *no* safe harbor (LinkedIn v. hiQ enforced UA anti-automation
-  terms; Meta v. Bright Data read the terms as governing the account holder's
-  "use") [19][20]. Enforcement is real and tightening (account restriction/
-  suspension; 2026 extension ban waves) [11].
-- **Chrome Web Store policy** independently forbids extensions that "facilitate
-  unauthorized access... circumventing login restrictions," so shipping active
-  evasion as a *feature* is a store-review risk on top of the ToS risk [16].
-
-**Therefore:** better evasion does not make us compliant on a ToS-hostile site;
-it just delays a ban and raises our own risk. "Which sites do we automate at
-all, and how do we degrade when a site says no" is a **policy/consent decision**
-(Options 2 and 6), not a detection-evasion problem.
-
----
-
-## Proposed decisions (fill in the `DECISION:` lines)
-
-| # | Option | Effective? | Durable? | Store-safe / ToS-safe? | Recommendation |
-|---|--------|-----------|----------|------------------------|----------------|
-| 0 | Human-cadence pacing (shipped/prototyped) | Partial | No (harm-reduction) | Yes | Keep; treat as floor, not fix |
-| 1 | Challenge hand-back to user | High | Yes | Yes | **Build next** |
-| 2 | Co-pilot / assist-only on guarded sites | High | Yes | Yes (sidesteps ToS) | **Adopt for hostile sites** |
-| 3 | Minimize CDP footprint (trusted Input, no `Runtime.enable`) | Medium-High | Yes-ish | Yes | **Build** (preview build) |
-| 4 | Richer human-like input dynamics | Low-Medium | No (arms race) | Yes | Incremental only |
-| 5 | Prefer official APIs over DOM driving | High | Yes | Yes (sanctioned) | **Adopt as first choice** |
-| 6 | Site-posture tiers / graceful "no" | High | Yes | Yes | **Adopt as policy** |
-| 7 | Declared legitimate-agent trust lane (Web Bot Auth) | Unknown | Potentially | Yes (opt-in) | Track, don't build yet |
-| — | Fingerprint/webdriver spoofing, proxies, CAPTCHA-solvers | ~50% caught | No | **No** — reject | **Do not pursue** |
-
----
-
-## The options
-
-### Option 0 — Human-cadence action pacing *(baseline; already prototyped)*
-
-Jittered minimum interval between consecutive same-site interactions
-(click/type/navigate/page_keys), first-action-free, reads never paced.
-Implemented as a default pre-tool-use hook behind a `webActionPacingEnabled`
-setting.
-
-- **Effect:** Directly addresses the velocity signal that caused the trigger
-  block. Jitter over a fixed delay matters — uniform timing is itself a tell [15].
-- **Limit:** Behavioral classifiers still detect statistical regularity in
-  jittered timing [8]. This is harm-reduction, **not** a durable defense.
-- **DECISION:** Keep as the floor / default posture? (Recommended: yes.)
-
-### Option 1 — Challenge hand-back to the user *(highest leverage)*
-
-Detect a visible challenge (CAPTCHA / verification / velocity wall — DOM/URL
-signatures for the major vendors), **pause** the actor, surface it in the side
-panel, let the user solve it in their own session with one tap, then **resume**.
-
-- **Why it wins:** A human-solved challenge passes 100%. Passive scorers
-  (reCAPTCHA v3) return a 0.0-1.0 risk score and never present a puzzle — there
-  is *nothing to solve* programmatically; you can only avoid depressing the
-  score or hand off the downstream v2/Turnstile puzzle the site invokes [4].
-  Turns an hour-long wall into a 5-second interruption.
-- **Fit:** We already have the confirm round-trip (`ctx.confirm`) and actor
-  pause/resume machinery — this is a detector + resume, not new infrastructure.
-- **Open risk:** if passive scoring already depressed the session's trust score
-  before any visible challenge, handing back the puzzle may not fully recover it
-  (Open Question B).
-- **DECISION:** Build? Which vendors' challenge signatures in v1?
-
-### Option 2 — Co-pilot / assist-only on guarded sites
-
-On sites that fight automation, the agent does the reading, planning, and
-**drafting**, and hands the *sensitive* action to the user's real click ("found
-the 5 people, drafted the messages — press send").
-
-- **Why it wins twice:** (a) The input that trips detection is genuinely the
-  user's (`isTrusted`, real cadence). (b) Assisting a human is not "automating
-  the site," which is the clean answer to the **ToS** problem — the durable
-  resolution for hostile sites, not just the detection one.
-- **DECISION:** Adopt for the ToS-hostile tier (Option 6)? Is "assist-only" a
-  per-site mode or a global fallback when a challenge/ToS flag is hit?
-
-### Option 3 — Minimize the CDP footprint *(preview build)*
-
-Today the debugger pool calls `Runtime.enable` on attach and clicks via
-`Runtime.callFunctionOn` (`this.click()`). The sniffable part is the **Runtime
-domain being enabled** [2]; newer anti-detect frameworks specifically avoid it.
-The upgrade — **already flagged as a TODO in `clickBackendNode`** ("a real-event
-upgrade: `DOM.getBoxModel` + `Input.dispatchMouseEvent` is a follow-up") — is to
-click by dispatching a **real trusted mouse event at the element's coordinates**
-via the Input domain, *without* enabling Runtime. Detach when idle.
-
-- **Why it's good:** *More* human (a real pointer event, not a JS `.click()`)
-  **and** it drops the specific fingerprint the preview build exposes. Genuine
-  footprint reduction — **not** spoofing.
-- **Scope note:** store build has no CDP at all, so this is a preview/dev
-  improvement; it also informs Open Question A (is trusted-input-via-CDP net
-  better or worse than synthetic-events-via-scripting?).
-- **DECISION:** Build the Input-domain click/type path? Detach-when-idle policy?
-
-### Option 4 — Richer human-like input dynamics
-
-Beyond pacing: mouse-move paths into a target before clicking, per-keystroke
-timing variance, short dwell before acting.
-
-- **Reality check:** Incremental harm-reduction on the behavioral layer, but an
-  **arms race** — GAN/diffusion-generated human-like input reduces but never
-  eliminates detection [8]. Worth a little; not worth a lot.
-- **DECISION:** How far, if at all? (Recommended: minimal — keystroke variance
-  and pre-click dwell, stop there.)
-
-### Option 5 — Prefer official APIs over driving the DOM
-
-Where a site offers a sanctioned API, route through it (peerd already has the
-API-actor / sessionless `fetch_url` origin substrate) instead of puppeteering
-the page. Make "is there an API for this?" a step *before* "drive the page."
-
-- **Why it wins:** Sanctioned, never bot-walled, no ToS violation. Strictly the
-  best path where it exists.
-- **DECISION:** Add an API-first preference to the web actor's planning? Curate
-  a small map of sites → official API where known?
-
-### Option 6 — Site-posture tiers / graceful "no"
-
-Extend the existing denylist idea into a posture ladder:
-**blocked** (banks/health/password managers — already denied) →
-**assist-only** (ToS-hostile sites default to Option 2) →
-**automate** (everything else, paced). Respect explicit rate/`robots`/challenge
-signals as backoff triggers.
-
-- **Why:** Human-cadence changes *detection* but not the *contractual* violation
-  [11][19][20], so the honest control is a policy decision to not fully automate
-  ToS-hostile sites.
-- **DECISION:** Introduce the assist-only tier? Seed list (professional networks,
-  etc.), and is it user-overridable with a risk-acknowledged confirm?
-
-### Option 7 — Declared legitimate-agent trust lane *(track, don't build)*
-
-Emerging standards (e.g. Web Bot Auth / agent trust management, referenced by at
-least one major vendor) offer a **declared, cryptographically signed** identity
-for legitimate agents — opting *in* rather than evading [8]. An undeclared
-extension riding the user's session is exactly the "human-like but
-machine-driven" bucket intent-detection targets [8].
-
-- **DECISION:** Watch and revisit? (Recommended: monitor; no build yet — nascent,
-  adoption unclear, and it's a different product posture.)
-
----
-
-## Deliberately NOT pursuing (and why)
-
-All four are documented **arms-race** moves, roughly half-caught today,
-re-detected via cross-attribute inconsistency, and they are the documented
-**threat-actor** toolkit — adopting any of them invites Chrome Web Store
-rejection under the "unauthorized access" policy and legal/ToS exposure, while
-chasing defenses our real-session model **already passes cleanly**.
-
-- **Webdriver/CDP fingerprint masking, canvas/WebGL/TLS spoofing.** Catchable and
-  *actively suspicious*: spoofed fingerprints leave inconsistencies real devices
-  never have (9 of the top-10 highest-evasion "iPhone" resolutions don't exist on
-  any real iPhone); baseline evasion is only ~52.9% / ~44.6% [1]. We'd be
-  *degrading* our natural consistency — the opposite of the goal.
-- **Residential proxy rotation.** We have no backend and no proxies; our real IP
-  is already clean [5]. Proxies are the threat-actor pattern and pure store-risk.
-- **Third-party CAPTCHA-solving services.** CAPTCHA-solving has eroded CAPTCHA
-  effectiveness [10], but wiring a solving service in is the threat-actor pattern,
-  a store-policy violation, and pointless when Option 1 (hand the puzzle to the
-  human who's *right there*) is free and 100% reliable.
-
----
-
-## Open questions (carried from the research; decide or spike)
-
-- **A. Trusted-CDP vs synthetic-scripting — which is more detectable?** The store
-  build avoids the CDP footprint but dispatches `isTrusted=false` synthetic
-  events; the preview build has trusted input but the CDP instrumentation tell.
-  Which net-loses more trust? (Bears directly on Option 3 and the store default.)
-- **B. Does hand-back recover a depressed score?** Passive scorers (reCAPTCHA v3,
-  DataDome) may flag a session *before* any visible challenge. Does solving the
-  downstream puzzle restore trust, or is the session already burned? (Bears on
-  Option 1's ceiling.)
-- **C. Positive allowlist of ToS-safe targets?** Beyond the denylist, is there any
-  major site whose Terms *explicitly permit* user-initiated automation of one's
-  own account — enabling a "known-safe to automate" list, not only a denylist?
-- **D. Web Bot Auth viability** for a user-authorized browser-native agent (Option 7).
-
-## Honesty notes
-
-- Three claims were **checked and did NOT survive** verification, and are
-  therefore *not* relied on above: (1) a specific durability stat for
-  fingerprint-inconsistency detectors; (2) the exact client-side `Error.stack`
-  getter CDP-detection snippet (the classic `Runtime.enable` serialization trap
-  reportedly broke with a ~mid-2025 V8 change — the *structural* CDP signal
-  stands, the specific probe is in flux); (3) that CAPTCHA-solving services work
-  by farming to human solvers. Where a killed claim had a confirmed weaker form
-  (e.g. the ~50%-caught baseline), only the confirmed form is used.
-- Several detection-capability claims cite **anti-bot vendors** (commercial
-  incentive to overstate); the load-bearing cores are corroborated by
-  independent/academic sources (arXiv 2406.07647; mouse-biometrics papers) and by
-  the bypass-building community itself agreeing CDP underlies the major frameworks.
-- Legal claims are **US-jurisdiction** (N.D. Cal.), rest on reputable secondary
-  analyses of real rulings, and one (hiQ CFAA) came via a stipulated judgment —
-  enforceability generalizes; exact reasoning is case- and jurisdiction-specific.
-
-## Sources
-
-1. FP-Inconsistent measurement study — arXiv 2406.07647 (ACM IMC 2025)
-2. DataDome — the CDP signal & headless-Chrome detection
-4. Google reCAPTCHA v3 docs (passive scoring)
-5. Trend Micro — CAPTCHA-breaking services & residential proxies
-8. DataDome — behavioral bot classification; mouse-biometrics literature (arXiv 2208.09061)
-10. (as 5) CAPTCHA-solving erosion
-11. LinkedIn Help a1340567 / a1341387; User Agreement §8.2 (extension automation ban)
-15. Ethical scraping / rate-limiting — jittered vs uniform timing
-16. Chrome Web Store program policies (unauthorized-access prohibition)
-19. LinkedIn v. hiQ — UA anti-automation enforceable (breach of contract)
-20. Meta v. Bright Data — terms govern the logged-in account holder
+The issue is the live design record. The code and packaging tests are the source
+of truth for shipped behavior.

--- a/docs/store/LISTING.md
+++ b/docs/store/LISTING.md
@@ -1,10 +1,10 @@
-# Chrome Web Store — listing copy & asset checklist
+# Chrome Web Store listing and asset checklist
 
 ## Name
 
 peerd
 
-## Summary (132 chars max — also the manifest description)
+## Summary (132 chars max, also the manifest description)
 
 > An AI assistant that automates tasks in your browser. Local-first:
 > your own API key, no account, no servers, no tracking.
@@ -20,6 +20,10 @@ a capability of it. No module-by-module enumeration, no "harness", no
 peerd is an AI assistant that lives in your browser's side panel and
 does things for you, not just answers questions.
 
+peerd is an experimental beta. Breaking changes and incomplete browser support
+are expected. Review the privacy and security notes before using it with
+sensitive data.
+
 Give it a task in plain language (typed or spoken):
 
 • "Summarize this article and pull out every cited statistic."
@@ -30,7 +34,7 @@ Give it a task in plain language (typed or spoken):
 
 The assistant reads the page you're on, clicks, types, and navigates,
 visibly, in your tabs. When a task needs real computation, it runs the
-work in WebAssembly sandboxes that exist entirely inside your browser —
+work in WebAssembly sandboxes that exist entirely inside your browser,
 from a quick script, to compiled tools (query a SQLite file, convert a
 format), to a full Linux environment. Nothing is installed on your
 machine.
@@ -45,20 +49,22 @@ peerd is local-first and has no backend:
   ever sent to the provider you selected.
 • Conversations, settings, and history live in your browser's local
   storage. No account, no sync, no analytics, no telemetry.
-• A built-in audit log shows every network request the assistant made,
-  including the ones peerd blocked.
+• A built-in Activity log shows tool outcomes, direct open-web fetches,
+  and policy denials.
 
 GUARDRAILS ON BY DEFAULT
 
 • peerd refuses to operate on sensitive sites out of the box: banks,
   brokerages, crypto exchanges and wallets, health portals, government
-  services, password managers, and identity providers.
-• It blocks arbitrary localhost and local-network web access. The local
-  AI-provider path is opt-in and separate from open-web browsing tools.
+  services, and password managers.
+• Direct fetch and document-reading tools block localhost and private-network
+  targets. Browser navigation does not currently carry that private-network
+  guard and remains subject only to denylist and origin policies. Local AI
+  providers use a separate opt-in path.
 • Risky actions ask for your confirmation first.
 
-You'll need an API key from your AI provider to use peerd. peerd is
-independent software and is not affiliated with any AI provider.
+Choose a supported local provider or supply your own provider API key. peerd is
+independent software and is not affiliated with any provider.
 
 ---
 
@@ -74,8 +80,8 @@ English
 
 | Asset | Spec | Status |
 |---|---|---|
-| Store icon | 128×128 PNG, 96×96 art + 16px transparent padding | ✅ `extension/icons/icon128.png` — rainbow-stripe icon, spec-compliant padding. Padded source `docs/store/assets/peerd-icon-128.svg`; full-bleed master + 256/512 renders `docs/store/assets/peerd-icon*`. 16/32/48 stay full-bleed by design, since padding at toolbar sizes shrinks the art too far |
-| Screenshots (≥1, max 5) | 1280×800 or 640×400 | ☐ capture — see shot list below |
+| Store icon | 128×128 PNG, 96×96 art + 16px transparent padding | ✅ `extension/icons/icon128.png`, with spec-compliant padding. Padded source: `docs/store/assets/peerd-icon-128.svg`. Full-bleed master and larger renders: `docs/store/assets/peerd-icon*`. The smaller toolbar icons stay full bleed. |
+| Screenshots (≥1, max 5) | 1280×800 or 640×400 | ☐ capture, see shot list below |
 | Small promo tile | 440×280 PNG | ✅ `docs/store/assets/promo-440x280.png` |
 | Marquee promo tile (optional) | 1400×560 PNG | ✅ `docs/store/assets/marquee-1400x560.png` |
 | Privacy policy URL | published page | ☐ publish `docs/store/PRIVACY.md` at https://peerd.ai/privacy (deploys from the `peerd-site` repo) |
@@ -86,7 +92,7 @@ English
 1. Side panel open next to a real article, mid-task: user asked for a
    summary, assistant's answer visible. (Hero shot.)
 2. The assistant operating a page: tab group visible, automation in
-   progress. (Shoot from the store build — it operates pages via
+   progress. (Shoot from the store build because it operates pages via
    chrome.scripting, so there is no debugger banner to stage.)
 3. VM tab with the terminal: `uname -a` output after "boot a linux vm".
 4. Audit log view: allowed + denied entries visible (show a denylist

--- a/docs/store/OPEN-DECISIONS.md
+++ b/docs/store/OPEN-DECISIONS.md
@@ -20,6 +20,14 @@ future store update requires a separate review decision.
 The store package keeps remote skill installation disabled. Local skill text is
 supported. The live feature gate and service-worker checks are the authority.
 
+### Remote JavaScript imports
+
+The current Script and Notebook resolver can fetch HTTPS JavaScript and execute
+it in a sealed worker. The store package does not disable that path. Store
+submission is blocked until packaging removes or disables remote imports, or a
+documented Chrome Web Store decision accepts and accurately discloses the
+isolated-worker behavior.
+
 ### Dweb
 
 The store package omits `peerd-distributed`. The preview package includes it.
@@ -27,15 +35,18 @@ Packaging and boundary checks verify that store artifacts contain no dweb code.
 
 ### Anti-bot behavior
 
-Challenge handling and site automation limits remain open product questions.
-See [`ANTI-BOT-POSTURE.md`](ANTI-BOT-POSTURE.md). peerd does not use fingerprint
-spoofing, proxies, CAPTCHA solvers, or other challenge bypasses.
+The non-evasion posture is fixed. peerd does not use fingerprint spoofing,
+proxies, challenge solvers, or similar bypasses. Adaptive per-origin pacing is
+designed in issue #234 but is not wired into the extension. Challenge handoff
+and assist-only behavior still need implementation and field testing. See
+[`ANTI-BOT-POSTURE.md`](ANTI-BOT-POSTURE.md).
 
 ## Submission checks
 
 Before a store submission:
 
 - confirm the current package contents with the packaging and verification commands
+- resolve the remote JavaScript import blocker and verify the uploaded artifact
 - review `PERMISSION-JUSTIFICATIONS.md`, `PRIVACY.md`, and `REVIEWER-NOTES.md`
 - replace any submission placeholders, including the reviewer demo URL
 - verify the public privacy policy URL in the store dashboards

--- a/docs/store/PERMISSION-JUSTIFICATIONS.md
+++ b/docs/store/PERMISSION-JUSTIFICATIONS.md
@@ -1,9 +1,8 @@
-# Chrome Web Store — paste-ready dashboard text
+# Chrome Web Store dashboard text
 
-Everything in this file is written to be pasted into the **Privacy
-practices** tab of the developer dashboard. Each justification is under
-the dashboard's length limit. Do not free-type at submission; copy from
-here.
+This file is the draft source for the **Privacy practices** tab of the developer
+dashboard. Do not paste it into a submission until every maintainer note and
+blocker below is resolved against the package being uploaded.
 
 ---
 
@@ -18,15 +17,17 @@ here.
 > assistant runs computations a task needs, voice input is another way
 > to give the assistant a task, and the local audit log shows the user
 > what the assistant did. There is no second product: no content
-> alteration, no search/new-tab takeover, no data collection. The
-> extension is local-first — the user supplies their own AI provider
-> API key, and there is no backend service.
+> alteration, no search/new-tab takeover, no developer-operated data
+> collection. The
+> extension is local-first. The user configures their own provider, using
+> either their own API key or a supported local provider. There is no backend
+> service.
 
 ---
 
 ## Permission justifications
 
-### `debugger` — NOT requested by the store package
+### `debugger` is not requested by the store package
 
 > The store package does **not** request the `debugger` permission. The
 > assistant operates web pages entirely through `chrome.scripting`
@@ -35,9 +36,9 @@ here.
 > no Chrome DevTools Protocol use in this package and nothing to justify
 > here.
 >
-> (Maintainer note — not dashboard copy: the optional Chrome DevTools
-> Protocol path — used only to drive sites that ship Trusted Types /
-> strict CSP, which reject injected scripts — ships in the separate
+> (Maintainer note, not dashboard copy: the optional Chrome DevTools
+> Protocol path is used only to drive sites that ship Trusted Types or
+> strict CSP, which reject injected scripts. It ships in the separate
 > GitHub-distributed *preview* channel, gated by an in-app "Advanced
 > automation" switch. If it is ever added to a store update, it will be
 > declared as a required permission with its own justification at that
@@ -48,9 +49,9 @@ here.
 > The assistant reads page content and performs DOM actions (click,
 > type, extract text) in the user's current task context by injecting
 > small, bundled content functions via `chrome.scripting.executeScript`.
-> All injected code ships inside the extension package; nothing is
-> fetched or generated remotely. Injection happens only when the user
-> has given the assistant a task that requires the page.
+> All code injected into a page ships inside the extension package. Page
+> injection happens only when the user has given the assistant a task that
+> requires the page.
 
 ### `tabs`
 
@@ -70,71 +71,89 @@ here.
 
 ### `storage`
 
-> All user data is local by design: the encrypted API-key vault,
-> conversation history, settings, the denylist, and the audit log live
-> in `chrome.storage.local` / IndexedDB. Nothing is synced or
-> transmitted; this permission is what makes the no-backend design
-> possible.
+> The encrypted API-key vault, conversation history, settings, denylist,
+> and audit log are stored in `chrome.storage.local` or IndexedDB. peerd
+> does not sync this storage to a developer server. Messages and task
+> context are sent only as needed to the model provider selected by the
+> user.
 
 ### `offscreen`
 
-> Voice input is transcribed locally by a WebAssembly speech model
-> (Moonshine). The offscreen document hosts the microphone capture and
-> the WASM transcriber so they can run while the user works, without
-> requiring a visible page. Audio never leaves the device in this path.
+> The offscreen document hosts isolated worker processes for delegated
+> assistants and headless JavaScript jobs. It also keeps extension work
+> alive across service-worker suspension, extracts web pages and documents,
+> and hosts microphone capture and Moonshine speech transcription without a
+> visible page. Audio stays on the device when Moonshine is selected.
 
 ### `sidePanel`
 
-> The side panel is the product's primary UI: the conversation with the
-> assistant, settings, and the audit log live there, alongside the page
-> the assistant is working on.
+> The side panel is the product's primary task UI. It shows the conversation
+> beside the page the assistant is working on. Settings and the Activity log
+> open in a separate extension page.
 
 ### Host permission `<all_urls>`
 
-> The assistant must be able to read and act on whatever page the user
-> gives it a task on — which site that is is the user's choice at task
-> time and cannot be enumerated in advance. Access is exercised only in
-> service of an active user task; it is constrained by a default-ON
-> denylist of sensitive sites (banks, health, password managers, etc.),
-> a private-network/SSRF block, and a local audit log of every request,
-> allowed or denied.
+> The assistant must be able to read and act on whatever page the user gives it
+> a task on. Which site that is remains the user's choice at task time and
+> cannot be enumerated in advance. Page injection and page automation occur
+> only during an active user task. A default-ON denylist constrains page access
+> on sensitive sites such as banks, health portals, and password managers.
+> Direct fetch and document-reading paths also block private-network targets.
+> Provider setup and user-enabled runtime downloads are separate user-initiated
+> network uses.
+> The local Activity log records tool outcomes, direct open-web fetches, and
+> policy denials.
 
 ---
 
 ## Remote code question
 
-Answer: **No, I am not using remote code.**
+**Submission blocker. Do not answer No for the current package.**
 
-> All executable code — JavaScript and WebAssembly, including the
-> CheerpX VM runtime — is packaged in the extension. Vendored
-> third-party code is pinned and hash-documented in per-directory
-> SOURCE.txt files. Network fetches retrieve data only: model API
-> responses, a voice model verified against pinned SHA-384 hashes
-> before use, a Debian filesystem image interpreted as data by the
-> sandboxed WASM VM, and web pages the user asks the assistant to read.
+The Script and Notebook module resolver accepts HTTPS JavaScript imports. It
+fetches the source through peerd's audited web relay and executes it as a blob
+module in a sealed worker. The current store package does not disable that path.
+
+This matches the Chrome Web Store dashboard's definition of remotely hosted
+code. Before submission, either disable and verify remote imports in the store
+artifact, or obtain a clear policy decision for the isolated-worker exemption
+and declare the behavior accurately. Do not reuse the old data-only answer.
+
+Current source: `extension/peerd-engine/module-resolver.js` and
+`extension/offscreen/job-runner.js`.
 
 ---
 
 ## Data-usage form (Privacy practices tab)
 
-What the extension handles. Check ONLY:
+The current behavior handles at least:
 
-- **Authentication information** — the user's own AI-provider API key.
+- **Authentication information:** the user's own AI-provider API key.
   Stored encrypted, locally; transmitted only to the provider the user
   configured, never to the developer (no developer servers exist).
-- **Website content** — pages the assistant reads to perform a task the
+- **Website content:** pages the assistant reads to perform a task the
   user gave it. This is sent to the user's configured AI provider as part
-  of the user's own prompt; and, for the open-web read tools
-  (`call_api`/`read_article`/`web_search`), peerd also requests the
-  third-party site itself (as a browser would). That open-web path is not
-  allowlist-restricted — it is gated by an SSRF block, a sensitive-site
-  denylist, and a local audit log. No website content is sent to the
-  developer (there are no developer servers).
+  of the user's own prompt. `fetch_url`, document readers, and browser tools
+  may also request the third-party site needed for the task. Those paths use
+  SSRF checks, a sensitive-site denylist where applicable, and the local audit
+  log. No website content is sent to the developer.
+- **Web browsing activity:** peerd reads task-relevant tab URLs and titles. The
+  local Activity log records tool outcomes, direct open-web fetches, and policy
+  denials. peerd does not read or upload the browser's general history database.
+- **Personal communications and user-provided content:** prompts, conversation
+  history, and task-relevant page content may be stored locally and sent to the
+  selected model provider. Page content can itself contain messages or other
+  personal data.
+- **Voice input:** voice is off by default. When enabled, the default automatic
+  engine prefers the browser's Web Speech service, which may send audio to the
+  browser vendor. The user can select local Moonshine transcription to keep
+  audio on the device.
 
-Everything else (location, web history, user activity, personal
-communications, financial/health info, personally identifiable info):
-**not collected**. Note: the denylist specifically blocks the assistant
-from operating on financial and health sites.
+Do not use a blanket "everything else not collected" statement. A user can ask
+peerd to process page content containing personally identifiable, financial, or
+health information, even though the default denylist reduces that exposure.
+Review the current dashboard category names and the uploaded package before
+selecting the final checkboxes.
 
 Certifications (check all three):
 - I do not sell or transfer user data to third parties, outside of the
@@ -145,4 +164,4 @@ Certifications (check all three):
   for lending purposes ✔
 
 Privacy policy URL: `https://peerd.ai/privacy` (publish
-`the website/privacy.html` there first).
+`docs/store/PRIVACY.md` through the `peerd-site` repository first).

--- a/docs/store/PRIVACY.md
+++ b/docs/store/PRIVACY.md
@@ -1,6 +1,6 @@
 # peerd Privacy Policy
 
-**Effective date:** July 12, 2026
+**Effective date:** August 6, 2026
 
 **Applies to:** all peerd browser extension distribution channels
 
@@ -30,8 +30,10 @@ peerd stores local extension data such as:
 Vault encryption does not apply to every item in extension storage. The
 security documentation defines the current storage boundaries.
 
-Voice input is transcribed locally by default. peerd does not retain recorded
-audio.
+Voice is off by default. When enabled, the automatic engine prefers the
+browser's Web Speech service, which may send audio to the browser vendor. The
+user can select Moonshine for local transcription. peerd does not retain
+recorded audio.
 
 ## Data sent from the device
 
@@ -39,13 +41,18 @@ audio.
 
 Messages and task context are sent to the model provider selected by the user.
 Requests use the user's provider key when required. The provider's privacy
-policy applies to that data.
+policy applies to that data. Depending on the task, this content may include
+personal communications, identifying information, or other sensitive material
+present in the user's prompt or page. The default denylist reduces access to
+some sensitive sites but is not a guarantee about the content of every page.
 
 ### Websites and user-directed network requests
 
-peerd can request websites and APIs needed for a task. Network policy blocks
-private network targets and configured sensitive sites on supported paths. The
-local audit log records allowed and denied requests.
+peerd can request websites and APIs needed for a task. Direct fetch and
+document-reading paths block private-network targets. Configured sensitive-site
+rules apply on supported browser and fetch paths. The local Activity log records
+tool outcomes, direct open-web fetches, and policy denials. It is not a complete
+record of every network request or visited URL.
 
 ### Runtime assets
 
@@ -53,16 +60,32 @@ Some features download public runtime assets, such as a speech model or a
 WebVM disk image. Integrity and source controls are defined in the code and
 vendored dependency records.
 
+Script and Notebook jobs can also import JavaScript from an HTTPS URL. peerd
+fetches that source through its audited web path and executes it in a sealed
+worker. Store packages must disable this path or disclose an accepted policy
+exemption before submission.
+
 ### Browser speech services
 
-If local transcription is unavailable and the user chooses the browser speech
-fallback, the browser may send audio to its own speech service. The browser
-vendor controls that service.
+When voice is enabled, the default automatic engine prefers the browser's Web
+Speech service. The browser may send audio to its own speech service, which is
+controlled by the browser vendor. Users can select Moonshine for local
+transcription instead.
 
 ### Preview dweb
 
-Preview builds can use signaling servers for peer discovery and WebRTC for
-peer-to-peer traffic when the dweb is enabled. Store builds omit the dweb.
+Preview builds can use signaling servers for peer discovery and WebRTC when the
+dweb is enabled. Direct and agent-to-agent messages, published agent profiles,
+and shared peer-to-peer app bundles can be sent to peers. Recipients may retain
+data they receive even after the sender removes a local copy. Signaling servers
+may keep their own operational logs, but they do not control data already held
+by peers.
+
+The optional preview dweb agent currently uses one model conversation across
+messages from different peers. Until peer-scoped histories and exact reply
+grants are implemented, one peer may be able to prompt it to reveal information
+from another peer conversation. Keep the dweb agent disabled unless you accept
+this risk. Store builds omit the dweb.
 
 ## What peerd does not do
 

--- a/docs/store/REVIEWER-NOTES.md
+++ b/docs/store/REVIEWER-NOTES.md
@@ -1,5 +1,10 @@
 # Chrome Web Store reviewer notes
 
+**Blocked draft. Do not submit this text with the current package.** Script and
+Notebook jobs can fetch and execute HTTPS JavaScript modules. Resolve the remote
+code decision in `OPEN-DECISIONS.md`, verify the uploaded artifact, and then
+replace the blocked section below with accurate final text.
+
 One placeholder must be filled before submitting: the demo video URL below.
 No test API key is provided. The demo video covers
 the full flow instead.
@@ -13,38 +18,43 @@ speaks a task; the assistant performs it by reading and interacting
 with web pages, and by running computations in sandboxes (a WebAssembly
 Linux VM and a JavaScript sandbox that can also run WebAssembly (WASI)
 programs) that exist entirely inside the browser. It is local-first, uses
-bring-your-own-key providers, and has no account, hosted agent backend,
-analytics, or telemetry. The developer does not receive or store extension
-data through the extension.
+user-configured cloud or local providers, and has no account, hosted agent
+backend, analytics, or telemetry. The developer does not receive or store
+extension data through the extension.
 
 ## How to test
 
 1. Install, open the side panel (toolbar icon).
-2. Onboarding asks for an AI provider API key. peerd is
-   bring-your-own-key with no accounts, so there is no test credential
-   to share; the demo video below shows every flow end-to-end instead.
+2. Create and unlock the local vault, then complete the short profile
+   onboarding. Open Settings, then Providers & models. Add a provider key or
+   choose a supported keyless local provider. No hosted peerd account or shared
+   test credential exists; the demo video shows the configured flow.
 3. Ask something that exercises page automation, e.g. open any article
    and ask "summarize this page", or "open hacker news and tell me the
    top three stories".
 4. VM demo: ask "boot a linux vm and run uname -a". First boot streams
    the public Debian image from disks.webvm.io (see below).
-5. The audit log (in the side panel) shows every outbound request the
-   agent made, including denied ones.
+5. The Activity page shows tool outcomes, direct open-web fetches, and policy
+   denials.
 
 **Demo video** (full agent flow, VM boot, automation, audit log):
 «VIDEO URL»
 
 ## Remotely hosted code
 
-There is no remotely hosted code. These are the five places a scan
-will flag:
+The current package can fetch HTTPS JavaScript through the audited web relay
+and execute it as a blob module inside sealed Script and Notebook workers. Do
+not claim that the package contains no remotely hosted code. Store submission
+is blocked until this path is disabled and verified in the store artifact, or
+the behavior receives a documented policy decision and accurate disclosure.
+
+Other network-loaded assets that a scan may flag are listed below:
 
 1. **CheerpX (x86-in-WASM runtime) is fully vendored** in
    `vendor/cheerpx/`, version-pinned, with provenance and the SHA-256
    of the entry file documented in `vendor/cheerpx/SOURCE.txt`. Every
    vendored dependency in `vendor/` carries the same SOURCE.txt
-   treatment. No CDN script loading anywhere; the package is vanilla,
-   unobfuscated ES modules.
+   treatment. Packaged extension code is vanilla, unobfuscated ES modules.
 2. **`disks.webvm.io` (vm-tab)** streams a stock Debian *filesystem
    image*. These bytes are interpreted as an ext2 disk by the sandboxed WASM VM.
    It is data, not extension code, equivalent to a game loading an
@@ -99,12 +109,12 @@ and three things keep that honest regardless of channel:
 
 - A denylist, ON by default, refuses to operate on banks, brokerages,
   crypto exchanges and wallets, health portals, government services,
-  password managers, and identity providers (the categories where
+  and password managers (the categories where
   automation could do harm). See
   `peerd-egress/denylist/default.json`; the service worker blocks all
   tool dispatch until the denylist is loaded (no cold-start race).
 - Page actions run only during an active, user-initiated task.
-- Every action goes to the local audit log, including denied attempts.
+- Tool outcomes and policy denials go to the local Activity log.
 
 Maintainer note (not for the dashboard): an optional Chrome DevTools
 Protocol path for sites that ship Trusted Types or strict CSP (Gmail,
@@ -118,9 +128,12 @@ forbids `debugger` under `optional_permissions`).
 
 ## Why `<all_urls>`
 
-Which site the user will ask the assistant to work on is the user's
-choice at task time. Access is exercised only during an active user
-task and is constrained by the same denylist + SSRF block + audit log.
+Which site the user will ask the assistant to work on is the user's choice at
+task time. Page injection and page automation occur only during an active user
+task. The denylist applies to page access. Direct fetch and document-reading
+paths also apply private-network checks. Provider setup and user-enabled runtime
+downloads are separate user-initiated network uses. Tool outcomes and policy
+denials are recorded locally.
 
 ## Egress posture (honest scope)
 
@@ -133,10 +146,11 @@ We separate two things on purpose:
   allowlist because the target is user-selected. It enforces a scheme
   check, an SSRF/private-network block (IPv4 + structural IPv6, incl.
   the cloud-metadata IP and IPv4-mapped forms), a sensitive-site
-  denylist, fail-closed redirect handling, and a full audit log, but
+  denylist, fail-closed redirect handling, and local records for direct fetches
+  and policy denials, but
   **not** a per-host allowlist. Traffic to an arbitrary *public* domain
   over this path is not categorically prevented. The web actor is keyless, its tool access is
-  narrowed, and the audit log records every request. We do not claim otherwise.
+  narrowed. We do not claim otherwise.
 
 The Notebook specifically: the `js_notebook` Web Worker runs
 agent-authored code, so its raw network primitives (XHR / WebSocket /
@@ -153,10 +167,11 @@ which is governed by the open-web `webFetch` gates above.
 pages the user asks it to read from the extension's service worker.
 The target set is user-chosen and cannot be enumerated in a manifest.
 The egress layer enforces what the manifest cannot express: a hardcoded
-allowlist for credentialed provider calls, the denylist + SSRF block
-for everything else, and the audit log for all of it. The generated manifest
-and store posture tests are the authority for the narrow non-HTTPS sources used
-by local providers and runtime assets.
+allowlist for credentialed provider calls and the denylist plus private-network
+checks on direct open-web fetch paths. Local records cover tool outcomes,
+direct fetches, and policy denials. The generated manifest and store posture
+tests are the authority for the narrow non-HTTPS sources used by local
+providers and runtime assets.
 
 ## Privacy posture (for the data form)
 

--- a/packaging/check-doc-paths.ts
+++ b/packaging/check-doc-paths.ts
@@ -21,6 +21,7 @@ import { REPO_ROOT } from './lib.ts';
 export const CHECKED_DOCS = [
   'README.md', 'CLAUDE.md', 'SECURITY.md', 'CONTRIBUTING.md',
   'docs/security/THREAT-MODEL.md',
+  'docs/security/LIFECYCLE-CONTRACT.md',
   'docs/security/HARDENING-ROADMAP.md',
   'docs/security/RED-TEAM-RESULTS.md',
 ];

--- a/tests/red-team/README.md
+++ b/tests/red-team/README.md
@@ -21,7 +21,7 @@ peerd's core invariants. It is not a complete adversarial audit.
   workflows cannot manipulate the user, poison durable memory, mislead a
   confirmation prompt, or induce a bad action that is not itself blocked by a
   gate. Those are architectural and UX questions; the threat model names the
-  relevant residual risks (R1–R11) rather than claiming they are closed.
+  relevant residual risks rather than claiming they are closed.
 
 The honest posture is: peerd has a formal threat model and CI-gated red-team
 probes for its core security invariants. It is not a claim that peerd is immune
@@ -49,6 +49,9 @@ to prompt injection.
 | 06 | Malicious iframe or sandboxed code escapes | Notebook realm seal, App-iframe shim, WebVM HTTP bridge |
 | 07 | Private-network URL attempts SSRF | `isPrivateOrLocalHost` guard and redirect fail-closed |
 | 08 | Prompt-injection benchmark versus browser-use agents | keyless heap, exposure and tier gates, Plan mode, denylist, fence |
+| 09 | Hostile page content steers reads, writes, or egress | content disarmament, user-generated-content confirmation, egress checks |
+| 10 | A moved or redirected tab retasks a web actor | origin lock, landing checks, trusted terminal reply |
+| 11 | Login orchestration captures a credential | verified affordance, fixed confirmation, user-held authentication factor |
 
 ### Scenario 05 and MCP
 


### PR DESCRIPTION
## Summary

- refresh the README, contribution guide, design indexes, security guidance,
  and store drafts against current code
- add a lifecycle and recovery contract that states shipped behavior and open
  gaps without treating tested planners as wired features
- correct store disclosures for browser support, voice, audit coverage,
  private-network scope, dweb privacy, and local providers
- block store submission guidance on the unresolved remote JavaScript path and
  document its Notebook trust boundary
- refresh the red-team report and scenario guide

This documentation update does not close the underlying implementation gaps.
They remain tracked in #306, #318, #329, #330, and #331.

## Review coverage

- technical accuracy against implementation and tests
- user-facing setup, privacy, recovery, and store language
- model-facing trust boundaries, error guidance, and recovery behavior
- style and attribution scan

## Verification

- `bun run check:docpaths`
- `bun run check:hygiene`
- `bun test ./tests/packaging/check-doc-paths.test.ts ./tests/packaging/source-hygiene.test.ts ./tests/red-team`
- `bun run typecheck`
- `bun run lint`
- `git diff --check`
