### PR TITLE
feat: isolate Firefox actors in workers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,9 +342,11 @@ gotchas to know going in:
   keyed by the lineage root, and an actor's actor reply resolves into
   its tool result (an ephemeral child has no later turn to wake).
 - The heap split — EVERY non-orchestrator agent loop runs in its OWN
-  dedicated offscreen Worker heap (`peerd-runtime/actor/actor-worker-core.js`
+  dedicated Worker heap (`peerd-runtime/actor/actor-worker-core.js`
   drives it; `offscreen/actor-worker.js` + `actor-runner.js` +
-  `background/offscreen-actor-client.js` host + relay it). One substrate,
+  `background/offscreen-actor-client.js` host + relay it). Chrome starts the
+  runner from its offscreen document. Firefox starts the same runner directly
+  from its extension background page. One substrate,
   two shapes: a BOUND actor (web/webvm/notebook/app, instance-pinned) and an
   EPHEMERAL actor (spawned — tool-less = pure reasoning, tool-bearing =
   a narrowed-general toolset). The worker holds NO key, NO `chrome.*`, NO
@@ -352,19 +354,18 @@ gotchas to know going in:
   call (the SW adds `getSecret`+`safeFetch`; the key never enters the worker)
   and every tool call (the SW rebuilds the caller's instance-pinned or
   `grantedTools`-restricted ctx and re-checks it, NEVER trusting the worker's
-  args). Both relays are pinned to the OFFSCREEN DOCUMENT as sender and carry a
-  per-run GRANT minted SW-side (`isOffscreenSender` + the grants map): the sender
-  check is the boundary — `runtime.sendMessage` can't address one context, so the
-  job and its token reach every extension page — and the token adds run identity
-  plus liveness on top, so a replayed relay from a settled run is refused. So the
+  args). Chrome pins both relays to the offscreen document and a per-run grant.
+  Firefox keeps the runner and relay calls inside the background page behind a
+  private object-identity sender. The grant adds run identity and liveness on
+  both hosts, so a replayed relay from a settled run is refused. A run-scoped,
+  acknowledged Firefox `storage.session` heartbeat keeps the MV3 event page
+  alive only while actor work is active, then stops after the last turn settles.
+  A lost heartbeat pauses actor work until a manual probe succeeds. So the
   actor fence is a MEMORY boundary, not a prompt boundary: untrusted
   page/instance/response content stays behind the heap, one process-eviction from
-  the vault DK no longer reachable. Chrome-only (needs the offscreen API); Firefox
-  falls back to an in-SW loop with no heap separation — its SPAWNED children keep
-  the keyless custody (throwing credential stubs; the SW-owned `callModel` wrapper
-  adds the real ones at the call boundary), its BOUND actors go through
-  `runAgentTurn` and still hold live credentials — the honest residual,
-  THREAT-MODEL R1. why it matters: prompt
+  the vault DK no longer reachable. A versioned readiness and realm probe must
+  pass before a model call or tool relay can begin. A missing or failed host
+  refuses the actor turn before any target action. why it matters: prompt
   injection has no filter — the fix is to never hand untrusted reasoning the
   authority in the first place.
 - Voice — local transcription via Moonshine (WASM, SRI-pinned model

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ and product behavior may change. It can drive browser pages and use API keys, so
 review the security model before using it with sensitive data.
 
 Chromium is the primary product target. Firefox support is experimental and
-lacks several execution and actor-isolation features available on Chrome.
+lacks several execution features available on Chrome.
 
 The code is the source of truth for current behavior. Start with
 [`CLAUDE.md`](CLAUDE.md), then read the relevant module under `extension/`.
@@ -47,9 +47,9 @@ External HTTP and HTTPS links require user confirmation.
 
 peerd uses browser isolation, narrow tool exposure, service-worker policy gates,
 and explicit egress controls. The main agent delegates environment work to
-keyless actors. On Chrome, non-orchestrator agent loops run in separate worker
-heaps. Firefox uses a more limited fallback where browser APIs do not provide the
-same isolation features.
+keyless actors. On Chrome and Firefox, non-orchestrator agent loops run in
+separate dedicated worker heaps. If the browser cannot prove that boundary,
+the actor request does not run and performs no work on its target.
 
 Network behavior depends on the operation. Model calls, web reads, runtime asset
 loads, sandbox traffic, and preview dweb traffic use different scoped paths and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,16 +58,28 @@ Understanding the boundaries helps you scope a report:
   Preview dweb builds also use signaling and peer-to-peer WebRTC. The current
   implementations live in `peerd-egress/`, `peerd-engine/`,
   `peerd-distributed/`, and the service-worker wiring.
-- **Untrusted-content boundary.** The main agent never sees raw page content.
-  Page and DOM work is delegated to a per-tab **web actor**. On Chrome, that
-  actor runs in its own Worker heap with no key or `chrome.*` access. Firefox
-  lacks the offscreen API, so its fallback actor loop shares the service-worker
-  realm. The fallback loop receives throwing credential stubs, and the service
-  worker adds live provider functions only at the model-call boundary. Every
-  tool call is still re-checked. Untrusted results return only as
-  `wrapUntrusted`-fenced data. Firefox therefore has credential custody, tool
-  gates, and the data fence, but not Chrome's memory boundary. This remaining
-  difference is a known risk.
+- **Untrusted-content boundary (the heap split).** The main agent never
+  sees raw page content: page/DOM work is delegated to a per-tab **web
+  actor**, a separate agent loop that runs in its own Worker heap on Chrome
+  and Firefox, holds no key and no extension APIs. Model calls and agent tool
+  operations go through the service worker, which holds the key and re-checks
+  every request. This is a memory boundary, not a general code sandbox. The
+  worker still has standard Worker web APIs, but model output is not evaluated
+  as code in that realm. Untrusted content (page text,
+  command output, file contents) stays inside that heap and returns to the
+  orchestrator only as a `wrapUntrusted`-fenced summary. Actors run the
+  same way: keyless, in their own heap, with a narrowed toolset. This is
+  the main prompt-injection defense. It is a memory boundary, not a prompt
+  convention. Chrome hosts the worker from its offscreen document. Firefox
+  hosts it from the extension background page. A versioned startup probe must
+  prove a separate worker realm before any model or tool request can run. While
+  a Firefox actor turn is active, a run-scoped `storage.session` heartbeat keeps
+  the MV3 event page alive. Firefox must acknowledge the first heartbeat before
+  actor work starts. The heartbeat stops when the last active actor turn ends.
+  A heartbeat failure pauses actor work until a manual retry proves the host.
+  Durable recovery never repeats an actor request after a background restart.
+  Requests known not to have started are reported as Not run. Ambiguous requests
+  are reported as Outcome unknown and require inspection before retry.
 - **Policy-gated tool dispatch** with a local, append-only audit log. The
   current policy checks and hooks live in `peerd-runtime/tools/`.
 - **What the model reads is what you could have seen.** Bytes that are

--- a/docs/security/ARC-TESTING.md
+++ b/docs/security/ARC-TESTING.md
@@ -76,9 +76,25 @@ boundary. See the residual risks in the threat model.
 
 ## Firefox
 
-Firefox does not provide the same offscreen actor isolation host as Chrome.
-Treat this as a known residual risk. A test pass on Firefox does not prove heap
-separation.
+Firefox hosts the actor runner from its extension background page instead of an
+offscreen document. Verify an `actor_ran_isolated` audit entry records the
+background-page worker host, a dedicated worker, a successful realm proof, and
+no extension APIs in the worker. Break the worker import in a test package and
+verify actor work is marked Not run, no target action runs, and Retry is shown.
+Reload the background and verify the failure remains stored until a manual probe
+succeeds. Close every extension UI during a delayed actor turn and verify an
+acknowledged product `storage.session` heartbeat runs after the normal
+event-page idle window while the isolated turn is still active. The test must
+not create a separate storage listener or extension view that could keep the
+page alive. Physically
+close the extension UI and keep a plain page focused through the parent
+continuation. The heartbeat, actor request, and final result must keep one
+background boot identity, and the
+actor request must complete exactly once. Force a failure after a successful actor tool call and
+verify the parent model and UI report Outcome unknown, pause actor work, and do
+not retry automatically. Simulate a second background loss during recovery and verify no
+queued, started, or legacy request is executed from storage. Keep the recovery
+record until its Not run or Outcome unknown warning is accepted by the session.
 
 ## Evidence
 

--- a/docs/security/RED-TEAM-RESULTS.md
+++ b/docs/security/RED-TEAM-RESULTS.md
@@ -79,11 +79,11 @@ _Last run: 2026-08-07 · Bun 1.3.9 · 11 scenarios._
 - Asset: API key + any vault secret + the orchestrator’s authority
 - Claim checked: Actor loops receive no live credential functions, broker-owned provider fields are restored only at the model boundary, isolated relays drop functions, and actor results return as structurally-fenced untrusted data.
 - Threat-model invariant: INV-3
-- Defenses exercised: makeTurnDriver (bound fallback custody and broker overwrite), restrictCtxCapabilities (tool-context narrowing), makeRelayedCallModel (isolated boundary function strip), makeActorSummaryFence + wrapUntrusted (untrusted-data fence), neutralizeFence (structural break-out defense)
+- Defenses exercised: makeTurnDriver (background actor refusal), restrictCtxCapabilities (tool-context narrowing), makeRelayedCallModel (isolated boundary function strip), makeActorSummaryFence + wrapUntrusted (untrusted-data fence), neutralizeFence (structural break-out defense)
 
 | Probe (adversary action) | Result | Evidence |
 |--------------------------|--------|----------|
-| bound Firefox actor tries to carry live credentials and broker fields in its loop frame | blocked | secret=ActorCredentialBoundaryError/secret network=ActorCredentialBoundaryError/provider-network provider=anthropic/claude-test brokerCredentials=true |
+| bound actor tries to enter the privileged background loop | blocked | result=undefined loopEntered=false modelCalled=false refused=true releases=1 |
 | actor granted [read_memory] tries to read a secret | blocked | getSecret & safeFetch stripped from the narrowed ctx; input untouched |
 | actor granted [read_page, click, type] tries to read a secret | blocked | getSecret & safeFetch stripped from the narrowed ctx; input untouched |
 | actor granted [script, read_memory, write_memory] tries to read a secret | blocked | getSecret & safeFetch stripped from the narrowed ctx; input untouched |

--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -31,9 +31,10 @@ will eventually be prompt-injected, and that no content filter reliably prevents
 this. peerd does not rely on filtering. Instead it separates untrusted reasoning
 from dangerous capability in three ways:
 
-1. Memory. Where the browser provides an isolated host, reasoning that reads a
-   page runs in a separate worker heap. Firefox currently uses the keyless
-   in-service-worker fallback described in R1, without heap isolation.
+1. Memory. Reasoning that reads a page runs in a separate dedicated worker heap.
+   Chrome hosts it from an offscreen document. Firefox hosts it from the
+   extension background page. Actor work fails closed if the boundary cannot be
+   proved.
 2. Policy. Every tool call is checked at dispatch against a fixed set of gates.
 3. Chokepoints. All outbound network traffic and all signing pass through a single
    audited path.
@@ -52,7 +53,7 @@ between them.
 
 | Surface | What runs there | Holds the key |
 |---|---|---|
-| Service worker (`background/`) | Orchestrator agent loop, tool dispatch and gates, vault, egress wrappers, all relays. Firefox also runs fallback actor loops here | Yes. Fallback actor loop frames receive no live credential functions, but share this realm |
+| Privileged background (`background/`) | Orchestrator agent loop, tool dispatch and gates, vault, egress wrappers, and actor relays. Firefox also starts actor workers here | Yes. Actor loops run in separate dedicated worker heaps |
 | Offscreen document (`offscreen/`, Chrome) | Hosts isolated actor workers, headless `script`, voice, and the dweb base network | No. Actor worker heaps are keyless |
 | Side panel (`sidepanel/`) | The chat UI, confirm prompts, settings | No |
 | Sandbox tabs (`engine-tabs/vm-tab/`, `engine-tabs/notebook-tab/`, `engine-tabs/app-tab/`) | WebVM (CheerpX), Notebook (sealed worker), App (opaque origin iframe) | No |
@@ -79,25 +80,23 @@ holds both untrusted input and dangerous capability. Enforcement lives in
 |---|---|---|
 | The user | Everything: unlocking the vault, approving confirms, installing skills and imports | (the root of trust) |
 | The orchestrator (main agent loop, in the service worker) | The conversation, planning, and delegating a plain-language goal to an actor | Hold an environment's low-level tools, read raw page bytes, or run untrusted code directly |
-| A bound actor (web, webvm, notebook, app) | Driving one tab, VM, notebook, or app. It holds only that instance's tools, keyless, in its own worker heap on Chrome | Touch another instance or kind, hold the key, or return anything to the orchestrator except a `wrapUntrusted`-fenced summary |
-| An actor | A short-lived actor spawned to break down a task. Keyless, with a narrowed toolset. It gets its own heap when an isolated host is available | Escalate past its grant or hold the key. Every tool call is re-checked in the service worker |
-| The dweb actor (preview, opt-in) | Monitoring inbound mesh traffic and A2A over the mesh. Keyless, with its own heap when an isolated host is available | Delegate on an inbound (untrusted) turn, or sign as the user without consent |
+| A bound actor (web, webvm, notebook, app) | Driving one tab, VM, notebook, or app. It holds only that instance's tools, keyless, in its own worker heap | Touch another instance or kind, hold the key, or return anything to the orchestrator except a `wrapUntrusted`-fenced summary |
+| An actor | A short-lived actor spawned to break down a task. Keyless, with a narrowed toolset and its own heap | Escalate past its grant or hold the key. Every tool call is re-checked in the privileged background |
+| The dweb actor (preview, opt-in) | Monitoring inbound mesh traffic and A2A over the mesh. Keyless, with its own heap | Delegate on an inbound (untrusted) turn, or sign as the user without consent |
 | The egress chokepoint (`safeFetch` and `webFetch`) | Every outbound byte: the allowlist for credentialed calls, or the SSRF and denylist checks for open-web calls | Be bypassed. A bare `fetch` is forbidden by lint across the project |
 
 ### 3.2 Trust boundaries
 
-- B1. Untrusted content and the orchestrator's heap. When an isolated host is
-  available, page text, command output, file contents, and peer bytes are read in
-  a separate keyless actor worker and return only as `wrapUntrusted`-fenced data
+- B1. Untrusted content and the orchestrator's heap. Page text, command output,
+  file contents, and peer bytes are read in a separate keyless actor worker and
+  return only as `wrapUntrusted`-fenced data
   (`peerd-runtime/actor/actor-worker-core.js`,
-  `background/offscreen-actor-client.js`). Firefox currently shares the
-  service-worker realm. Its actor loop still receives throwing credential stubs,
-  but it does not have this memory boundary. See R1.
-- B2. An actor loop and the network or the key. On the isolated path, model and
-  tool calls leave the worker only through service-worker-gated relays. On the
-  fallback path, the loop receives throwing credential stubs. In both cases the
-  service worker adds live provider functions only at the model-call boundary
-  and re-checks every tool call.
+  `background/offscreen-actor-client.js`). A versioned readiness and realm probe
+  must pass before work starts. Missing or failed isolation refuses the actor
+  turn before any target action.
+- B2. An actor loop and the network or the key. Model and tool calls leave the
+  worker only through privileged, gated relays. The host adds live provider
+  functions only at the model-call boundary and re-checks every tool call.
 - B3. The extension and the open web. All outbound bytes pass through
   `peerd-egress/fetch/`: `safeFetch` (exact-origin provider allowlist, carries the
   key) or `webFetch` (SSRF and private-network block plus denylist, keyless).
@@ -147,10 +146,9 @@ Can: serve arbitrary HTML, JS, and text, plant prompt-injection payloads in cont
 the agent reads, try to induce fetches, and run script in its own origin.
 Cannot: reach the vault key, run in a privileged context, or make the agent's
 authority act outside its gates.
-Defenses: where an isolated host is available, the memory boundary keeps page
-bytes out of the orchestrator's heap (B1). Every web actor loop is keyless: the
-isolated worker receives stubs in `actor-worker-core.js`, and the Firefox fallback
-receives stubs in `loop/turn-driver.js`. The credentialed egress path is an
+Defenses: the memory boundary keeps page bytes out of the orchestrator's heap
+(B1). Every web actor loop is keyless and receives stubs in
+`actor-worker-core.js`. The credentialed egress path is an
 exact-origin allowlist (`safeFetch`). Open-web fetches are gated by the SSRF block
 and the denylist (`webFetch`). Page text is `wrapUntrusted`-fenced with a delimiter
 the page cannot forge (`tools/prompt-wrap.js`).
@@ -191,11 +189,10 @@ Defenses: the gate stack (`tools/gates.js`). The exposure gate hides low-level D
 and page tools from the main turn. The actor-tier gate pins each actor to its kind's
 toolset and instance and refuses actor-only tools on non-actor contexts. Plan and Act
 mode blocks writes (`permissions/policy.js`). The origin gate applies the denylist.
-Every tool call carries an append-only audit entry. On the isolated path,
+Every tool call carries an append-only audit entry. In the actor worker,
 `actor-worker-core.js` strips every function before the model request crosses the
-`postMessage` relay. On the fallback path, the actor loop receives throwing
-credential stubs and the service-worker-owned provider wrapper overwrites its
-credential fields at the call boundary.
+relay. The privileged provider wrapper overwrites worker-controlled provider,
+model, host, and credential fields at the call boundary.
 Proven by: scenarios 03, 08 (and 05 for delegation).
 
 ### 5.5 Malicious extension (out of scope, see section 7)
@@ -259,26 +256,19 @@ Code: `peerd-egress/denylist/denylist.js`, `fetch/web-fetch.js`,
 <a id="inv-3"></a>
 ### INV-3. Actor loops receive no live credential functions and return fenced data
 Every actor loop receives throwing `getSecret` and `safeFetch` stubs. This is
-enforced in `actor-worker-core.js` for isolated workers, `actor/spawn.js` for the
-spawned in-service-worker fallback, and `loop/turn-driver.js` for the bound
-fallback. Service-worker-owned wrappers add the live functions only at the model
-provider boundary. An isolated worker also cannot pass functions across its relay
-because `makeRelayedCallModel` drops them. Every untrusted summary re-enters the
+enforced in `actor-worker-core.js`. Privileged wrappers add the live functions
+only at the model provider boundary. A worker cannot pass functions across its
+relay because `makeRelayedCallModel` drops them. Every untrusted summary re-enters the
 orchestrator wrapped as data (`makeActorSummaryFence` and `wrapUntrusted`) with a
-delimiter the content cannot forge (`neutralizeFence`). The Firefox fallback has
-credential custody but not heap isolation. See R1.
-Code: `peerd-runtime/actor/spawn.js`, `peerd-runtime/actor/actor-worker-core.js`,
-`peerd-runtime/loop/turn-driver.js`, `tools/prompt-wrap.js`.
-
-The proof is composite. Red-team scenario 03 drives the production turn driver to
-check the bound fallback stubs and broker-owned field overwrite, then checks the
-isolated relay and result fence. The browser test in
-`extension/tests/unit/peerd-runtime/turn-driver-credentials.test.js` runs the real
-turn driver and agent loop together. The installed-XPI Firefox smoke in
-`scripts/firefox/run-runtime-tests.mjs` proves that the packaged browser takes the
-in-service-worker route, attaches the key only at the provider request boundary,
-and returns the actor result through the matching untrusted-content fence. The XPI
-smoke does not claim heap isolation or inspect JavaScript closure reachability.
+delimiter the content cannot forge (`neutralizeFence`).
+Code: `peerd-runtime/actor/actor-worker-core.js`,
+`background/offscreen-actor-client.js`, `background/direct-actor-host.js`,
+`offscreen/actor-runner.js`, `offscreen/actor-worker-protocol.js`, and
+`tools/prompt-wrap.js`. The browser custody test proves an actor cannot enter the
+privileged turn driver. The installed-XPI Firefox smoke proves the packaged extension
+starts a dedicated Worker, verifies its realm, attaches credentials only in the host,
+keeps one background heap alive past the event-page idle window, and returns one
+fenced result without replay. Red-team: scenario 03.
 
 <a id="inv-4"></a>
 ### INV-4. A tampered or re-attributed peer bundle is detectable and rejected
@@ -603,26 +593,25 @@ verifies against its persisted public key; the Bun tier can only prove this over
 These are stated plainly. Several are deliberate tradeoffs. All are things a reader
 evaluating peerd should know. Each cites where it lives in the code.
 
-- R1. The heap split is Chrome-only. It needs the offscreen API. On Firefox, and for
-  a run that never started offscreen, the actor falls back to an in-service-worker
-  loop. Capability gates and keyless loop custody still apply, but the memory
-  boundary is not universal.
-  (`background/service-worker.js` offscreen fallback.)
-
-  Both fallback lanes keep live credentials out of the loop frame:
-
-  - A spawned child receives throwing `getSecret` and `safeFetch` stubs. Its
-    service-worker-owned model wrapper adds the live functions at the provider call
-    boundary (`actor/spawn.js`, `keylessCredentials`).
-  - A bound actor receives the same custody when it falls through to `runAgentTurn`.
-    The turn driver derives the posture from the persisted session kind and adds the
-    live functions only inside its provider wrapper (`loop/turn-driver.js`).
-
-  Neither lane has heap separation, which is the deeper point: the child's untrusted
-  transcript shares a realm with the vault broker and the engine clients, so a
-  memory-disclosure bug there is not fenced the way it is on Chrome. Extending the
-  isolated host to Firefox, or failing closed when it is unavailable, remains P0-1 in
-  [`HARDENING-ROADMAP.md`](HARDENING-ROADMAP.md).
+- R1. Actor isolation depends on the browser's dedicated Worker implementation.
+  Chrome starts the runner from its offscreen document. Firefox starts the same
+  runner from the extension background page. A startup handshake checks the
+  protocol, worker realm, host canary separation, and absence of extension APIs
+  before any model or tool relay. Firefox uses a run-scoped, acknowledged
+  `storage.session` heartbeat while the background page owns an active Worker.
+  A failed heartbeat pauses actor work until a manual probe succeeds. The
+  durable actor mailbox never replays stored work after a background
+  restart: queued work becomes Not run, while started and legacy work becomes
+  Outcome unknown until the target is checked. If the
+  startup proof fails twice before work starts,
+  the capability becomes visibly unavailable and actor tools fail closed. This
+  guards against missing support and startup faults. It does not protect against
+  a browser engine defect that breaks Worker isolation itself. The dedicated
+  Worker also retains standard web APIs such as `fetch`; it is a memory boundary,
+  not a sealed code sandbox. Model output is not evaluated as code in that realm,
+  and model or tool requests use the privileged relay paths.
+  (`offscreen/actor-runner.js`, `offscreen/actor-worker-protocol.js`,
+  `background/direct-actor-host.js`, `peerd-runtime/actor/isolation.js`.)
 - R2 (narrowed). Memory poisoning. The auto-memory digest excludes tool results and
   synthetic messages, but still includes raw assistant text, which can echo
   attacker-paraphrased content, and an approved note persists into every future prompt.

--- a/extension/background/actor-isolation-state.js
+++ b/extension/background/actor-isolation-state.js
@@ -1,0 +1,54 @@
+// @ts-check
+// Durable fail-closed state for the actor Worker host. The key includes both
+// host and protocol, so a browser-host change or protocol bump gets a fresh
+// health record instead of inheriting an incompatible failure.
+
+const KEY_PREFIX = 'actorIsolationFailure';
+
+/**
+ * @param {{ host?: string|null }} capability
+ * @param {number} protocol
+ */
+export const actorIsolationFailureKey = (capability, protocol) =>
+  `${KEY_PREFIX}:${String(capability?.host ?? 'none')}:v${protocol}`;
+
+/**
+ * @param {Object} deps
+ * @param {{ get: (key: string) => Promise<Record<string, any>>, set: (items: Record<string, any>) => Promise<void>, remove: (key: string) => Promise<void> }} deps.storage
+ * @param {number} deps.protocol
+ * @param {() => number} [deps.now]
+ */
+export const makeActorIsolationStateStore = ({ storage, protocol, now = Date.now }) => ({
+  /** @param {{ host?: string|null }} capability */
+  load: async (capability) => {
+    const key = actorIsolationFailureKey(capability, protocol);
+    const record = (await storage.get(key))?.[key];
+    if (record?.status !== 'temporarily_unavailable'
+        || record?.host !== capability?.host
+        || record?.protocol !== protocol) return null;
+    return {
+      status: /** @type {const} */ ('temporarily_unavailable'),
+      host: capability?.host ?? null,
+      reason: typeof record.reason === 'string' ? record.reason : 'The actor worker host did not start.',
+      retryable: true,
+    };
+  },
+
+  /** @param {{ host?: string|null }} capability @param {unknown} reason @param {string} code */
+  markUnavailable: async (capability, reason, code) => {
+    const key = actorIsolationFailureKey(capability, protocol);
+    await storage.set({
+      [key]: {
+        status: 'temporarily_unavailable',
+        host: capability?.host ?? null,
+        protocol,
+        reason: /** @type {{ message?: string }} */ (reason)?.message ?? String(reason || 'The actor worker host did not start.'),
+        code,
+        recordedAt: now(),
+      },
+    });
+  },
+
+  /** @param {{ host?: string|null }} capability */
+  clear: async (capability) => storage.remove(actorIsolationFailureKey(capability, protocol)),
+});

--- a/extension/background/actor-recovery-gate.js
+++ b/extension/background/actor-recovery-gate.js
@@ -1,0 +1,111 @@
+// @ts-check
+
+/**
+ * Collect internal mailbox correlations only from a durably appended user
+ * message. The bound keeps malformed persisted data from becoming an
+ * unbounded storage-removal request.
+ * @param {any} message
+ * @returns {string[]}
+ */
+export const actorDeliveryIdsFromMessage = (message) => {
+  if (message?.role !== 'user') return [];
+  const deliveryIds = new Set();
+  const addDeliveryId = (/** @type {unknown} */ id) => {
+    if (typeof id === 'string' && id.length > 0 && id.length <= 512) deliveryIds.add(id);
+  };
+  addDeliveryId(message.actorReply?.actorDeliveryId);
+  for (const result of Array.isArray(message.toolResults) ? message.toolResults : []) {
+    addDeliveryId(result?.actorDeliveryId);
+    if (Array.isArray(result?.actorDeliveryIds)) {
+      for (const id of result.actorDeliveryIds) addDeliveryId(id);
+    }
+  }
+  return [...deliveryIds];
+};
+
+/**
+ * Serialize passive actor-mailbox recovery and expose one gate for automatic
+ * work. A retained receipt means storage did not accept the warning, so model
+ * work stays paused while a later passive retry is scheduled.
+ *
+ * @param {Object} deps
+ * @param {() => Promise<{ redrained: number, retained: number }>} deps.redrain
+ * @param {(fn: () => void, delayMs: number) => any} [deps.schedule]
+ * @param {number} [deps.retryMs]
+ * @param {(error: unknown) => void} [deps.log]
+ */
+export const makeActorRecoveryGate = ({
+  redrain,
+  schedule = (fn, delayMs) => setTimeout(fn, delayMs),
+  retryMs = 1_000,
+  log = () => {},
+}) => {
+  /** @type {Promise<{ redrained: number, retained: number }> | null} */
+  let recoveryPromise = null;
+  let retryScheduled = false;
+  /** @type {Map<string, () => Promise<any>|any>} */
+  const pendingActions = new Map();
+  /** @type {Promise<void> | null} */
+  let flushPromise = null;
+
+  const flushPendingActions = () => {
+    if (flushPromise) return flushPromise;
+    flushPromise = (async () => {
+      while (pendingActions.size > 0) {
+        const batch = [...pendingActions.values()];
+        pendingActions.clear();
+        for (const action of batch) {
+          try { await action(); }
+          catch (error) { log(error); }
+        }
+      }
+    })().finally(() => { flushPromise = null; });
+    return flushPromise;
+  };
+
+  const recover = () => {
+    if (recoveryPromise) return recoveryPromise;
+    recoveryPromise = redrain()
+      .catch((error) => {
+        log(error);
+        return { redrained: 0, retained: 1 };
+      })
+      .then(async (status) => {
+        if (status.retained > 0) {
+          recoveryPromise = null;
+          if (!retryScheduled) {
+            retryScheduled = true;
+            schedule(() => {
+              retryScheduled = false;
+              void recover();
+            }, retryMs);
+          }
+        } else {
+          await flushPendingActions();
+        }
+        return status;
+      });
+    return recoveryPromise;
+  };
+
+  /** @returns {Promise<boolean>} */
+  const ready = async () => (await recover()).retained === 0;
+
+  /**
+   * Queue automatic work behind recovery. A stable key makes repeated boot,
+   * alarm, and unlock nudges collapse to one eventual action.
+   * @param {string} key
+   * @param {() => Promise<any>|any} action
+   */
+  const runWhenReady = async (key, action) => {
+    const recovery = await recover();
+    if (recovery.retained > 0) {
+      pendingActions.set(key, action);
+      return false;
+    }
+    await action();
+    return true;
+  };
+
+  return { recover, ready, runWhenReady };
+};

--- a/extension/background/context-snapshots.js
+++ b/extension/background/context-snapshots.js
@@ -4,10 +4,9 @@
 // "What did the model actually see?" — per model call, a SHAPED snapshot
 // of the request args (system, messages, tools, params) is recorded into
 // a per-session capped ring. Three SW seams feed it and together cover
-// every model call peerd makes: the turn driver's failover wrapper (the
-// orchestrator plus bound-actor in-SW fallback), the 'actor/model-call'
-// relay route (every isolated actor heap), and spawn's capped wrapper (the
-// spawned in-SW fallback loop when offscreen is unavailable). Held in SW
+// every model call peerd makes: the turn driver's failover wrapper for the
+// orchestrator and the 'actor/model-call' relay route for every isolated actor
+// heap. Held in SW
 // memory only, with the same lifetime posture as
 // the script-runs op mirror — so it answers "what just happened", not
 // "what happened last week"; the debug bundle exports whatever is live

--- a/extension/background/direct-actor-host.js
+++ b/extension/background/direct-actor-host.js
@@ -1,0 +1,379 @@
+// @ts-check
+// Firefox MV3 background-page host for the actor worker runner. Unlike the
+// Chrome offscreen transport, this path is entirely in-process: no runtime
+// message exposes actor relay routes or the per-run grant to extension pages.
+
+import { runActor, abortActor } from '/offscreen/actor-runner.js';
+
+/**
+ * Own the Firefox event-page heartbeat behind one serialized state machine.
+ * Firefox resets an MV3 event page's idle budget when storage.session changes.
+ * This is Mozilla's documented extension-side workaround until the platform
+ * exposes an official long-task lifetime signal.
+ * @param {Object} deps
+ * @param {{ set: (items: Record<string, unknown>) => Promise<void>, remove: (key: string) => Promise<void> }} deps.storage
+ * @param {string} deps.key
+ * @param {number} deps.intervalMs
+ * @param {number} deps.ackTimeoutMs
+ * @param {() => string} [deps.makeLeaseId]
+ * @param {typeof setInterval} [deps.setIntervalFn]
+ * @param {typeof clearInterval} [deps.clearIntervalFn]
+ * @param {typeof setTimeout} [deps.setTimeoutFn]
+ * @param {typeof clearTimeout} [deps.clearTimeoutFn]
+ * @param {(error: Error) => void} [deps.onLost]
+ */
+export const makeStorageSessionKeepAlive = ({
+  storage,
+  key,
+  intervalMs,
+  ackTimeoutMs,
+  makeLeaseId = () => crypto.randomUUID(),
+  setIntervalFn = setInterval,
+  clearIntervalFn = clearInterval,
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
+  onLost = () => {},
+}) => {
+  let leaseIntended = false;
+  let leaseEstablished = false;
+  let leaseId = '';
+  let sequence = 0;
+  /** @type {ReturnType<typeof setInterval>|null} */
+  let interval = null;
+  /** @type {Promise<void>|null} */
+  let pendingWrite = null;
+  /** @type {Promise<void>} */
+  let cleanupBarrier = Promise.resolve();
+  let cleanupPending = false;
+  /** @type {{ leaseId: string, sequence: number, resolve: () => void, reject: (error: Error) => void, timeout: ReturnType<typeof setTimeout> } | null} */
+  let pendingAcknowledgment = null;
+  /** @type {Promise<unknown>} */
+  let transition = Promise.resolve();
+
+  /** @param {() => unknown|Promise<unknown>} operation */
+  const queue = (operation) => {
+    const result = transition.then(operation);
+    transition = result.catch(() => {});
+    return result;
+  };
+
+  const writeHeartbeat = async () => {
+    sequence += 1;
+    const value = { leaseId, sequence };
+    let resolveAcknowledgment = () => {};
+    /** @type {(error: Error) => void} */
+    let rejectAcknowledgment = () => {};
+    /** @type {Promise<void>} */
+    const acknowledgment = new Promise((resolve, reject) => {
+      resolveAcknowledgment = resolve;
+      rejectAcknowledgment = reject;
+    });
+    const timeout = setTimeoutFn(() => {
+      const pending = pendingAcknowledgment;
+      if (pending?.leaseId !== value.leaseId || pending?.sequence !== value.sequence) return;
+      pendingAcknowledgment = null;
+      pending.reject(new Error('actor host storage heartbeat was not acknowledged'));
+    }, ackTimeoutMs);
+    const expected = {
+      ...value,
+      resolve: resolveAcknowledgment,
+      reject: rejectAcknowledgment,
+      timeout,
+    };
+    pendingAcknowledgment = expected;
+    const write = storage.set({ [key]: value });
+    pendingWrite = write;
+    try {
+      await Promise.all([write, acknowledgment]);
+      if (pendingWrite === write) pendingWrite = null;
+    } catch (error) {
+      if (pendingAcknowledgment === expected && expected) {
+        clearTimeoutFn(expected.timeout);
+        pendingAcknowledgment = null;
+        expected.reject(error instanceof Error ? error : new Error(String(error)));
+        await acknowledgment.catch(() => {});
+      }
+      throw error;
+    }
+  };
+
+  const clearHeartbeat = async () => {
+    if (interval !== null) {
+      clearIntervalFn(interval);
+      interval = null;
+    }
+    const write = pendingWrite;
+    if (write) {
+      await write.catch(() => {});
+      if (pendingWrite === write) pendingWrite = null;
+    }
+    await storage.remove(key);
+  };
+
+  const beginCleanup = () => {
+    if (cleanupPending) return cleanupBarrier;
+    cleanupPending = true;
+    cleanupBarrier = clearHeartbeat()
+      .catch(() => {})
+      .finally(() => { cleanupPending = false; });
+    return cleanupBarrier;
+  };
+
+  const waitForCleanup = async () => {
+    if (!cleanupPending) return;
+    /** @type {ReturnType<typeof setTimeout>|null} */
+    let timeout = null;
+    const finished = await Promise.race([
+      cleanupBarrier.then(() => true),
+      new Promise((resolve) => {
+        timeout = setTimeoutFn(() => resolve(false), ackTimeoutMs);
+      }),
+    ]);
+    if (timeout !== null) clearTimeoutFn(timeout);
+    if (!finished) throw new Error('previous actor host heartbeat cleanup is still pending');
+  };
+
+  const loseLease = (/** @type {unknown} */ reason) => {
+    if (!leaseIntended) return;
+    const notify = leaseEstablished;
+    leaseIntended = false;
+    leaseEstablished = false;
+    if (notify) onLost(reason instanceof Error ? reason : new Error(String(reason)));
+    void beginCleanup();
+  };
+
+  const tick = () => {
+    void queue(async () => {
+      if (!leaseIntended) return;
+      try {
+        await writeHeartbeat();
+      } catch (error) {
+        loseLease(error);
+      }
+    });
+  };
+
+  // why: a crash can strand the session key. Every acquisition waits on this
+  // barrier, but a stuck storage removal gets only the bounded startup budget.
+  void beginCleanup();
+
+  const start = async () => {
+    await waitForCleanup();
+    await queue(async () => {
+      leaseIntended = true;
+      leaseEstablished = false;
+      leaseId = makeLeaseId();
+      sequence = 0;
+      try {
+        await writeHeartbeat();
+        if (!leaseIntended) {
+          void beginCleanup();
+          throw new Error('actor host storage heartbeat stopped during startup');
+        }
+        leaseEstablished = true;
+        interval = setIntervalFn(tick, intervalMs);
+      } catch (error) {
+        leaseIntended = false;
+        leaseEstablished = false;
+        void beginCleanup();
+        throw error;
+      }
+    });
+  };
+
+  const stop = () => {
+    leaseIntended = false;
+    leaseEstablished = false;
+    if (interval !== null) {
+      clearIntervalFn(interval);
+      interval = null;
+    }
+    if (cleanupPending) return;
+    // why: actor completion must not wait forever on best-effort storage
+    // cleanup. A later start observes the barrier and fails closed if needed.
+    void beginCleanup();
+  };
+
+  // why: Mozilla's workaround requires an extension listener for the
+  // storage.session change event. Matching the exact lease generation makes
+  // each write prove that event path before actor work begins or continues.
+  /** @param {Record<string, { oldValue?: unknown, newValue?: unknown }>} changes */
+  const onChanged = (changes) => {
+    if (!Object.hasOwn(changes, key)) return false;
+    const value = /** @type {{ leaseId?: unknown, sequence?: unknown } | undefined} */ (
+      changes[key]?.newValue
+    );
+    const oldValue = /** @type {{ leaseId?: unknown } | undefined} */ (
+      changes[key]?.oldValue
+    );
+    const expected = pendingAcknowledgment;
+    if (expected
+        && value?.leaseId === expected.leaseId
+        && value?.sequence === expected.sequence) {
+      clearTimeoutFn(expected.timeout);
+      pendingAcknowledgment = null;
+      expected.resolve();
+      return true;
+    }
+    // A cold-start cleanup event can arrive after its remove() promise settles.
+    // If a heartbeat write is pending, wait for that exact write's event or its
+    // timeout instead of mistaking the earlier deletion for active tampering.
+    if (value === undefined
+        && (expected || oldValue?.leaseId !== leaseId)) return false;
+    if (!leaseIntended) return false;
+    const error = new Error('actor host storage heartbeat changed unexpectedly');
+    if (expected) {
+      clearTimeoutFn(expected.timeout);
+      pendingAcknowledgment = null;
+      expected.reject(error);
+    }
+    void queue(() => loseLease(error));
+    return false;
+  };
+
+  return { start, stop, onChanged };
+};
+
+/**
+ * @param {Object} deps
+ * @param {string} deps.workerUrl
+ * @param {typeof runActor} [deps.run]
+ * @param {typeof abortActor} [deps.abort]
+ * @param {() => void|Promise<void>} [deps.startKeepAlive]
+ * @param {() => void|Promise<void>} [deps.stopKeepAlive]
+ */
+export const makeDirectActorHost = ({
+  workerUrl,
+  run = runActor,
+  abort = abortActor,
+  startKeepAlive = () => {},
+  stopKeepAlive = () => {},
+}) => {
+  // Object identity is the sender proof. It never leaves this closure and is
+  // never posted, serialized, stored, or exposed on runtime.onMessage.
+  const relaySender = Object.freeze({});
+  /** @type {Record<string, (payload: any, sender?: unknown) => any> | null} */
+  let relayRoutes = null;
+  let activeRuns = 0;
+  /** @type {Promise<void>} */
+  let keepAliveTransition = Promise.resolve();
+  /** @type {Promise<void>|null} */
+  let keepAliveReady = null;
+  /** @type {Error|null} */
+  let keepAliveLoss = null;
+  /** @type {Map<symbol, { runId: string|null, settle: (error: Error) => void }>} */
+  const activeRunLosses = new Map();
+
+  /** @param {() => void|Promise<void>} operation */
+  const queueKeepAliveTransition = (operation) => {
+    const result = keepAliveTransition.then(operation);
+    // why: one rejected transition must not poison a later manual retry.
+    keepAliveTransition = result.catch(() => {});
+    return result;
+  };
+  /** @param {boolean} allowRecovery */
+  const retainBackground = async (allowRecovery) => {
+    if (keepAliveLoss) {
+      if (!allowRecovery || activeRuns > 0) throw keepAliveLoss;
+      keepAliveLoss = null;
+    }
+    activeRuns += 1;
+    if (activeRuns === 1) keepAliveReady = queueKeepAliveTransition(startKeepAlive);
+    const ready = keepAliveReady;
+    if (!ready) {
+      activeRuns = Math.max(0, activeRuns - 1);
+      throw new Error('keepalive lease was not created');
+    }
+    try {
+      await ready;
+    } catch (error) {
+      activeRuns = Math.max(0, activeRuns - 1);
+      if (activeRuns === 0 && keepAliveReady === ready) {
+        keepAliveReady = null;
+        // Keep cleanup serialized without making a pre-start refusal wait on a
+        // storage call that may itself be stuck. A later acquisition queues
+        // behind this cleanup before it can start.
+        void queueKeepAliveTransition(stopKeepAlive).catch(() => {});
+      }
+      throw error;
+    }
+  };
+  const releaseBackground = async () => {
+    activeRuns = Math.max(0, activeRuns - 1);
+    if (activeRuns !== 0 || !keepAliveReady) return;
+    keepAliveReady = null;
+    // Queue the clear before yielding. A new run then queues its start after
+    // this clear and cannot lose its newly-created heartbeat to an older release.
+    await queueKeepAliveTransition(stopKeepAlive).catch(() => {});
+  };
+
+  /** @param {Record<string, (payload: any, sender?: unknown) => any>} routes */
+  const bindRelayRoutes = (routes) => { relayRoutes = routes; };
+  const isRelaySender = (/** @type {unknown} */ sender) => sender === relaySender;
+  const failKeepAlive = (/** @type {unknown} */ reason) => {
+    const error = reason instanceof Error ? reason : new Error(String(reason));
+    if (keepAliveLoss) return;
+    keepAliveLoss = error;
+    for (const { runId, settle } of activeRunLosses.values()) {
+      if (runId) abort(runId);
+      settle(error);
+    }
+  };
+
+  /** @param {{ type?: string, runId?: string, job?: any }} message */
+  const sendMessage = async (message) => {
+    if (message?.type === 'actor/abort') {
+      if (typeof message.runId === 'string') abort(message.runId);
+      return { ok: true };
+    }
+    if (message?.type !== 'actor/run' || !message.job) {
+      return { ok: false, started: false, code: 'actor_host_bad_request', error: 'direct actor host: unsupported request' };
+    }
+    if (!relayRoutes) {
+      return { ok: false, started: false, code: 'actor_host_not_ready', error: 'direct actor host: relay routes are not bound' };
+    }
+    try {
+      await retainBackground(message.job.probeOnly === true);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      return {
+        ok: false,
+        started: false,
+        code: 'actor_host_keepalive_failed',
+        error: `direct actor host: could not retain background: ${detail}`,
+      };
+    }
+    try {
+      const runKey = Symbol('direct-actor-run');
+      const runId = typeof message.job.runId === 'string' ? message.job.runId : null;
+      const keepAliveLost = new Promise((resolve) => {
+        activeRunLosses.set(runKey, {
+          runId,
+          settle: (error) => resolve({
+            ok: false,
+            started: true,
+            phase: 'run',
+            code: 'actor_host_keepalive_lost',
+            error: `direct actor host: ${error.message}`,
+            outcomeKnown: false,
+          }),
+        });
+      });
+      const actorRun = run(message.job, {
+        workerUrl,
+        sendToSW: async (type, payload) => {
+          const route = relayRoutes?.[type];
+          if (!route) return { ok: false, error: `direct actor host: unknown relay '${type}'` };
+          return route(payload, relaySender);
+        },
+      });
+      try {
+        return await Promise.race([actorRun, keepAliveLost]);
+      } finally {
+        activeRunLosses.delete(runKey);
+      }
+    } finally { await releaseBackground(); }
+  };
+
+  return { bindRelayRoutes, isRelaySender, failKeepAlive, sendMessage };
+};

--- a/extension/background/offscreen-actor-client.js
+++ b/extension/background/offscreen-actor-client.js
@@ -1,5 +1,5 @@
 // @ts-check
-// background/offscreen-actor-client.js — the SW-side client for EVERY offscreen
+// background/offscreen-actor-client.js — the privileged-host client for EVERY isolated
 // agent loop (the heap split): ephemeral spawned reasoners (spawn.js) AND bound
 // actors (the actor turn). One client, one set of routes (model-call + tool-dispatch
 // + loop-event); a reasoning child grants no tools, so it only ever exercises
@@ -10,7 +10,7 @@
 // there — the pin, the gate, the engine clients, the tabs, and the audit are ALL
 // SW-side. It NEVER trusts the worker's call args (they may derive from injected
 // instance/page output): it re-pins the bound instance and runs the full gate,
-// exactly as the in-SW actor turn does.
+// with the same policy on every browser host.
 //
 // Pure shell — every IO injected — so it is unit-testable without a browser.
 
@@ -21,7 +21,8 @@
 // inbound turns until somebody deliberately classifies it here.
 /**
  * @param {Object} deps
- * @param {() => Promise<void>} deps.ensureOffscreen
+ * @param {() => Promise<void>} [deps.ensureHost]
+ * @param {() => Promise<void>} [deps.ensureOffscreen] legacy Chrome host alias
  * @param {(msg: object) => Promise<any>} deps.sendMessage
  * @param {(args: object) => AsyncIterable<any>} deps.callModel
  * @param {(name: string) => Promise<string | null>} deps.getSecret
@@ -41,7 +42,7 @@
  * @param {string} [deps.EXPOSURE_REVIEW]  issue 160 - the review-exemption marker. A review
  *   child's session record carries `review:true` (persisted SW-side at spawn); the
  *   tool-dispatch route re-stamps ctx.exposure from it so the tier gate admits the
- *   three instance reads on the offscreen path too, not just the in-SW fallback.
+ *   three instance reads on every dedicated-worker host.
  *   Optional and fail-closed: not injected → nothing is ever stamped.
  * @param {() => number} [deps.now]
  * @param {(call: Record<string, any>) => void} [deps.recordModelCall]  the context
@@ -49,13 +50,14 @@
  *   identity (never the worker's own claim). Optional; defaults to a no-op.
  * @param {(msg: Record<string, any>) => void} [deps.broadcastOp]  announce each settled
  *   ACTOR tool dispatch on the UI ports ('actor/op' — bounded name/ok only).
- *   The offscreen heap emits no turn/tool-use, so this is how the eval harness's OM2W
+ *   The isolated heap emits no turn/tool-use, so this is how the eval harness's OM2W
  *   recorder (and any activity view) sees what an actor did. Optional; defaults to a no-op.
- * @param {(sender: unknown) => boolean} [deps.isOffscreenSender]  is this message from the
- *   OFFSCREEN DOCUMENT? The three relay routes below refuse anything else. REQUIRED in
+ * @param {(sender: unknown) => boolean} [deps.isRelaySender]  is this message from the
+ *   exact actor host? The three relay routes below refuse anything else. REQUIRED in
  *   production and fail-CLOSED by omission (an unwired client refuses every relay), because
  *   this is the boundary, not a hint — see the grants-map note for why the token alone is
  *   not sufficient.
+ * @param {(sender: unknown) => boolean} [deps.isOffscreenSender] legacy Chrome sender alias
  * @param {() => string} [deps.mintRelayToken]  mints the per-run relay grant (below).
  *   Injected so the grant is testable without a browser; defaults to crypto.randomUUID.
  * @param {(sessionId: string) => Promise<string | null>} [deps.spendRefusalFor]  spend-limit
@@ -68,19 +70,21 @@
  *   supplied from the runtime capability manifest; omission fails closed.
  */
 export const makeOffscreenActorClient = ({
-  ensureOffscreen, sendMessage, callModel, getSecret, safeFetch,
+  ensureHost, ensureOffscreen, sendMessage, callModel, getSecret, safeFetch,
   sessions, buildToolContext, dispatchToolCall, pinActorCall, restrictCtxCapabilities, ownedTabFor, EXPOSURE_ACTOR, EXPOSURE_REVIEW, now = Date.now,
   recordModelCall = () => {},
   broadcastOp = (/** @type {any} */ _msg) => {},
   mintRelayToken = () => globalThis.crypto.randomUUID(),
   spendRefusalFor = undefined,
-  isOffscreenSender = () => false,
+  isRelaySender, isOffscreenSender,
   inboundDwebToolNames = [],
 }) => {
+  const ensureActorHost = ensureHost ?? ensureOffscreen ?? (async () => {});
+  const relaySenderAllowed = isRelaySender ?? isOffscreenSender ?? (() => false);
   const inboundDwebTools = new Set(inboundDwebToolNames);
   let seq = 0;
   /**
-   * @type {Map<string, { runId: string, actorSessionId: string, inbound: boolean, allowedTools: Set<string> | null, actorSurface?: 'tools'|'code', signal: AbortSignal }>} relay grants:
+   * @type {Map<string, { runId: string, actorSessionId: string, provider: string, model: string, ollamaHost?: string, inbound: boolean, allowedTools: Set<string> | null, actorSurface?: 'tools'|'code', relaySignal: AbortSignal }>} relay grants:
    * token → the identity of the run it was minted for.
    *
    * why a grant and not the message's own `actorSessionId`/`runId`: these three routes
@@ -124,27 +128,33 @@ export const makeOffscreenActorClient = ({
    * session (and a human label for WHOSE call this is) is stashed at run() time. */
   const runMeta = new Map();
   /**
-   * @param {{ actorSessionId: string, message: string, systemPrompt: string, provider: string, model: string, depth?: number, maxSteps?: number, maxOutputTokens?: number, tools?: any[], priorMessages?: any[], reasoning?: object, contextWindow?: number, budgetMs?: number, oneShot?: boolean, actorType?: string, backing?: string, actorSurface?: 'tools'|'code', tabUrl?: string, origin?: string, inbound?: boolean }} job
+   * @param {{ actorSessionId: string, message: string, systemPrompt: string, provider: string, model: string, ollamaHost?: string, probeOnly?: boolean, depth?: number, maxSteps?: number, maxOutputTokens?: number, tools?: any[], priorMessages?: any[], reasoning?: object, contextWindow?: number, budgetMs?: number, oneShot?: boolean, actorType?: string, backing?: string, actorSurface?: 'tools'|'code', tabUrl?: string, origin?: string, inbound?: boolean }} job
    * @param {{ signal?: AbortSignal, onEvent?: (ev: object) => void }} [opts]
    */
   const run = async (job, { signal, onEvent } = {}) => {
-    // Stop can land while Chrome is still creating the offscreen document. Do
-    // not mint a relay grant or dispatch actor/run for a turn that is already
-    // over; actor/abort cannot cancel a Worker that does not exist yet.
+    // A cancelled turn must not create a host, mint authority, or start a Worker.
+    // why: Stop can win before an async actor reaches this client; sending abort
+    // before actor/run exists cannot cancel the Worker that actor/run then creates.
     if (signal?.aborted) {
-      return { ok: false, started: true, aborted: true, error: 'actor aborted before offscreen startup' };
+      return { ok: false, started: true, phase: 'startup', code: 'actor_run_aborted', error: 'actor run aborted', aborted: true };
     }
-    await ensureOffscreen();
+    try {
+      await ensureActorHost();
+    } catch (error) {
+      return {
+        ok: false, started: false, phase: 'startup', code: 'actor_host_unavailable',
+        error: `actor host unavailable: ${/** @type {{ message?: string }} */ (error)?.message ?? String(error)}`,
+      };
+    }
     if (signal?.aborted) {
-      return { ok: false, started: true, aborted: true, error: 'actor aborted during offscreen startup' };
+      return { ok: false, started: true, phase: 'startup', code: 'actor_run_aborted', error: 'actor run aborted', aborted: true };
     }
     const runId = `aw-${now().toString(36)}-${++seq}`;
     const relayToken = mintRelayToken();
-    // This controller belongs to the RUN, not to its caller. The outer signal
-    // chains into it, but runner timeout/crash/normal settlement abort it too so
-    // an already-admitted SW relay cannot outlive the Worker whose request it
-    // serves. The signal rides in the host-only grant; the Worker never sees it.
-    const runController = new AbortController();
+    // This controller is the authoritative relay lifetime. Put it in the grant
+    // itself so a route that already resolved the token can re-check authority
+    // after every await, even after run() retires the Map entry.
+    const relayController = new AbortController();
     // Only the SW caller can stamp `inbound:true`. From here onward the bit is
     // monotonic: the runner/Worker may echo it but can never widen its tool grant
     // or rebuild a trusted ctx. Unknown inbound actor kinds get no tools.
@@ -158,11 +168,13 @@ export const makeOffscreenActorClient = ({
       ? new Set((tools ?? []).map((tool) => tool?.name).filter((name) => typeof name === 'string'))
       : null;
     grants.set(relayToken, {
-      runId, actorSessionId: job.actorSessionId, inbound, allowedTools,
+      runId, actorSessionId: job.actorSessionId,
+      provider: job.provider, model: job.model,
+      inbound, allowedTools, relaySignal: relayController.signal,
+      ...(job.ollamaHost ? { ollamaHost: job.ollamaHost } : {}),
       ...(job.actorSurface === 'code' || job.actorSurface === 'tools'
         ? { actorSurface: job.actorSurface }
         : {}),
-      signal: runController.signal,
     });
     if (onEvent) runOnEvent.set(runId, onEvent);
     runMeta.set(runId, {
@@ -171,7 +183,7 @@ export const makeOffscreenActorClient = ({
     });
     const abortRelays = () => {
       abortedRuns.add(runId);   // cover a model-call that hasn't reached the route yet
-      runController.abort();
+      relayController.abort();
       for (const ac of inflight.get(runId) ?? []) { try { ac.abort(); } catch { /* already */ } }
     };
     const abortRun = () => {
@@ -201,6 +213,8 @@ export const makeOffscreenActorClient = ({
       // Drop the abort listener a completed-without-Stop run left attached (a no-op if
       // it already fired under {once:true}); keeps nothing dangling on the turn signal.
       signal?.removeEventListener('abort', abortRun);
+      relayController.abort();
+      for (const ac of inflight.get(runId) ?? []) { try { ac.abort(); } catch { /* already */ } }
       // Retiring the grant is what makes it a liveness check: every relay for
       // this run is refused from here on, so a late/replayed one can't dispatch.
       grants.delete(relayToken);
@@ -218,10 +232,10 @@ export const makeOffscreenActorClient = ({
    * that as a hard refusal, so an unauthorized caller learns nothing beyond "no".
    * @param {{ relayToken?: unknown }} [msg]
    * @param {unknown} [sender]  the second argument makeDispatcher hands a handler
-   * @returns {{ runId: string, actorSessionId: string, inbound: boolean, allowedTools: Set<string> | null, actorSurface?: 'tools'|'code', signal: AbortSignal } | null}
+   * @returns {{ runId: string, actorSessionId: string, provider: string, model: string, ollamaHost?: string, inbound: boolean, allowedTools: Set<string> | null, actorSurface?: 'tools'|'code', relaySignal: AbortSignal } | null}
    */
   const grantFor = (msg, sender) => {
-    if (!isOffscreenSender(sender)) return null;
+    if (!relaySenderAllowed(sender)) return null;
     const token = msg?.relayToken;
     if (typeof token !== 'string' || token.length === 0) return null;
     return grants.get(token) ?? null;
@@ -243,7 +257,7 @@ export const makeOffscreenActorClient = ({
       const key = runId;
       // Race guard 1: a Stop that fired BEFORE this call reached the route (the card
       // appears first) → refuse without ever making the key-bearing request.
-      if (abortedRuns.has(key)) return { ok: false, error: 'aborted' };
+      if (grant.relaySignal.aborted || abortedRuns.has(key)) return { ok: false, error: 'aborted' };
       // Spend-limit preflight, script/model-call's posture applied to the actor lane:
       // an actor's model calls spend the user's money on the OWNING chat session, so a
       // session past the hard cap must not be pushed further by its own actors. Without
@@ -253,10 +267,9 @@ export const makeOffscreenActorClient = ({
         const refusal = await spendRefusalFor(grant.actorSessionId).catch(() => null);
         if (refusal) return { ok: false, error: refusal };
       }
-      // The run may have settled while the spend preflight was reading state.
-      // Its grant object remains locally reachable, so the run-owned signal is
-      // the durable liveness proof even after the grants Map entry is retired.
-      if (grant.signal.aborted || abortedRuns.has(key)) return { ok: false, error: 'aborted' };
+      // The host may have settled while the spend lookup was in flight. A
+      // token lookup made before settlement is not continuing authority.
+      if (grant.relaySignal.aborted || abortedRuns.has(key)) return { ok: false, error: 'aborted' };
       const ac = new AbortController();
       const set = inflight.get(key) ?? new Set();
       set.add(ac); inflight.set(key, set);
@@ -265,11 +278,17 @@ export const makeOffscreenActorClient = ({
       // runMeta stash, never the worker's args (a worker must not be able to
       // relabel whose context this was).
       const meta = runMeta.get(key);
-      if (meta) recordModelCall({ ...(args ?? {}), sessionId: meta.sessionId, label: meta.label });
+      const pinnedArgs = {
+        ...(args ?? {}),
+        provider: grant.provider,
+        model: grant.model,
+        ollamaHost: grant.ollamaHost,
+      };
+      if (meta) recordModelCall({ ...pinnedArgs, sessionId: meta.sessionId, label: meta.label });
       /** @type {any[]} */
       const events = [];
       try {
-        for await (const ev of callModel({ ...(args ?? {}), getSecret, safeFetch, signal: ac.signal })) events.push(ev);
+        for await (const ev of callModel({ ...pinnedArgs, getSecret, safeFetch, signal: ac.signal })) events.push(ev);
         // Race guard 2: a Stop that fired DURING the call → honor it even if the stream
         // still fulfilled (a fake responder, or a provider that flushed before cancel),
         // so a mid-call abort never delivers a completed turn.
@@ -292,8 +311,8 @@ export const makeOffscreenActorClient = ({
         // that could name its own session would inherit any actor's pin and toolset.
         const grant = grantFor(msg, sender);
         if (!grant) return { ok: false, error: 'actor/tool-dispatch: unauthorized relay' };
+        if (grant.relaySignal.aborted) return { ok: false, error: 'aborted' };
         const { actorSessionId } = grant;
-        if (grant.signal.aborted) return { ok: false, error: 'actor/tool-dispatch: run aborted' };
         const call = msg.call;
         // Descriptor narrowing makes the model unlikely to ask; this check is the
         // authority wall. The grant's set was minted from the SW-stamped inbound
@@ -302,7 +321,7 @@ export const makeOffscreenActorClient = ({
           return { ok: false, error: `tool_not_available_to_inbound_actor: ${call?.name}` };
         }
         const rec = await sessions.get(actorSessionId);
-        if (grant.signal.aborted) return { ok: false, error: 'actor/tool-dispatch: run aborted' };
+        if (grant.relaySignal.aborted) return { ok: false, error: 'aborted' };
         if (!rec) return { ok: false, error: 'actor/tool-dispatch: unknown session' };
 
         // Phase 4 — a spawned child is a tool-bearing EPHEMERAL actor. Its toolset is the
@@ -323,6 +342,7 @@ export const makeOffscreenActorClient = ({
             sessionId: actorSessionId,
             ...(grant.inbound ? { synthetic: true, trusted: false } : {}),
           });
+          if (grant.relaySignal.aborted) return { ok: false, error: 'aborted' };
           // Stamp the child lineage on every audit its tools emit (parity with spawn.js's taggedAudit).
           const audit = (/** @type {any} */ entry) => /** @type {any} */ (base).audit?.({ ...entry, details: { ...(entry?.details ?? {}), parentSessionId: rec.parentSessionId, actorSessionId, depth: rec.depth } });
           // #160: re-stamp the review-exemption marker from the PERSISTED record
@@ -333,13 +353,14 @@ export const makeOffscreenActorClient = ({
           // fallback path. Fail-closed: rec.review !== true, or no injected
           // EXPOSURE_REVIEW, stamps nothing.
           const ctx = restrictCtxCapabilities({
-            ...base, audit, abortSignal: grant.signal,
+            ...base, audit, abortSignal: grant.relaySignal,
             // Monotonic backstop: even a miswired context builder cannot erase
             // the provenance attached to this live SW grant.
             ...(grant.inbound ? { synthetic: true, trusted: false, inbound: true } : {}),
             ...(rec.review === true && EXPOSURE_REVIEW ? { exposure: EXPOSURE_REVIEW } : {}),
           }, granted);
           const result = await dispatchToolCall(call, ctx);
+          if (grant.relaySignal.aborted) return { ok: false, error: 'aborted' };
           return { ok: true, result };
         }
 
@@ -363,13 +384,14 @@ export const makeOffscreenActorClient = ({
           ...(grant.actorSurface ? { actorSurface: grant.actorSurface } : {}),
           ...(grant.inbound ? { synthetic: true, trusted: false } : {}),
         });
+        if (grant.relaySignal.aborted) return { ok: false, error: 'aborted' };
         // Stop/cancel belongs to the ACTOR TURN, not only spawned children.
         // Thread the live SW-owned signal into every bound context so a
         // page_code/a2a_run/site_client_run tool cannot outlive the reasoning
         // worker that invoked it.
         const stamped = {
           ...base,
-          abortSignal: grant.signal,
+          abortSignal: grant.relaySignal,
           ...(grant.inbound ? { synthetic: true, trusted: false, inbound: true } : {}),
         };
         // Strip the ctx's closures as well as its descriptors: an injected model
@@ -387,6 +409,7 @@ export const makeOffscreenActorClient = ({
         // Announce the settled dispatch — pure, privacy-minimal observability.
         // Arguments can contain form text, credentials, or attacker-derived
         // bytes, so no UI port receives them.
+        if (grant.relaySignal.aborted) return { ok: false, error: 'aborted' };
         // why: an OFFSCREEN actor turn emits no turn/tool-use broadcast (that
         // path is turn-driver's, in-SW only) — without this the eval harness's
         // OM2W recorder can't see the actor's page actions. Best-effort.
@@ -413,6 +436,7 @@ export const makeOffscreenActorClient = ({
       // fabricated progress/cost events into another run's UI.
       const grant = grantFor(msg, sender);
       if (!grant) return { ok: false, error: 'actor/loop-event: unauthorized relay' };
+      if (grant.relaySignal.aborted) return { ok: false, error: 'aborted' };
       try { if (msg.event) runOnEvent.get(grant.runId)?.(msg.event); } catch { /* never break the relay */ }
       return { ok: true };
     },

--- a/extension/background/offscreen-actor-client.js
+++ b/extension/background/offscreen-actor-client.js
@@ -1,5 +1,5 @@
 // @ts-check
-// background/offscreen-actor-client.js — the privileged-host client for EVERY isolated
+// background/offscreen-actor-client.js: the privileged-host client for EVERY isolated
 // agent loop (the heap split): ephemeral spawned reasoners (spawn.js) AND bound
 // actors (the actor turn). One client, one set of routes (model-call + tool-dispatch
 // + loop-event); a reasoning child grants no tools, so it only ever exercises

--- a/extension/background/offscreen-js-client.js
+++ b/extension/background/offscreen-js-client.js
@@ -27,7 +27,7 @@ export const makeOffscreenJsClient = ({ ensureOffscreen, sendMessage }) => ({
    *   workspaceSessionId mounts the durable per-session workspace as the job's
    *   OPFS root (trusted job param — the tool derives it from ctx.session, the
    *   worker can never name its own root).
-   * @returns {Promise<{ value: unknown, consoleOutput: {level:string,text:string}[], durationMs: number, error: string|null, usedEgress?: boolean, usedActors?: boolean, actorDeliveryIds?: string[], usedWorkspace?: boolean, workspaceOverBudget?: boolean, actorsTrace?: Array<{ seq: number, method: string, to?: string, goal?: string, ok: boolean, ms: number, error?: string, settled?: boolean, actorFailed?: boolean, cancelled?: boolean }>, usedProvider?: boolean, providerCalls?: number, providerTokens?: number }>}
+   * @returns {Promise<{ value: unknown, consoleOutput: {level:string,text:string}[], durationMs: number, error: string|null, errorCode?: string, usedEgress?: boolean, usedActors?: boolean, actorDeliveryIds?: string[], usedWorkspace?: boolean, workspaceOverBudget?: boolean, actorsTrace?: Array<{ seq: number, method: string, to?: string, goal?: string, ok: boolean, ms: number, error?: string, settled?: boolean, actorFailed?: boolean, cancelled?: boolean }>, usedProvider?: boolean, providerCalls?: number, providerTokens?: number }>}
    */
   execHeadless: async (code, { timeoutMs, a2a, ownerSessionId, actors, ownerToolUseId, runId, caps, siteFetch, toolbox, workspaceSessionId, signal } = {}) => {
     const wallMs = typeof timeoutMs === 'number' && Number.isFinite(timeoutMs)

--- a/extension/background/offscreen-js-client.js
+++ b/extension/background/offscreen-js-client.js
@@ -27,7 +27,7 @@ export const makeOffscreenJsClient = ({ ensureOffscreen, sendMessage }) => ({
    *   workspaceSessionId mounts the durable per-session workspace as the job's
    *   OPFS root (trusted job param — the tool derives it from ctx.session, the
    *   worker can never name its own root).
-   * @returns {Promise<{ value: unknown, consoleOutput: {level:string,text:string}[], durationMs: number, error: string|null, usedEgress?: boolean, usedActors?: boolean, usedWorkspace?: boolean, workspaceOverBudget?: boolean, actorsTrace?: Array<{ seq: number, method: string, to?: string, goal?: string, ok: boolean, ms: number, error?: string, settled?: boolean, actorFailed?: boolean, cancelled?: boolean }>, usedProvider?: boolean, providerCalls?: number, providerTokens?: number }>}
+   * @returns {Promise<{ value: unknown, consoleOutput: {level:string,text:string}[], durationMs: number, error: string|null, usedEgress?: boolean, usedActors?: boolean, actorDeliveryIds?: string[], usedWorkspace?: boolean, workspaceOverBudget?: boolean, actorsTrace?: Array<{ seq: number, method: string, to?: string, goal?: string, ok: boolean, ms: number, error?: string, settled?: boolean, actorFailed?: boolean, cancelled?: boolean }>, usedProvider?: boolean, providerCalls?: number, providerTokens?: number }>}
    */
   execHeadless: async (code, { timeoutMs, a2a, ownerSessionId, actors, ownerToolUseId, runId, caps, siteFetch, toolbox, workspaceSessionId, signal } = {}) => {
     const wallMs = typeof timeoutMs === 'number' && Number.isFinite(timeoutMs)

--- a/extension/background/routes/actors.js
+++ b/extension/background/routes/actors.js
@@ -178,6 +178,12 @@ export const makeActorsRoutes = (deps) => {
             // let page/instance text become an authoritative chained goal.
             awaitReply: true, awaitSignal: askController.signal,
           });
+          // Custody is independent of the code-visible outcome. Once an awaited
+          // actor reply exists, its mailbox row must survive until the OUTER
+          // script tool result commits. Keep the id host-only while threading it
+          // through both relay heaps; the worker receives only resp.value/error.
+          const actorDeliveryId = typeof result?.actorDeliveryId === 'string'
+            ? result.actorDeliveryId : undefined;
           const ms = Date.now() - startedAt;
           const outcome = askOutcome(result, {
             timedOut, aborted: !timedOut && askController.signal.aborted,
@@ -191,20 +197,24 @@ export const makeActorsRoutes = (deps) => {
             });
             mirror({
               ok: false, ms, settled: true, error: outcome.error,
+              ...(actorDeliveryId ? { actorDeliveryId } : {}),
               ...(cancelled ? { cancelled: true } : {}),
             });
             return {
               ok: false, error: outcome.error,
+              ...(actorDeliveryId ? { actorDeliveryId } : {}),
               ...(cancelled ? { cancelled: true } : {}),
             };
           }
           pushOp('replied', { ms, ...(outcome.failed ? { failed: true } : {}) });
           mirror({
             ok: true, ms, settled: true,
+            ...(actorDeliveryId ? { actorDeliveryId } : {}),
             ...(outcome.failed ? { actorFailed: true } : {}),
           });
           return {
             ok: true,
+            ...(actorDeliveryId ? { actorDeliveryId } : {}),
             value: shapeActorsResult(msg.method === 'ask' ? 'ask' : 'call', {
               ok: true, reply: outcome.reply, failed: outcome.failed,
             }),

--- a/extension/background/routes/session-mutations.js
+++ b/extension/background/routes/session-mutations.js
@@ -16,7 +16,7 @@ export const makeSessionMutationRoutes = (deps) => {
   const {
     vault, auditLog, pushState, sessions, sessionCache, sessionState, autoMemory,
     resolvePermission, normalizeMode, normalizeConfirmActions, SessionNotFoundError,
-    maybeAutoResume, haltGoalRun, turnSlots, actorMessaging, nukeSessionWorkspace,
+    maybeAutoResumeAfterRecovery, haltGoalRun, turnSlots, actorMessaging, nukeSessionWorkspace,
     purgeLifecycleSession,
   } = deps;
 
@@ -101,7 +101,7 @@ export const makeSessionMutationRoutes = (deps) => {
       // #72: auto-resume — if THIS chat's last turn was reclaimed mid-flight
       // (SW eviction etc.), continue it now. Fire-and-forget; gated + deduped
       // inside the helper, so opening a normally-finished chat is a no-op.
-      maybeAutoResume(sessionId);
+      maybeAutoResumeAfterRecovery(sessionId);
       // Auto-memory lifecycle seam: switching AWAY from a session with
       // real substance. Fire-and-forget — the switch itself never waits
       // on (or fails with) the extraction.

--- a/extension/background/routes/sessions.js
+++ b/extension/background/routes/sessions.js
@@ -21,13 +21,19 @@ export const makeSessionRoutes = (deps) => {
     runAgentTurn, runInit, handleSystemCommand, handleToolsCommand,
     postChatNote, spawnActor, requestReview, appClient,
     browser, originOfTabUrl, matchesDenylist, denylistStore,
-    startGoalRun, haltGoalRun, ensureSession, actorMessaging,
+    startGoalRun, haltGoalRun, ensureSession, actorRecoveryReady, actorMessaging,
     actorLifecycle,
     // The debug surface: the pure assembler + tree walk from
     // peerd-runtime/observability, the SW's live snapshot ring, and the
     // settings/channel/version identity the bundle stamps.
     settingsStore, contextSnapshots, assembleDebugBundle, childSessionIdsOf, CHANNEL,
   } = deps;
+
+  const recoveryReadyForUserTurn = async () => {
+    if (await actorRecoveryReady()) return true;
+    postChatNote('Actor recovery is still being recorded. Wait a moment, then send again.');
+    return false;
+  };
 
   return {
     // --- agent ---
@@ -83,7 +89,7 @@ export const makeSessionRoutes = (deps) => {
       if (typeof text !== 'string' || !text.trim()) {
         return { ok: false, error: 'empty-message' };
       }
-      const trimmedGoal = text.trim();
+      const trimmed = text.trim();
       // Goal mode (the mode-row Goal toggle): run autonomous turns in THIS chat
       // until the agent calls complete_goal (or the cap / Stop). The goal is the
       // first, visible message; continuations are hidden synthetic turns, so the
@@ -91,28 +97,19 @@ export const makeSessionRoutes = (deps) => {
       // front (a fresh chat has none yet — same lazy-create the model turn does).
       if (goal === true) {
         if (!startGoalRun || !ensureSession) return { ok: false, error: 'goal-mode-unavailable' };
+        if (!(await recoveryReadyForUserTurn())) return { ok: false, error: 'actor-recovery-pending' };
         try {
           const sessionId = await ensureSession();
-          await startGoalRun({ sessionId, goal: trimmedGoal });
+          await startGoalRun({ sessionId, goal: trimmed });
         } catch (e) {
           console.error('[sw] goal start threw', e);
           postChatNote(`Goal couldn't start: ${/** @type {{ message?: string }} */ (e)?.message ?? String(e)}`);
         }
         return { ok: true, handled: 'goal' };
       }
-      // A normal (non-goal) user message while a goal run is live means the user
-      // is steering / taking over — halt the run so it doesn't auto-continue on
-      // top of the new message.
-      if (haltGoalRun) {
-        const curSid = await sessionCache.sessionGet('currentSessionId');
-        // Awaited: durably forget the run so a steer-takeover can't be undone by
-        // a resume() on the next unlock (parity with agent/stop; #60).
-        if (curSid) await haltGoalRun(/** @type {any} */ (curSid));
-      }
       // /init is handled in the SW, not sent to the model (feature 01) —
       // check it BEFORE composer expansion so the slash command short-
       // circuits the turn entirely (it drafts AGENTS.md, no model call).
-      const trimmed = text.trim();
       if (trimmed === '/init' || trimmed.startsWith('/init ')) {
         runInit().catch((/** @type {unknown} */ e) => {
           console.error('[sw] /init threw', e);
@@ -139,6 +136,18 @@ export const makeSessionRoutes = (deps) => {
           postChatNote(`/tools failed: ${/** @type {{ message?: string }} */ (e)?.message ?? String(e)}`);
         });
         return { ok: true, handled: 'tools' };
+      }
+      // A user turn must not pass an uncommitted actor recovery receipt. Return
+      // a typed retryable error instead of accepting and silently dropping it.
+      if (!(await recoveryReadyForUserTurn())) return { ok: false, error: 'actor-recovery-pending' };
+      // A normal (non-goal) user message while a goal run is live means the user
+      // is steering / taking over. Halt only after this send is accepted so a
+      // recovery pause cannot discard the draft and stop the user's goal too.
+      if (haltGoalRun) {
+        const curSid = await sessionCache.sessionGet('currentSessionId');
+        // Awaited: durably forget the run so a steer-takeover can't be undone by
+        // a resume() on the next unlock (parity with agent/stop; #60).
+        if (curSid) await haltGoalRun(/** @type {any} */ (curSid));
       }
       // Composer expansion (feature 04): rewrite /commands and @-references
       // BEFORE the turn starts. @tab/@file pulls (possibly untrusted)

--- a/extension/background/routes/system.js
+++ b/extension/background/routes/system.js
@@ -21,6 +21,7 @@ export const makeSystemRoutes = (deps) => {
     inspectImport, applyImport, settingsStore, saveUserHook,
     CHANNEL, DEFAULT_SETTINGS, ExportPassphraseError, dwebTransfer,
     onSettingsChanging, onSettingsChanged, privateTransferAuthorization,
+    retryActorIsolation,
   } = deps;
 
   return {
@@ -29,6 +30,7 @@ export const makeSystemRoutes = (deps) => {
     // pushed over its port, but deliberately holds no port. It fetches on
     // load and refetches on focus; sendMessage also revives a dead SW.
     'state/get': async () => ({ ok: true, state: await buildStateSnapshot() }),
+    'actor-isolation/retry': async () => retryActorIsolation(),
 
     // --- logs (human-facing audit log) ---
     // The agent can already introspect this (inspect kind:'audit_log'); this route

--- a/extension/background/routes/vault.js
+++ b/extension/background/routes/vault.js
@@ -21,7 +21,7 @@ export const makeVaultRoutes = (deps) => {
   const {
     vault, auditLog, kv, idb, base64ToBytes,
     ensureOffscreen, maybeStartBaseNetwork, pushState, purgeVaultBlob,
-    confirmCoordinator, sessionCache, maybeAutoResume, resumeGoalRuns, resumeSchedules,
+    confirmCoordinator, sessionCache, maybeAutoResumeAfterRecovery, resumeGoalRuns, resumeSchedules,
     VaultAlreadyInitializedError, WrongPassphraseError, VaultNotInitializedError,
     RecoveryPassphraseNotSetError, PrfNotEnrolledError, PrfUnlockFailedError,
     VaultLockedError,
@@ -67,7 +67,7 @@ export const makeVaultRoutes = (deps) => {
           // interrupted (a cold SW wake unlocks here; finish what the eviction
           // cut off). Fire-and-forget; gated + deduped in the helper.
           .then(() => sessionCache.sessionGet('currentSessionId'))
-          .then((/** @type {any} */ cur) => maybeAutoResume(cur))
+          .then((/** @type {any} */ cur) => maybeAutoResumeAfterRecovery(cur))
           .catch(() => {});
         // Background scheduling: run any routine that came due while the vault
         // was locked (tick() deferred it) now that the key is back.
@@ -206,7 +206,7 @@ export const makeVaultRoutes = (deps) => {
           // #72: then auto-resume the current chat if its last turn was
           // interrupted. Fire-and-forget; gated + deduped in the helper.
           .then(() => sessionCache.sessionGet('currentSessionId'))
-          .then((/** @type {any} */ cur) => maybeAutoResume(cur))
+          .then((/** @type {any} */ cur) => maybeAutoResumeAfterRecovery(cur))
           .catch(() => {});
         // Background scheduling: drain routines that came due while locked.
         Promise.resolve(resumeSchedules?.()).catch(() => {});

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -37,6 +37,9 @@ import {
   CHANNEL_DEFAULTS, CHANNEL, DWEB_ENABLED, REMOTE_MODULE_IMPORTS_ENABLED,
 } from '/shared/channel-config.js';
 import { REMOTE_SKILL_INSTALL } from '/shared/flags.js';
+import { ACTOR_WORKER_PROTOCOL } from '/offscreen/actor-worker-protocol.js';
+import { makeActorIsolationStateStore } from './actor-isolation-state.js';
+import { actorDeliveryIdsFromMessage, makeActorRecoveryGate } from './actor-recovery-gate.js';
 
 import {
   // vault
@@ -292,6 +295,8 @@ import {
   // DESIGN-17: the message_actor orchestrator + the actor capability-tier
   // helpers the actor tool context is built from (keyless strip + kind scope).
   makeActorMessaging, restrictCtxCapabilities, actorAllowedToolsFor, EXPOSURE_ACTOR, EXPOSURE_REVIEW, pinActorCall, actorDescriptors, buildAncestry,
+  actorIsolationCapability, actorIsolationAvailable, actorIsolationTemporarilyUnavailable,
+  actorIsolationRefusal, actorIsolationSpawnRefusal, filterByActorIsolation, actorIsolationPromptBlock,
   actorsCallToOp, shapeActorsResult, askOutcome, ACTORS_ASK_DEFAULT_TIMEOUT_MS,
   ACTORS_RUN_MAX_OPS, ACTORS_TRACE_TARGET_MAX_CHARS, ACTORS_TRACE_ERROR_MAX_CHARS,
   canonicalCodeTraceLabel, DWEB_INBOUND_TOOL_NAMES, resolveWebActorSurface,
@@ -335,6 +340,7 @@ import { createScriptRunRegistry } from './script-runs.js';
 import { createContextSnapshots } from './context-snapshots.js';
 import { confirmGrantKey } from './confirm-grant-key.js';
 import { makeOffscreenActorClient } from './offscreen-actor-client.js';
+import { makeDirectActorHost, makeStorageSessionKeepAlive } from './direct-actor-host.js';
 import { makeOffscreenPdfClient } from './offscreen-pdf-client.js';
 import { makeOffscreenDocClient } from './offscreen-doc-client.js';
 import { makeOffscreenWebClient } from './offscreen-web-client.js';
@@ -889,7 +895,15 @@ const originCredentialRoutes = makeOriginCredentialRoutes({
 // 2. Layer 2 — runtime owns sessions + agent loop
 // ---------------------------------------------------------------------------
 
-const sessions = createSessionStore({ idb });
+// The actor mailbox is declared later with the actor wiring. Keep a mutable
+// post-commit seam here so an awaited actor reply is acknowledged only after
+// its parent tool-result message has reached durable session history.
+/** @type {(sessionId: string, message: import('/peerd-provider/types.js').InternalMessage) => Promise<void>} */
+let onSessionMessageAppended = async () => {};
+const sessions = createSessionStore({
+  idb,
+  onMessageAppended: (sessionId, message) => onSessionMessageAppended(sessionId, message),
+});
 
 // Memory store (V1.5). Binds the egress `idb` adapter to the
 // 'agents_memory' object store. The loader assembles the always-loaded
@@ -1593,6 +1607,9 @@ const buildToolContext = async (/** @type {any} */ { sessionId: overrideSessionI
     })
     : undefined;
   const ctx = {
+    // One browser-neutral execution-boundary value. Descriptor filtering is
+    // model UX; this dispatch-time gate stamp is the authority backstop.
+    actorIsolation,
     // why: the exposure gate (gates.js) reads this. 'main' is set ONLY on
     // the main agent turn; it makes the main-hidden DOM/page tools refuse
     // at dispatch, so a prompt-injected model can't reach them by name.
@@ -2114,27 +2131,7 @@ const forwardActorEvent = (/** @type {any} */ ev) => {
 
 const spawnActorCore = makeSpawnActor({
   sessions,
-  runUserTurn,
-  callModel: /** @type {any} */ (callModel),
-  // why the closure: contextSnapshots is declared further down the module —
-  // defer the reference to call time (the postChatNote late-dep pattern).
-  recordModelCall: (/** @type {Record<string, any>} */ call) => contextSnapshots.record(call),
-  getSecret,
-  safeFetch,
   appendAudit: /** @type {any} */ (auditLog.append),
-  buildToolContext,
-  dispatchToolCall: /** @type {any} */ (dispatchToolCall),
-  // why: resolve background-tabs from CURRENT settings at call time, not
-  // boot — settings load async and can change over the SW's life. This
-  // design 01: a spawned child renders its prompt FRESH per spawn (no cross-turn
-  // cache to bust), so it embeds its own temporal grounding — without this an
-  // ephemeral child gets zero time bytes (the main path's <context> message is
-  // built only in turn-driver and never reaches a child). Caller-supplied
-  // temporalBlock still wins.
-  renderSystemPrompt: (/** @type {any} */ opts) => renderSystemPrompt({
-    temporalBlock: buildTemporalBlock({ lastTurnAt: null, nowMs: Date.now() }),
-    ...opts,
-  }),
   getToolDescriptors: () => listTools().map((t) => ({ name: t.name, description: t.description, schema: t.schema })),
   // PR #134 phase 1: children run UNDER turn slots so Stop / cancel / the
   // wall-clock timeout can abort them. Lazy arrows — turnSlots is defined
@@ -2143,22 +2140,22 @@ const spawnActorCore = makeSpawnActor({
     claim: (/** @type {string} */ sessionId) => turnSlots.claim(sessionId),
     stop: (/** @type {string} */ sessionId) => turnSlots.stop(sessionId),
   },
-  // Heap split: run a child's loop in a dedicated offscreen Worker instead of the
-  // in-SW loop — the SAME substrate a bound actor uses (an actor is an ephemeral
+  // Heap split: run a child's loop in a dedicated Worker. The SAME substrate a
+  // bound actor uses (an actor is an ephemeral
   // actor: tool-less = pure reasoning, tool-bearing = a narrowed-general toolset), so
   // it flows through the ONE actorClient. A LAZY arrow — actorClient is a const
-  // assigned LATER in module init (after ensureOffscreen); reading it at wiring time
-  // would see the TDZ, so we only DEREFERENCE at call time. null on Firefox / when
-  // offscreen is unavailable → the unavailable sentinel so spawn.js falls back to the
-  // in-SW loop. The key never enters the worker; the model call and every tool call
+  // assigned LATER in module init (after host detection); reading it at wiring time
+  // would see the TDZ, so we only DEREFERENCE at call time. Null means no conforming
+  // worker host exists and spawn.js refuses. The key never enters the worker; the model call and every tool call
   // relay back to SW-gated routes. Adapt the child job shape (sessionId/task/tools) to
   // the actor run shape (actorSessionId/message/tools); the 'actor/tool-dispatch' route
   // rebuilds the child's restricted ctx from the persisted grantedTools (never the
   // worker's args). Tools default to [] (a pure-reasoning child that never dispatches).
   runChildOffscreen: (/** @type {any} */ job, /** @type {any} */ opts) => actorClient
-    ? actorClient.run({
+    ? runActorIsolated({
       actorSessionId: job.sessionId, message: job.task, systemPrompt: job.systemPrompt,
       provider: job.provider, model: job.model, depth: job.depth,
+      ollamaHost: settingsStore.get().ollamaHost,
       maxSteps: job.maxSteps, maxOutputTokens: job.maxOutputTokens, budgetMs: job.budgetMs,
       tools: job.tools ?? [],
     }, opts)
@@ -2175,7 +2172,12 @@ const spawnActorCore = makeSpawnActor({
 
 // SW-bound spawn. Defaults the live forwarder so neither surface has to
 // wire streaming; an explicit onEvent in `req` still wins.
-const spawnActor = (/** @type {any} */ req) => spawnActorCore({ onEvent: forwardActorEvent, ...req });
+const spawnActor = async (/** @type {any} */ req) => {
+  await actorIsolationReady;
+  return actorIsolationAvailable(actorIsolation)
+    ? spawnActorCore({ onEvent: forwardActorEvent, ...req })
+    : actorIsolationSpawnRefusal(actorIsolation, req?.parentDepth);
+};
 // PR #134 phase 5: the live-children registry riding on the spawn orchestrator —
 // agent/stop and actor_cancel walk it to end whole delegation subtrees.
 const actorLifecycle = {
@@ -2581,9 +2583,9 @@ const maybeNudgeDebuggerGrant = (/** @type {any} */ result) => {
 const domRefs = createRefRegistry();
 
 const ensureOffscreen = async () => {
-  // why: Firefox has no chrome.offscreen — its MV3 background is an event
-  // page, which doesn't need the keepalive trick (different lifetime
-  // model). Degrade quietly instead of throwing on every vault unlock:
+  // why: Firefox has no chrome.offscreen. Actor turns use a run-scoped session
+  // heartbeat in direct-actor-host.js; the other offscreen-only services
+  // remain unavailable. Degrade quietly instead of throwing on every unlock:
   // the offscreen-hosted voice transcriber is simply absent there (the
   // mic UI's capability detection already reports voice unsupported).
   if (typeof (/** @type {any} */ (browser)).offscreen?.createDocument !== 'function') {
@@ -2636,6 +2638,61 @@ const ensureOffscreen = async () => {
 // the agent can act on, instead of dispatching a job message no context answers
 // and surfacing an opaque "headless job failed".
 const offscreenAvailable = typeof (/** @type {any} */ (browser)).offscreen?.createDocument === 'function';
+// Firefox MV3 runs this module in an extension background page/event page. It
+// can host a dedicated Worker directly. Chrome runs it as a service worker,
+// where `document` is absent and the offscreen host above is required.
+const backgroundPageWorkerAvailable = !offscreenAvailable
+  && typeof document !== 'undefined'
+  && typeof Worker === 'function';
+const ACTOR_HOST_KEEPALIVE_KEY = 'peerdActorHostKeepAlive';
+const ACTOR_HOST_KEEPALIVE_MS = 10_000;
+const ACTOR_HOST_KEEPALIVE_ACK_MS = 2_000;
+let notifyActorHostKeepAliveLost = (/** @type {Error} */ _error) => {};
+const actorHostKeepAlive = backgroundPageWorkerAvailable
+  ? makeStorageSessionKeepAlive({
+    storage: browser.storage.session,
+    key: ACTOR_HOST_KEEPALIVE_KEY,
+    intervalMs: ACTOR_HOST_KEEPALIVE_MS,
+    ackTimeoutMs: ACTOR_HOST_KEEPALIVE_ACK_MS,
+    onLost: (error) => notifyActorHostKeepAliveLost(error),
+  })
+  : null;
+// why: Firefox currently has no official long-task lifetime signal for MV3
+// event pages. Mozilla Bug 1851373 documents storage.session activity plus a
+// synchronously registered change listener as the extension-side workaround.
+// The helper verifies the exact lease generation before actor work begins.
+if (actorHostKeepAlive) {
+  browser.storage.session.onChanged.addListener((changes) => {
+    actorHostKeepAlive.onChanged(changes);
+  });
+}
+const baseActorIsolation = actorIsolationCapability({
+  offscreenWorker: offscreenAvailable,
+  backgroundPageWorker: backgroundPageWorkerAvailable,
+});
+const actorIsolationState = makeActorIsolationStateStore({
+  storage: browser.storage.local,
+  protocol: ACTOR_WORKER_PROTOCOL,
+});
+let actorIsolation = actorIsolationAvailable(baseActorIsolation)
+  ? {
+    status: /** @type {const} */ ('temporarily_unavailable'),
+    host: baseActorIsolation.host,
+    reason: 'Actor isolation state is loading.',
+    retryable: false,
+  }
+  : baseActorIsolation;
+const actorIsolationReady = actorIsolationAvailable(baseActorIsolation)
+  ? actorIsolationState.load(baseActorIsolation)
+    .then((stored) => {
+      actorIsolation = /** @type {typeof baseActorIsolation} */ (stored ?? baseActorIsolation);
+      return actorIsolation;
+    })
+    .catch((error) => {
+      actorIsolation = actorIsolationTemporarilyUnavailable(baseActorIsolation, error);
+      return actorIsolation;
+    })
+  : Promise.resolve(actorIsolation);
 // Relays that redeem an offscreen worker's authority need the exact browser-
 // owned host, not the broader "one of our extension pages" sender check.
 const isOffscreenSender = (/** @type {any} */ sender) => senderIsOffscreen(sender, {
@@ -2785,15 +2842,57 @@ const rootChatSessionFor = async (sessionId) => {
   return null;
 };
 
-// The heap split: the ONE offscreen agent-loop client. It runs every non-
+// Firefox hosts the same worker runner directly from its background page. The
+// relay sender is a private object identity and these routes are never exposed
+// through runtime.onMessage on that path.
+const directActorHost = baseActorIsolation.host === 'background-page-worker'
+  ? makeDirectActorHost({
+    workerUrl: browser.runtime.getURL('offscreen/actor-worker.js'),
+    // Firefox MV3 event pages may unload while an unreturned task is pending.
+    // A small storage.session change refreshes the idle budget only while a run
+    // is active. The packaged lifetime lane proves this exact host.
+    startKeepAlive: () => actorHostKeepAlive?.start(),
+    stopKeepAlive: () => actorHostKeepAlive?.stop(),
+  })
+  : null;
+let actorHostLossPersistence = Promise.resolve();
+notifyActorHostKeepAliveLost = (error) => {
+  // Pause actor exposure before settling current runs. A later user retry must
+  // establish a fresh heartbeat and realm proof before actors become available.
+  actorIsolation = actorIsolationTemporarilyUnavailable(baseActorIsolation, error);
+  directActorHost?.failKeepAlive(error);
+  actorHostLossPersistence = (async () => {
+    let persisted = true;
+    try {
+      await actorIsolationState.markUnavailable(
+        baseActorIsolation,
+        error,
+        'actor_host_keepalive_lost',
+      );
+    } catch { persisted = false; }
+    await auditLog.append({
+      type: 'actor_isolation_unavailable',
+      details: {
+        host: baseActorIsolation.host,
+        code: 'actor_host_keepalive_lost',
+        retryable: true,
+        persisted,
+      },
+    }).catch(() => {});
+    await pushState().catch(() => {});
+  })();
+};
+
+// The heap split: the ONE isolated agent-loop client. It runs every non-
 // orchestrator loop — an ephemeral reasoning actor (spawn.js, tools:[]) OR a
 // bound actor (VM/Notebook/App/web) — in its own dedicated Worker heap. Its
 // 'actor/tool-dispatch' route builds the actor's instance-pinned, gated ctx SW-side
 // and dispatches there — the worker holds no
-// key, no engine clients, no chrome.*. Null when offscreen is unavailable.
-const actorClient = offscreenAvailable ? makeOffscreenActorClient({
-  ensureOffscreen,
-  sendMessage: (m) => browser.runtime.sendMessage(m),
+// key, no engine clients, no browser extension APIs. Null only when no
+// dedicated-worker host exists.
+const actorClient = actorIsolationAvailable(baseActorIsolation) ? makeOffscreenActorClient({
+  ensureHost: offscreenAvailable ? ensureOffscreen : async () => {},
+  sendMessage: directActorHost?.sendMessage ?? ((m) => browser.runtime.sendMessage(m)),
   callModel: /** @type {any} */ (callModel),
   getSecret,
   safeFetch,
@@ -2815,8 +2914,8 @@ const actorClient = offscreenAvailable ? makeOffscreenActorClient({
   recordModelCall: contextSnapshots.record,
   // Announce each settled ACTOR tool dispatch on the UI ports (lazy: uiPorts is
   // defined below, read at call time — same pattern as ownedTabFor). why: the
-  // offscreen actor heap has no turn/tool-use broadcast (that's turn-driver's,
-  // in-SW only), so without this the eval harness's OM2W recorder — and any
+  // isolated actor heap has no turn/tool-use broadcast, so without this the
+  // eval harness's OM2W recorder — and any
   // activity view — is blind to what an actor actually did.
   broadcastOp: (/** @type {any} */ msg) => uiPorts.broadcast(msg),
   // The relay boundary. `runtime.sendMessage` cannot address one extension
@@ -2825,7 +2924,7 @@ const actorClient = offscreenAvailable ? makeOffscreenActorClient({
   // three relay routes to the offscreen document is therefore what actually
   // keeps another first-party page from dispatching as an actor; the token
   // carries run identity and liveness on top of it.
-  isOffscreenSender,
+  isRelaySender: directActorHost?.isRelaySender ?? isOffscreenSender,
   inboundDwebToolNames: DWEB_INBOUND_TOOL_NAMES,
   // Spend-limit preflight for the actor lane. Two tallies, because they fail in
   // different directions and each alone leaves a hole:
@@ -2852,6 +2951,102 @@ const actorClient = offscreenAvailable ? makeOffscreenActorClient({
     return null;
   },
 }) : null;
+directActorHost?.bindRelayRoutes(actorClient?.routes ?? {});
+
+const ACTOR_HOST_STARTUP_CODES = new Set([
+  'actor_host_unavailable',
+  'actor_host_not_ready',
+  'actor_host_keepalive_failed',
+  'actor_worker_spawn_failed',
+  'actor_worker_start_timeout',
+  'actor_worker_crashed',
+  'actor_worker_message_error',
+  'actor_worker_protocol_error',
+]);
+
+/**
+ * Run on the detected dedicated-worker host. A failure before the realm proof
+ * is safe to retry once because no model call or tool relay could have begun.
+ * Every post-proof failure is terminal for that turn.
+ * @param {any} job
+ * @param {any} [opts]
+ */
+const runActorIsolated = async (job, opts) => {
+  await actorIsolationReady;
+  if (!actorClient || !actorIsolationAvailable(actorIsolation)) {
+    return actorIsolationRefusal(actorIsolation, { targetRead: false, targetChanged: false });
+  }
+  let result = await actorClient.run(job, opts);
+  if (result?.started || result?.ok || !ACTOR_HOST_STARTUP_CODES.has(result?.code)) return result;
+  // Stop can win while the first host proof is failing. A second Worker would
+  // be safe from relays but would still be needless post-cancel execution.
+  if (opts?.signal?.aborted) return { ...result, aborted: true };
+  result = await actorClient.run(job, opts);
+  if (result?.started || result?.ok || !ACTOR_HOST_STARTUP_CODES.has(result?.code)) return result;
+  actorIsolation = actorIsolationTemporarilyUnavailable(baseActorIsolation, result?.error ?? 'actor worker startup failed');
+  let persisted = true;
+  try {
+    await actorIsolationState.markUnavailable(
+      baseActorIsolation,
+      result?.error ?? 'actor worker startup failed',
+      result?.code ?? 'unknown',
+    );
+  } catch { persisted = false; }
+  auditLog.append({
+    type: 'actor_isolation_unavailable',
+    details: { host: baseActorIsolation.host, code: result?.code ?? 'unknown', retryable: true, persisted },
+  }).catch(() => {});
+  void pushState().catch(() => {});
+  return {
+    ...actorIsolationRefusal(actorIsolation, { targetRead: false, targetChanged: false }),
+    cause: result?.error ?? null,
+  };
+};
+
+const retryActorIsolation = async () => {
+  await actorIsolationReady;
+  await actorHostLossPersistence;
+  if (!actorIsolationAvailable(baseActorIsolation)) return actorIsolationRefusal(baseActorIsolation);
+  const result = await actorClient?.run({
+    actorSessionId: '__actor_isolation_probe__',
+    message: '', systemPrompt: '', provider: '', model: '', probeOnly: true,
+  });
+  if (!result?.ok) {
+    actorIsolation = actorIsolationTemporarilyUnavailable(baseActorIsolation, result?.error ?? 'actor worker startup failed');
+    let persisted = true;
+    try {
+      await actorIsolationState.markUnavailable(
+        baseActorIsolation,
+        result?.error ?? 'actor worker startup failed',
+        result?.code ?? 'unknown',
+      );
+    } catch { persisted = false; }
+    auditLog.append({
+      type: 'actor_isolation_retry_failed',
+      details: { host: baseActorIsolation.host, code: result?.code ?? 'unknown', performed: false, persisted },
+    }).catch(() => {});
+    await pushState();
+    return { ...actorIsolationRefusal(actorIsolation), cause: result?.error ?? null };
+  }
+  try {
+    await actorIsolationState.clear(baseActorIsolation);
+  } catch (error) {
+    actorIsolation = actorIsolationTemporarilyUnavailable(baseActorIsolation, error);
+    auditLog.append({
+      type: 'actor_isolation_retry_failed',
+      details: { host: baseActorIsolation.host, code: 'actor_isolation_state_clear_failed', performed: false, persisted: true },
+    }).catch(() => {});
+    await pushState();
+    return { ...actorIsolationRefusal(actorIsolation), cause: actorIsolation.reason };
+  }
+  actorIsolation = baseActorIsolation;
+  auditLog.append({
+    type: 'actor_isolation_restored',
+    details: { host: actorIsolation.host, realmVerified: true, extensionApisPresent: false },
+  }).catch(() => {});
+  await pushState();
+  return { ok: true, capability: { ...actorIsolation } };
+};
 
 // The PDF-extraction client (the read_pdf tool). ensureOffscreen, then a
 // 'pdf/extract' message to offscreen/pdf-extract.js (pdf.js in a Worker).
@@ -3180,6 +3375,7 @@ const sessionState = makeSessionState();
  * derived from the vault, never the secret itself.
  */
 const buildStateSnapshot = async () => {
+  await actorIsolationReady;
   const sessionId = await sessionCache.sessionGet('currentSessionId');
   // prfEnrolled is cheap to read (one kv.get) and the side panel uses it
   // (permission resolved per-path below — needs the session record.)
@@ -3204,6 +3400,7 @@ const buildStateSnapshot = async () => {
       },
       session: { sessionId: null, messages: [], permission, customSystemPrompt: null, toolManifest: null },
       providers: { current: resolveActiveProvider().name, hasKey: false, model: resolveActiveProvider().model, defaultRunnerModel: resolveActiveProvider().defaultRunnerModel },
+      capabilities: { actorExecution: { ...actorIsolation } },
       settings: { ...settingsStore.get() },
       pendingConfirm: null,
       streaming: false,
@@ -3266,6 +3463,7 @@ const buildStateSnapshot = async () => {
       // honestly reads as e.g. claude-haiku-4-5, not "inherit".
       defaultRunnerModel: activeProv.defaultRunnerModel,
     },
+    capabilities: { actorExecution: { ...actorIsolation } },
     profile: {
       id: profile.id,
       peerName: profile.peerName,
@@ -3570,6 +3768,8 @@ const { runAgentTurn, maybeAutoResume } = makeTurnDriver({
   // plus the engine-actor reconcile (VM/Notebook/App swap after their first turn).
   reconcilePrewalk: prewalk.reconcile, maybePrewalkSwap: prewalk.maybeSwap,
   reconcileEngineActor: prewalk.reconcileEngineActor,
+  getActorIsolation: () => actorIsolation,
+  waitForActorIsolation: () => actorIsolationReady,
   // postChatNote is declared just below this call — defer the reference so it
   // resolves at call-time (the same late-declared-dep pattern the orchestrator
   // wiring above uses, see the note at the postChatNote site).
@@ -4164,7 +4364,10 @@ const listApiIntegrations = async (/** @type {string | null | undefined} */ chat
 
 // DESIGN-17 P1 — the DURABLE MESSAGE MAILBOX. An in-flight engine message→reply
 // correlation persists here, so an SW death between accept and deliver() doesn't
-// silently drop the reply-wake; redrain() re-queues it on boot. chrome.storage.
+// silently drop the reply-wake. The queued to started transition is the durable
+// no-replay boundary. Recovery never executes stored work: queued entries become
+// Not run notices, while started and legacy entries become Outcome unknown.
+// chrome.storage.
 // session (not local): a pending message only makes sense within ONE browser
 // session — a full browser restart drops the orchestrator turn anyway, so a stale
 // resurrection would be wrong. The blob is keyed by correlationId for O(1) removal.
@@ -4173,18 +4376,26 @@ const ACTOR_MAILBOX_KEY = 'actorMailbox';
 // otherwise clobber. A promise chain makes each update see the prior one's write.
 let mailboxChain = Promise.resolve();
 const mailboxUpdate = (/** @type {(m: Record<string, any>) => Record<string, any>} */ mutate) => {
-  mailboxChain = mailboxChain.then(async () => {
+  const operation = mailboxChain.catch(() => {}).then(async () => {
     const cur = await sessionCache.sessionGet(ACTOR_MAILBOX_KEY);
     const base = (cur && typeof cur === 'object') ? /** @type {Record<string, any>} */ (cur) : {};
     await sessionCache.sessionSet(ACTOR_MAILBOX_KEY, mutate(base));
-    // why log (not swallow): a persist failure silently degrades a message to
-    // heap-only (P0) durability — surface it so a lost-wake-after-restart is at
-    // least explicable in the SW console rather than a mystery.
-  }).catch((e) => console.warn('[actor] mailbox persist failed — message is heap-only this SW lifetime', e));
-  return mailboxChain;
+  });
+  // Keep the serialization lane usable after a failure, but return the original
+  // rejecting operation to the caller. message_actor then reports Not run and
+  // starts no actor side effect.
+  mailboxChain = operation.catch((e) => console.warn('[actor] mailbox persist failed — request not run', e));
+  return operation;
 };
 const actorMailbox = {
   append: (/** @type {{ id: string }} */ e) => mailboxUpdate((m) => ({ ...m, [e.id]: e })),
+  markStarted: (/** @type {string} */ id) => mailboxUpdate((m) => {
+    const entry = m[id];
+    if (!entry || typeof entry !== 'object' || (entry.state !== undefined && entry.state !== 'queued')) {
+      throw new Error('actor mailbox entry is missing or not queued');
+    }
+    return { ...m, [id]: { ...entry, state: 'started', startedAt: Date.now() } };
+  }),
   remove: (/** @type {string} */ id) => mailboxUpdate((m) => { const n = { ...m }; delete n[id]; return n; }),
   // Carry the storage KEY as the entry id so redrain can PRUNE a malformed/legacy
   // value (one missing its own id) under its real key — else it would skip forever
@@ -4195,6 +4406,11 @@ const actorMailbox = {
     return Object.entries(/** @type {Record<string, any>} */ (m))
       .map(([k, v]) => (v && typeof v === 'object') ? { ...v, id: v.id ?? k } : { id: k });
   },
+};
+
+onSessionMessageAppended = async (_sessionId, message) => {
+  const deliveryIds = actorDeliveryIdsFromMessage(message);
+  await Promise.all(deliveryIds.map((id) => actorMailbox.remove(id)));
 };
 
 // Lazily mint a web actor for a tab (the analog of mintActor). No registry
@@ -4364,9 +4580,7 @@ const mintWebActor = async (/** @type {string} */ ownerChatId) => mintWebSession
 // undefined in the 0-tab state, where buildToolContext leaves activeTab unset so fetch_url
 // works and the DOM tools fail closed (the pin) until navigate adopts a tab. Re-mints when
 // the bound session vanished (SW death cleared session storage). The owner is the SENDER
-// chat (threaded by the messaging layer), NOT the ambient active chat — equal on the live
-// path (the sender gate proves it), but on a boot redrain the focused chat may differ, so
-// resolving by sender is what re-attaches a redrained message to its real actor.
+// chat threaded by the messaging layer, not the ambient active chat.
 const resolveWebActor = async (/** @type {string | null | undefined} */ ownerOverride) => {
   const ownerChatId = ownerOverride ?? /** @type {string | null} */ (await sessionCache.sessionGet('currentSessionId'));
   if (!ownerChatId) return null;
@@ -4898,9 +5112,25 @@ const a2aCallRoute = async (/** @type {{ method?: string, args?: any, ownerSessi
   }
 };
 
-const handleDwebAgentInbound = (/** @type {{ from?: string, data?: unknown, ts?: number }} */ evt) => {
+// Assigned after the durable mailbox is wired. Runtime messages cannot arrive
+// until module evaluation finishes, and the fail-closed default prevents an
+// automatic peer wake from racing incomplete boot wiring.
+/** @type {(key: string, action: () => Promise<any>|any) => Promise<boolean>} */
+let runWhenActorRecoveryReady = async () => false;
+let dwebRecoveryWakeSequence = 0;
+
+const handleDwebAgentInbound = async (/** @type {{ from?: string, data?: unknown, ts?: number }} */ evt) => {
   if (!dwebAgentOn() || vault.isLocked()) return;           // opt-out or locked → drop
+  await actorIsolationReady;
+  if (!dwebAgentOn() || vault.isLocked()) return;
   const did = typeof evt?.from === 'string' ? evt.from : 'unknown';
+  if (!actorIsolationAvailable(actorIsolation)) {
+    auditLog.append({
+      type: 'dweb_agent_inbound_dropped',
+      details: { did, reason: 'actor_isolation_unavailable', performed: false },
+    }).catch(() => {});
+    return;
+  }
   // A2A routing FIRST: an inbound a2a REPLY resolves a pending ask and is
   // consumed (never a wake); an a2a ask/tell falls through to the fenced wake
   // below (the actor sees a peer's request). A non-a2a DM also falls through.
@@ -4934,7 +5164,8 @@ const handleDwebAgentInbound = (/** @type {{ from?: string, data?: unknown, ts?:
   const canReplyToPeer = ownsThread && deliver?.kind === 'ask';
   const body = typeof evt?.data === 'string' ? evt.data : JSON.stringify(evt?.data ?? null);
   auditLog.append({ type: 'dweb_agent_inbound', details: { did, chars: body.length, ...(convId ? { convId } : {}) } }).catch(() => {});
-  (async () => {
+  await runWhenActorRecoveryReady(`dweb-inbound:${++dwebRecoveryWakeSequence}`, async () => {
+    if (!dwebAgentOn() || vault.isLocked()) return;
     const actor = await resolveDwebActor();
     if (!actor) return;
     const fenced = wrapUntrusted({ origin: did, tool: 'mesh_inbound', body: body.slice(0, 16 * 1024) });
@@ -4952,12 +5183,10 @@ const handleDwebAgentInbound = (/** @type {{ from?: string, data?: unknown, ts?:
     turnSlots.runWhenIdle(actor.actorSessionId, () => {
       (async () => {
         const before = ((await sessions.get(actor.actorSessionId))?.messages ?? []).length;
-        // HEAP ISOLATION: the inbound wake feeds LIVE untrusted peer bytes to the
-        // actor's reasoning, so it MUST run in the offscreen keyless worker like
-        // every other actor turn — never in-SW alongside the vault DK. Mirror the
-        // message_actor path: offscreen first, fall back to the in-SW driver only
-        // where offscreen is unavailable (Firefox). runActorTurnOffscreen claims
-        // the slot itself; we're already inside runWhenIdle, so no double-claim.
+        // HEAP ISOLATION: the inbound wake feeds live untrusted peer bytes to the
+        // actor's reasoning, so it must run in a dedicated keyless worker. A host
+        // failure drops the wake after audit; it never moves those bytes into the
+        // privileged background heap.
         const off = await runActorTurnOffscreen({
           actorSessionId: actor.actorSessionId, message: wake,
           instanceId: 'dweb', kind: 'dweb', oneShot: false, display: null,
@@ -4965,11 +5194,7 @@ const handleDwebAgentInbound = (/** @type {{ from?: string, data?: unknown, ts?:
           // preserves this monotonic bit and rebuilds synthetic/untrusted ctx from it.
           inbound: true,
         });
-        if (!off) {
-          // INBOUND: synthetic + NOT trusted — the sender gate refuses any delegation
-          // from this turn; the tier gate holds it to the dweb toolset.
-          await runAgentTurn({ sessionId: actor.actorSessionId, userText: wake, synthetic: true, trusted: false });
-        }
+        if (off?.stopped) return;
         const s = await sessions.get(actor.actorSessionId);
         const note = off?.result ?? finalAssistantText(/** @type {any} */ ({ messages: (s?.messages ?? []).slice(before) })) ?? '';
         // Trickle up ONLY the notable: the lore's stay-quiet default is enforced
@@ -5005,12 +5230,12 @@ const handleDwebAgentInbound = (/** @type {{ from?: string, data?: unknown, ts?:
         });
       })().catch((e) => console.warn('[sw] dweb agent inbound wake failed', e));
     });
-  })().catch(() => {});
+  });
 };
 
 browser.runtime.onMessage.addListener((/** @type {any} */ msg) => {
   if (msg?.type === 'dweb/base-room/event' && msg.roomId === DWEB_AGENT_ROOM && msg.event === 'direct') {
-    handleDwebAgentInbound(msg.data ?? {});
+    void handleDwebAgentInbound(msg.data ?? {});
   }
   return false;   // never claims the message — the dwapp bridge path is untouched
 });
@@ -5018,7 +5243,7 @@ browser.runtime.onMessage.addListener((/** @type {any} */ msg) => {
 // Resolve (+ lazy-mint) the API actor a chat owns for `origin`. The integration
 // AUTO-FORMS on first address (the same lazy-mint shape as the web actor). Re-mints when
 // the bound session vanished (SW death cleared session storage). Owner is the SENDER chat
-// (threaded by the messaging layer) so a boot redrain re-attaches to the right integration.
+// threaded by the messaging layer so each chat keeps its own integration.
 const resolveApiActor = async (/** @type {string} */ origin, /** @type {string | null | undefined} */ ownerOverride) => {
   const ownerChatId = ownerOverride ?? /** @type {string | null} */ (await sessionCache.sessionGet('currentSessionId'));
   if (!ownerChatId) return null;
@@ -5095,21 +5320,23 @@ browser.tabs?.onRemoved?.addListener((/** @type {number} */ tabId) => {
   pageActivity.release(tabId).catch(() => {});
 });
 
-// Heap-split phase 2: run an ENGINE actor's loop (vm/notebook/app) in its own
-// offscreen Worker heap. Renders the actor prompt + descriptors SW-side (the
+// Heap-split phase 2: run an actor loop in its own dedicated Worker heap.
+// Renders the actor prompt + descriptors in the privileged host (the
 // worker never assembles them), seeds the worker with the actor's prior history
 // (statefulness), forwards loop events to the card, and persists the turn back.
-// Returns the runActorTurn reply shape, or null to FALL BACK to the in-SW turn
-// (offscreen unavailable / never started). The worker holds no key, no engine
-// clients, no chrome.* — its model call + every tool call relay to SW-gated routes.
+// Returns the runActorTurn reply shape. It never falls back to the background
+// heap: unavailable or failed isolation is a visible stopped turn.
 const runActorTurnOffscreen = async (/** @type {any} */ { actorSessionId, message, instanceId, kind, actorTabId, oneShot, display, inbound }) => {
-  if (!actorClient) return null;
+  await actorIsolationReady;
+  if (!actorClient || !actorIsolationAvailable(actorIsolation)) {
+    const refusal = actorIsolationRefusal(actorIsolation, { targetRead: false, targetChanged: false });
+    return { result: refusal.error, stopped: true, isolationFailure: refusal };
+  }
   const loaded = await sessions.get(actorSessionId);
-  if (!loaded) return null;
-  // Engine-actor prewalk swap on the OFFSCREEN path. reconcileEngineActor is ALSO
-  // wired into the in-SW turn-driver, but a Chrome engine actor runs HERE and
-  // returns before that path is reached — so without this the swap NEVER fires on
-  // the primary platform. why here: the worker is seeded from rec.provider/rec.model
+  if (!loaded) return { result: 'the actor session no longer exists.', stopped: true };
+  // Engine-actor prewalk swap on the isolated path. The background turn driver
+  // refuses actor sessions, so this is the one place an engine actor can swap.
+  // why here: the worker is seeded from rec.provider/rec.model
   // below, so the swap must land (and persist) before we read them; costOf + the
   // card then also read the executor model. No-op for a non-engine / unarmed actor
   // (returns the record unchanged when there's no prewalk).
@@ -5118,9 +5345,9 @@ const runActorTurnOffscreen = async (/** @type {any} */ { actorSessionId, messag
   catch (e) { console.warn('[actor] engine prewalk reconcile failed', e); }
   const { controller, release } = turnSlots.claim(actorSessionId);
   try {
-    // Prompt PARITY with the in-SW actor turn: temporal grounding + any /system
-    // override (rec.customSystemPrompt). Actors get no memory/skills block (same
-    // as turn-driver). Absolute-time temporal block (an actor has no prev-turn gap).
+    // Bound-actor prompt contract: temporal grounding + any /system override
+    // (rec.customSystemPrompt). Actors get no memory/skills block. Absolute-time
+    // temporal block (an actor has no prev-turn gap).
     const temporalBlock = buildTemporalBlock({ lastTurnAt: null, nowMs: Date.now() });
     // PR #119 surface parity: the OFFSCREEN actor path must thread the web
     // actor's action surface exactly like the in-SW path — same setting-derived
@@ -5195,19 +5422,30 @@ const runActorTurnOffscreen = async (/** @type {any} */ { actorSessionId, messag
         if (ownedTab != null) tabUrl = (await browser.tabs.get(ownedTab).catch(() => null))?.url;
       }
     }
-    const r = await actorClient.run({
+    const r = await runActorIsolated({
       actorSessionId, message, systemPrompt,
       provider: rec.provider, model: rec.model, depth: rec.depth,
-      // maxSteps omitted → the worker's runUserTurn uses its OWN default (parity
-      // with the in-SW path, not a hardcoded fifth of it). Seed the actor's prior
-      // history for statefulness.
+      ollamaHost: settingsStore.get().ollamaHost,
+      // maxSteps omitted → the worker's runUserTurn uses its OWN default, not a
+      // hardcoded fifth of it. Seed the actor's prior history for statefulness.
       tools, priorMessages: rec.messages ?? [], reasoning, contextWindow,
       // Phase 3 web/API parity: oneShot loop mode + the self-fence provenance.
       oneShot: oneShot === true, actorType: kind, backing: rec.backing, tabUrl, origin: apiOrigin,
       ...(actorSurface ? { actorSurface } : {}),
       inbound: inbound === true,
     }, { signal: controller.signal, onEvent });
-    if (!(r.ok || r.started)) return null; // never started → caller falls back to in-SW
+    if (!(r.ok || r.started)) {
+      const error = r.error ?? 'the isolated actor worker did not start';
+      auditLog.append({
+        type: 'actor_isolation_failure',
+        details: { host: actorIsolation.host, kind, instanceId, code: r.code ?? 'unknown', performed: false },
+      }).catch(() => {});
+      if (display && uiConnected()) {
+        uiPorts.broadcast({ type: 'turn/actor-error', parentToolUseId: display.parentToolUseId, error });
+        uiPorts.broadcast({ type: 'turn/actor-done', parentToolUseId: display.parentToolUseId, sessionId: actorSessionId, ok: false, aborted: false });
+      }
+      return { result: error, stopped: true, isolationFailure: r };
+    }
     // Persist THIS turn's FULL transcript (user + assistant rounds + tool_use/
     // tool_result), not a lossy user+finalText pair — so a long-lived actor keeps
     // its tool-round memory across turns, matching the in-SW path.
@@ -5241,9 +5479,59 @@ const runActorTurnOffscreen = async (/** @type {any} */ { actorSessionId, messag
         }
       } catch { /* cost telemetry is best-effort */ }
     }
-    auditLog.append({ type: 'actor_ran_offscreen', details: { heapSplit: true, kind, instanceId, ok: r.ok === true, aborted: r.aborted === true, persistOk } }).catch(() => {});
-    if (display && uiConnected()) uiPorts.broadcast({ type: 'turn/actor-done', parentToolUseId: display.parentToolUseId, sessionId: actorSessionId, ok: r.ok === true, aborted: r.aborted === true });
-    return finalActorTurnReply(/** @type {any} */ ({ messages: newMessages }));
+    const fresh = finalActorTurnReply(/** @type {any} */ ({ messages: newMessages }));
+    const persistedAssistantError = [...newMessages].reverse()
+      .find((entry) => entry?.role === 'assistant' && typeof entry?.error === 'string')?.error ?? null;
+    const executionError = r.ok === true || r.aborted === true
+      ? null
+      : (r.error ?? 'the isolated actor turn failed before it produced a reply');
+    const terminalError = !persistOk
+      ? 'the actor ran, but its response could not be saved reliably; the outcome is unknown and must not be retried automatically.'
+      : (persistedAssistantError ?? executionError);
+    const outcomeUnknown = terminalError != null
+      && (!persistOk || r.outcomeKnown !== true);
+    const turnOk = persistOk && persistedAssistantError == null && r.ok === true && r.aborted !== true;
+    auditLog.append({
+      type: 'actor_ran_isolated',
+      details: {
+        host: actorIsolation.host, workerType: 'dedicated', realmVerified: true,
+        extensionApisPresent: false, actorSessionId, kind, instanceId,
+        ok: turnOk, aborted: r.aborted === true, persistOk,
+        ...(terminalError && r.aborted !== true ? {
+          performed: outcomeUnknown,
+          outcomeKnown: !outcomeUnknown,
+        } : {}),
+      },
+    }).catch(() => {});
+    if (display && uiConnected()) {
+      if (terminalError) {
+        uiPorts.broadcast({
+          type: 'turn/actor-error', parentToolUseId: display.parentToolUseId,
+          error: terminalError, outcomeKnown: !outcomeUnknown,
+        });
+      }
+      uiPorts.broadcast({ type: 'turn/actor-done', parentToolUseId: display.parentToolUseId, sessionId: actorSessionId, ok: turnOk, aborted: r.aborted === true });
+    }
+    if (!persistOk) {
+      return {
+        result: terminalError,
+        stopped: true,
+        executionFailed: true,
+        outcomeKnown: false,
+        persistenceFailure: { performed: true, outcomeKnown: false, retryable: false },
+      };
+    }
+    if (terminalError) {
+      return {
+        result: terminalError,
+        stopped: true,
+        executionFailed: true,
+        outcomeKnown: !outcomeUnknown,
+        executionFailure: r,
+      };
+    }
+    if (r.aborted === true) return { result: fresh.result, stopped: true, aborted: true };
+    return fresh;
   } finally {
     release();
     // The turn is over, so the pill comes down — leaving it up through the idle
@@ -5283,8 +5571,8 @@ const actorMessaging = makeActorMessaging({
     // The chat's WEB ACTOR — the 0-or-1-tab entry point for page-driving / session web
     // work, addressed by the literal 'web'. It decides fetch-vs-render itself: a
     // pure-fetch task never opens a tab; navigate adopts one on the render path. Owned by
-    // the SENDER chat (opts.senderSessionId), not the ambient active chat — so a boot
-    // redrain re-attaches to the right actor. (A numeric tabId, below, targets the
+    // the SENDER chat (opts.senderSessionId), not the ambient active chat. A numeric
+    // tabId below targets the
     // actor owning that SPECIFIC existing tab — e.g. one the orchestrator open_tab'd.)
     if (String(instanceId) === 'web') return resolveWebActor(opts.senderSessionId);
     // The DWEB ACTOR — the global mesh operator, addressed by the literal 'dweb'.
@@ -5370,11 +5658,6 @@ const actorMessaging = makeActorMessaging({
     const display = parentToolUseId
       ? { parentToolUseId, kind, instanceId, name }
       : undefined;
-    // Count the actor's messages BEFORE the turn so we read only the reply THIS
-    // turn produced — finalAssistantText scans backward and would otherwise return a
-    // PRIOR exchange's reply when this turn was Stop-cascaded before emitting any
-    // text (the stale-reply bug). `stopped` lets the caller mark the wake failed.
-    const before = (await sessions.get(actorSessionId))?.messages?.length ?? 0;
     // issue 251 — clear any report left over from an earlier turn BEFORE running,
     // so a stop can only ever be attributed to the turn that caused it. A stale
     // report surfacing on a later, unrelated message would be a lie in the one
@@ -5405,40 +5688,41 @@ const actorMessaging = makeActorMessaging({
       landingStopReports.delete(actorSessionId);
       return { result: report, stopped: true };
     };
-    // Heap-split: every BOUND actor runs its loop in its own offscreen Worker heap —
+    // Heap-split: every BOUND actor runs its loop in its own dedicated Worker heap —
     // engine kinds (vm/notebook/app, phase 2) AND the web/API actor (phase 3, the
     // highest-value isolation: it ingests untrusted PAGE/response content). Its DOM
-    // tools + fetch_url run SW-side via the 'actor/tool-dispatch' relay (chrome.* is
-    // SW-only); the worker holds no key, no chrome.*. Returns the reply, or null to
-    // fall back to the in-SW turn below (offscreen unavailable / never started).
+    // tools + fetch_url run in the privileged host via the gated relay; the worker
+    // holds no key or extension APIs. There is no background-heap fallback.
     if (kind === 'webvm' || kind === 'notebook' || kind === 'app' || kind === 'web' || kind === 'dweb') {
-      const off = await runActorTurnOffscreen({ actorSessionId, message: deliveredMessage, instanceId, kind, actorTabId, oneShot: oneShot === true, display });
-      if (off) return withLandingStop(off);
+      const off = await runActorTurnOffscreen({ actorSessionId, message: deliveredMessage, instanceId, kind, actorTabId, oneShot: oneShot === true, display, inbound: false });
+      return withLandingStop(off);
     }
-    // oneShot: the loop synthesizes the reply from the first clean tool round and
-    // stops (no summarize inference) — finalAssistantText below reads that synthetic
-    // assistant message exactly like a normal reply, so nothing else changes here.
-    try {
-      await runAgentTurn({ sessionId: actorSessionId, userText: deliveredMessage, synthetic: false, activeTabId: actorTabId, display, oneShot: oneShot === true });
-    } finally {
-      // why here too: runActorTurnOffscreen takes the pill down in its own
-      // finally, but this is the IN-SW fallback the offscreen path returns null
-      // for (Firefox has no offscreen API). Without it the pill outlives the
-      // turn on Firefox and sits on "Thinking…" forever — peerd saying it is
-      // working while nothing is happening, the exact misreading the indicator
-      // exists to prevent. The GROUP still stays; only the pill comes down.
-      const drivenTabId = webActorTabBindings.tabFor(actorSessionId);
-      if (typeof drivenTabId === 'number') pageActivity.idle(drivenTabId).catch(() => {});
-    }
-    const s = await sessions.get(actorSessionId);
-    const fresh = finalActorTurnReply(/** @type {any} */ ({
-      messages: (s?.messages ?? []).slice(before),
-    }));
-    return withLandingStop(fresh);
+    return withLandingStop({ result: `actor kind ${kind || 'unknown'} is unsupported`, stopped: true });
   },
   reenter: ({ userText, sessionId, synthetic, trusted, actorReply }) => runAgentTurn({ userText, sessionId, synthetic, trusted, actorReply }),
+  // Restart recovery is a receipt, not a turn. Persist it directly with a
+  // stable id so a second background loss can finish the same append without
+  // duplicating the notice or giving the model another chance to act.
+  recordRecovery: async ({ userText, sessionId, actorReply, recoveryId }) => {
+    await sessions.appendMessage(sessionId, {
+      role: 'user',
+      content: userText,
+      synthetic: true,
+      actorReply,
+      id: `actor-recovery:${sessionId}:${recoveryId}`,
+      when: Date.now(),
+    });
+    await pushState();
+    return true;
+  },
+  deliveryCommitted: async ({ sessionId, deliveryId }) => {
+    const session = await sessions.get(sessionId);
+    return (session?.messages ?? []).some((message) =>
+      actorDeliveryIdsFromMessage(message).includes(deliveryId));
+  },
   turnSlots,
   getActiveSessionId: () => /** @type {Promise<any>} */ (sessionCache.sessionGet('currentSessionId')),
+  getActorIsolation: () => actorIsolation,
   // PR #134 phase 3 — the shell walk behind the trusted-lineage gate. The pure
   // walk (fail-closed rules + hop cap + cycle guard) lives in delegation-lineage
   // so it's unit-tested; here we only inject the store read. spawnedTrusted per
@@ -5466,20 +5750,23 @@ const actorMessaging = makeActorMessaging({
   log: (/** @type {any[]} */ ...a) => console.warn('[actor]', ...a),
 });
 
-// Redrain the durable mailbox ONCE per SW lifetime, the moment the vault is
-// unlocked (a re-queued actor turn needs the model key). Boots already-unlocked
-// → fires from the attemptResume chain below; booted locked → fires on the first
-// unlock via the subscription. The once-guard prevents a double-drain (entries
-// aren't cleared until their turn SETTLES, so a second drain would double-deliver).
-let mailboxRedrained = false;
-const maybeRedrainMailbox = () => {
-  if (mailboxRedrained || vault.isLocked()) return;
-  mailboxRedrained = true;
-  Promise.resolve(actorMessaging.redrain())
-    .then((r) => { if (r?.redrained) console.warn('[actor] redrained', r.redrained, 'pending message(s) after restart'); })
-    .catch((e) => console.error('[sw] actor redrain failed', e));
+// Recover the durable mailbox before any automatic model work. Stored actor work
+// is never executed here. A failed receipt stays durable and gets another passive
+// write attempt in this background lifetime; a later background boot also retries.
+const actorRecoveryGate = makeActorRecoveryGate({
+  redrain: () => actorMessaging.redrain(),
+  log: (e) => console.error('[sw] actor redrain failed', e),
+});
+runWhenActorRecoveryReady = actorRecoveryGate.runWhenReady;
+const maybeRedrainMailbox = actorRecoveryGate.recover;
+const actorRecoveryReady = actorRecoveryGate.ready;
+const maybeAutoResumeAfterRecovery = (/** @type {string | null | undefined} */ sessionId) => {
+  if (!sessionId) return Promise.resolve(false);
+  return actorRecoveryGate.runWhenReady(
+    `auto-resume:${sessionId}`,
+    () => maybeAutoResume(sessionId),
+  );
 };
-vault.subscribe(() => { maybeRedrainMailbox(); });
 
 // ---------------------------------------------------------------------------
 // 5b. /init — workspace scan → draft AGENTS.md → confirm → persist (V1.5)
@@ -5643,7 +5930,9 @@ const haltGoalRun = (/** @type {string} */ sid) => /** @type {any} */ (goalRunne
 // §2.5: session archive/delete purges its lifecycle state — pending recovery
 // notices + nonterminal operations settle cancelled (boot.purgeSession).
 const purgeLifecycleSession = (/** @type {string} */ sid) => lifecycleBoot.purgeSession(sid);
-const resumeGoalRuns = () => /** @type {any} */ (goalRunner)?.resume();
+const resumeGoalRuns = () => actorRecoveryGate.runWhenReady(
+  'goal-resume',
+  () => /** @type {any} */ (goalRunner)?.resume());
 // Background scheduling: drive a full scheduler catch-up. The SINGLE entry point
 // for every wake (alarm, onStartup, cold boot, vault unlock) so the ordering is
 // defined in ONE place and can't drift per-caller.
@@ -5658,10 +5947,11 @@ const resumeGoalRuns = () => /** @type {any} */ (goalRunner)?.resume();
 // Sequencing resume() → load() → tick() closes that window. Both resume() and
 // load() are idempotent (skip ids already live), so calling this from every wake
 // — even one where goal runs were already resumed — is safe.
-const resumeSchedules = () => Promise.resolve(/** @type {any} */ (goalRunner)?.resume())
-  .catch(() => {})
-  .then(() => /** @type {any} */ (scheduler)?.load())
-  .then(() => /** @type {any} */ (scheduler)?.tick())
+const resumeSchedules = () => actorRecoveryGate.runWhenReady('schedules', async () => {
+    await Promise.resolve(/** @type {any} */ (goalRunner)?.resume()).catch(() => {});
+    await /** @type {any} */ (scheduler)?.load();
+    await /** @type {any} */ (scheduler)?.tick();
+  })
   .catch((e) => console.error('[sw] schedule catch-up failed', e));
 const ensureSession = ensureCurrentSession;
 
@@ -5736,6 +6026,7 @@ const makeSystemRouteSet = () => makeSystemRoutes({
   uiPorts, loadUserEndpoints, inspectImport, applyImport, settingsStore, saveUserHook,
   CHANNEL, DEFAULT_SETTINGS, ExportPassphraseError, dwebTransfer,
   onSettingsChanging, onSettingsChanged, privateTransferAuthorization,
+  retryActorIsolation,
 });
 const makeSettingsRouteSet = () => makeSettingsRoutes({
   vault, auditLog, pushState, kv, memory, settingsStore,
@@ -5776,7 +6067,10 @@ browser.runtime.onMessage.addListener(/** @type {any} */ (makeDispatcher({
   // actor card + cost meter). Serves both spawned reasoners and bound actors; a
   // reasoning child never exercises tool-dispatch. actorClient is defined above (after
   // ensureOffscreen), before this dispatcher literal — safe to spread.
-  ...(actorClient?.routes ?? {}),
+  // Chrome's offscreen document relays over runtime messaging. Firefox's
+  // direct background-page host binds these routes in-process above, so they
+  // must not be callable from any extension page.
+  ...(offscreenAvailable ? (actorClient?.routes ?? {}) : {}),
   // The script tool's actors-in-code relay: live-run/owner/grant verified,
   // then every ask re-enters the existing messageActor gate chain.
   ...makeActorsRoutes({
@@ -5795,7 +6089,7 @@ browser.runtime.onMessage.addListener(/** @type {any} */ (makeDispatcher({
     scriptModelCallRoute(msg, sender),
   ...makeVaultRoutes({
     vault, auditLog, kv, idb, base64ToBytes, ensureOffscreen, maybeStartBaseNetwork,
-    pushState, purgeVaultBlob, confirmCoordinator, sessionCache, maybeAutoResume, resumeGoalRuns,
+    pushState, purgeVaultBlob, confirmCoordinator, sessionCache, maybeAutoResumeAfterRecovery, resumeGoalRuns,
     resumeSchedules,
     VaultAlreadyInitializedError, WrongPassphraseError, VaultNotInitializedError,
     RecoveryPassphraseNotSetError, PrfNotEnrolledError, PrfUnlockFailedError,
@@ -5831,7 +6125,7 @@ browser.runtime.onMessage.addListener(/** @type {any} */ (makeDispatcher({
     browser, originOfTabUrl, matchesDenylist, denylistStore,
     // goal mode (the mode-row Goal toggle): start an autonomous run, and halt
     // any active one when the user stops or steers with a fresh message.
-    startGoalRun, haltGoalRun, ensureSession,
+    startGoalRun, haltGoalRun, ensureSession, actorRecoveryReady,
     // DESIGN-17 P1: agent/stop cascades to this chat's in-flight actors.
     actorMessaging,
     // PR #134 phase 5: agent/stop also cascades through the live actor
@@ -5896,7 +6190,7 @@ browser.runtime.onMessage.addListener(/** @type {any} */ (makeDispatcher({
   ...makeSessionMutationRoutes({
     vault, auditLog, pushState, sessions, sessionCache, sessionState, autoMemory,
     resolvePermission, normalizeMode, normalizeConfirmActions, SessionNotFoundError,
-    maybeAutoResume, haltGoalRun,
+    maybeAutoResumeAfterRecovery, haltGoalRun,
     // session/reset (New chat) must stop the abandoned session's live turn AND
     // cascade to its in-flight actors — same primitives agent/stop uses — so
     // background web/VM/App work doesn't keep running on the orphaned session.
@@ -6117,7 +6411,11 @@ ensureOffscreen().then(async () => {
 // is still there and we can pick up where we left off — no passphrase
 // re-entry required. Returns false (no-op) if the vault was never
 // unlocked or session storage was cleared.
-vault.attemptResume().then((resumed) => {
+vault.attemptResume().then(async (resumed) => {
+  // A passive recovery receipt must be durable before any automatic model turn
+  // can inspect this history. If storage is temporarily unavailable, keep the
+  // mailbox row, retry the receipt separately, and leave automatic work paused.
+  await maybeRedrainMailbox();
   if (resumed) {
     console.log('[sw] vault resumed from session storage');
     auditLog.append({ type: 'vault_unlocked' }).catch(() => {});
@@ -6142,23 +6440,24 @@ vault.attemptResume().then((resumed) => {
     // drive() awaits. Sequencing it ahead of maybeAutoResume guarantees the
     // goalActiveFor guard in maybeAutoResume sees the goal run and bails —
     // otherwise the two could race to drive the SAME interrupted session.
-    Promise.resolve(goalRunner?.resume())
-      .catch((e) => console.error('[sw] goal resume failed', e))
-      .then(() => settingsStore.load())
-      .then(() => sessionCache.sessionGet('currentSessionId'))
-      .then((/** @type {any} */ cur) => maybeAutoResume(cur)).catch(() => {});
+    actorRecoveryGate.runWhenReady('boot-resume', async () => {
+      await Promise.resolve(goalRunner?.resume())
+        .catch((e) => console.error('[sw] goal resume failed', e));
+      await settingsStore.load();
+      const currentSessionId = /** @type {string | null | undefined} */ (
+        await sessionCache.sessionGet('currentSessionId')
+      );
+      await maybeAutoResume(currentSessionId);
+    }).catch(() => {});
   } else {
     // Vault not resumed (locked): still rehydrate goal runs so the Goal bar is
     // restored; their next turn pauses on the locked vault and waits for unlock.
     // No auto-resume here — it needs an unlocked vault to call the model.
-    goalRunner?.resume().catch((e) => console.error('[sw] goal resume failed', e));
+    actorRecoveryGate.runWhenReady(
+      'locked-goal-resume',
+      () => goalRunner?.resume(),
+    ).catch((e) => console.error('[sw] goal resume failed', e));
   }
-  // DESIGN-17 P1: redrain any in-flight actor message→reply correlations the SW
-  // death interrupted. Once-guarded + internally gated on an unlocked vault (a
-  // re-queued actor turn needs the model key); also fires on the first vault
-  // unlock if the SW booted locked. resolveActor lazy-loads the registries, so
-  // no ordering vs goal/auto-resume above is needed (actor sessions are separate).
-  maybeRedrainMailbox();
 }).catch((e) => console.error('[sw] attemptResume failed', e));
 
 // One-time cleanup of Ralph's leftover storage. Ralph (removed 2026-06-22) wrote

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -2913,14 +2913,14 @@ const actorClient = actorIsolationAvailable(baseActorIsolation) ? makeOffscreenA
   EXPOSURE_REVIEW,
   recordModelCall: contextSnapshots.record,
   // Announce each settled ACTOR tool dispatch on the UI ports (lazy: uiPorts is
-  // defined below, read at call time — same pattern as ownedTabFor). why: the
+  // defined below, read at call time, using the same pattern as ownedTabFor). why: the
   // isolated actor heap has no turn/tool-use broadcast, so without this the
-  // eval harness's OM2W recorder — and any
-  // activity view — is blind to what an actor actually did.
+  // eval harness's OM2W recorder and any
+  // activity view are blind to what an actor actually did.
   broadcastOp: (/** @type {any} */ msg) => uiPorts.broadcast(msg),
   // The relay boundary. `runtime.sendMessage` cannot address one extension
   // context, so the actor/run job (grant token included) is broadcast to every
-  // listener — the side panel and the engine tab pages among them. Pinning the
+  // listener, including the side panel and the engine tab pages. Pinning the
   // three relay routes to the offscreen document is therefore what actually
   // keeps another first-party page from dispatching as an actor; the token
   // carries run identity and liveness on top of it.
@@ -4384,7 +4384,7 @@ const mailboxUpdate = (/** @type {(m: Record<string, any>) => Record<string, any
   // Keep the serialization lane usable after a failure, but return the original
   // rejecting operation to the caller. message_actor then reports Not run and
   // starts no actor side effect.
-  mailboxChain = operation.catch((e) => console.warn('[actor] mailbox persist failed — request not run', e));
+  mailboxChain = operation.catch((e) => console.warn('[actor] mailbox persist failed: request not run', e));
   return operation;
 };
 const actorMailbox = {
@@ -5688,7 +5688,7 @@ const actorMessaging = makeActorMessaging({
       landingStopReports.delete(actorSessionId);
       return { result: report, stopped: true };
     };
-    // Heap-split: every BOUND actor runs its loop in its own dedicated Worker heap —
+    // Heap-split: every BOUND actor runs its loop in its own dedicated Worker heap.
     // engine kinds (vm/notebook/app, phase 2) AND the web/API actor (phase 3, the
     // highest-value isolation: it ingests untrusted PAGE/response content). Its DOM
     // tools + fetch_url run in the privileged host via the gated relay; the worker

--- a/extension/eval/eval-engine.js
+++ b/extension/eval/eval-engine.js
@@ -131,7 +131,7 @@ export function createEvalEngine({ browser, log = () => {}, onProgress = () => {
       // actor_create/spawn path). Fold it into the SAME runner bucket — without
       // this an engine actor's spend is invisible here, so the engine-actor
       // prewalk down-shift wouldn't register in the A/B. Tokens ride msg.usage
-      // (absent on the in-SW fallback, which sends cost only); the SW-priced USD
+      // from the isolated relay; the SW-priced USD
       // (msg.cost.cost) is accumulated so the row reports the actor's REAL spend.
       case 'turn/actor-cost':
         if (msg.usage) {
@@ -140,9 +140,9 @@ export function createEvalEngine({ browser, log = () => {}, onProgress = () => {
           turn.runner.cacheReadTokens += msg.usage.cacheReadTokens || 0;
           turn.runner.cacheWriteTokens += msg.usage.cacheWriteTokens || 0;
         }
-        // USD accounting differs by broadcaster: the offscreen heap-split path
-        // (service-worker) fires ONCE per actor turn with that turn's TOTAL, while
-        // the in-SW path (turn-driver onCost) RE-EMITS a GROWING CUMULATIVE per
+        // USD accounting differs by broadcaster: the isolated actor path fires
+        // ONCE per turn with that turn's TOTAL, while the main turn-driver path
+        // RE-EMITS a GROWING CUMULATIVE per
         // usage fold. Key the latest value per actor turn (parentToolUseId) and sum
         // the keys — correct for both; a straight += multiply-counts the in-SW stream.
         if (typeof msg.cost?.cost === 'number') {

--- a/extension/home/home.js
+++ b/extension/home/home.js
@@ -26,6 +26,7 @@ import { ContactsSection } from './contacts-section.js';
 import { INITIAL_STATE, reduceChat, putSpawnedSession } from '../sidepanel/chat-reducer.js';
 import { ChatView } from '../sidepanel/components/chat-view.js';
 import { ConfirmModal, NoticeBar } from '../sidepanel/components/app.js';
+import { ActorIsolationBanner } from '../sidepanel/components/actor-isolation-banner.js';
 import { VaultGate } from '../sidepanel/components/vault-gate.js';
 import { OnboardingView, needsOnboarding } from '../sidepanel/components/onboarding-view.js';
 import { peerNotifications } from '/shared/peer-notifications.js';
@@ -602,6 +603,7 @@ const HomeApp = {
           currentState.notices?.length
             ? m(NoticeBar, { notices: currentState.notices, uiActions })
             : null,
+          m(ActorIsolationBanner, { capability: currentState.capabilities?.actorExecution, send }),
           // Chat is single-homed: when the side panel owns it, home shows tools
           // only — so give an obvious way to bring chat back (the inverse of
           // "Pop to side", since that button rode away with the chat). Closing

--- a/extension/offscreen/actor-runner.js
+++ b/extension/offscreen/actor-runner.js
@@ -6,6 +6,8 @@
 // holds the key, engine clients, instance pin, and gate), forwards its loop events,
 // and resolves with the turn result.
 
+import { ACTOR_WORKER_PROTOCOL, ACTOR_WORKER_STARTUP_MS, validActorWorkerRealm } from './actor-worker-protocol.js';
+
 const MAX_CONCURRENT = 4;
 let active = 0;
 let seq = 0;
@@ -57,16 +59,27 @@ export const abortActor = (runId) => {
 
 /**
  * Run one BOUND-actor turn in a dedicated Worker.
- * @param {{ runId?: string, relayToken?: string, actorSessionId: string, message: string, systemPrompt: string, provider: string, model: string, depth?: number, maxSteps?: number, maxOutputTokens?: number, tools?: any[], priorMessages?: any[], reasoning?: object, contextWindow?: number, budgetMs?: number, oneShot?: boolean, actorType?: string, backing?: string, tabUrl?: string, origin?: string, inbound?: boolean }} job
- * @param {{ workerUrl: string, sendToSW: (type: string, payload: object) => Promise<any> }} deps
- * @returns {Promise<{ ok: boolean, started?: boolean, finalText?: string, newMessages?: any[], usage?: object, stopReason?: string, toolCalls?: number, error?: string, aborted?: boolean }>}
+ * @param {{ runId?: string, relayToken?: string, actorSessionId: string, message: string, systemPrompt: string, provider: string, model: string, probeOnly?: boolean, depth?: number, maxSteps?: number, maxOutputTokens?: number, tools?: any[], priorMessages?: any[], reasoning?: object, contextWindow?: number, budgetMs?: number, oneShot?: boolean, actorType?: string, backing?: string, tabUrl?: string, origin?: string, inbound?: boolean }} job
+ * @param {{ workerUrl: string, sendToSW: (type: string, payload: object) => Promise<any>, createWorker?: (url: string) => Worker, startupMs?: number }} deps
+ * @returns {Promise<{ ok: boolean, started?: boolean, phase?: string, code?: string, finalText?: string, newMessages?: any[], usage?: object, stopReason?: string, toolCalls?: number, error?: string, aborted?: boolean, outcomeKnown?: boolean }>}
  */
-export const runActor = async (job, { workerUrl, sendToSW }) => {
+export const runActor = async (job, {
+  workerUrl,
+  sendToSW,
+  createWorker = (url) => new Worker(url, { type: 'module' }),
+  startupMs = ACTOR_WORKER_STARTUP_MS,
+}) => {
   const runId = job.runId ?? `aw-${++seq}`;
   if (consumeEarlyAbort(runId)) {
-    return { ok: false, started: true, aborted: true, error: 'actor aborted before worker start' };
+    return {
+      ok: false, started: true, phase: 'startup', code: 'actor_run_aborted',
+      aborted: true, error: 'actor aborted before worker start',
+    };
   }
-  if (active >= MAX_CONCURRENT) return { ok: false, started: false, error: `actor worker rejected: ${MAX_CONCURRENT} already running` };
+  if (active >= MAX_CONCURRENT) return {
+    ok: false, started: false, phase: 'admission', code: 'actor_worker_busy',
+    error: `actor worker rejected: ${MAX_CONCURRENT} already running`,
+  };
   active++;
   // The SW-minted relay grant for this run. It stays in THIS scope — never posted to
   // the Worker — so the untrusted heap can't lift it, and every relay below carries it
@@ -76,18 +89,85 @@ export const runActor = async (job, { workerUrl, sendToSW }) => {
   const budgetMs = Number.isFinite(job.budgetMs) && /** @type {number} */ (job.budgetMs) > 0 ? /** @type {number} */ (job.budgetMs) : 10 * 60_000;
   /** @type {Worker | null} */
   let worker = null;
+  const canaryName = `__peerd_actor_host_${Math.random().toString(36).slice(2)}`;
+  const canaryValue = Object.freeze({});
   try {
-    worker = new Worker(workerUrl, { type: 'module' });
+    Object.defineProperty(globalThis, canaryName, { value: canaryValue, configurable: true });
+    worker = createWorker(workerUrl);
     liveWorkers.set(runId, worker);
     const w = worker;
     return await new Promise((resolve) => {
       let settled = false;
-      const finish = (/** @type {any} */ v) => { if (!settled) { settled = true; resolve(v); } };
-      const timer = setTimeout(() => { try { w.terminate(); } catch { /* gone */ } finish({ ok: false, started: true, aborted: true, error: `actor timed out after ${budgetMs}ms` }); }, budgetMs);
+      let started = false;
+      let relayedToolRequests = 0;
+      /** @type {'awaiting-ready'|'awaiting-probe'|'ready'} */
+      let readiness = 'awaiting-ready';
+      let budgetTimer = /** @type {ReturnType<typeof setTimeout> | null} */ (null);
+      const probeId = `probe-${runId}`;
+      const finish = (/** @type {any} */ value) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(startupTimer);
+        if (budgetTimer) clearTimeout(budgetTimer);
+        try { w.terminate(); } catch { /* gone */ }
+        try { delete globalThis[/** @type {keyof typeof globalThis} */ (canaryName)]; } catch { /* best effort */ }
+        resolve(value);
+      };
+      const protocolFailure = (/** @type {string} */ error) => finish({
+        ok: false, started, phase: started ? 'run' : 'startup',
+        code: 'actor_worker_protocol_error', error,
+      });
+      const startupTimer = setTimeout(() => finish({
+        ok: false, started: false, phase: 'startup',
+        code: 'actor_worker_start_timeout', error: `actor worker did not become ready within ${startupMs}ms`,
+      }), startupMs);
 
       w.addEventListener('message', async (/** @type {MessageEvent} */ ev) => {
         const m = /** @type {any} */ (ev.data);
         if (!m || typeof m !== 'object') return;
+        if (m.type === 'ready') {
+          if (readiness !== 'awaiting-ready' || m.protocol !== ACTOR_WORKER_PROTOCOL || !validActorWorkerRealm(m.realm)) {
+            protocolFailure('actor worker returned an invalid readiness proof');
+            return;
+          }
+          readiness = 'awaiting-probe';
+          w.postMessage({ type: 'probe', protocol: ACTOR_WORKER_PROTOCOL, rid: probeId, canaryName });
+          return;
+        }
+        if (m.type === 'probe-response') {
+          if (readiness !== 'awaiting-probe' || m.protocol !== ACTOR_WORKER_PROTOCOL || m.rid !== probeId
+              || m.canaryAbsent !== true || globalThis[/** @type {keyof typeof globalThis} */ (canaryName)] !== canaryValue) {
+            protocolFailure('actor worker failed the separate-realm probe');
+            return;
+          }
+          readiness = 'ready';
+          clearTimeout(startupTimer);
+          if (job.probeOnly === true) {
+            finish({
+              ok: true, started: false, phase: 'startup', code: 'actor_worker_ready',
+              workerType: 'dedicated', realmVerified: true, extensionApisPresent: false,
+            });
+            return;
+          }
+          budgetTimer = setTimeout(() => finish({
+            ok: false, started: true, phase: 'run', code: 'actor_worker_timeout', aborted: true,
+            error: `actor timed out after ${budgetMs}ms`,
+          }), budgetMs);
+          started = true;
+          w.postMessage({
+            type: 'run', runId, sessionId: job.actorSessionId, message: job.message, systemPrompt: job.systemPrompt,
+            provider: job.provider, model: job.model, depth: job.depth, tools: job.tools ?? [],
+            priorMessages: job.priorMessages ?? [],
+            maxSteps: job.maxSteps, maxOutputTokens: job.maxOutputTokens, reasoning: job.reasoning, contextWindow: job.contextWindow,
+            oneShot: job.oneShot, actorType: job.actorType, backing: job.backing, tabUrl: job.tabUrl, origin: job.origin,
+            inbound: job.inbound === true,
+          });
+          return;
+        }
+        if (readiness !== 'ready') {
+          protocolFailure(`actor worker sent '${String(m.type)}' before readiness`);
+          return;
+        }
         if (m.type === 'model-request') {
           try {
             const resp = await sendToSW('actor/model-call', { relayToken, args: m.args });
@@ -97,6 +177,9 @@ export const runActor = async (job, { workerUrl, sendToSW }) => {
           return;
         }
         if (m.type === 'tool-request') {
+          // Count at the privileged relay boundary. The Worker result is not
+          // trusted to report whether an external action may have started.
+          relayedToolRequests += 1;
           try {
             // The SW pins the bound instance + gates + dispatches (never trusts the
             // worker's call args) and returns the ToolResult. The relay grant keys
@@ -109,42 +192,48 @@ export const runActor = async (job, { workerUrl, sendToSW }) => {
         }
         if (m.type === 'loop-event') { sendToSW('actor/loop-event', { relayToken, event: m.event }).catch(() => {}); return; }
         if (m.type === 'done') {
-          clearTimeout(timer); try { w.terminate(); } catch { /* gone */ }
           const r = m.result ?? {};
           // No `aborted` here: a Stop-cascade is stamped at the SW client (which alone
           // sees signal.aborted AND whether a reply came back). The runner only marks
           // `aborted` for its OWN wall-clock timeout below.
-          if (r.error) finish({ ok: false, started: true, error: r.error, finalText: r.finalText ?? '', newMessages: r.newMessages ?? [], usage: r.usage, stopReason: r.stopReason });
-          else finish({ ok: true, started: true, finalText: r.finalText ?? '', newMessages: r.newMessages ?? [], usage: r.usage, stopReason: r.stopReason, toolCalls: r.toolCalls ?? 0 });
+          if (r.error) {
+            const toolCalls = relayedToolRequests;
+            finish({
+              ok: false, started: true, error: r.error,
+              finalText: r.finalText ?? '', newMessages: r.newMessages ?? [],
+              usage: r.usage, stopReason: r.stopReason, toolCalls,
+              // A graceful provider failure before any tool request has a known
+              // outcome. Worker/protocol crashes use the separate error path and
+              // remain unknown because their partial state cannot be trusted.
+              outcomeKnown: relayedToolRequests === 0,
+            });
+          }
+          else finish({ ok: true, started: true, finalText: r.finalText ?? '', newMessages: r.newMessages ?? [], usage: r.usage, stopReason: r.stopReason, toolCalls: relayedToolRequests });
         }
         if (m.type === 'error') {
-          clearTimeout(timer); try { w.terminate(); } catch { /* gone */ }
-          finish({ ok: false, started: true, error: m.error ?? 'actor worker error' });
+          finish({ ok: false, started: true, phase: 'run', code: 'actor_worker_error', error: m.error ?? 'actor worker error' });
         }
       });
       w.addEventListener('error', (/** @type {any} */ e) => {
-        clearTimeout(timer); try { w.terminate(); } catch { /* gone */ }
-        finish({ ok: false, started: true, error: `actor worker crashed: ${e?.message ?? 'no detail'}` });
+        finish({
+          ok: false, started, phase: started ? 'run' : 'startup', code: 'actor_worker_crashed',
+          error: `actor worker crashed: ${e?.message ?? 'no detail'}`,
+        });
       });
-      w.postMessage({
-        type: 'run', runId, sessionId: job.actorSessionId, message: job.message, systemPrompt: job.systemPrompt,
-        provider: job.provider, model: job.model, depth: job.depth, tools: job.tools ?? [],
-        // priorMessages seeds the actor's history — a bound actor is STATEFUL
-        // across turns (dropping it made every offscreen turn amnesiac).
-        priorMessages: job.priorMessages ?? [],
-        maxSteps: job.maxSteps, maxOutputTokens: job.maxOutputTokens, reasoning: job.reasoning, contextWindow: job.contextWindow,
-        // Phase 3: oneShot loop mode (parity with the in-SW delegation path) + the
-        // web/API actor's self-fence provenance (actorType/backing/tabUrl/origin →
-        // the worker rebuilds ctx.fenceActorSummary). Undefined for engine actors.
-        oneShot: job.oneShot, actorType: job.actorType, backing: job.backing, tabUrl: job.tabUrl, origin: job.origin,
-        // Provenance is host-stamped and monotonic. The Worker consumes it for
-        // loop semantics; actual tool authority remains enforced by the SW grant.
-        inbound: job.inbound === true,
+      w.addEventListener('messageerror', () => {
+        finish({
+          ok: false, started, phase: started ? 'run' : 'startup', code: 'actor_worker_message_error',
+          error: 'actor worker sent a message that could not be decoded',
+      });
       });
     });
   } catch (e) {
-    return { ok: false, started: false, error: `actor worker spawn failed: ${/** @type {{ message?: string }} */ (e)?.message ?? String(e)}` };
+    return {
+      ok: false, started: false, phase: 'startup', code: 'actor_worker_spawn_failed',
+      error: `actor worker spawn failed: ${/** @type {{ message?: string }} */ (e)?.message ?? String(e)}`,
+    };
   } finally {
+    try { delete globalThis[/** @type {keyof typeof globalThis} */ (canaryName)]; } catch { /* best effort */ }
     liveWorkers.delete(runId);
     active--;
   }

--- a/extension/offscreen/actor-worker-protocol.js
+++ b/extension/offscreen/actor-worker-protocol.js
@@ -1,0 +1,12 @@
+// @ts-check
+// Versioned handshake shared by the actor Worker and both browser hosts.
+
+export const ACTOR_WORKER_PROTOCOL = 1;
+export const ACTOR_WORKER_STARTUP_MS = 10_000;
+
+/** @param {any} realm */
+export const validActorWorkerRealm = (realm) => realm?.dedicatedWorker === true
+  && realm?.window === false
+  && realm?.document === false
+  && realm?.browser === false
+  && realm?.chrome === false;

--- a/extension/offscreen/actor-worker.js
+++ b/extension/offscreen/actor-worker.js
@@ -8,6 +8,7 @@
 // heap. Module worker → strict.
 import { runUserTurn } from '/peerd-runtime/loop/agent-loop.js';
 import { makeInMemorySessions, makeRelayedCallModel, makeRelayedToolDispatch, runActorLoop, makeActorSummaryFence } from '/peerd-runtime/actor/actor-worker-core.js';
+import { ACTOR_WORKER_PROTOCOL } from './actor-worker-protocol.js';
 
 let seq = 0;
 let runId = '';
@@ -16,10 +17,21 @@ const modelPending = new Map();
 /** @type {Map<string, (v: any) => void>} rid → pending tool-dispatch resolver */
 const toolPending = new Map();
 const abort = new AbortController();
+let hasRun = false;
 
 self.addEventListener('message', async (/** @type {MessageEvent} */ ev) => {
   const m = /** @type {any} */ (ev.data);
   if (!m || typeof m !== 'object') return;
+
+  if (m.type === 'probe') {
+    self.postMessage({
+      type: 'probe-response',
+      protocol: ACTOR_WORKER_PROTOCOL,
+      rid: m.rid,
+      canaryAbsent: typeof m.canaryName === 'string' && !(m.canaryName in globalThis),
+    });
+    return;
+  }
 
   if (m.type === 'model-response') { modelPending.get(m.rid)?.({ events: m.events }); modelPending.delete(m.rid); return; }
   if (m.type === 'model-error') { modelPending.get(m.rid)?.({ error: m.error }); modelPending.delete(m.rid); return; }
@@ -35,6 +47,11 @@ self.addEventListener('message', async (/** @type {MessageEvent} */ ev) => {
   }
 
   if (m.type === 'run') {
+    if (hasRun) {
+      self.postMessage({ type: 'error', runId, error: 'actor worker refused a second run' });
+      return;
+    }
+    hasRun = true;
     runId = m.runId;
     const requestModel = (/** @type {object} */ args) => new Promise((resolve) => {
       const rid = `mc-${++seq}`;
@@ -81,4 +98,19 @@ self.addEventListener('message', async (/** @type {MessageEvent} */ ev) => {
       self.postMessage({ type: 'error', runId, error: /** @type {{ message?: string }} */ (e)?.message ?? String(e) });
     }
   }
+});
+
+// Posted only after the complete module graph evaluated and the listener above
+// was installed. The host validates this plus a per-run realm canary before it
+// sends any model input or grants tool relays.
+self.postMessage({
+  type: 'ready',
+  protocol: ACTOR_WORKER_PROTOCOL,
+  realm: {
+    dedicatedWorker: globalThis.constructor?.name === 'DedicatedWorkerGlobalScope',
+    window: typeof window !== 'undefined',
+    document: typeof document !== 'undefined',
+    browser: 'browser' in globalThis,
+    chrome: 'chrome' in globalThis,
+  },
 });

--- a/extension/offscreen/job-runner.js
+++ b/extension/offscreen/job-runner.js
@@ -146,7 +146,7 @@ let activeJobs = 0;
  *   DIRECT-CALLER seam (tests) — offscreen.js never forwards it from a
  *   message, so the production budget cannot be picked over the wire.
  * @param {{ sendToSW: (type: string, payload: object) => Promise<any>, abortRun?: (runId: string, ownerSessionId?: string) => Promise<unknown>, extractMarkdown?: import('/shared/fetch-extract.js').ExtractMarkdownFn, opfsForRoot?: typeof opfsHelpers }} deps
- * @returns {Promise<{ value: unknown, consoleOutput: {level:string,text:string}[], durationMs: number, error: string|null, errorCode?: string, usedEgress?: boolean, usedActors?: boolean, usedWorkspace?: boolean, workspaceOverBudget?: boolean, actorsTrace?: Array<object>, codeTrace?: Array<object>, usedProvider?: boolean, providerCalls?: number, providerTokens?: number }>}
+ * @returns {Promise<{ value: unknown, consoleOutput: {level:string,text:string}[], durationMs: number, error: string|null, errorCode?: string, usedEgress?: boolean, usedActors?: boolean, actorDeliveryIds?: string[], usedWorkspace?: boolean, workspaceOverBudget?: boolean, actorsTrace?: Array<object>, codeTrace?: Array<object>, usedProvider?: boolean, providerCalls?: number, providerTokens?: number }>}
  */
 export const runJob = async (job, deps) => {
   if (activeJobs >= MAX_CONCURRENT_JOBS) {
@@ -511,6 +511,15 @@ const _runJob = async ({ code, timeoutMs = 30000, startedAt, deadlineAt, a2a = f
   const actorsTrace = [];
   let actorsSeq = 0;
   let usedActors = false;
+  // Awaited actor replies stay in the durable mailbox until the script tool
+  // result that consumed them commits. The worker never sees these host-only
+  // ids; the offscreen host gathers them from SW responses and returns them as
+  // custody metadata beside the run result.
+  /** @type {Set<string>} */
+  const actorDeliveryIds = new Set();
+  const actorCustody = () => actorDeliveryIds.size > 0
+    ? { actorDeliveryIds: [...actorDeliveryIds] }
+    : {};
   // The sub-model meter (design 5): host-counted, so the [MODEL CALLS n |
   // tokens t] line the orchestrator reads is never the realm's own claim.
   // Calls count every relayed attempt (an attempt is potential spend); tokens
@@ -548,7 +557,7 @@ const _runJob = async ({ code, timeoutMs = 30000, startedAt, deadlineAt, a2a = f
         abortHostOperations();
         try { worker.terminate(); } catch {}
         recordToolboxUse(false);
-        resolve({ value: undefined, consoleOutput: [], durationMs: timeoutMs, error: `job timed out after ${timeoutMs}ms`, usedEgress, usedActors, usedPage, images: pageImages, usedWorkspace, workspaceOverBudget, actorsTrace, codeTrace, usedProvider, providerCalls, providerTokens });
+        resolve({ value: undefined, consoleOutput: [], durationMs: timeoutMs, error: `job timed out after ${timeoutMs}ms`, usedEgress, usedActors, ...actorCustody(), usedPage, images: pageImages, usedWorkspace, workspaceOverBudget, actorsTrace, codeTrace, usedProvider, providerCalls, providerTokens });
       }, Math.ceil(remainingMs()));
       // Stop plumbing: a runId-carrying job can be terminated from the SW
       // (script tool abort). The trace survives — partial work stays visible.
@@ -557,7 +566,7 @@ const _runJob = async ({ code, timeoutMs = 30000, startedAt, deadlineAt, a2a = f
           clearTimeout(timer);
           abortHostOperations();
           try { worker.terminate(); } catch {}
-          resolve({ value: undefined, consoleOutput: [], durationMs: 0, error: 'job aborted (Stop)', usedEgress, usedActors, usedPage, images: pageImages, usedWorkspace, workspaceOverBudget, actorsTrace, codeTrace, usedProvider, providerCalls, providerTokens });
+          resolve({ value: undefined, consoleOutput: [], durationMs: 0, error: 'job aborted (Stop)', usedEgress, usedActors, ...actorCustody(), usedPage, images: pageImages, usedWorkspace, workspaceOverBudget, actorsTrace, codeTrace, usedProvider, providerCalls, providerTokens });
         };
         liveJobs.set(runId, { kill, owner: ownerSessionId });
         // Stop already arrived while we were still building — honor it now.
@@ -655,6 +664,9 @@ const _runJob = async ({ code, timeoutMs = 30000, startedAt, deadlineAt, a2a = f
               }),
               (response) => response?.ok === true && response?.value?.failed !== true,
             );
+            if (typeof resp?.actorDeliveryId === 'string') {
+              actorDeliveryIds.add(resp.actorDeliveryId);
+            }
             entry.ms = Math.round(performance.now() - t0);
             entry.settled = true;
             if (resp?.ok) {
@@ -857,7 +869,7 @@ const _runJob = async ({ code, timeoutMs = 30000, startedAt, deadlineAt, a2a = f
               value: undefined, consoleOutput: [], durationMs: 0,
               error: `import resolution failed: ${error.message}`,
               errorCode: error.code,
-              usedEgress, usedActors, usedPage, images: pageImages,
+              usedEgress, usedActors, ...actorCustody(), usedPage, images: pageImages,
               usedWorkspace, workspaceOverBudget, actorsTrace, codeTrace,
               usedProvider, providerCalls, providerTokens,
             });
@@ -916,7 +928,7 @@ const _runJob = async ({ code, timeoutMs = 30000, startedAt, deadlineAt, a2a = f
           // this error; a user-code line number is actionable, a blob one isn't.
           const error = m.error ? mapWorkerError(m.error, blobUrl, bodyLine, 'job.js') : null;
           recordToolboxUse(!error);
-          resolve({ value: m.value, consoleOutput: m.consoleOutput, durationMs: Math.min(timeoutMs, Math.max(0, Date.now() - runStartedAt)), error, usedEgress, usedActors, usedPage, images: pageImages, usedWorkspace, workspaceOverBudget, actorsTrace, codeTrace, usedProvider, providerCalls, providerTokens });
+          resolve({ value: m.value, consoleOutput: m.consoleOutput, durationMs: Math.min(timeoutMs, Math.max(0, Date.now() - runStartedAt)), error, usedEgress, usedActors, ...actorCustody(), usedPage, images: pageImages, usedWorkspace, workspaceOverBudget, actorsTrace, codeTrace, usedProvider, providerCalls, providerTokens });
         }
       });
 
@@ -928,7 +940,7 @@ const _runJob = async ({ code, timeoutMs = 30000, startedAt, deadlineAt, a2a = f
           e.error?.stack || e.error?.message || e.message || 'worker crashed (no detail)',
           blobUrl, bodyLine, 'job.js');
         recordToolboxUse(false);
-        resolve({ value: undefined, consoleOutput: [], durationMs: 0, error: `worker error: ${detail}`, usedEgress, usedActors, usedPage, images: pageImages, usedWorkspace, workspaceOverBudget, actorsTrace, codeTrace, usedProvider, providerCalls, providerTokens });
+        resolve({ value: undefined, consoleOutput: [], durationMs: 0, error: `worker error: ${detail}`, usedEgress, usedActors, ...actorCustody(), usedPage, images: pageImages, usedWorkspace, workspaceOverBudget, actorsTrace, codeTrace, usedProvider, providerCalls, providerTokens });
       });
     });
   } finally {

--- a/extension/options/components/options-app.js
+++ b/extension/options/components/options-app.js
@@ -22,6 +22,7 @@ import { SkillsView } from '/sidepanel/components/skills-view.js';
 import { HooksView } from '/sidepanel/components/hooks-view.js';
 import { DenylistView } from '/sidepanel/components/denylist-view.js';
 import { LearnedOriginsView } from '/sidepanel/components/learned-origins-view.js';
+import { ActorIsolationBanner } from '/sidepanel/components/actor-isolation-banner.js';
 import { ProvidersSection } from '../sections/providers.js';
 import { BehaviorSection } from '../sections/behavior.js';
 import { VoiceSection } from '../sections/voice.js';
@@ -226,6 +227,7 @@ export const OptionsApp = {
       ]),
       m('main.options-content', m('.options-page', [
         m('h2', SECTION_TITLES[section] ?? 'Settings'),
+        m(ActorIsolationBanner, { capability: state.capabilities?.actorExecution, send }),
         OptionsApp.section(vnode),
       ])),
     ]);

--- a/extension/options/options.css
+++ b/extension/options/options.css
@@ -95,6 +95,12 @@
   padding: 24px 28px 56px;
 }
 
+.options-page > .actor-isolation-banner {
+  border: 1px solid var(--border);
+  border-radius: var(--r2);
+  margin-bottom: 18px;
+}
+
 /* why the max-width: styles.css assumed a ~400px panel where lines
  * could never run long; a full tab needs an explicit readable column. */
 .options-page { max-width: 760px; }

--- a/extension/options/sections/providers.js
+++ b/extension/options/sections/providers.js
@@ -144,6 +144,8 @@ export const ProvidersSection = {
   view: ({ attrs: { state, send }, state: ui }) => {
     const provider = state.providers ?? { current: 'anthropic', hasKey: false };
     const providerModel = state.settings?.providerModel ?? '';
+    const actorExecution = state.capabilities?.actorExecution;
+    const actorUnavailable = actorExecution && actorExecution.status !== 'available';
 
     // Per-provider key prefixes — a cheap "looks like a real key" format
     // check so a wrong paste is caught at save time instead of silently
@@ -472,6 +474,7 @@ export const ProvidersSection = {
           m('label', { for: 'runner-model' }, 'Web actor model'),
           m('input', {
             id: 'runner-model',
+            'aria-describedby': actorUnavailable ? 'runner-model-hint runner-model-status' : 'runner-model-hint',
             type: 'text',
             spellcheck: false,
             // why: blank no longer means "inherit chat model" — it means this
@@ -485,13 +488,18 @@ export const ProvidersSection = {
             },
           }),
         ]),
-        m('p.hint', [
+        m('p.hint', { id: 'runner-model-hint' }, [
           'The web actor — peerd’s page reader and operator — runs on a fast, cheap ',
           'model by default: ',
           m('code', runnerPlaceholder),
           ' on ', m('strong', defaultProvRow?.label ?? 'this provider'),
           '. Leave blank for that default, or pin any same-provider model id.',
         ]),
+        actorUnavailable
+          ? m('p.hint', { id: 'runner-model-status' }, actorExecution.status === 'temporarily_unavailable'
+              ? 'Actor work is paused. You can set this now; it will apply after actor execution recovers.'
+              : 'This browser cannot run actors. You can still save this setting for a browser that can.')
+          : null,
         resetRow(send, ['providerName', 'providerModel', 'runnerModel']),
 
         m('p.muted.settings-footer', [

--- a/extension/peerd-provider/adapters/anthropic.js
+++ b/extension/peerd-provider/adapters/anthropic.js
@@ -129,9 +129,9 @@ export async function* callAnthropic(args) {
       'anthropic-dangerous-direct-browser-access': 'true',
     },
     body: JSON.stringify(body),
-    // AbortSignal flows through to native fetch — when the user clicks
-    // Stop or sends a new message mid-stream, the SSE body stream is
-    // cut and the SW reclaims its socket promptly.
+    // AbortSignal flows through to native fetch. Stop or a new message cuts
+    // the local SSE consumer and prevents late bytes from re-entering the
+    // agent. Physical socket teardown remains browser-managed.
     signal,
   };
 

--- a/extension/peerd-provider/adapters/local-webgpu.js
+++ b/extension/peerd-provider/adapters/local-webgpu.js
@@ -186,8 +186,15 @@ export async function* callLocalWebgpu({ messages, system, model = LOCAL_MODEL_I
   }
   let outTokens = 0;
   try {
+    // The local-model transport needs only role + content. Project that exact
+    // shape before runtime messaging so host-only custody ids never cross a
+    // provider boundary, even to an on-device provider.
+    const transportMessages = messages.map((/** @type {any} */ message) => ({
+      role: message?.role,
+      content: message?.content,
+    }));
     const tokenStream = (async function* () {
-      for await (const tok of generateLocal({ messages, system, tools, model, signal })) {
+      for await (const tok of generateLocal({ messages: transportMessages, system, tools, model, signal })) {
         outTokens += 1; // ~one streamer chunk ≈ one token (good enough for the cost split)
         yield tok;
       }

--- a/extension/peerd-provider/types.js
+++ b/extension/peerd-provider/types.js
@@ -22,6 +22,11 @@
  *   inside the tool_result content on Anthropic, and as a follow-on user image
  *   message on OpenAI (its tool role takes string content only). Never persisted.
  * @property {import('/shared/tool-types.js').ToolMeta} [meta]   dispatcher meta — UI uses this
+ * @property {string} [actorDeliveryId]            internal mailbox correlation;
+ *   retained in local history for post-commit acknowledgement and ignored by
+ *   provider formatters
+ * @property {string[]} [actorDeliveryIds]         internal mailbox correlations
+ *   for a tool result that consumed multiple replies; ignored by providers
  */
 
 /**
@@ -53,7 +58,7 @@
  *                                               trim drop-summary, loop/trim.js); consumers
  *                                               that must skip non-human content check it
  *                                               (e.g. memory/auto-memory.js)
- * @property {{ kind: string, instanceId: string, name?: string, failed?: boolean }} [actorReply]
+ * @property {{ kind: string, instanceId: string, name?: string, failed?: boolean, outcomeKnown?: boolean, performed?: boolean, actorDeliveryId?: string }} [actorReply]
  *                                               set on an actor's reply-wake (a synthetic turn
  *                                               the chat SHOWS, attributed to the actor —
  *                                               unlike the hidden plumbing synthetics)

--- a/extension/peerd-runtime/actor/actor-messaging.js
+++ b/extension/peerd-runtime/actor/actor-messaging.js
@@ -24,9 +24,11 @@
 // this path; it never blocked the orchestrator, and the fence is now uniform.)
 //
 // Durable mailbox (P1). The correlation is persisted (deps.mailbox): an SW death
-// between accept and deliver() no longer drops the reply-wake — redrain() re-queues
-// every pending message on boot (mirrors goalRunner.resume). The default no-op
-// mailbox keeps the pure-heap behavior in tests.
+// between accept and deliver() no longer drops the reply-wake. Each entry is
+// persisted as queued, then moved to started before actor work can begin. Boot
+// recovery never executes a stored request automatically. Queued work is reported
+// as Not run; started or legacy work is reported as outcome unknown. The default
+// no-op mailbox keeps pure-heap tests lightweight.
 //
 // Posture (PR #134 — spawned as async actors): a message is accepted when the
 // turn is NOT `inbound` AND the sender passes the TRUSTED-LINEAGE gate
@@ -58,13 +60,14 @@
 // orphan turn nobody consumes AND rebuild its context on the MAIN exposure
 // surface, escalating past the child's narrowed toolset.
 
-import { escapeAttr } from '/shared/util.js';
+import { escapeAttr, uuidv7 } from '/shared/util.js';
 import { ASYNC_ACTOR_ACTORS, mayMessageActor, messageProvenance } from './delegation-lineage.js';
 // #241 — the deterministic schema boundary for an untrusted actor's reply.
 // Pure policy (no IO), imported directly like the other pure helpers here; the
 // FLAG that turns it on is injected (schemaValidatedReplies), SW-side.
 import { validateActorReply, renderValidatedReply, REPLY_VALIDATION_FAILED } from './reply-schema.js';
 import { ABORT_STEER } from '../loop/turn-slots.js';
+import { actorIsolationAvailable, actorIsolationRefusal } from './isolation.js';
 
 /**
  * The reason a turn's abort signal carries, when it carries one.
@@ -115,15 +118,21 @@ const SCHEMA_VALIDATED_KINDS = new Set(['web', 'api']);
  *   chat that sent this message — the chat-scoped WEB actor (to:'web') is owned by it,
  *   so it must be threaded (not re-derived from the ambient active chat, which is wrong
  *   on a boot redrain). Engine/per-tab kinds ignore it (globally/tab keyed).
- * @param {(opts: { actorSessionId: string, message: string, actorTabId?: number, instanceId: string, kind: string, parentToolUseId?: string, name?: string, oneShot?: boolean }) => Promise<{ result: string, stopped?: boolean }>} deps.runActorTurn
+ * @param {(opts: { actorSessionId: string, message: string, actorTabId?: number, instanceId: string, kind: string, parentToolUseId?: string, name?: string, oneShot?: boolean }) => Promise<{ result: string, stopped?: boolean, executionFailed?: boolean, outcomeKnown?: boolean }>} deps.runActorTurn
  *   Drive ONE actor turn (runAgentTurn against the actor session) and
  *   resolve with its final assistant text. parentToolUseId (the message_actor
  *   tool_use id, absent on a boot redrain) keys the actor's live DISPLAY stream
  *   to its card. Contracted to CLAIM the actor's
  *   turn slot (so runWhenIdle drains correctly).
- * @param {(opts: { userText: string, sessionId: string, synthetic: boolean, trusted?: boolean, actorReply?: { kind: string, instanceId: string, name?: string, failed: boolean } }) => Promise<unknown>} deps.reenter
+ * @param {(opts: { userText: string, sessionId: string, synthetic: boolean, trusted?: boolean, actorReply?: { kind: string, instanceId: string, name?: string, failed: boolean, outcomeKnown?: boolean, performed?: boolean, actorDeliveryId?: string } }) => Promise<unknown>} deps.reenter
  *   Re-enter a session with a (synthetic) turn — the SW's runAgentTurn. trusted:true
  *   marks a first-party continuation allowed to message actors (the reply-wake).
+ * @param {(opts: { userText: string, sessionId: string, synthetic: true, actorReply: { kind: string, instanceId: string, name?: string, failed: boolean, outcomeKnown?: boolean, performed?: boolean }, recoveryId: string }) => Promise<boolean>} [deps.recordRecovery]
+ *   Persist a restart notice without running a model turn. The shell gives the
+ *   notice a stable id derived from recoveryId, making a second restart safe.
+ * @param {(opts: { sessionId: string, deliveryId: string }) => Promise<boolean>} [deps.deliveryCommitted]
+ *   Check whether the original reply or outer tool result is already durable.
+ *   Recovery removes that mailbox row without adding a second warning.
  * @param {{ runWhenIdle: (sessionId: string, fn: () => void) => void, advanceQueue?: (sessionId: string) => void, stop?: (sessionId: string) => boolean }} deps.turnSlots
  * @param {() => Promise<string | null>} deps.getActiveSessionId
  * @param {(sessionId: string) => Promise<Array<import('./delegation-lineage.js').LineageHop>>} [deps.getAncestry]
@@ -133,22 +142,25 @@ const SCHEMA_VALIDATED_KINDS = new Set(['web', 'api']);
  *   Default returns [] — FAIL-CLOSED: without a chain only the foreground chat
  *   itself passes the gate, and provenance collapses to the sender.
  * @param {() => boolean} deps.isVaultLocked
+ * @param {() => import('./isolation.js').ActorIsolationCapability | null} [deps.getActorIsolation]
  * @param {(opts: { origin: string, tool: string, body: string, retrievedAt?: string }) => string} deps.wrapUntrusted
  * @param {(entry: object) => Promise<unknown>} [deps.appendAudit]
  * @param {() => number} [deps.now]
  * @param {{ outstanding?: number, rateCap?: number, rateWindowMs?: number, resultChars?: number }} [deps.caps]
  * @param {(...args: unknown[]) => void} [deps.log]
- * @param {{ append: (e: { id: string, senderSessionId: string, to: string, message: string, createdAt: number, provenance?: { rootSessionId: string, lineagePath: string[] }, oneShot?: boolean }) => Promise<unknown>, remove: (id: string) => Promise<unknown>, load: () => Promise<any[]> }} [deps.mailbox]
+ * @param {{ append: (e: { id: string, senderSessionId: string, to: string, message: string, createdAt: number, state?: 'queued'|'started', kind?: string, name?: string, provenance?: { rootSessionId: string, lineagePath: string[] }, oneShot?: boolean }) => Promise<unknown>, markStarted?: (id: string) => Promise<unknown>, remove: (id: string) => Promise<unknown>, load: () => Promise<any[]> }} [deps.mailbox]
  *   DURABLE MAILBOX (DESIGN-17 P1). Persists EVERY actor's in-flight
  *   message→reply correlation — web included — so an SW death between accept and
- *   deliver() doesn't silently drop the reply-wake. append() on accept, remove()
- *   on settle, load() at boot (redrain). Default no-op = the pure-heap behavior
- *   tests run with. Mirrors goal-runner's persist/resume.
+ *   deliver() doesn't silently drop the reply-wake. append() records queued,
+ *   markStarted() commits the no-replay boundary before dispatch, remove() runs
+ *   after reply delivery, and load() feeds boot recovery. Mirrors goal-runner
+ *   persistence.
  */
 export const makeActorMessaging = (deps) => {
   const {
     resolveActor, runActorTurn, reenter, turnSlots,
     getActiveSessionId, isVaultLocked, wrapUntrusted,
+    getActorIsolation = () => null,
     getAncestry = async () => [],
     // #241 — when this reads true, an untrusted actor's (web/api) reply must be a
     // strict JSON envelope, validated by deterministic code before it reaches the
@@ -161,9 +173,18 @@ export const makeActorMessaging = (deps) => {
     // half has the same property for free (ctx.schemaReply is stamped per turn),
     // so reading per reply is what keeps the two halves ONE switch.
     schemaValidatedReplies = () => false,
+    recordRecovery = async () => false,
+    deliveryCommitted = async () => false,
     appendAudit = async () => {}, now = Date.now, caps = {}, log = () => {},
-    mailbox = { append: async () => {}, remove: async () => {}, load: async () => [] },
+    mailbox: mailboxInput = {},
   } = deps;
+  const mailbox = {
+    append: async (/** @type {any} */ _entry) => {},
+    markStarted: async (/** @type {string} */ _id) => {},
+    remove: async (/** @type {string} */ _id) => {},
+    load: async () => /** @type {any[]} */ ([]),
+    ...mailboxInput,
+  };
 
   // The kinds oneShot is honored for — the agent's OWN engine sandboxes, whose
   // raw results are (relatively) trusted instance output. Never web/api/dweb.
@@ -227,7 +248,6 @@ export const makeActorMessaging = (deps) => {
   };
   // Monotonic correlation id — durable-mailbox key + de-dupe. Process-unique
   // (not now()-derived, which is fixed in tests and collides on same-ms sends).
-  let seq = 0;
 
   /** @param {string} root @param {string} actorSessionId */
   const trackActor = (root, actorSessionId) => {
@@ -290,8 +310,8 @@ export const makeActorMessaging = (deps) => {
   // Build the ONE reply text shape (trusted lead + fenced body) both reply
   // modes share: deliver() re-enters a long-lived sender with it; the
   // awaitReply path (an actor's call) resolves it into the tool result.
-  /** @param {string} instanceId @param {string} kind @param {string|undefined} name @param {string} body @param {boolean} [failed] */
-  const replyText = (instanceId, kind, name, body, failed = false) => {
+  /** @param {string} instanceId @param {string} kind @param {string|undefined} name @param {string} body @param {boolean} [failed] @param {boolean} [outcomeUnknown] @param {boolean|undefined} [performed] */
+  const replyText = (instanceId, kind, name, body, failed = false, outcomeUnknown = false, performed = undefined) => {
     const wrapped = wrapUntrusted({
       origin: instanceId, tool: 'message_actor', body,
       retrievedAt: new Date(now()).toISOString(),
@@ -318,10 +338,33 @@ export const makeActorMessaging = (deps) => {
       : (kind === 'web' && /^https?:\/\//.test(String(instanceId)))
         ? `The ${instanceId} integration`
         : `The ${kind} actor ${safeName ? `${safeName} (${instanceId})` : instanceId}`;
-    const lead = failed
-      ? `${subject} could not complete your request:`
-      : `${subject} you messaged has replied:`;
+    const lead = outcomeUnknown
+      ? `${subject} did not complete cleanly. Its outcome is unknown. Do not retry automatically:`
+      : performed === false
+        ? `${subject} did not run the request:`
+        : failed
+        ? `${subject} could not complete your request:`
+        : `${subject} you messaged has replied:`;
     return `${lead}\n\n${wrapped}`;
+  };
+
+  // Build the one envelope used by live delivery and passive restart recovery.
+  // Only the locally composed lead is trusted. The body remains fenced even for
+  // fixed recovery copy, so the model-facing shape never depends on its source.
+  /** @param {string} instanceId @param {string} kind @param {string|undefined} name @param {string} body @param {boolean} failed @param {string|undefined} via @param {boolean} outcomeUnknown @param {boolean|undefined} performed @param {string|undefined} actorDeliveryId */
+  const deliveryEnvelope = (instanceId, kind, name, body, failed, via, outcomeUnknown, performed, actorDeliveryId = undefined) => {
+    const userText = replyText(instanceId, kind, name, body, failed, outcomeUnknown, performed);
+    const safeName = name ? escapeAttr(name.replace(/\s+/g, ' ').trim().slice(0, 80)) : undefined;
+    return {
+      userText,
+      actorReply: {
+        kind, instanceId, ...(safeName ? { name: safeName } : {}), failed,
+        ...(outcomeUnknown ? { outcomeKnown: false } : performed === false ? { outcomeKnown: true } : {}),
+        ...(performed !== undefined ? { performed } : {}),
+        ...(via ? { via } : {}),
+        ...(actorDeliveryId ? { actorDeliveryId } : {}),
+      },
+    };
   };
 
   // Re-enter the SENDER with the actor's reply as a synthetic, wrapUntrusted-
@@ -329,9 +372,8 @@ export const makeActorMessaging = (deps) => {
   // user's live turn (the focus/work-theft bug, DECISIONS #20). Only the one-line
   // lead is trusted; the actor's body is fenced (mandatory for App actors,
   // which render attacker content).
-  /** @param {string} senderSessionId @param {string} instanceId @param {string} kind @param {string|undefined} name @param {string} body @param {boolean} [failed] @param {string} [via] */
-  const deliver = (senderSessionId, instanceId, kind, name, body, failed = false, via = undefined) => {
-    const text = replyText(instanceId, kind, name, body, failed);
+  /** @param {string} senderSessionId @param {string} instanceId @param {string} kind @param {string|undefined} name @param {string} body @param {boolean} [failed] @param {string} [via] @param {boolean} [outcomeUnknown] @param {boolean} [performed] @param {string} [actorDeliveryId] @returns {Promise<boolean>} */
+  const deliver = (senderSessionId, instanceId, kind, name, body, failed = false, via = undefined, outcomeUnknown = false, performed = undefined, actorDeliveryId = undefined) => {
     // actorReply rides the wake so the UI can render the reply as its OWN
     // attributed chat bubble at the bottom (not buried in the tool-call card).
     // `synthetic` alone can't carry this — it also marks truncation/resume
@@ -339,23 +381,30 @@ export const makeActorMessaging = (deps) => {
     // lead is (it renders un-fenced in the bubble's attribution line). `via`
     // attributes a mediated delegation if a future async code surface routes
     // its reply here; without that, a late bubble would be unexplainable.
-    const safeName = name ? escapeAttr(name.replace(/\s+/g, ' ').trim().slice(0, 80)) : undefined;
-    const actorReply = { kind, instanceId, ...(safeName ? { name: safeName } : {}), failed, ...(via ? { via } : {}) };
-    turnSlots.runWhenIdle(senderSessionId, () => {
-      // trusted:true — the reply-wake is a FIRST-PARTY continuation (the sender's
-      // own actor replied), so the sender's turn that reads it MAY fire a
-      // follow-up message_actor. The reply BODY is still wrapUntrusted-fenced:
-      // trusted is about the turn's ORIGIN (peerd's own loop), not its content.
-      Promise.resolve(reenter({ userText: text, sessionId: senderSessionId, synthetic: true, trusted: true, actorReply }))
-        .catch((e) => log('reenter failed', e));
+    const { userText, actorReply } = deliveryEnvelope(
+      instanceId, kind, name, body, failed, via, outcomeUnknown, performed, actorDeliveryId,
+    );
+    return new Promise((resolve) => {
+      try {
+        turnSlots.runWhenIdle(senderSessionId, () => {
+          // trusted:true: the reply wake is a first-party continuation. The reply
+          // body remains fenced. Resolve false instead of rejecting because most
+          // live deliveries are fire-and-forget; recovery callers use the boolean
+          // to retain their durable record until the warning lands successfully.
+          Promise.resolve(reenter({ userText, sessionId: senderSessionId, synthetic: true, trusted: true, actorReply }))
+            .then(() => resolve(true), (e) => { log('reenter failed', e); resolve(false); });
+        });
+      } catch (e) {
+        log('reenter queue failed', e);
+        resolve(false);
+      }
     });
   };
 
-  // Queue ONE engine actor turn on its slot, route the fenced reply to the
-  // sender, and clear the mailbox entry on settle. Shared by a fresh message and a
-  // boot redrain() so the in-flight bookkeeping (count, Stop-cascade tracking,
-  // durable entry) stays identical on both paths. parentToolUseId (absent on a
-  // redrain — the orchestrator card is gone) keys the actor's display stream.
+  // Queue one engine actor turn on its slot and route the fenced reply to the
+  // sender. Durable acknowledgement belongs to the session post-commit hook;
+  // this module clears only correlations that provably have no persistence path.
+  // parentToolUseId keys the actor's display stream.
   //
   // Reply routing: `onReply` (the awaitReply path — an actor's call) receives
   // the composed reply text and its failed flag INSTEAD of the deliver() wake;
@@ -365,13 +414,13 @@ export const makeActorMessaging = (deps) => {
   //
   // Bookkeeping is keyed by rootSessionId (phase 4/5): the lineage root shares
   // one budget and one Stop generation, whoever in the tree actually sent.
-  /** @param {{ correlationId: string, senderSessionId: string, rootSessionId: string, actor: { instanceId: string, kind: string, actorSessionId: string, name?: string, tabId?: number }, message: string, parentToolUseId?: string, oneShot?: boolean, bare?: boolean, via?: string, onReply?: (text: string, failed: boolean) => void, deliverInstead?: () => boolean }} o */
+  /** @param {{ correlationId: string, senderSessionId: string, rootSessionId: string, actor: { instanceId: string, kind: string, actorSessionId: string, name?: string, tabId?: number }, message: string, parentToolUseId?: string, oneShot?: boolean, bare?: boolean, via?: string, onReply?: (text: string, failed: boolean, outcomeUnknown: boolean) => boolean|void, deliverInstead?: () => boolean }} o */
   const runEngineDelivery = ({ correlationId, senderSessionId, rootSessionId, actor, message, parentToolUseId, oneShot, bare, via, onReply, deliverInstead }) => {
     const { instanceId, kind, actorSessionId, name, tabId } = actor;
     trackActor(rootSessionId, actorSessionId);
     // Keyed on actorSessionId, NOT instanceId — must match the live-path track
     // (a constant 'web' instanceId would alias-collapse sender-scoped web actors;
-    // see the dedupe note in messageActor). clear() untracks with THIS key, so
+    // see the dedupe note in messageActor). clearTracking() uses THIS key, so
     // the track/untrack pair stays symmetric across both paths (#4/#8).
     const intentK = intentKey(actorSessionId, message);
     // Capture the root's Stop generation NOW — if the user Stops while this turn is
@@ -379,7 +428,7 @@ export const makeActorMessaging = (deps) => {
     // skip it when the slot finally frees (so Stop reaches queued work, not just the
     // running slot turnSlots.stop aborts). The bookkeeping is cleared either way.
     const genAtQueue = stopGen.get(rootSessionId) ?? 0;
-    const clear = () => {
+    const clearTracking = () => {
       decInFlight(rootSessionId);
       untrackActor(rootSessionId, actorSessionId);
       untrackIntent(rootSessionId, intentK);
@@ -390,8 +439,8 @@ export const makeActorMessaging = (deps) => {
       // the cancelled set after the queued-wake check had already passed — drop
       // it on settle so the set never grows past the in-flight deliveries.
       cancelledDeliveries.delete(correlationId);
-      mailbox.remove(correlationId).catch(() => {});
     };
+    const clearMailbox = () => mailbox.remove(correlationId).catch(() => {});
     // ONE reply seam for both modes (see routing note above). `bare` hands the
     // awaiting caller the RAW reply body instead of the formatted lead+fence:
     // the script surface's asks resolve into CODE, where fence markup is
@@ -405,8 +454,8 @@ export const makeActorMessaging = (deps) => {
     // a false "did not match format" reject. The schema's own field caps
     // (reply-schema.js) are the size bound for the validated path; the free-form
     // and error paths keep the RESULT_CHARS clamp on the way out.
-    /** @param {string} rawBody @param {boolean} failed */
-    const settle = (rawBody, failed) => {
+    /** @param {string} rawBody @param {boolean} failed @param {boolean} [outcomeUnknown] */
+    const settle = (rawBody, failed, outcomeUnknown = false) => {
       let outBody = rawBody;
       let outFailed = failed;
       // #241 — the deterministic schema boundary. An untrusted actor (web/api)
@@ -441,8 +490,28 @@ export const makeActorMessaging = (deps) => {
       // Ordering note (rebase onto #255): validation + the RESULT_CHARS clamp run
       // FIRST, so a degraded reply that lands on the later turn is the same
       // validated, bounded body the awaiting caller would have received.
-      if (onReply && !(deliverInstead && deliverInstead())) { onReply(bare ? outBody : replyText(instanceId, kind, name, outBody, outFailed), outFailed); return; }
-      deliver(senderSessionId, instanceId, kind, name, outBody, outFailed, via);
+      if (onReply && !(deliverInstead && deliverInstead())) {
+        const accepted = onReply(
+          bare ? outBody : replyText(instanceId, kind, name, outBody, outFailed, outcomeUnknown),
+          outFailed,
+          outcomeUnknown,
+        );
+        // An accepted awaited reply is not delivered until its parent tool
+        // result is committed to session history. Keep the mailbox row until
+        // that post-commit acknowledgement. If the caller has already stopped
+        // listening, this settled result has no persistence path, so close the
+        // correlation here instead of leaking it forever.
+        if (accepted !== true) clearMailbox();
+        return;
+      }
+      // Reentry success is not durability. The synthetic actorReply carries the
+      // correlation id into the appended user message; the session post-commit
+      // hook owns mailbox removal. A busy or failed parent keeps the row for
+      // passive recovery, and even a fulfilled turn cannot clear it early.
+      void deliver(
+        senderSessionId, instanceId, kind, name, outBody, outFailed, via,
+        outcomeUnknown, undefined, correlationId,
+      );
     };
     // Serialize on the ACTOR's slot — runWhenIdle runs the turn the moment the
     // actor is idle (never interrupting an in-flight actor turn). A thrown/
@@ -457,8 +526,15 @@ export const makeActorMessaging = (deps) => {
       // still resolve, or its tool call would hang past the Stop/abort that was
       // meant to end it.
       if ((stopGen.get(rootSessionId) ?? 0) !== genAtQueue || cancelledDeliveries.has(correlationId)) {
-        if (onReply) onReply(bare ? 'the request was stopped before the actor ran it.' : replyText(instanceId, kind, name, 'the request was stopped before the actor ran it.', true), true);
-        clear();
+        if (onReply) {
+          onReply(
+            bare ? 'the request was stopped before the actor ran it.' : replyText(instanceId, kind, name, 'the request was stopped before the actor ran it.', true),
+            true,
+            false,
+          );
+        }
+        clearTracking();
+        clearMailbox();
         // We were handed the idle actor slot but are DECLINING to run a turn
         // (Stopped after we queued). No claim/release will happen, so nothing
         // would re-drain the actor's queue — every turn queued behind us would
@@ -476,17 +552,26 @@ export const makeActorMessaging = (deps) => {
       const turnStartedAt = now();
       // Stamp WHOSE delivery now runs on this actor, so an awaitReply abort can
       // tell "my own turn is running (stop the slot)" from "a sibling's is
-      // (leave it alone)". Cleared self-scoped in clear().
+      // (leave it alone)". Cleared self-scoped in clearTracking().
       runningOnActor.set(actorSessionId, correlationId);
       Promise.resolve(runActorTurn({ actorSessionId, message, actorTabId: tabId, instanceId, kind, parentToolUseId, name, oneShot }))
         .then((res) => {
           log('actor.timing', { kind, instanceId, actorTurnMs: now() - turnStartedAt });
           // Unclamped in — settle applies the RESULT_CHARS ceiling per path, AFTER
           // schema validation (#241) so a valid envelope isn't truncated mid-JSON.
-          return settle(res?.result || '(the actor produced no text reply)', res?.stopped === true);
+          return settle(
+            res?.result || '(the actor produced no text reply)',
+            res?.stopped === true,
+            res?.outcomeKnown === false
+              || (res?.executionFailed === true && res?.outcomeKnown !== true),
+          );
         })
-        .catch((e) => settle(`the actor turn failed: ${/** @type {{ message?: string }} */ (e)?.message ?? String(e)}`, true))
-        .finally(clear);
+        .catch((e) => settle(
+          `the actor turn failed: ${/** @type {{ message?: string }} */ (e)?.message ?? String(e)}`,
+          true,
+          true,
+        ))
+        .finally(clearTracking);
     });
   };
 
@@ -504,7 +589,7 @@ export const makeActorMessaging = (deps) => {
    *   awaitSignal — the awaiting actor's AbortSignal (its wall-clock timeout
    *   / cancel). Only meaningful with awaitReply: the await races the reply
    *   against it so an aborted child unblocks instead of parking on a hung actor.
-   * @returns {Promise<{ ok: boolean, content?: string, error?: string }>}
+   * @returns {Promise<{ ok: boolean, content?: string, error?: string, code?: string, performed?: boolean, targetRead?: boolean, targetChanged?: boolean, retryable?: boolean, actorDeliveryId?: string }>}
    */
   const messageActor = async (req) => {
     const { to, message, senderSessionId, inbound, toolUseId, oneShot, awaitReply, awaitSignal, awaitCapMs, degradeToAsync, via, bareReply } = req;
@@ -542,6 +627,18 @@ export const makeActorMessaging = (deps) => {
     if (!senderAllowed) {
       log('REFUSED', { reason: 'sender_gate', senderSessionId, inbound });
       return { ok: false, error: 'message_actor: only the active foreground chat, its first-party autonomous continuation (a goal turn, or reacting to an actor reply), or a trusted-lineage actor it spawned may message an actor; untrusted/background senders are blocked' };
+    }
+
+    // Preserve sender-gate priority, then refuse before target resolution,
+    // rate accounting, mailbox persistence, tab creation, or any actor work.
+    const isolation = getActorIsolation();
+    if (isolation && !actorIsolationAvailable(isolation)) {
+      const refusal = actorIsolationRefusal(isolation);
+      appendAudit({
+        type: 'actor_isolation_refused',
+        details: { status: isolation.status, host: isolation.host, code: refusal.code, performed: false },
+      }).catch(() => {});
+      return refusal;
     }
 
     // The gate refused every falsy sender above; bind the narrowed string once
@@ -629,23 +726,65 @@ export const makeActorMessaging = (deps) => {
     // to the actor and gets woken with the reply on a
     // later turn (the actor model, uniformly). Persist the correlation to the
     // durable mailbox FIRST (await the write so the record is on disk before any
-    // actor side effect begins — closing the accept→persist window an SW death
-    // could otherwise drop), then queue the wake. The actor's slot serializes its
+    // requested actor work begins — closing the accept→persist window an SW death
+    // could otherwise drop), then queue the wake. Target resolution happened above
+    // and may itself have read or minted the actor binding, so a persistence failure
+    // reports that honestly even though it never queues the requested turn. The
+    // actor's slot serializes its
     // turns (one actor per tab/instance), and deliver() wrapUntrusted-fences the
     // reply — so a web actor's page-derived reply is fenced like any other
-    // untrusted content. A storage failure degrades to heap-only rather than
-    // throwing.
-    const correlationId = `${instanceId}:${++seq}:${nowMs}`;
-    // Persist oneShot too, so a redrain after an SW restart re-runs the turn in the
-    // same mode (a dropped flag would just fall back to a full summarize turn — safe,
-    // but inconsistent). Older entries without the field redrain as full turns.
-    // The provenance rides the envelope (phase 7) so a redrain can arbitrate —
-    // notably rerouting a reply whose awaiting sender was an ephemeral actor.
-    await Promise.resolve(mailbox.append({
-      id: correlationId, senderSessionId: sender, to: instanceId, message, createdAt: nowMs,
-      provenance: { rootSessionId, lineagePath: provenance.lineagePath },
-      ...(oneShot === true ? { oneShot: true } : {}),
-    })).catch(() => {});
+    // untrusted content. A storage failure refuses instead of running heap-only.
+    // Keep the durable key opaque and bounded. Actor addresses include API
+    // origins and may legitimately be much longer than the post-commit hook's
+    // defensive id ceiling; embedding the address would make those replies
+    // impossible to acknowledge. The mailbox record already stores `to`.
+    const correlationId = `actor:${uuidv7(() => nowMs)}`;
+    // Persist oneShot for diagnostics. The provenance rides the envelope so boot
+    // recovery can reroute a notice whose awaiting sender was ephemeral.
+    try {
+      await Promise.resolve(mailbox.append({
+        id: correlationId, senderSessionId: sender, to: instanceId, message, createdAt: nowMs,
+        state: 'queued', kind, ...(name ? { name } : {}),
+        provenance: { rootSessionId, lineagePath: provenance.lineagePath },
+        ...(oneShot === true ? { oneShot: true } : {}),
+      }));
+    } catch (error) {
+      decInFlight(rootSessionId);
+      untrackIntent(rootSessionId, intentK);
+      appendAudit({ type: 'actor_message_persist_failed', details: { to: instanceId, kind } }).catch(() => {});
+      return {
+        ok: false,
+        code: 'actor_mailbox_unavailable',
+        error: `message_actor: the actor turn was not queued because the durable mailbox could not record the request; target resolution may already have read or created its actor binding: ${/** @type {{ message?: string }} */ (error)?.message ?? String(error)}`,
+        performed: false,
+        targetRead: true,
+        targetChanged: true,
+        retryable: true,
+      };
+    }
+
+    // Commit the no-replay boundary before the delivery can enter the actor's
+    // slot. If this heap disappears after this write, boot recovery reports an
+    // unknown outcome instead of repeating a request that may have used tools.
+    // The small append-to-started window remains safely replayable because no
+    // actor work is queued until both writes finish.
+    try {
+      await Promise.resolve(mailbox.markStarted(correlationId));
+    } catch (error) {
+      decInFlight(rootSessionId);
+      untrackIntent(rootSessionId, intentK);
+      await mailbox.remove(correlationId).catch(() => {});
+      appendAudit({ type: 'actor_message_start_persist_failed', details: { to: instanceId, kind } }).catch(() => {});
+      return {
+        ok: false,
+        code: 'actor_mailbox_unavailable',
+        error: `message_actor: the actor turn was not run because its durable start state could not be saved: ${/** @type {{ message?: string }} */ (error)?.message ?? String(error)}`,
+        performed: false,
+        targetRead: true,
+        targetChanged: true,
+        retryable: true,
+      };
+    }
 
     // PR #134 — the ACTOR reply mode. An ephemeral child has no later turn
     // to wake (and waking its session would re-run it on the wrong exposure
@@ -700,7 +839,7 @@ export const makeActorMessaging = (deps) => {
           if (degradeToAsync === true && abortReasonOf(awaitSignal) === ABORT_STEER) { onCap(); return; }
           stopActorForAwait(correlationId, actor.actorSessionId);
           const notice = 'the request was aborted (timeout or cancel) before the actor replied.';
-          finish({ text: bareReply === true ? notice : replyText(instanceId, kind, name, notice, true), failed: true });
+          finish({ text: bareReply === true ? notice : replyText(instanceId, kind, name, notice, true), failed: true, outcomeUnknown: false });
         };
         // The await wall-clock cap → DEGRADE TO ASYNC. why distinct from onAbort:
         // Stop/cancel means "stop the work"; a too-slow reply does NOT — the actor
@@ -714,14 +853,15 @@ export const makeActorMessaging = (deps) => {
           if (done) return;
           degraded = true;
           const notice = `the ${kind} actor is still working; its reply will arrive as a fenced note on a later turn.`;
-          finish({ text: bareReply === true ? notice : replyText(instanceId, kind, name, notice, false), failed: false });
+          finish({ text: bareReply === true ? notice : replyText(instanceId, kind, name, notice, false), failed: false, outcomeUnknown: false });
         };
-        const finish = (/** @type {{ text: string, failed: boolean }} */ v) => {
-          if (done) return;
+        const finish = (/** @type {{ text: string, failed: boolean, outcomeUnknown: boolean, actorDeliveryId?: string }} */ v) => {
+          if (done) return false;
           done = true;
           if (capTimer) { clearTimeout(capTimer); capTimer = null; }
           try { awaitSignal?.removeEventListener?.('abort', onAbort); } catch { /* stub signal in tests */ }
           resolve(v);
+          return true;
         };
         // Queue the actor turn FIRST — so the delivery's bookkeeping (trackActor,
         // and the runningOnActor stamp if the idle slot runs it synchronously)
@@ -730,7 +870,7 @@ export const makeActorMessaging = (deps) => {
         runEngineDelivery({
           correlationId, senderSessionId: sender, rootSessionId, actor, message,
           parentToolUseId: toolUseId, oneShot: oneShot === true, bare: bareReply === true,
-          onReply: (text, failed) => finish({ text, failed }),
+          onReply: (text, failed, outcomeUnknown) => finish({ text, failed, outcomeUnknown, actorDeliveryId: correlationId }),
           deliverInstead: () => degraded,
         });
         if (awaitSignal) {
@@ -745,8 +885,19 @@ export const makeActorMessaging = (deps) => {
         }
       });
       return settled.failed
-        ? { ok: false, error: settled.text }
-        : { ok: true, content: settled.text };
+        ? {
+          ok: false,
+          error: settled.text,
+          ...(settled.actorDeliveryId ? { actorDeliveryId: settled.actorDeliveryId } : {}),
+          ...(settled.outcomeUnknown
+            ? { performed: true, outcomeKnown: false, retryable: false }
+            : {}),
+        }
+        : {
+          ok: true,
+          content: settled.text,
+          ...(settled.actorDeliveryId ? { actorDeliveryId: settled.actorDeliveryId } : {}),
+        };
     }
 
     runEngineDelivery({ correlationId, senderSessionId: sender, rootSessionId, actor, message, parentToolUseId: toolUseId, oneShot: oneShot === true, via });
@@ -762,38 +913,49 @@ export const makeActorMessaging = (deps) => {
     };
   };
 
-  // DURABLE REDRAIN (DESIGN-17 P1). Called once on SW boot, after the registries
-  // load + the vault unlocks (an actor turn needs the model key). Re-queues every
-  // persisted message (any kind, web included) so its reply still reaches the
-  // sender. Idempotent: a
-  // stale entry whose instance is gone (or whose sender vanished) wakes the sender
-  // with a failure note and clears; a still-live instance re-runs the turn normally
-  // (resolveActor re-mints a dropped forward pointer). Mirrors goalRunner.resume.
-  /** @returns {Promise<{ redrained: number }>} */
+  // DURABLE RECOVERY (kept as redrain for API compatibility). Called once on SW
+  // boot. It never executes stored actor work. A queued entry proves
+  // the actor was not dispatched, so the sender receives a Not run notice. A
+  // started or legacy entry cannot prove whether tools ran, so the sender receives
+  // Outcome unknown and must inspect the target before retrying. Each record is
+  // removed only after a stable-id passive notice is persisted. Recovery never
+  // invokes the model, so another background loss cannot retry the requested work.
+  /** @returns {Promise<{ redrained: number, retained: number }>} */
   const redrain = async () => {
     let entries;
     try { entries = await mailbox.load(); }
-    catch (e) { log('redrain load failed', e); return { redrained: 0 }; }
-    if (!Array.isArray(entries) || entries.length === 0) return { redrained: 0 };
-    let redrained = 0;
+    catch (e) { log('redrain load failed', e); return { redrained: 0, retained: 1 }; }
+    if (!Array.isArray(entries) || entries.length === 0) return { redrained: 0, retained: 0 };
+    let retained = 0;
     for (const e of entries) {
       if (!e?.id || typeof e.senderSessionId !== 'string' || typeof e.to !== 'string' || typeof e.message !== 'string') {
         if (e?.id) mailbox.remove(e.id).catch(() => {});
         continue;
       }
-      let actor = null;
-      // Thread the ORIGINAL sender so a web-actor (to:'web') redrain re-attaches to the
-      // sender's actor, not whatever chat is focused at boot.
-      try { actor = await resolveActor(e.to, { senderSessionId: e.senderSessionId }); }
-      catch { actor = null; }
-      // Phase 7 (envelope arbitration) — a redrained reply must reach a session
-      // that can actually receive a wake. When the envelope's provenance says
-      // the sender was NOT its own lineage root, the sender was an EPHEMERAL
-      // actor awaiting the reply in a tool call; that await died with the SW,
-      // and waking the child's session would run an orphan turn on the wrong
-      // exposure surface. Reroute to the ROOT — the chat that ultimately asked —
-      // which handles it like any other fenced actor note. Entries without
-      // provenance (pre-#134) keep the old sender-addressed behavior.
+      // The session append and mailbox acknowledgement are separate durable
+      // writes. A crash between them leaves the row even though the reply is
+      // already visible. Detect that committed custody marker first so recovery
+      // does not add a misleading duplicate warning. A failed read retains the
+      // row and the recovery gate, then retries passively.
+      let alreadyCommitted = false;
+      try {
+        alreadyCommitted = await deliveryCommitted({
+          sessionId: e.senderSessionId,
+          deliveryId: e.id,
+        });
+      } catch (error) {
+        log('delivery commit check failed', error);
+        retained += 1;
+        continue;
+      }
+      if (alreadyCommitted) {
+        try { await mailbox.remove(e.id); }
+        catch (error) {
+          log('committed delivery cleanup failed', error);
+          retained += 1;
+        }
+        continue;
+      }
       const wakeTarget = (typeof e.provenance?.rootSessionId === 'string'
         && e.provenance.rootSessionId !== e.senderSessionId)
         ? e.provenance.rootSessionId
@@ -801,31 +963,56 @@ export const makeActorMessaging = (deps) => {
       if (wakeTarget !== e.senderSessionId) {
         appendAudit({ type: 'actor_reply_rerouted', details: { to: e.to, senderSessionId: e.senderSessionId, rootSessionId: wakeTarget } }).catch(() => {});
       }
-      // The instance is gone (engine instance deleted, or a web actor's tab
-      // closed) → abandon it; wake the target so it isn't left waiting on a reply
-      // that can never come. A live instance (any kind, web included) re-runs.
-      if (!actor) {
-        deliver(wakeTarget, e.to, 'tab-hosted', undefined,
-          'could not be reached after a restart (its instance may have been closed). Re-issue the request if it still matters.', true);
-        mailbox.remove(e.id).catch(() => {});
-        appendAudit({ type: 'actor_message_abandoned', details: { to: e.to, senderSessionId: e.senderSessionId } }).catch(() => {});
+      const uncertain = e.state === 'started' || e.state === undefined;
+      if (uncertain) {
+        const envelope = deliveryEnvelope(
+          e.to,
+          typeof e.kind === 'string' ? e.kind : 'actor',
+          typeof e.name === 'string' ? e.name : undefined,
+          'peerd cannot confirm whether the previous request ran before the background host restarted. Check whether the requested action completed before trying again.',
+          true,
+          undefined,
+          true,
+          undefined,
+        );
+        let recorded = false;
+        try {
+          recorded = await recordRecovery({ ...envelope, sessionId: wakeTarget, synthetic: true, recoveryId: e.id });
+        } catch (error) { log('recovery notice failed', error); }
+        if (recorded) await mailbox.remove(e.id).catch(() => {});
+        else retained += 1;
+        appendAudit({
+          type: 'actor_message_outcome_unknown',
+          details: { to: e.to, senderSessionId: e.senderSessionId, outcomeKnown: false },
+        }).catch(() => {});
         continue;
       }
-      inFlight.set(wakeTarget, (inFlight.get(wakeTarget) ?? 0) + 1);
-      // Track the intent too (#4): runEngineDelivery's clear() unconditionally
-      // untrackIntent()s on settle, so a redrained turn that never tracked would
-      // decrement — and delete — a DIFFERENT live send's refcount, silently
-      // defeating the dedupe guard. Mirror the live path's trackIntent here so
-      // the ref is symmetric. Keyed on the resolved actorSessionId, as the live
-      // path (a constant 'web' instanceId would alias-collapse web actors — #8).
-      trackIntent(wakeTarget, intentKey(actor.actorSessionId, e.message));
-      // senderSessionId here is the DELIVERY address (deliver() wakes it) and the
-      // bookkeeping root on a redrain — for a rerouted entry both are the root.
-      runEngineDelivery({ correlationId: e.id, senderSessionId: wakeTarget, rootSessionId: wakeTarget, actor, message: e.message, oneShot: e.oneShot === true });
-      redrained += 1;
+      if (e.state !== 'queued') {
+        await mailbox.remove(e.id).catch(() => {});
+        continue;
+      }
+      const envelope = deliveryEnvelope(
+        e.to,
+        typeof e.kind === 'string' ? e.kind : 'actor',
+        typeof e.name === 'string' ? e.name : undefined,
+        'The background host restarted before this actor request was dispatched. It was not run. Re-issue it if it still matters.',
+        true,
+        undefined,
+        false,
+        false,
+      );
+      let recorded = false;
+      try {
+        recorded = await recordRecovery({ ...envelope, sessionId: wakeTarget, synthetic: true, recoveryId: e.id });
+      } catch (error) { log('recovery notice failed', error); }
+      if (recorded) await mailbox.remove(e.id).catch(() => {});
+      else retained += 1;
+      appendAudit({
+        type: 'actor_message_not_run',
+        details: { to: e.to, senderSessionId: e.senderSessionId, performed: false, outcomeKnown: true },
+      }).catch(() => {});
     }
-    log('redrained', redrained);
-    return { redrained };
+    return { redrained: 0, retained };
   };
 
   return { messageActor, redrain, actorsFor, stopActorsFor };

--- a/extension/peerd-runtime/actor/actor-messaging.js
+++ b/extension/peerd-runtime/actor/actor-messaging.js
@@ -720,19 +720,19 @@ export const makeActorMessaging = (deps) => {
     trackIntent(rootSessionId, intentK);
     appendAudit({ type: 'actor_message', details: { to: instanceId, kind, senderSessionId, rootSessionId, lineagePath: provenance.lineagePath, ...(typeof via === 'string' ? { via } : {}) } }).catch(() => {});
 
-    // ASYNC for EVERY long-lived sender — web included — unless the caller opted
+    // ASYNC for EVERY long-lived sender, including web, unless the caller opted
     // into `await:true`, which takes the awaitReply branch below instead. On THIS
     // path the orchestrator does not block: it hands a task
     // to the actor and gets woken with the reply on a
     // later turn (the actor model, uniformly). Persist the correlation to the
     // durable mailbox FIRST (await the write so the record is on disk before any
-    // requested actor work begins — closing the accept→persist window an SW death
+    // requested actor work begins, closing the accept→persist window an SW death
     // could otherwise drop), then queue the wake. Target resolution happened above
     // and may itself have read or minted the actor binding, so a persistence failure
     // reports that honestly even though it never queues the requested turn. The
     // actor's slot serializes its
     // turns (one actor per tab/instance), and deliver() wrapUntrusted-fences the
-    // reply — so a web actor's page-derived reply is fenced like any other
+    // reply, so a web actor's page-derived reply is fenced like any other
     // untrusted content. A storage failure refuses instead of running heap-only.
     // Keep the durable key opaque and bounded. Actor addresses include API
     // origins and may legitimately be much longer than the post-commit hook's

--- a/extension/peerd-runtime/actor/actor-worker-core.js
+++ b/extension/peerd-runtime/actor/actor-worker-core.js
@@ -23,7 +23,7 @@
 //     SW-side). why the SW MUST re-pin+gate: the worker's `call` args are
 //     attacker-influenceable (they derive from injected instance/page output), so
 //     the SW never trusts them — it force-pins the bound instance and runs the
-//     full gate, exactly as the in-SW actor path does.
+//     full gate, exactly as the privileged host policy requires.
 //
 // PURE / injected-IO → Bun-testable without a Worker: the imperative shell
 // (offscreen/actor-worker.js) wires self.postMessage/onmessage to these functions;
@@ -242,12 +242,12 @@ export const runActorLoop = async (deps, req) => {
     // worker cannot turn an inbound peer wake into a trusted continuation.
     ...(inbound === true ? { synthetic: true, trusted: false, inbound: true } : {}),
     ...(signal ? { signal } : {}),
-    // maxSteps: omit when undefined so runUserTurn uses its OWN default (parity
-    // with the in-SW actor path, which passes none). Only cap when the caller asks.
+    // maxSteps: omit when undefined so runUserTurn uses its OWN default. Only
+    // cap when the caller asks.
     ...(maxSteps != null ? { maxSteps } : {}),
     // oneShot: a message_actor delegation may ask the loop to synthesize its reply
     // from the first clean tool round and stop (no summarize inference) — parity
-    // with the in-SW path (turn-driver threads it to runAgentTurn).
+    // with the bound-actor contract.
     ...(oneShot === true ? { oneShot: true } : {}),
     // A web/API actor self-fences its own untrusted-provenance rolling summary on a
     // context trim (heap-split phase 3); absent for engine actors → summary verbatim.

--- a/extension/peerd-runtime/actor/async-actors.js
+++ b/extension/peerd-runtime/actor/async-actors.js
@@ -166,10 +166,10 @@ export const makeAsyncActors = (deps) => {
       const flag = outcomeUnknown
         ? ' (execution failed after work began; outcome unknown; do not retry automatically)'
         : c.executionFailed ? ' (failed before target work ran)'
-        : c.interrupted ? ' (interrupted before finishing — partial)'
-        : c.timedOut ? ' (hit its wall-clock timeout — partial)'
-        : c.stopped ? ' (stopped before finishing — partial)'
-        : c.exceeded ? ' (hit its step cap — may be incomplete)' : '';
+        : c.interrupted ? ' (interrupted before finishing, partial)'
+        : c.timedOut ? ' (hit its wall-clock timeout, partial)'
+        : c.stopped ? ' (stopped before finishing, partial)'
+        : c.exceeded ? ' (hit its step cap, may be incomplete)' : '';
       return `Actor "${c.task.slice(0, 80)}"${flag}:\n${wrapped}`;
     });
     const hasUnknownOutcome = finished.some((entry) => entry.executionFailed && entry.outcomeKnown === false);

--- a/extension/peerd-runtime/actor/async-actors.js
+++ b/extension/peerd-runtime/actor/async-actors.js
@@ -22,7 +22,7 @@
 
 /**
  * @param {Object} deps
- * @param {(req: object) => Promise<{ result?: string, sessionId?: string|null, exceeded?: boolean, refused?: boolean, timedOut?: boolean, stopped?: boolean }>} deps.spawnActor
+ * @param {(req: object) => Promise<{ result?: string, sessionId?: string|null, exceeded?: boolean, refused?: boolean, timedOut?: boolean, stopped?: boolean, executionFailed?: boolean, outcomeKnown?: boolean }>} deps.spawnActor
  *   The bound child runner (resolves when the child's whole loop finishes).
  * @param {{ runWhenIdle: (sessionId: string, fn: () => void) => void, isBusy: (sessionId: string) => boolean, stop?: (sessionId: string) => boolean }} deps.turnSlots
  *   stop (optional — PR #134): abort a child session's live turn slot, so
@@ -77,6 +77,8 @@ export const makeAsyncActors = (deps) => {
    * @property {boolean} interrupted
    * @property {boolean} timedOut     the child hit its wall-clock budget (PR #134)
    * @property {boolean} stopped      the child's slot was aborted (Stop cascade)
+   * @property {boolean} executionFailed the Worker failed after execution began
+   * @property {boolean} outcomeKnown false when effects may have landed before failure
    * @property {string | null} childSessionId
    * @property {boolean} reintegrated
    * @property {string[]} ring
@@ -160,15 +162,29 @@ export const makeAsyncActors = (deps) => {
       // a bare millisecond count in the wrapper. Keep the injected `now` for
       // determinism, formatted correctly.
       const wrapped = wrapUntrusted({ origin: 'spawned', tool: 'actor_create', body, retrievedAt: new Date(now()).toISOString() });
-      const flag = c.interrupted ? ' (interrupted before finishing — partial)'
+      const outcomeUnknown = c.executionFailed && c.outcomeKnown === false;
+      const flag = outcomeUnknown
+        ? ' (execution failed after work began; outcome unknown; do not retry automatically)'
+        : c.executionFailed ? ' (failed before target work ran)'
+        : c.interrupted ? ' (interrupted before finishing — partial)'
         : c.timedOut ? ' (hit its wall-clock timeout — partial)'
         : c.stopped ? ' (stopped before finishing — partial)'
         : c.exceeded ? ' (hit its step cap — may be incomplete)' : '';
       return `Actor "${c.task.slice(0, 80)}"${flag}:\n${wrapped}`;
     });
+    const hasUnknownOutcome = finished.some((entry) => entry.executionFailed && entry.outcomeKnown === false);
+    const hasKnownFailure = finished.some((entry) => entry.executionFailed && entry.outcomeKnown !== false);
     const lead = finished.length === 1
-      ? 'An actor you started earlier has finished. Here is its result:'
-      : `${finished.length} spawned you started earlier have finished. Here are their results:`;
+      ? hasUnknownOutcome
+        ? 'An actor you started earlier stopped after execution began. Its outcome is unknown. Do not retry automatically. Here is the failure:'
+        : hasKnownFailure
+          ? 'An actor you started earlier failed before target work ran. Here is the failure:'
+        : 'An actor you started earlier has finished. Here is its result:'
+      : hasUnknownOutcome
+        ? `${finished.length} spawned actors completed or failed. Review each result and do not automatically retry an unknown outcome:`
+        : hasKnownFailure
+          ? `${finished.length} spawned actors completed or failed before target work ran. Review each result:`
+        : `${finished.length} actors you started earlier have finished. Here are their results:`;
     const wakeText = `${lead}\n\n${blocks.join('\n\n')}`;
 
     // Passive surfacing if the parent is NOT the user's active chat (#20).
@@ -213,6 +229,7 @@ export const makeAsyncActors = (deps) => {
     const entry = {
       taskId, task: String(req.task ?? ''), status: 'running', result: '',
       exceeded: false, interrupted: false, timedOut: false, stopped: false,
+      executionFailed: false, outcomeKnown: true,
       childSessionId: null, reintegrated: false, ring: [],
     };
     kids.set(taskId, entry);
@@ -254,8 +271,10 @@ export const makeAsyncActors = (deps) => {
       // a cancel: mark terminal, surface on the bar, no wake. A TIMEOUT is
       // different — the parent is still working and wants the partial — so
       // timedOut still drains. (A goal/auto continuation isn't a user Stop; those
-      // don't cascade stopSubtree, so they never reach here as `stopped`.)
-      if (patch.stopped === true) {
+      // don't cascade stopSubtree, so they never reach here as `stopped`.) A
+      // post-start Worker failure also carries stopped:true, but must drain its
+      // unknown-outcome warning instead of disappearing like a user cancel.
+      if (patch.stopped === true && patch.executionFailed !== true) {
         Object.assign(entry, patch, { status: 'cancelled' });
         onTasksChanged(parentSessionId);
         return;
@@ -272,9 +291,22 @@ export const makeAsyncActors = (deps) => {
         exceeded: out.exceeded === true || out.refused === true,
         timedOut: out.timedOut === true,
         stopped: out.stopped === true,
+        executionFailed: out.executionFailed === true,
+        outcomeKnown: out.outcomeKnown !== false,
         childSessionId: out.sessionId ?? entry.childSessionId,
       }))
-      .catch((e) => settle({ result: `actor errored: ${/** @type {{ message?: string }} */ (e)?.message ?? String(e)}`, interrupted: true }));
+      .catch((e) => {
+        const failure = /** @type {{ message?: string, executionFailed?: boolean, outcomeKnown?: boolean }} */ (e);
+        if (failure.outcomeKnown === false) {
+          settle({
+            result: failure.message ?? 'actor transcript persistence failed',
+            executionFailed: true,
+            outcomeKnown: false,
+          });
+          return;
+        }
+        settle({ result: `actor errored: ${failure.message ?? String(e)}`, interrupted: true });
+      });
 
     return {
       ok: true,

--- a/extension/peerd-runtime/actor/isolation.js
+++ b/extension/peerd-runtime/actor/isolation.js
@@ -1,0 +1,131 @@
+// @ts-check
+// Browser-neutral actor isolation capability. This is the single policy value
+// shared by prompt/tool exposure, dispatch, state snapshots, and the UI.
+
+export const ACTOR_ISOLATION_HOST_OFFSCREEN = 'offscreen-document-worker';
+export const ACTOR_ISOLATION_HOST_BACKGROUND = 'background-page-worker';
+
+export const ACTOR_ISOLATION_TEMPORARY_USER_FAILURE = 'The actor request was not run because its isolated worker was temporarily unavailable. When actor work is ready, retry the request. (actor_isolation_temporarily_unavailable)';
+export const ACTOR_ISOLATION_UNSUPPORTED_USER_FAILURE = 'The actor request was not run because this browser cannot provide the required isolated worker. (actor_isolation_unavailable)';
+
+export const ACTOR_ISOLATION_UNAVAILABLE_TOOLS = Object.freeze(new Set([
+  'message_actor',
+  'actor_create',
+  'request_review',
+]));
+
+/**
+ * @typedef {'available'|'unsupported'|'temporarily_unavailable'} ActorIsolationStatus
+ * @typedef {'offscreen-document-worker'|'background-page-worker'|null} ActorIsolationHost
+ * @typedef {{ status: ActorIsolationStatus, host: ActorIsolationHost, reason: string|null, retryable: boolean }} ActorIsolationCapability
+ */
+
+/**
+ * Resolve the host this browser can actually provide. Browser names are not
+ * consulted: capability detection keeps forks and future engines honest.
+ * @param {{ offscreenWorker: boolean, backgroundPageWorker: boolean }} support
+ * @returns {ActorIsolationCapability}
+ */
+export const actorIsolationCapability = ({ offscreenWorker, backgroundPageWorker }) => {
+  if (offscreenWorker) {
+    return { status: 'available', host: ACTOR_ISOLATION_HOST_OFFSCREEN, reason: null, retryable: false };
+  }
+  if (backgroundPageWorker) {
+    return { status: 'available', host: ACTOR_ISOLATION_HOST_BACKGROUND, reason: null, retryable: false };
+  }
+  return {
+    status: 'unsupported',
+    host: null,
+    reason: 'This browser cannot create the dedicated worker required for actor isolation.',
+    retryable: false,
+  };
+};
+
+/** @param {ActorIsolationCapability} capability */
+export const actorIsolationAvailable = (capability) => capability?.status === 'available' && capability.host !== null;
+
+/**
+ * Keep one turn's model contract coherent while still failing closed if a
+ * healthy boundary breaks after the turn starts.
+ * @param {ActorIsolationCapability|null} atTurnStart
+ * @param {ActorIsolationCapability|null} live
+ */
+export const actorIsolationForTurn = (atTurnStart, live) =>
+  atTurnStart && !actorIsolationAvailable(atTurnStart) ? atTurnStart : live;
+
+/**
+ * Turn a host failure into visible, retryable state without changing the host
+ * identity. A successful later probe restores the original available value.
+ * @param {ActorIsolationCapability} capability
+ * @param {unknown} error
+ * @returns {ActorIsolationCapability}
+ */
+export const actorIsolationTemporarilyUnavailable = (capability, error) => ({
+  status: 'temporarily_unavailable',
+  host: capability?.host ?? null,
+  reason: /** @type {{ message?: string }} */ (error)?.message ?? String(error || 'The actor worker host did not start.'),
+  retryable: true,
+});
+
+/**
+ * Stable fail-closed result. Callers that already resolved or minted an actor
+ * binding must say so instead of claiming the target was untouched.
+ * @param {ActorIsolationCapability} capability
+ * @param {{ targetRead?: boolean, targetChanged?: boolean }} [effects]
+ */
+export const actorIsolationRefusal = (capability, effects = {}) => ({
+  ok: false,
+  code: capability?.status === 'temporarily_unavailable'
+    ? 'actor_isolation_temporarily_unavailable'
+    : 'actor_isolation_unavailable',
+  error: capability?.status === 'temporarily_unavailable'
+    ? 'Actors were not run because the isolated worker is temporarily unavailable. Do not retry automatically. Use the Try again control in peerd first.'
+    : 'Actors were not run because this browser cannot provide the required isolated worker.',
+  performed: false,
+  targetRead: effects.targetRead === true,
+  targetChanged: effects.targetChanged === true,
+  retryable: capability?.retryable === true,
+});
+
+/**
+ * Refuse a spawned/review actor before its parent session is read or a child
+ * session is created. This is the central backstop for non-tool callers too.
+ * @param {ActorIsolationCapability} capability
+ * @param {number} [parentDepth]
+ */
+export const actorIsolationSpawnRefusal = (capability, parentDepth = 0) => {
+  const refusal = actorIsolationRefusal(capability);
+  return {
+    result: refusal.error,
+    sessionId: null,
+    toolCalls: 0,
+    durationMs: 0,
+    depth: (Number.isFinite(parentDepth) ? parentDepth : 0) + 1,
+    refused: /** @type {true} */ (true),
+  };
+};
+
+/**
+ * Hide actor-creating tools when their required execution boundary is absent.
+ * Inventory tools may remain visible so the model can still explain what exists.
+ * @template {{ name?: string }} T
+ * @param {T[]} descriptors
+ * @param {ActorIsolationCapability} capability
+ * @returns {T[]}
+ */
+export const filterByActorIsolation = (descriptors, capability) => actorIsolationAvailable(capability)
+  ? descriptors
+  : descriptors.filter((descriptor) => !ACTOR_ISOLATION_UNAVAILABLE_TOOLS.has(String(descriptor?.name ?? '')));
+
+/**
+ * The model-facing backstop for a turn whose static base prompt still explains
+ * actors. Tool exposure is the authority wall; this block makes the UX honest.
+ * @param {ActorIsolationCapability} capability
+ */
+export const actorIsolationPromptBlock = (capability) => {
+  if (actorIsolationAvailable(capability)) return '';
+  const recovery = capability?.retryable
+    ? 'The user must restore actor execution with the Try again control in peerd.'
+    : 'This browser cannot provide actor execution.';
+  return `<actor_execution status="${capability.status}">Actor requests will not run in this turn. Do not plan, create, message, or review through actors. Do not open or resolve an actor target. Do not retry automatically or promise later delivery. ${recovery}</actor_execution>`;
+};

--- a/extension/peerd-runtime/actor/spawn.js
+++ b/extension/peerd-runtime/actor/spawn.js
@@ -4,20 +4,21 @@
 // An actor is NOT a fourth engine kind — it's an orchestration
 // primitive. "Who is reasoning about the next step?" is the agent loop,
 // the *r* letter. So an actor is just a session with parentage that
-// runs the SAME runUserTurn loop the top-level chat does. This file
+// runs the SAME runUserTurn loop the top-level chat does in a dedicated Worker.
+// This file
 // sets up the call args (a fresh child session, a narrowed tool subset,
 // a task-focused system prompt, an output cap) and invokes the existing
-// loop. It does NOT duplicate the loop.
+// worker host. It does NOT duplicate the loop.
 //
 // Two surfaces call in here through one orchestrator (same audit, same
 // gates, same permission inheritance):
 //   - the `actor_create` tool        (the model decomposing a task)
 //   - the `actor/spawn` SW route    (Notebook code via peerd.runtime.runAgent)
 //
-// Functional-core/imperative-shell as everywhere else: every IO surface
-// (the loop, the model, the dispatcher, the session store, the prompt
-// renderer, audit) is INJECTED. That keeps this module unit-testable in
-// Bun without resolving the extension's `/`-rooted import graph.
+// Functional-core/imperative-shell as everywhere else: the session store,
+// worker host, prompt renderer, clock, and audit are injected. That keeps this
+// module unit-testable in Bun without resolving the extension's `/`-rooted
+// import graph.
 
 // Deep imports of PURE policy modules (not module barrels) so this file
 // stays importable under the bun test runner — same pattern as
@@ -26,7 +27,6 @@
 // manifest into the allow-set the narrowing intersects.
 import { confirmActionsFromRecord } from '../permissions/policy.js';
 import { resolveManifestAllow } from '../tools/manifests.js';
-import { ActorCredentialBoundaryError } from '../errors.js';
 // The MAIN-AGENT tool surface: an actor is a CHILD of the main agent and must hold
 // no more than it could. mainAgentDescriptors drops MAIN_AGENT_HIDDEN_TOOLS (the
 // actor-only DOM/page/fetch tools — read_page, page_exec, click, navigate, fetch_url,
@@ -34,10 +34,9 @@ import { ActorCredentialBoundaryError } from '../errors.js';
 // goes through the web actor via message_actor, never a raw grant); filterActorSurface
 // drops the actor-only instance tier (vm_*/js_*/app_*/edit_file — writes AND the
 // fenced reads, already gate-refused for a non-actor). Both are pure.
-import { mainAgentDescriptors, filterActorSurface, REVIEW_INSTANCE_READS, EXPOSURE_REVIEW } from '../tools/exposure.js';
+import { mainAgentDescriptors, filterActorSurface, REVIEW_INSTANCE_READS } from '../tools/exposure.js';
 
 /** @typedef {import('../sessions/types.js').Session} Session */
-/** @typedef {import('/peerd-provider/format/from-anthropic.js').ProviderEvent} ProviderEvent */
 
 // Guardrail defaults (docs/ACTORS.md §guardrails). Callers may lower
 // them per spawn; they can't be raised past the loop's own MAX_STEPS
@@ -57,6 +56,19 @@ export const DEFAULT_MAX_OUTPUT_TOKENS = 4096;
 // "can't be raised past the backstop" posture as maxSteps.
 export const DEFAULT_TIMEOUT_MS = 10 * 60_000;
 export const MAX_TIMEOUT_MS = 30 * 60_000;
+
+export class ActorPersistenceError extends Error {
+  /** @param {unknown} cause */
+  constructor(cause) {
+    super(`actor ran, but its transcript could not be saved reliably; the outcome is unknown and must not be retried automatically: ${/** @type {{ message?: string }} */ (cause)?.message ?? String(cause)}`);
+    this.name = 'ActorPersistenceError';
+    this.cause = cause;
+    this.performed = true;
+    this.outcomeKnown = false;
+    this.retryable = false;
+    this.executionFailed = true;
+  }
+}
 
 /**
  * Compute the tool subset an actor may use.
@@ -108,11 +120,9 @@ export const narrowTools = (available, { tools, allowRecursion = false, allow = 
 // crafted args) would have the vault one property access away in a SHARED heap.
 // We close it BY CONSTRUCTION: strip every capability closure that NONE of the
 // child's granted tools consume, so a narrowed child's context literally has no
-// path to secrets/egress/spawn. The heap split now runs the child's loop in its
-// OWN Worker heap (offscreen path) where it never receives these closures at all
-// — this restrict is the SW-side ctx build the tool-dispatch route reuses per
-// relayed call, AND the standalone defense for the in-SW fallback (Firefox /
-// offscreen unavailable), where the shared-heap soft spot still applies.
+// path to secrets/egress/spawn. The child loop runs in its own Worker heap where
+// it never receives these closures. This restriction is the privileged ctx build
+// the tool-dispatch route reuses for each relayed call.
 //
 // The lists below are the COMPLETE set of ctx.<cap> readers among tools
 // (grep `ctx.<cap>` over tools/**). getSecret/safeFetch have NO tool reader —
@@ -259,18 +269,7 @@ export const finalActorTurnReply = (session) => {
  *
  * @param {Object} deps
  * @param {ReturnType<typeof import('../sessions/store.js').createSessionStore>} deps.sessions
- * @param {typeof import('../loop/agent-loop.js').runUserTurn} deps.runUserTurn
- * @param {(args: object) => AsyncIterable<any>} deps.callModel
- *   provider stream factory; element type is the erased ProviderEvent union
- *   (the SW binds a real provider, tests bind a mock — kept `any` so a mock
- *   stream doesn't have to reconstruct the full discriminated union)
- * @param {(name: string) => Promise<string | null>} deps.getSecret
- * @param {(resource: string | URL | Request, init?: RequestInit) => Promise<Response>} deps.safeFetch
  * @param {(entry: object) => Promise<unknown>} deps.appendAudit
- * @param {(opts: { sessionId: string, activeTabId?: number }) => Promise<object>} deps.buildToolContext
- *   SW variant of buildToolContext that targets an explicit session id.
- * @param {(call: import('/shared/tool-types.js').ToolCall, ctx: object) => Promise<import('/shared/tool-types.js').ToolResult | { ok: boolean, content?: string, error?: string }>} deps.dispatchToolCall
- * @param {(opts: object) => Promise<string>} deps.renderSystemPrompt
  * @param {() => Array<{ name: string, description: string, schema: object }>} deps.getToolDescriptors
  *   Returns the full registered tool descriptor set (parent's tools).
  * @param {() => number} [deps.now]
@@ -280,42 +279,34 @@ export const finalActorTurnReply = (session) => {
  *   and actorCancel all reach it via the slot's controller. The default is a
  *   standalone stub (a fresh controller per spawn, stop() a no-op) so orchestrators
  *   that never stop children (tests, cheap-call harnesses) need no wiring.
- * @param {(call: Record<string, any>) => void} [deps.recordModelCall]
- *   The context inspector's capture hook — sees the in-SW fallback loop's model
- *   calls (the offscreen path is captured at the actor relay). Optional no-op.
  * @param {(fn: () => void, ms: number) => unknown} [deps.setTimer]
  * @param {(handle: unknown) => void} [deps.clearTimer]
  *   Injected timer pair (setTimeout/clearTimeout in the SW) so the timeout is
  *   Bun-testable without real waiting.
- * @param {((job: object, opts?: { signal?: AbortSignal, onEvent?: (ev: object) => void }) => Promise<{ ok: boolean, started?: boolean, finalText?: string, newMessages?: any[], usage?: any, stopReason?: string, toolCalls?: number, error?: string, aborted?: boolean }>) | null} [deps.runChildOffscreen]
- *   Heap split: run a child's loop in a dedicated offscreen Worker (its own heap;
+ * @param {((job: object, opts?: { signal?: AbortSignal, onEvent?: (ev: object) => void }) => Promise<{ ok: boolean, started?: boolean, code?: string, finalText?: string, newMessages?: any[], usage?: any, stopReason?: string, toolCalls?: number, error?: string, aborted?: boolean, outcomeKnown?: boolean }>) | null} [deps.runChildOffscreen]
+ *   Heap split: run a child's loop in a dedicated Worker (its own heap;
  *   key never enters it). Tool-less children only relay the model call; tool-bearing
  *   children (job.tools set) also relay each tool call to the SW-gated dispatch.
- *   null = use the in-SW loop.
+ *   null means actor execution is refused.
  * @param {((task: string, effectiveTools: string[]) => Promise<string> | string) | null} [deps.renderSystemPromptForChild]
- *   Render the child's system prompt SW-side for the offscreen path (the worker
+ *   Render the child's system prompt in the privileged host (the worker
  *   never assembles it). Required alongside runChildOffscreen.
  */
 export const makeSpawnActor = (deps) => {
   const {
-    sessions, runUserTurn, callModel, getSecret, safeFetch,
-    appendAudit, buildToolContext, dispatchToolCall,
-    renderSystemPrompt, getToolDescriptors,
+    sessions, appendAudit, getToolDescriptors,
     now = Date.now,
     turnSlots = {
       claim: () => ({ controller: new AbortController(), release: () => {} }),
       stop: () => false,
     },
     setTimer = (/** @type {() => void} */ fn, /** @type {number} */ ms) => setTimeout(fn, ms),
-    // The context inspector's capture hook (optional no-op, same contract as
-    // the turn driver's): sees the in-SW fallback loop's model calls.
-    recordModelCall = () => {},
     clearTimer = (/** @type {unknown} */ handle) => clearTimeout(/** @type {any} */ (handle)),
     // Heap-split phase 1: run a PURE-REASONING (empty granted toolset) child in a
-    // dedicated offscreen Worker — its own heap, no key, no chrome.*, egress-less.
+    // dedicated Worker — its own heap, no key or extension APIs.
     // Tool-bearing children run here too (heap-split phase 4): their tool calls
-    // relay to the SW-gated dispatch. null → the in-SW loop (Firefox / offscreen
-    // unavailable). renderSystemPromptForChild renders the child's prompt SW-side so
+    // relay to the SW-gated dispatch. A missing host fails closed.
+    // renderSystemPromptForChild renders the child's prompt host-side so
     // the worker never assembles it.
     runChildOffscreen = null,
     renderSystemPromptForChild = null,
@@ -393,12 +384,7 @@ export const makeSpawnActor = (deps) => {
    *   run (default DEFAULT_TIMEOUT_MS, clamped to MAX_TIMEOUT_MS)
    * @param {(ev: object) => void} [req.onEvent]   live forwarder for the side panel
    * @param {string} [req.parentToolUseId]         links the parent's card → child session
-   * @param {boolean} [req.persistDeltas=true]      set false for ephemeral
-   *   children (e.g. cheap-call): skips the per-streamed-delta full-record
-   *   IDB rewrite. Finalization writes still happen — the result extraction
-   *   below reads the COMPLETED session, which is the only persistence an
-   *   ephemeral child needs (a mid-run SW death orphans the await anyway).
-   * @returns {Promise<{ result: string, sessionId: string | null, toolCalls: number, durationMs: number, depth: number, usage?: { inputTokens: number, outputTokens: number, cacheReadTokens: number, cacheWriteTokens: number }, exceeded?: true, refused?: true, timedOut?: true, stopped?: true }>}
+   * @returns {Promise<{ result: string, sessionId: string | null, toolCalls: number, durationMs: number, depth: number, usage?: { inputTokens: number, outputTokens: number, cacheReadTokens: number, cacheWriteTokens: number }, exceeded?: true, refused?: true, timedOut?: true, stopped?: true, executionFailed?: true, outcomeKnown?: boolean }>}
    */
   const spawnActor = async (req) => {
     const {
@@ -418,7 +404,6 @@ export const makeSpawnActor = (deps) => {
       timeoutMs,
       onEvent,
       parentToolUseId,
-      persistDeltas = true,
     } = req;
 
     if (typeof task !== 'string' || task.trim().length === 0) {
@@ -598,94 +583,7 @@ export const makeSpawnActor = (deps) => {
     // ctx and races the actor reply against it, so the timeout / cancel that
     // fires this controller also unblocks the awaiting child.
 
-    // The in-SW tool dispatcher — built LAZILY, only on the fallback path. The
-    // offscreen happy path dispatches SW-side in the actor/tool-dispatch route
-    // (rebuilding the child ctx from the persisted grantedTools), so building this
-    // here — including the awaited buildToolContext — would be wasted work AND would
-    // couple the offscreen run to a ctx build it never uses (a transient vault/settings
-    // read that throws here would fail an offscreen child before it even starts). A
-    // tools:[] actor is pure reasoning and never stands one up at all.
-    /** @returns {Promise<((call: import('/shared/tool-types.js').ToolCall) => Promise<import('/shared/tool-types.js').ToolResult>) | undefined>} */
-    const buildInSwToolDispatch = async () => {
-      if (subsetDescriptors.length === 0) return undefined;
-      const baseCtx = await buildToolContext({ sessionId: child.sessionId });
-      // why restrictCtxCapabilities: capability-by-need. buildToolContext returns
-      // the full capability surface (secrets/egress/spawn closures); we remove the
-      // ones no granted tool needs so a narrowed child has no closure path to them
-      // even if a granted tool were confused into reaching for one.
-      // abortSignal (#1/#3): the child's own abort signal, so a blocking tool
-      // (message_actor awaitReply) can race its wait against it and unwind when
-      // the wall-clock timeout / cancel fires — restrictCtxCapabilities passes
-      // through any key not in CAPABILITY_CONSUMERS, so this survives the strip.
-      // The review marker is stamped HERE, SW-side, from the trusted spawn req —
-      // never carried in from a worker or a model arg. gates.js keys the #160
-      // exemption on it (positively, and only for the three read names).
-      const childCtx = restrictCtxCapabilities({
-        ...baseCtx, audit: taggedAudit, abortSignal: controller.signal,
-        ...(review ? { exposure: EXPOSURE_REVIEW } : {}),
-      }, allowedNames);
-      return (call) => {
-        // Defense in depth: even if the model hallucinates a tool name
-        // outside its granted subset, the dispatch refuses it. The
-        // descriptor narrowing is what the model SEES; this is what it
-        // can DO.
-        if (!allowedNames.has(call.name)) {
-          return Promise.resolve({
-            ok: false,
-            error: `tool_not_available_to_actor: ${call.name}`,
-            meta: { toolName: call.name, primitive: 'unknown', gates: [], durationMs: 0 },
-          });
-        }
-        // why: dispatchToolCall's union return (a loose { ok, content?, error? }
-        // for test mocks) is the dispatcher's real ToolResult at runtime.
-        return /** @type {Promise<import('/shared/tool-types.js').ToolResult>} */ (
-          dispatchToolCall(call, childCtx));
-      };
-    };
-
-    // why no customSystemPrompt here: the parent session's /system
-    // instructions are deliberately NOT inherited — an actor gets its
-    // own task framing (taskOverride) and nothing else. The instructions
-    // are user preferences for the parent CONVERSATION; leaking them
-    // would distort the child's one-shot task and silently widen the
-    // blast radius of a session-scoped instruction. Inheritance is
-    // "absent", by design.
     const effectiveTools = subsetDescriptors.map(({ name }) => name);
-    const getSystemPrompt = () => renderSystemPrompt({ taskOverride: task, effectiveTools });
-
-    // Guardrail 5 (output cap): inject maxTokens into every model call.
-    // Also the context inspector's THIRD seam: this wrapper only feeds the
-    // in-SW fallback loop (Firefox / offscreen never started) — the
-    // offscreen path's calls are captured at the actor/model-call relay.
-    /** @param {object} modelArgs */
-    const cappedCallModel = (modelArgs) => {
-      recordModelCall({ ...modelArgs, sessionId: child.sessionId, label: `actor d${depth} (in-SW)` });
-      // The credentials are added HERE, at the call boundary, and nowhere else —
-      // the same custody shape the offscreen relay uses (actor/model-call adds
-      // getSecret + safeFetch to the worker's relayed args). See keylessCredentials
-      // below for why the loop itself is handed throwing stubs instead.
-      return callModel({ ...modelArgs, getSecret, safeFetch, maxTokens: maxOutputTokens });
-    };
-
-    // The in-SW fallback's keyless custody. This path runs a CHILD loop — whose
-    // context is untrusted by construction — in the service-worker realm, so it
-    // cannot have heap separation (that is the standing residual: on Chrome every
-    // child gets its own offscreen Worker; this branch exists for Firefox, which
-    // has no offscreen API, and for a run that never started).
-    //
-    // What it CAN have, and now does, is the same credential custody as the
-    // offscreen path: the loop is handed stubs that throw, and the real
-    // getSecret/safeFetch are closed over by cappedCallModel above. Previously the
-    // live credentials were passed straight into runUserTurn, which forwards them
-    // into every model call AND leaves them reachable from the loop's own frame —
-    // so the "keyless fallback" the docs claimed was true of the tool context
-    // (restrictCtxCapabilities strips both unconditionally) but not of the loop.
-    // Now it is true of both, and the residual is honestly just the shared heap.
-    const keylessCredentials = {
-      getSecret: async () => { throw new ActorCredentialBoundaryError('secret'); },
-      safeFetch: async () => { throw new ActorCredentialBoundaryError('provider-network'); },
-    };
-
     // why: the child's model usage is yielded as 'usage' events but is NOT
     // folded into the parent/main turn tally (the main SW only accumulates its
     // OWN session's usage). That means actor spend is naturally SEPARATE from
@@ -697,7 +595,9 @@ export const makeSpawnActor = (deps) => {
     let lastStopReason;
     const usage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
     let start = 0;
-    let ranOffscreen = false;
+    let isolationRefused = false;
+    let executionFailed = false;
+    let outcomeKnown = true;
     // MED-3: the slot is CLAIMED, the child REGISTERED, and the wall-clock timer
     // ARMED above — three resources the finally below is the sole releaser of.
     // So the try must open HERE, before anything else that can throw. In
@@ -711,15 +611,12 @@ export const makeSpawnActor = (deps) => {
       // Announce the child up-front so the side panel can map the parent's
       // tool card → this session id and render live, before any loop event.
       onEvent?.({ type: 'actor-start', parentToolUseId, parentSessionId, sessionId: child.sessionId, depth, task });
-      // Heap split: EVERY child runs its loop in a dedicated offscreen Worker — its
-      // own heap, no key, no chrome.*, no egress. A tool-LESS child (phase 1) only
+      // Heap split: EVERY child runs its loop in a dedicated Worker — its own
+      // heap, no key or extension APIs. A tool-LESS child (phase 1) only
       // relays its model call; a tool-BEARING child (phase 4) also relays each tool
       // call to the SW, which rebuilds the child's restricted ctx from the persisted
-      // grantedTools and dispatches there (so script and friends run from the child's
-      // own heap, keyless). Falls back to the in-SW loop when offscreen isn't wired
-      // (Firefox), when the prompt renderer is absent, or when the offscreen run
-      // HARD-fails to start (a normal completion, even error/abort, does NOT fall back
-      // — that would double-run).
+      // grantedTools and dispatches there. A missing or failed host is terminal:
+      // no child loop may run in the privileged background heap.
       const canRunOffscreen = typeof runChildOffscreen === 'function'
         && typeof renderSystemPromptForChild === 'function';
       if (canRunOffscreen) {
@@ -732,24 +629,52 @@ export const makeSpawnActor = (deps) => {
           // it makes relays back to the SW-gated, grantedTools-checked dispatch.
           tools: subsetDescriptors,
         }, { signal: controller.signal, onEvent });
-        // Fall back to the in-SW loop ONLY when the worker never STARTED (offscreen
-        // unavailable / concurrency cap / spawn throw). A run that STARTED — even if
-        // it errored, aborted, or timed out — may have billed model calls, so
-        // re-running it in-SW would double-run; surface it as-is instead.
         if (r && (r.ok || r.started)) {
-          ranOffscreen = true;
           // Reconstruct the child transcript SW-side (the worker's heap held it) so
           // finalAssistantText + the card read a coherent session. Prefer the worker's
           // FULL transcript when it crossed back (a tool-bearing child has tool rounds
           // worth showing on the card); fall back to a user+answer pair for a tool-less
           // child or when no transcript came back. Cast: minimal role/content records.
           const newMessages = Array.isArray(r.newMessages) ? r.newMessages : [];
+          const persistMessage = async (/** @type {any} */ message) => {
+            try {
+              await sessions.appendMessage(child.sessionId, message);
+            } catch (error) {
+              taggedAudit({
+                type: 'actor_persistence_failed',
+                details: { error: /** @type {{ message?: string }} */ (error)?.message ?? String(error), performed: true, outcomeKnown: false },
+              }).catch(() => {});
+              throw new ActorPersistenceError(error);
+            }
+          };
           if (newMessages.length > 0) {
-            for (const m of newMessages) await sessions.appendMessage(child.sessionId, /** @type {any} */ (m)).catch(() => {});
+            for (const m of newMessages) await persistMessage(m);
           } else {
             const stamp = new Date(now()).toISOString();
-            await sessions.appendMessage(child.sessionId, /** @type {any} */ ({ id: `off-u-${now()}`, when: stamp, role: 'user', content: task })).catch(() => {});
-            await sessions.appendMessage(child.sessionId, /** @type {any} */ ({ id: `off-a-${now()}`, when: stamp, role: 'assistant', content: r.finalText ?? '' })).catch(() => {});
+            await persistMessage({ id: `off-u-${now()}`, when: stamp, role: 'user', content: task });
+            await persistMessage({
+              id: `off-a-${now()}`, when: stamp, role: 'assistant',
+              content: r.ok || r.aborted ? (r.finalText ?? r.error ?? '') : '',
+              ...(!r.ok && !r.aborted ? {
+                error: r.outcomeKnown === true
+                  ? (r.error ?? 'The actor model request was not run.')
+                  : `The actor worker stopped after execution began. Its outcome is unknown and must not be retried automatically. ${r.error ?? 'No failure detail was returned.'}`,
+              } : {}),
+            });
+          }
+          if (!r.ok && !r.aborted) {
+            executionFailed = true;
+            outcomeKnown = r.outcomeKnown === true;
+            // A Worker can return partial transcript bytes before its host sees
+            // the crash. Append a terminal error so those bytes cannot be
+            // mistaken for a completed result by finalActorTurnReply.
+            if (!outcomeKnown && newMessages.length > 0
+                && !newMessages.some((message) => message?.role === 'assistant' && typeof message?.error === 'string')) {
+              await persistMessage({
+                id: `off-error-${now()}`, when: new Date(now()).toISOString(), role: 'assistant', content: '',
+                error: `The actor worker stopped after execution began. Its outcome is unknown and must not be retried automatically. ${r.error ?? 'No failure detail was returned.'}`,
+              });
+            }
           }
           toolCalls = r.toolCalls ?? 0;
           lastStopReason = r.aborted ? 'aborted' : (r.stopReason ?? (r.ok ? 'end_turn' : undefined));
@@ -760,47 +685,35 @@ export const makeSpawnActor = (deps) => {
             usage.cacheWriteTokens += r.usage.cacheWriteTokens || 0;
           }
           taggedAudit(r.ok
-            ? { type: 'actor_ran_offscreen', details: { heapSplit: true } }
-            : { type: 'actor_offscreen_error', details: { heapSplit: true, error: r.error ?? 'unknown', aborted: r.aborted === true } }).catch(() => {});
+            ? { type: 'actor_ran_isolated', details: { workerType: 'dedicated', realmVerified: true } }
+            : {
+              type: 'actor_isolated_error',
+              details: {
+                error: r.error ?? 'unknown', aborted: r.aborted === true,
+                ...(!r.aborted ? {
+                  performed: !outcomeKnown,
+                  outcomeKnown,
+                } : {}),
+              },
+            }).catch(() => {});
         } else {
-          // Never started → defensive fallback to the in-SW loop, so a reasoning
-          // child never just dies on infra it couldn't even reach.
-          taggedAudit({ type: 'actor_offscreen_fallback', details: { error: r?.error ?? 'unknown' } }).catch(() => {});
+          isolationRefused = true;
+          const error = r?.error ?? 'actor isolation unavailable';
+          const stamp = new Date(now()).toISOString();
+          await sessions.appendMessage(child.sessionId, /** @type {any} */ ({ id: `iso-u-${now()}`, when: stamp, role: 'user', content: task })).catch(() => {});
+          await sessions.appendMessage(child.sessionId, /** @type {any} */ ({ id: `iso-a-${now()}`, when: stamp, role: 'assistant', content: error })).catch(() => {});
+          taggedAudit({
+            type: 'actor_isolation_failure',
+            details: { error, code: r?.code ?? 'unknown', performed: false },
+          }).catch(() => {});
         }
-      }
-      if (!ranOffscreen) {
-        // Lazily stand up the in-SW dispatcher — ONLY now, on the fallback (see
-        // buildInSwToolDispatch). The offscreen path above never reaches here.
-        const toolDispatch = await buildInSwToolDispatch();
-        for await (const ev of runUserTurn({
-          sessionId: child.sessionId,
-          userText: task,
-          callModel: cappedCallModel,
-          // Stubs, not the live credentials — cappedCallModel adds the real ones at
-          // the call boundary. See keylessCredentials above.
-          ...keylessCredentials,
-          sessions,
-          getSystemPrompt,
-          appendAudit: taggedAudit,
-          tools: subsetDescriptors,
-          toolDispatch,
-          maxSteps,
-          persistDeltas,
-          now,
-          // Phase 1: the child is abortable — Stop cascades, actorCancel, and
-          // the wall-clock timer all fire this controller.
-          signal: controller.signal,
-        })) {
-          if (ev.type === 'tool-use') toolCalls++;
-          if (ev.type === 'stop') lastStopReason = ev.stopReason;
-          if (ev.type === 'usage' && ev.usage) {
-            usage.inputTokens += ev.usage.inputTokens || 0;
-            usage.outputTokens += ev.usage.outputTokens || 0;
-            usage.cacheReadTokens += ev.usage.cacheReadTokens || 0;
-            usage.cacheWriteTokens += ev.usage.cacheWriteTokens || 0;
-          }
-          onEvent?.(ev);
-        }
+      } else {
+        isolationRefused = true;
+        const error = 'actor isolation unavailable: no dedicated worker host is wired';
+        const stamp = new Date(now()).toISOString();
+        await sessions.appendMessage(child.sessionId, /** @type {any} */ ({ id: `iso-u-${now()}`, when: stamp, role: 'user', content: task })).catch(() => {});
+        await sessions.appendMessage(child.sessionId, /** @type {any} */ ({ id: `iso-a-${now()}`, when: stamp, role: 'assistant', content: error })).catch(() => {});
+        taggedAudit({ type: 'actor_isolation_failure', details: { error, performed: false } }).catch(() => {});
       }
     } finally {
       clearTimer(timer);
@@ -813,7 +726,8 @@ export const makeSpawnActor = (deps) => {
 
     const durationMs = now() - start;
     const final = await sessions.get(child.sessionId);
-    const result = finalAssistantText(final);
+    const completion = finalActorTurnReply(final);
+    const result = completion.result;
     // Guardrail 5 (step cap): a max_steps stop means the actor ran out
     // of room before finishing. Surface it so the caller (and the model)
     // knows the result may be partial.
@@ -824,14 +738,18 @@ export const makeSpawnActor = (deps) => {
     // finally's clearTimer, which must NOT relabel a complete result as partial.
     // Gate both flags on lastStopReason==='aborted' (a real abort unwind), then
     // split by cause: timer → timedOut, anything else (Stop cascade, cancel) →
-    // stopped. A non-aborted finish is neither.
+    // stopped. Persisted provider errors are also stopped so partial text never
+    // presents a failed turn as success.
     const aborted = lastStopReason === 'aborted';
     const timedOut = aborted && timerFired;
-    const stopped = aborted && !timerFired;
+    const stopped = (aborted && !timerFired) || completion.stopped === true;
 
     taggedAudit({
       type: 'actor_completed',
-      details: { toolCalls, durationMs, exceeded, timedOut, stopped, resultChars: result.length },
+      details: {
+        toolCalls, durationMs, exceeded, timedOut, stopped, resultChars: result.length,
+        ...(executionFailed ? { executionFailed: true, outcomeKnown } : {}),
+      },
     }).catch(() => {});
 
     return {
@@ -844,6 +762,8 @@ export const makeSpawnActor = (deps) => {
       ...(exceeded ? { exceeded: true } : {}),
       ...(timedOut ? { timedOut: true } : {}),
       ...(stopped ? { stopped: true } : {}),
+      ...(isolationRefused ? { refused: true } : {}),
+      ...(executionFailed ? { executionFailed: true, outcomeKnown } : {}),
     };
   };
 

--- a/extension/peerd-runtime/actor/spawn.js
+++ b/extension/peerd-runtime/actor/spawn.js
@@ -303,7 +303,7 @@ export const makeSpawnActor = (deps) => {
     setTimer = (/** @type {() => void} */ fn, /** @type {number} */ ms) => setTimeout(fn, ms),
     clearTimer = (/** @type {unknown} */ handle) => clearTimeout(/** @type {any} */ (handle)),
     // Heap-split phase 1: run a PURE-REASONING (empty granted toolset) child in a
-    // dedicated Worker — its own heap, no key or extension APIs.
+    // dedicated Worker with its own heap and no key or extension APIs.
     // Tool-bearing children run here too (heap-split phase 4): their tool calls
     // relay to the SW-gated dispatch. A missing host fails closed.
     // renderSystemPromptForChild renders the child's prompt host-side so
@@ -611,7 +611,7 @@ export const makeSpawnActor = (deps) => {
       // Announce the child up-front so the side panel can map the parent's
       // tool card → this session id and render live, before any loop event.
       onEvent?.({ type: 'actor-start', parentToolUseId, parentSessionId, sessionId: child.sessionId, depth, task });
-      // Heap split: EVERY child runs its loop in a dedicated Worker — its own
+      // Heap split: EVERY child runs its loop in a dedicated Worker with its own
       // heap, no key or extension APIs. A tool-LESS child (phase 1) only
       // relays its model call; a tool-BEARING child (phase 4) also relays each tool
       // call to the SW, which rebuilds the child's restricted ctx from the persisted

--- a/extension/peerd-runtime/index.js
+++ b/extension/peerd-runtime/index.js
@@ -117,6 +117,14 @@ export { makeAsyncActors } from './actor/async-actors.js';
 // DESIGN-17: the message_actor orchestrator (the mailbox to a tab-hosted
 // instance's actor — the async-actors shape, specialized).
 export { makeActorMessaging } from './actor/actor-messaging.js';
+export {
+  actorIsolationCapability, actorIsolationAvailable,
+  actorIsolationTemporarilyUnavailable, actorIsolationRefusal, actorIsolationSpawnRefusal,
+  filterByActorIsolation, actorIsolationPromptBlock,
+  ACTOR_ISOLATION_HOST_OFFSCREEN, ACTOR_ISOLATION_HOST_BACKGROUND,
+  ACTOR_ISOLATION_UNAVAILABLE_TOOLS, ACTOR_ISOLATION_TEMPORARY_USER_FAILURE,
+  ACTOR_ISOLATION_UNSUPPORTED_USER_FAILURE,
+} from './actor/isolation.js';
 // A2A — the agent-to-agent code surface: the pure translation + the mesh
 // dispatch/correlation the a2a/call route runs.
 export { meshCallToOp, shapeMeshResult } from './actor/a2a-api.js';
@@ -255,8 +263,8 @@ export {
   actorAllowedTools, isAllowedForActorType, actorDescriptors, filterActorSurface,
   // DESIGN-18: backing-aware allow-set (an API actor is fetch_url-only).
   actorAllowedToolsFor, isAllowedForActor,
-  // Heap-split phase 2: the per-instance pin, shared by the in-SW actor turn and
-  // the offscreen actor tool relay (one implementation on a security seam).
+  // Heap-split phase 2: the per-instance pin used by the privileged actor tool
+  // relay (one implementation on a security seam).
   pinActorCall,
 } from './tools/exposure.js';
 // Per-session tool exposure manifests (ROADMAP) — presets-as-data + the

--- a/extension/peerd-runtime/loop/agent-loop.js
+++ b/extension/peerd-runtime/loop/agent-loop.js
@@ -163,6 +163,9 @@ export const stripCrossModelThinking = (messages, model) => messages.map((msg) =
  * @param {(resource: string | URL | Request, init?: RequestInit) => Promise<Response>} ctx.safeFetch
  * @param {ReturnType<typeof import('../sessions/store.js').createSessionStore>} ctx.sessions
  * @param {() => Promise<string>} ctx.getSystemPrompt
+ *   Renders the system prompt for the current model contract. When refreshTools
+ *   is present, it is called after each successful tool refresh so policy-driven
+ *   prompt suffixes and the advertised tools advance together.
  * @param {(entry: { type: string, sessionId?: string, details?: object }) => Promise<unknown>} ctx.appendAudit
  * @param {ReadonlyArray<{ name: string, description: string, schema: object }>} [ctx.tools]
  *   Tool descriptors passed to the provider. Optional.
@@ -364,10 +367,10 @@ export async function* runUserTurn(ctx) {
     }
   }
 
-  // 2. Render the system prompt once per turn. We don't re-render on
-  // every step — the prompt assembly is provider-agnostic and depends
-  // only on session-stable context (date).
-  const system = await getSystemPrompt();
+  // 2. Seed the model contract. Main turns refresh both pieces at each step:
+  // most renders are byte-identical and preserve the prompt cache, while a live
+  // policy transition deliberately changes the prompt beside its tool cut.
+  let system = await getSystemPrompt();
 
   // Helper: was the turn aborted? Used at iteration boundaries; the
   // stream catch block has its own AbortError handling.
@@ -396,12 +399,23 @@ export async function* runUserTurn(ctx) {
       return;
     }
 
-    // Recompute the advertised tools for THIS step — mid-turn exposure changes
-    // (dweb engagement, a goal run starting/stopping) show on the next step.
-    // A failure keeps the prior set — never break the turn on a tool refresh.
+    // Recompute the advertised tools for THIS step so mid-turn exposure changes
+    // show on the next model call. Re-render the system only after a successful
+    // refresh: the turn driver binds policy-dependent prompt text to the same
+    // snapshot as the returned descriptors. A refresh failure keeps both prior
+    // values instead of creating a mixed model contract.
     if (typeof refreshTools === 'function') {
-      try { activeTools = await refreshTools(); }
-      catch { /* keep the prior tool set */ }
+      let nextTools = activeTools;
+      let toolsRefreshed = false;
+      try {
+        nextTools = await refreshTools();
+        toolsRefreshed = true;
+      } catch { /* keep the prior model contract */ }
+      if (toolsRefreshed) {
+        const nextSystem = await getSystemPrompt();
+        activeTools = nextTools;
+        system = nextSystem;
+      }
     }
 
     /** @type {InternalMessage} */

--- a/extension/peerd-runtime/loop/agent-loop.js
+++ b/extension/peerd-runtime/loop/agent-loop.js
@@ -214,7 +214,7 @@ export const stripCrossModelThinking = (messages, model) => messages.map((msg) =
  *   from the chat UI, like the truncation-continue path). Used by the
  *   async-actor reintegration wake (DESIGN-11): the child's result
  *   re-enters its parent as a synthetic user turn rather than a real one.
- * @param {{ kind: string, instanceId: string, name?: string, failed?: boolean }} [ctx.actorReply]
+ * @param {{ kind: string, instanceId: string, name?: string, failed?: boolean, outcomeKnown?: boolean, performed?: boolean, actorDeliveryId?: string }} [ctx.actorReply]
  *   Set on an ACTOR's reply-wake: stamps who replied onto the appended
  *   message so the chat surfaces it as its own attributed bubble (the one
  *   synthetic turn the UI shows).
@@ -932,11 +932,19 @@ export async function* runUserTurn(ctx) {
       // requested page survives instead of being re-cut by the 8k backstop.
       // Guarded to `ok && paged` so a normal firehose result still gets 8k'd.
       const paged = dispatchResult.ok && dispatchResult.paged === true;
+      const actorDeliveryIds = Array.isArray(dispatchResult.actorDeliveryIds)
+        ? [...new Set(dispatchResult.actorDeliveryIds.filter(
+          (id) => typeof id === 'string' && id.length > 0))]
+        : [];
       const block = {
         tool_use_id: tu.id,
         content: redactToolResult(rawContent, paged ? { maxChars: PAGED_MAX_CHARS } : undefined),
         is_error: !dispatchResult.ok,
         meta: dispatchResult.meta,
+        ...(typeof dispatchResult.actorDeliveryId === 'string'
+          ? { actorDeliveryId: dispatchResult.actorDeliveryId }
+          : {}),
+        ...(actorDeliveryIds.length > 0 ? { actorDeliveryIds } : {}),
       };
       return { tu, dispatchResult, block };
     };

--- a/extension/peerd-runtime/loop/turn-driver.js
+++ b/extension/peerd-runtime/loop/turn-driver.js
@@ -188,6 +188,11 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
   const actorIsolationAtTurnStart = getActorIsolation();
   const effectiveActorIsolation = () =>
     actorIsolationForTurn(actorIsolationAtTurnStart, getActorIsolation());
+  // The prompt and tool descriptors for one model step must describe one
+  // isolation state. refreshMainTools advances this snapshot only after it has
+  // built the matching descriptor list. Dispatch still checks live state and
+  // fails closed if the worker boundary changes after the model call starts.
+  let actorIsolationForModelStep = effectiveActorIsolation();
   /** @type {string|undefined} */
   const actorType = isActor ? turnSession.actorType : undefined;
   /** @type {string|undefined} */
@@ -298,59 +303,60 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
     recoveryBlock = await Promise.resolve(drainRecoveryNotices(sessionId))
       .catch(() => '');
   }
-  const actorExecutionBlock = !isActor && actorIsolationAtTurnStart
-    ? actorIsolationPromptBlock(actorIsolationAtTurnStart)
-    : '';
+  const actorExecutionBlock = () => {
+    if (isActor) return '';
+    const isolation = actorIsolationForModelStep;
+    return isolation ? actorIsolationPromptBlock(isolation) : '';
+  };
   const contextMessage = isActor
     ? ''
     : [buildTemporalContext({ temporalBlock, activeTab: activeTabContext }), recoveryBlock]
       .filter(Boolean).join('\n\n');
 
+  /** @type {string|null} */
+  let systemPromptBase = null;
   const getSystemPrompt = async () => {
-    // why: re-read the session record at render time so a /system change
-    // (set or clear) takes effect on the very next turn. The block is the
-    // user's per-session augmentation — appended as <session_instructions>,
-    // never replacing the base prompt (the base carries the security/
-    // defense text). Absent → collapses to nothing. The per-change cache
-    // break this causes is by design.
-    const promptSession = await sessions.get(sessionId);
-    // Prewalk: the planning nudge rides the prompt ONLY during the planning
-    // phase. Because the prompt re-renders per turn, the executor's first
-    // turn simply never contains it — the "prune the planning instruction"
-    // half of the handoff falls out of the render, no history surgery.
-    const prewalkBlock = !isActor && promptSession?.prewalk?.phase === 'planning'
-      ? `\n\n${PREWALK_NUDGE}`
-      : '';
-    return (await renderSystemPrompt({
-      memoryBlock,
-      // design 01: the MAIN system string must be byte-stable to cache, so the
-      // orchestrator's volatile temporal bytes ride a leading <context> message
-      // (contextMessage below) instead of the system block. An ACTOR re-renders
-      // its system prompt per turn and keeps embedding the block (relocating it
-      // there too would need offscreen-worker plumbing — deferred). '' for the
-      // main path collapses the {{TEMPORAL_BLOCK}} placeholder cleanly.
-      temporalBlock: isActor ? temporalBlock : '',
-      skillsBlock,
-      customSystemPrompt: promptSession?.customSystemPrompt,
-      // DESIGN-17: an actor gets a kind-specific tuned block appended (the base
-      // template — incl. all the security/defense text — survives verbatim).
-      // DESIGN-18: backing distinguishes a tab-backed web actor (DOM lore) from an
-      // API actor (fetch-only origin lore) — both are actorType:'web'. instanceId lets
-      // an API actor's lore name the ONE origin it owns.
-      // PR #119: a tab web actor's action surface ('tools'|'code'), resolved by
-      // buildToolContext from the setting — the prompt teaches page.* for 'code'.
-      // #241: schemaReply rides the SAME stamp — buildToolContext sets it from the
-      // setting that arms the reply validator, so an actor is never told to emit
-      // the envelope by a build that wouldn't validate it (or vice versa).
-      ...(isActor ? {
-        actorType, backing: actorBacking, instanceId: actorInstanceId,
-        actorSurface: toolContext.actorSurface, schemaReply: toolContext.schemaReply,
-        effectiveTools: toolDescriptors.map((/** @type {any} */ tool) => tool.name),
-        inbound: toolContext.inbound === true,
-      } : {}),
-    // why await: renderSystemPrompt is async — concatenating the un-awaited
-    // promise would bake "[object Promise]" into the prompt.
-    })) + prewalkBlock + (actorExecutionBlock ? `\n\n${actorExecutionBlock}` : '');
+    // Keep the ordinary system body turn-stable. A /system or prewalk change
+    // takes effect on the next turn, matching the original render-once
+    // behavior. Only the actor-execution suffix can change between steps.
+    if (systemPromptBase === null) {
+      const promptSession = await sessions.get(sessionId);
+      const prewalkBlock = !isActor && promptSession?.prewalk?.phase === 'planning'
+        ? `\n\n${PREWALK_NUDGE}`
+        : '';
+      systemPromptBase = (await renderSystemPrompt({
+        memoryBlock,
+        // design 01: the MAIN system string must be byte-stable to cache, so the
+        // orchestrator's volatile temporal bytes ride a leading <context> message
+        // (contextMessage below) instead of the system block. An ACTOR re-renders
+        // its system prompt per turn and keeps embedding the block. Relocating it
+        // there too would need offscreen-worker plumbing and is deferred. '' for the
+        // main path collapses the {{TEMPORAL_BLOCK}} placeholder cleanly.
+        temporalBlock: isActor ? temporalBlock : '',
+        skillsBlock,
+        customSystemPrompt: promptSession?.customSystemPrompt,
+        // DESIGN-17: an actor gets a kind-specific tuned block appended. The base
+        // template, including all security and defense text, survives verbatim.
+        // DESIGN-18: backing distinguishes a tab-backed web actor (DOM lore) from an
+        // API actor (fetch-only origin lore). Both are actorType:'web'. instanceId lets
+        // an API actor's lore name the ONE origin it owns.
+        // PR #119: a tab web actor's action surface ('tools'|'code'), resolved by
+        // buildToolContext from the setting. The prompt teaches page.* for 'code'.
+        // #241: schemaReply rides the SAME stamp. buildToolContext sets it from the
+        // setting that arms the reply validator, so an actor is never told to emit
+        // the envelope by a build that wouldn't validate it (or vice versa).
+        ...(isActor ? {
+          actorType, backing: actorBacking, instanceId: actorInstanceId,
+          actorSurface: toolContext.actorSurface, schemaReply: toolContext.schemaReply,
+          effectiveTools: toolDescriptors.map((/** @type {any} */ tool) => tool.name),
+          inbound: toolContext.inbound === true,
+        } : {}),
+      // why await: renderSystemPrompt is async. Concatenating the un-awaited
+      // promise would bake "[object Promise]" into the prompt.
+      })) + prewalkBlock;
+    }
+    const executionBlock = actorExecutionBlock();
+    return systemPromptBase + (executionBlock ? `\n\n${executionBlock}` : '');
   };
 
   // Tool descriptors passed to the provider — name, description, and
@@ -425,8 +431,10 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
       ),
     );
     const isolation = effectiveActorIsolation();
-    return (isolation ? filterByActorIsolation(exposed, isolation) : exposed)
+    const descriptors = (isolation ? filterByActorIsolation(exposed, isolation) : exposed)
       .map((/** @type {any} */ t) => ({ name: t.name, description: t.description, schema: t.schema }));
+    actorIsolationForModelStep = isolation;
+    return descriptors;
   };
   // DESIGN-17: an actor sees a FIXED set — its own kind's toolset (no
   // progressive disclosure; the actor gate is the wall). REPLACE both the
@@ -693,9 +701,9 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
       getSystemPrompt,
       appendAudit: /** @type {any} */ (auditLog.append),
       tools: toolDescriptors,
-      // why: the loop calls this each step to get the current tool list, so a
-      // mid-turn exposure change (dweb engagement, goal start/stop) shows on
-      // the next step. An actor uses a fixed-set refresh (the gate is the wall).
+      // why: the loop calls this before each model step, then re-renders the
+      // system prompt against the isolation snapshot selected here. Mid-turn
+      // exposure changes therefore update the prompt and tools together.
       refreshTools,
       toolDispatch,
       classifyToolCall,

--- a/extension/peerd-runtime/loop/turn-driver.js
+++ b/extension/peerd-runtime/loop/turn-driver.js
@@ -37,9 +37,13 @@ import { PREWALK_NUDGE } from './prewalk.js';
 // main system string byte-stable and prompt-cacheable (design 01).
 import { buildTemporalContext } from './system-prompt.js';
 import { DWEB_INBOUND_TOOL_NAMES } from '../actor/capability-manifest.js';
+import {
+  actorIsolationAvailable, actorIsolationForTurn, actorIsolationPromptBlock, actorIsolationRefusal,
+  ACTOR_ISOLATION_UNAVAILABLE_TOOLS, filterByActorIsolation,
+} from '../actor/isolation.js';
 
 /**
- * The in-SW fallback's positive inbound authority check. Kept pure/exported so
+ * The positive inbound authority check. Kept pure/exported so
  * the hidden-tool forgery case is pinned without constructing a whole turn.
  * @param {{ isActor: boolean, inbound: boolean, actorType?: string, name?: string }} input
  */
@@ -83,6 +87,11 @@ export const makeTurnDriver = (/** @type {any} */ deps) => {
     // carried — including the do-not-repeat instruction for outcome_unknown.
     // Optional so actor/test drivers stay inert.
     drainRecoveryNotices = null,
+    // Live execution-boundary capability. Null keeps older test harnesses inert.
+    getActorIsolation = () => null,
+    // The service-worker shell hydrates durable actor-host health before a
+    // turn may snapshot it. Tests and non-browser callers stay synchronous.
+    waitForActorIsolation = async () => {},
   } = deps;
 
 /**
@@ -93,6 +102,10 @@ export const makeTurnDriver = (/** @type {any} */ deps) => {
  */
 const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, sessionId: targetSessionId = null, synthetic = false, trusted = false, resume = false, activeTabId = null, display = null, oneShot = false, actorReply = null }) => {
   if (vault.isLocked()) throw new VaultLockedError();
+  // why before session work: a cold background page starts fail-closed while
+  // durable actor-host health loads. Sampling that sentinel would falsely tell
+  // the model actors are unavailable and can consume a mailbox wake for good.
+  await waitForActorIsolation();
 
   // Lazy session create — bind the chat to whatever provider/model the user
   // has configured (no provider is assumed on a fresh install; see
@@ -155,6 +168,26 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
     } catch (e) { console.warn('[turn] prewalk reconcile failed', e); }
   }
   const isActor = turnSession?.kind === 'actor';
+  const isSpawned = turnSession?.kind === 'spawned';
+  // Defensive backstop for auto-resume and any future caller: actor sessions
+  // are driven only by the dedicated-worker host. Reaching this in-background
+  // turn driver is a refusal, never a degraded execution mode.
+  if (isActor || isSpawned) {
+    auditLog.append({
+      type: 'actor_background_turn_refused',
+      sessionId,
+      details: { reason: 'dedicated_worker_required', performed: false },
+    }).catch(() => {});
+    releaseTurnSlot();
+    return;
+  }
+  // why snapshot: an unavailable boundary stays unavailable to the model for
+  // this whole turn even if a user retry repairs it mid-turn. That keeps the
+  // system prompt, descriptor list, and dispatch story coherent. A boundary
+  // that fails after the turn starts can still remove tools immediately.
+  const actorIsolationAtTurnStart = getActorIsolation();
+  const effectiveActorIsolation = () =>
+    actorIsolationForTurn(actorIsolationAtTurnStart, getActorIsolation());
   /** @type {string|undefined} */
   const actorType = isActor ? turnSession.actorType : undefined;
   /** @type {string|undefined} */
@@ -164,12 +197,8 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
   // the egress boundary scopes to the FIXED origin for an API actor.
   /** @type {'tab'|'api'|undefined} */
   const actorBacking = isActor ? turnSession.backing : undefined;
-  // Firefox has no offscreen actor host, so a bound actor can reach this
-  // in-service-worker loop. Keep the live provider credentials out of that
-  // loop frame just as the spawned-actor fallback does. The model wrapper
-  // below restores them only at the provider-call boundary. This narrows
-  // custody but does not create heap isolation; that contract is tracked
-  // separately in #305.
+  // Defense in depth: if a future caller bypasses the dedicated-worker
+  // refusal above, no actor loop receives live credential functions.
   const loopCredentials = isActor
     ? {
       getSecret: async () => { throw new ActorCredentialBoundaryError('secret'); },
@@ -269,6 +298,9 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
     recoveryBlock = await Promise.resolve(drainRecoveryNotices(sessionId))
       .catch(() => '');
   }
+  const actorExecutionBlock = !isActor && actorIsolationAtTurnStart
+    ? actorIsolationPromptBlock(actorIsolationAtTurnStart)
+    : '';
   const contextMessage = isActor
     ? ''
     : [buildTemporalContext({ temporalBlock, activeTab: activeTabContext }), recoveryBlock]
@@ -318,7 +350,7 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
       } : {}),
     // why await: renderSystemPrompt is async — concatenating the un-awaited
     // promise would bake "[object Promise]" into the prompt.
-    })) + prewalkBlock;
+    })) + prewalkBlock + (actorExecutionBlock ? `\n\n${actorExecutionBlock}` : '');
   };
 
   // Tool descriptors passed to the provider — name, description, and
@@ -380,7 +412,7 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
     // SIXTH cut (DESIGN-17): the actor surface. The actor-only instance tier
     // (writes AND the fenced reads) LEAVES the main agent (it delegates via
     // message_actor, which it keeps). Outermost so it composes over everything.
-    const descriptors = filterActorSurface(
+    const exposed = filterActorSurface(
       filterByGoalActive(
         filterByDwebActive(
           filterByDwebEnabled(
@@ -391,8 +423,10 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
         ),
         !!goalActiveFor?.(sessionId),
       ),
-    ).map((/** @type {any} */ t) => ({ name: t.name, description: t.description, schema: t.schema }));
-    return descriptors;
+    );
+    const isolation = effectiveActorIsolation();
+    return (isolation ? filterByActorIsolation(exposed, isolation) : exposed)
+      .map((/** @type {any} */ t) => ({ name: t.name, description: t.description, schema: t.schema }));
   };
   // DESIGN-17: an actor sees a FIXED set — its own kind's toolset (no
   // progressive disclosure; the actor gate is the wall). REPLACE both the
@@ -415,13 +449,21 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
   const refreshTools = isActor ? refreshActorTools : refreshMainTools;
   const toolDescriptors = await refreshTools();
   const toolDispatch = async (/** @type {any} */ call) => {
-    // The descriptor filter is model guidance; this is the in-SW fallback's
-    // authority wall. A remote-peer wake may use only the positive inbound
-    // dweb subset even if it forges a hidden tool name.
+    // The descriptor filter is model guidance. A remote-peer wake may use only
+    // the positive inbound dweb subset even if it forges a hidden tool name.
     if (!inboundActorCallAllowed({
       isActor, inbound: toolContext.inbound === true, actorType, name: call?.name,
     })) {
       return { ok: false, error: `tool_not_available_to_inbound_actor: ${call?.name}` };
+    }
+    const isolation = effectiveActorIsolation();
+    if (!isActor && isolation && !actorIsolationAvailable(isolation)
+        && ACTOR_ISOLATION_UNAVAILABLE_TOOLS.has(String(call?.name ?? ''))) {
+      const refusal = actorIsolationRefusal(isolation);
+      return {
+        ...refusal,
+        meta: { toolName: call?.name, primitive: 'spawned', gates: [], durationMs: 0 },
+      };
     }
     // DESIGN-17 per-instance pin: force an actor's instance-target arg to its
     // BOUND instance before dispatch, so it can only ever touch its own (the gate
@@ -545,7 +587,7 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
   /** @type {{ provider: string, model: string } | null} */ let failoverLastGood = null;
   const callModelWithFailover = async function* (/** @type {any} */ modelArgs) {
     // Pin the first candidate to the persisted turn record. The loop normally
-    // forwards those same values, but the in-SW actor is not a trust boundary:
+    // forwards those same values, but the loop is not the credential boundary:
     // it must not select another keyed adapter by colliding with broker fields.
     // Later calls stay on a successful failover candidate for this turn.
     const start = failoverLastGood ?? {
@@ -553,9 +595,8 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
       model: costSession?.model ?? modelArgs.model,
     };
     const chain = resolveFailoverChain(start);
-    // The context inspector sees main turns and the bound-actor in-SW
-    // fallback here. Offscreen actors use the actor/model-call relay; spawned
-    // in-SW children use their capped wrapper.
+    // The context inspector sees orchestrator turns here. Every actor model
+    // call uses the isolated actor relay.
     // record() is contractually non-throwing; label with the provider the
     // call will actually start on.
     recordModelCall({
@@ -563,7 +604,7 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
       provider: start.provider,
       model: start.model,
       sessionId,
-      label: isActor ? `actor ${actorType ?? 'bound'} (in-SW)` : 'main',
+      label: 'main',
     });
     // why: the Ollama adapter reads `ollamaHost` to reach a remote daemon (issue
     // #104). Thread it from settings for every candidate; non-ollama adapters
@@ -574,9 +615,8 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
       const cand = chain[i];
       let streamedContent = false;
       try {
-        // The loop forwards its credential fields with every model call. For
-        // an in-SW actor those fields are throwing stubs, so all broker-owned
-        // fields must come AFTER modelArgs. Reversing this order lets the loop
+        // The loop forwards credential fields with every model call. All
+        // broker-owned fields must come AFTER modelArgs. Reversing this order lets the loop
         // change credential custody, provider choice, or cancellation.
         for await (const ev of callModel({
           ...modelArgs,
@@ -646,9 +686,8 @@ const runAgentTurn = async (/** @type {any} */ { userText, attachments = null, s
       // persistently-overloaded or out-of-credit provider switches to a
       // configured fallback mid-turn instead of failing the whole turn.
       callModel: callModelWithFailover,
-      // Bound actors on the in-SW fallback get throwing stubs. Main turns keep
-      // the live functions. callModelWithFailover brokers the real credentials
-      // at the provider boundary for both paths.
+      // Only orchestrator turns reach this driver. Actor sessions are refused
+      // above and use the dedicated-worker host.
       ...loopCredentials,
       sessions,
       getSystemPrompt,

--- a/extension/peerd-runtime/sessions/store.js
+++ b/extension/peerd-runtime/sessions/store.js
@@ -63,9 +63,40 @@ const MSGS = 'session_messages';
  *   test fakes still work). why any-valued: records are untyped IDB blobs.
  * @param {() => number} [deps.now]              injectable clock
  * @param {() => string} [deps.makeId]           injectable id generator
+ * @param {(sessionId: string, message: InternalMessage) => Promise<void>|void} [deps.onMessageAppended]
+ *   post-commit hook. Runs only after the message row and session index are
+ *   durable. A hook failure cannot roll back or fail an already-committed append.
  */
-export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
+export const createSessionStore = ({ idb, now = Date.now, makeId, onMessageAppended = async () => {} }) => {
   const generateId = makeId ?? (() => uuidv7(now));
+
+  // Session metadata uses read-modify-write updates. Serialize every operation
+  // that can write that record, including a legacy read that migrates it. A
+  // message append and a cost/model/archive update must not both read the same
+  // metadata snapshot and let the later put erase the other's msgIndex or field.
+  /** @type {Map<string, Promise<unknown>>} */
+  const sessionChains = new Map();
+  /**
+   * @template T
+   * @param {string} sessionId
+   * @param {() => Promise<T>} operation
+   * @returns {Promise<T>}
+   */
+  const enqueueSessionOperation = (sessionId, operation) => {
+    const previous = sessionChains.get(sessionId) ?? Promise.resolve();
+    const current = previous.catch(() => {}).then(operation);
+    sessionChains.set(sessionId, current);
+    void current.finally(() => {
+      if (sessionChains.get(sessionId) === current) sessionChains.delete(sessionId);
+    }).catch(() => {});
+    return current;
+  };
+
+  /** @param {string} sessionId @param {InternalMessage} message */
+  const notifyMessageAppended = async (sessionId, message) => {
+    try { await onMessageAppended(sessionId, message); }
+    catch { /* the append is already durable; recovery can retry the receipt */ }
+  };
 
   // ---- message-record helpers -------------------------------------------
 
@@ -239,7 +270,10 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
   };
 
   /** @returns {Promise<Session | undefined>} */
-  const get = async (/** @type {string} */ sessionId) => assemble(await getRecord(sessionId));
+  const get = (/** @type {string} */ sessionId) => enqueueSessionOperation(
+    sessionId,
+    async () => assemble(await getRecord(sessionId)),
+  );
 
   /**
    * @returns {Promise<Session[]>}
@@ -277,13 +311,13 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
     return out.sort((a, b) => b.createdAt - a.createdAt);
   };
 
-  const archive = async (/** @type {string} */ sessionId) => {
+  const archive = (/** @type {string} */ sessionId) => enqueueSessionOperation(sessionId, async () => {
     const record = await getRecord(sessionId);
     if (!record) throw new SessionNotFoundError(sessionId);
     const updated = { ...record, archivedAt: now() };
     await idb.put(STORE, updated);
     return assemble(updated);
-  };
+  });
 
   /**
    * Metadata-only lookup of a live actor session by its self-description — used to
@@ -316,11 +350,20 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
    * @param {string} sessionId
    * @param {InternalMessage} message
    */
-  const appendMessage = async (sessionId, message) => {
+  const appendMessage = (sessionId, message) => enqueueSessionOperation(sessionId, async () => {
     const record = await getRecord(sessionId);
     if (!record) throw new SessionNotFoundError(sessionId);
     const seq = record.msgIndex.length;
     const id = messageKey(sessionId, message, seq);
+    // why idempotent by message id: crash recovery writes stable-id receipts.
+    // If the message and index both landed before a background loss, the retry
+    // must return the existing session instead of appending the same receipt a
+    // second time. The message row is written before the index below, so an id in
+    // msgIndex also proves its body was already stored.
+    if (record.msgIndex.includes(id)) {
+      await notifyMessageAppended(sessionId, message);
+      return assemble(record);
+    }
     await idb.put(MSGS, { id, sessionId, seq, message });
     const updated = { ...record, msgIndex: [...record.msgIndex, id] };
     if (!record.title && message.role === 'user' && typeof message.content === 'string') {
@@ -328,8 +371,9 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
       if (cleaned) updated.title = cleaned.slice(0, 60);
     }
     await idb.put(STORE, updated);
+    await notifyMessageAppended(sessionId, message);
     return assemble(updated);
-  };
+  });
 
   /**
    * Patch the streaming assistant message in place (matched by id). This is
@@ -363,13 +407,13 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
    * @param {string} sessionId
    * @param {Record<string, unknown>} patch
    */
-  const update = async (sessionId, patch) => {
+  const update = (sessionId, patch) => enqueueSessionOperation(sessionId, async () => {
     const record = await getRecord(sessionId);
     if (!record) throw new SessionNotFoundError(sessionId);
     const updated = { ...record, ...patch };
     await idb.put(STORE, updated);
     return assemble(updated);
-  };
+  });
 
   /**
    * Set or CLEAR the session's user-authored system-prompt augmentation
@@ -380,7 +424,7 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
    * @param {string} sessionId
    * @param {string | null | undefined} text
    */
-  const setCustomSystemPrompt = async (sessionId, text) => {
+  const setCustomSystemPrompt = (sessionId, text) => enqueueSessionOperation(sessionId, async () => {
     const record = await getRecord(sessionId);
     if (!record) throw new SessionNotFoundError(sessionId);
     const { customSystemPrompt: _removed, ...rest } = record;
@@ -389,7 +433,7 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
       : rest;
     await idb.put(STORE, updated);
     return assemble(updated);
-  };
+  });
 
   /**
    * Set or CLEAR the session's tool exposure manifest (the /tools command).
@@ -397,7 +441,7 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
    * @param {string} sessionId
    * @param {import('../tools/manifests.js').ToolManifest | null | undefined} manifest
    */
-  const setToolManifest = async (sessionId, manifest) => {
+  const setToolManifest = (sessionId, manifest) => enqueueSessionOperation(sessionId, async () => {
     const record = await getRecord(sessionId);
     if (!record) throw new SessionNotFoundError(sessionId);
     const { toolManifest: _removed, ...rest } = record;
@@ -405,7 +449,7 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
     const updated = normalized ? { ...rest, toolManifest: normalized } : rest;
     await idb.put(STORE, updated);
     return assemble(updated);
-  };
+  });
 
   /**
    * Persist the session's accumulated cost/usage tally (feature 06).
@@ -415,13 +459,13 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
    * @param {string} sessionId
    * @param {import('../cost/accumulator.js').CostTally} cost
    */
-  const setCost = async (sessionId, cost) => {
+  const setCost = (sessionId, cost) => enqueueSessionOperation(sessionId, async () => {
     const record = await getRecord(sessionId);
     if (!record) throw new SessionNotFoundError(sessionId);
     const updated = { ...record, cost };
     await idb.put(STORE, updated);
     return assemble(updated);
-  };
+  });
 
   /**
    * Set or CLEAR the session's prewalk state (loop/prewalk.js). null removes
@@ -434,7 +478,7 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
    * @param {import('../loop/prewalk.js').PrewalkState | null} state
    * @param {{ provider?: string, model?: string }} [modelPatch]
    */
-  const setPrewalk = async (sessionId, state, modelPatch) => {
+  const setPrewalk = (sessionId, state, modelPatch) => enqueueSessionOperation(sessionId, async () => {
     const record = await getRecord(sessionId);
     if (!record) throw new SessionNotFoundError(sessionId);
     const { prewalk: _removed, ...rest } = record;
@@ -445,7 +489,7 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
     };
     await idb.put(STORE, updated);
     return assemble(updated);
-  };
+  });
 
   /**
    * Persist the session's rolling trim-summary state.
@@ -453,13 +497,13 @@ export const createSessionStore = ({ idb, now = Date.now, makeId }) => {
    * @param {string} sessionId
    * @param {import('../loop/rolling-summary.js').TrimSummaryState} state
    */
-  const setTrimSummary = async (sessionId, state) => {
+  const setTrimSummary = (sessionId, state) => enqueueSessionOperation(sessionId, async () => {
     const record = await getRecord(sessionId);
     if (!record) throw new SessionNotFoundError(sessionId);
     const updated = { ...record, trimSummary: state };
     await idb.put(STORE, updated);
     return assemble(updated);
-  };
+  });
 
   return Object.freeze({
     create,

--- a/extension/peerd-runtime/sessions/types.js
+++ b/extension/peerd-runtime/sessions/types.js
@@ -59,7 +59,7 @@
  * @property {'webvm' | 'notebook' | 'app' | 'web' | 'dweb'} [actorType]  webvm/notebook/app = engine kinds; web = a browser tab OR (DESIGN-18) an API origin; dweb = the mesh operator (global singleton)
  * @property {'tab' | 'api'} [backing]         DESIGN-18: a `web` actor's backing — 'tab' (default; absent = tab) drives a DOM at a MUTABLE origin; 'api' owns ONE FIXED origin, fetch-only, no tab ever
  * @property {import('../actor/origin-lock.js').ActorOriginState} [originState]  issue 251: a TAB-backed web actor's origin authority — ROAMING (browses, owns nothing) or BOUND (owns one credentialed origin), plus the owned origin and the excursion counters. Durable because it IS the authority: losing it across a service-worker eviction turns a bound actor back into an unbounded one. Absent on every kind with no tab.
- * @property {boolean} [review]               issue 160: the review-exemption marker. Set server-side at create() by spawn.js (from the trusted review orchestrator, never a model/worker arg); the offscreen tool-dispatch route re-stamps ctx.exposure='review' from it so the reviewer's three instance reads are admitted on the offscreen path, not just the in-SW fallback.
+ * @property {boolean} [review]               issue 160: the review-exemption marker. Set server-side at create() by spawn.js (from the trusted review orchestrator, never a model/worker arg); the isolated tool-dispatch route re-stamps ctx.exposure='review' from it so the reviewer's three instance reads are admitted on every worker host.
  *
  * Cost/usage telemetry (feature 06). Accumulated client-side from
  * provider `usage` events × the local pricing table. Absent on sessions

--- a/extension/peerd-runtime/tools/defs/actor-create.js
+++ b/extension/peerd-runtime/tools/defs/actor-create.js
@@ -26,7 +26,7 @@ const MAX_RESULT_CHARS = 200 * 1024;
  * @typedef {{
  *   result: string, sessionId: string | null, toolCalls: number,
  *   durationMs: number, depth: number, exceeded?: true, refused?: true,
- *   timedOut?: true, stopped?: true,
+ *   timedOut?: true, stopped?: true, executionFailed?: true, outcomeKnown?: boolean,
  * }} SpawnActorResult
  */
 /**
@@ -153,11 +153,46 @@ export const actorCreateTool = {
     if (typeof sctx.spawnActor !== 'function') {
       return { ok: false, error: 'actor_orchestrator_unavailable' };
     }
-    const out = await sctx.spawnActor(req);
+    let out;
+    try {
+      out = await sctx.spawnActor(req);
+    } catch (error) {
+      const failure = /** @type {{ message?: string, performed?: boolean, outcomeKnown?: boolean, retryable?: boolean }} */ (error);
+      if (failure.outcomeKnown === false) {
+        return {
+          ok: false,
+          error: 'Actor execution failed after work began. Its outcome is unknown. Do not retry automatically. The actor transcript could not be saved reliably.',
+          performed: true,
+          outcomeKnown: false,
+          retryable: false,
+        };
+      }
+      throw error;
+    }
     if (out.refused) {
       // Surface a refusal as an error result so the model sees it clearly
       // and can adjust (e.g. stop trying to recurse deeper).
       return { ok: false, error: out.result };
+    }
+    const outcomeUnknown = out.outcomeKnown === false
+      || (out.executionFailed === true && out.outcomeKnown !== true);
+    if (outcomeUnknown) {
+      return {
+        ok: false,
+        error: formatActorResult(out),
+        performed: true,
+        outcomeKnown: false,
+        retryable: false,
+      };
+    }
+    if (out.executionFailed === true) {
+      return {
+        ok: false,
+        error: formatActorResult(out),
+        performed: false,
+        outcomeKnown: true,
+        retryable: true,
+      };
     }
     return { ok: true, content: formatActorResult(out) };
   },
@@ -170,7 +205,11 @@ const formatActorResult = (out) => {
     const head = result.slice(0, MAX_RESULT_CHARS);
     result = `${head}\n\n…[result truncated at ${MAX_RESULT_CHARS} chars — expand the card in the side panel for the full transcript]`;
   }
-  const flag = out.timedOut ? ' — HIT WALL-CLOCK TIMEOUT, result is partial'
+  const outcomeUnknown = out.outcomeKnown === false
+    || (out.executionFailed === true && out.outcomeKnown !== true);
+  const flag = outcomeUnknown ? ' — EXECUTION FAILED AFTER WORK BEGAN'
+    : out.executionFailed ? ' — FAILED BEFORE TARGET WORK RAN'
+    : out.timedOut ? ' — HIT WALL-CLOCK TIMEOUT, result is partial'
     : out.stopped ? ' — STOPPED before finishing, result is partial'
     : out.exceeded ? ' — HIT STEP CAP, result may be incomplete' : '';
   // why UNTRUSTED (parity with the async path, async-actors.js): the child's
@@ -180,6 +219,9 @@ const formatActorResult = (out) => {
   // relayed can't steer the parent. The sync path fenced nothing before (MED-1).
   const wrapped = wrapUntrusted({ origin: 'spawned', tool: 'actor_create', body: result || '(actor returned no text)' });
   const lines = [
+    ...(outcomeUnknown
+      ? ['Actor execution failed after work began. Its outcome is unknown. Do not retry automatically.', '']
+      : []),
     `actor (session ${out.sessionId}, depth ${out.depth}) — `
       + `${out.toolCalls} tool call${out.toolCalls === 1 ? '' : 's'}, ${out.durationMs}ms${flag}`,
     '',

--- a/extension/peerd-runtime/tools/defs/actor-create.js
+++ b/extension/peerd-runtime/tools/defs/actor-create.js
@@ -203,15 +203,15 @@ const formatActorResult = (out) => {
   let result = out.result ?? '';
   if (result.length > MAX_RESULT_CHARS) {
     const head = result.slice(0, MAX_RESULT_CHARS);
-    result = `${head}\n\n…[result truncated at ${MAX_RESULT_CHARS} chars — expand the card in the side panel for the full transcript]`;
+    result = `${head}\n\n…[result truncated at ${MAX_RESULT_CHARS} chars; expand the card in the side panel for the full transcript]`;
   }
   const outcomeUnknown = out.outcomeKnown === false
     || (out.executionFailed === true && out.outcomeKnown !== true);
-  const flag = outcomeUnknown ? ' — EXECUTION FAILED AFTER WORK BEGAN'
-    : out.executionFailed ? ' — FAILED BEFORE TARGET WORK RAN'
-    : out.timedOut ? ' — HIT WALL-CLOCK TIMEOUT, result is partial'
-    : out.stopped ? ' — STOPPED before finishing, result is partial'
-    : out.exceeded ? ' — HIT STEP CAP, result may be incomplete' : '';
+  const flag = outcomeUnknown ? ': EXECUTION FAILED AFTER WORK BEGAN'
+    : out.executionFailed ? ': FAILED BEFORE TARGET WORK RAN'
+    : out.timedOut ? ': HIT WALL-CLOCK TIMEOUT, result is partial'
+    : out.stopped ? ': STOPPED before finishing, result is partial'
+    : out.exceeded ? ': HIT STEP CAP, result may be incomplete' : '';
   // why UNTRUSTED (parity with the async path, async-actors.js): the child's
   // result is model-authored from a fresh context over possibly page-derived
   // bytes, so it is DATA to the parent, not instructions. Only the one-line

--- a/extension/peerd-runtime/tools/defs/actor-list.js
+++ b/extension/peerd-runtime/tools/defs/actor-list.js
@@ -82,16 +82,17 @@ export const actorListTool = {
   name: 'actor_list',
   primitive: 'spawned',
   description: [
-    'Enumerate EVERY actor you can address with message_actor, in one call.',
+    'Enumerate actor targets in one call. The result includes actor_execution;',
+    'targets are addressable with message_actor only when its status is available.',
     'Returns a row per actor with: type (webvm | notebook | app | tab |',
     'integration), handle (pass it as message_actor `to`), name, live (has a',
     'warm tab / open page right now), current (this chat\'s default of that',
     'type — what an instance op defaults to), and detail (a tab\'s origin, an',
     'integration\'s keyed-ness, an app\'s tags). Use it to decide whether to',
     'reuse an existing instance/tab or spawn fresh, and to find the handle to',
-    'message. (The general "web" actor is always addressable as to:"web" and',
-    'is not listed here; likewise the mesh operator, when enabled, is always',
-    'addressable as to:"dweb". App full-text search is app_search.)',
+    'message. (When actor_execution is available, the general "web" actor is',
+    'addressable as to:"web" and is not listed here; likewise the mesh operator,',
+    'when enabled, is addressable as to:"dweb". App full-text search is app_search.)',
   ].join(' '),
   schema: { type: 'object', properties: {} },
   sideEffect: 'read',
@@ -109,6 +110,7 @@ export const actorListTool = {
      *   listApiIntegrations?: () => Promise<Array<{ origin: string, keyed: boolean, formed: boolean }>>,
      *   denylist?: string[],
      *   session?: { sessionId?: string },
+     *   actorIsolation?: { status: string, host: string|null, reason: string|null, retryable: boolean },
      * }} */ (/** @type {unknown} */ (ctx));
     const sessionId = c.session?.sessionId;
 
@@ -196,6 +198,10 @@ export const actorListTool = {
       structured,
       content: serializeListResult({
         count: actors.length,
+        actor_execution: c.actorIsolation ?? {
+          status: 'unsupported', host: null,
+          reason: 'Actor isolation capability was not provided.', retryable: false,
+        },
         // Tell the agent SOMETHING was withheld so it doesn't loop hunting for a
         // tab it can see in the browser but not here.
         ...(denylistedTabsHidden > 0 ? { denylisted_tabs_hidden: denylistedTabsHidden } : {}),

--- a/extension/peerd-runtime/tools/defs/message-actor.js
+++ b/extension/peerd-runtime/tools/defs/message-actor.js
@@ -25,7 +25,7 @@ const ORCHESTRATOR_AWAIT_CAP_MS = 3 * 60_000;
  * The ctx slot message_actor reads (an SW-injected extra, not on the base
  * ToolContext contract).
  * @typedef {Object} MessageActorCtx
- * @property {(req: { to: string, message: string, senderSessionId?: string|null, inbound?: boolean, toolUseId?: string, oneShot?: boolean, awaitReply?: boolean, awaitSignal?: any, degradeToAsync?: boolean, awaitCapMs?: number }) => Promise<{ ok: boolean, content?: string, error?: string }>} [messageActor]
+ * @property {(req: { to: string, message: string, senderSessionId?: string|null, inbound?: boolean, toolUseId?: string, oneShot?: boolean, awaitReply?: boolean, awaitSignal?: any, degradeToAsync?: boolean, awaitCapMs?: number }) => Promise<{ ok: boolean, content?: string, error?: string, actorDeliveryId?: string }>} [messageActor]
  * @property {{ sessionId?: string, kind?: string }} [session]
  * @property {boolean} [inbound]
  * @property {string} [toolUseId]
@@ -139,9 +139,19 @@ export const messageActorTool = {
       degradeToAsync: args?.await === true && c.session?.kind !== 'spawned',
       awaitCapMs: ORCHESTRATOR_AWAIT_CAP_MS,
     });
-    // Narrow the orchestrator's {ok, content?, error?} into the ToolResult union.
+    // Keep the internal delivery id until the caller's tool-result message is
+    // durably appended. The session store acknowledges the mailbox only after
+    // that commit, closing the crash window without exposing the id to the model.
     return res.ok
-      ? { ok: true, content: res.content ?? 'message delivered' }
-      : { ok: false, error: res.error ?? 'message_actor failed' };
+      ? {
+        ok: true,
+        content: res.content ?? 'message delivered',
+        ...(res.actorDeliveryId ? { actorDeliveryId: res.actorDeliveryId } : {}),
+      }
+      : {
+        ok: false,
+        error: res.error ?? 'message_actor failed',
+        ...(res.actorDeliveryId ? { actorDeliveryId: res.actorDeliveryId } : {}),
+      };
   },
 };

--- a/extension/peerd-runtime/tools/defs/script.js
+++ b/extension/peerd-runtime/tools/defs/script.js
@@ -45,6 +45,8 @@ const MAX_TIMEOUT_MS = 120_000;
  * @property {unknown} [value]
  * @property {boolean} [usedEgress]   the run called peerd.egress.fetch (job-runner)
  * @property {boolean} [usedActors]   the run delegated via the actors client
+ * @property {string[]} [actorDeliveryIds] durable mailbox correlations for
+ *   actor replies consumed by this run; host-only, never part of formatted output
  * @property {boolean} [usedPage]     the run consumed page/DOM/pixel data through page.*
  * @property {Array<{ data: string, mediaType: string }>} [images] host-captured page images (bounded by job-runner)
  * @property {boolean} [usedWorkspace]   the job was workspace-mounted (host-set, never inferred from ops)
@@ -181,6 +183,22 @@ export const scriptTool = {
       : clamp(args.timeoutMs ?? DEFAULT_TIMEOUT_MS, 1000, MAX_TIMEOUT_MS);
     /** @type {string | undefined} */
     let runId;
+    // A script can consume several actor replies. Custody follows the complete
+    // set into the one outer ToolResult that will be committed to history.
+    // Keep a host-owned union with the SW mirror so an offscreen transport loss
+    // after an actor reply cannot orphan its acknowledgement.
+    /** @type {Set<string>} */
+    const actorDeliveryIds = new Set();
+    const addActorDeliveryIds = (/** @type {unknown} */ ids) => {
+      if (!Array.isArray(ids)) return;
+      for (const id of ids) if (typeof id === 'string' && id) actorDeliveryIds.add(id);
+    };
+    const custody = () => actorDeliveryIds.size > 0
+      ? { actorDeliveryIds: [...actorDeliveryIds] }
+      : {};
+    const mirroredOps = () => runId && c.scriptRuns && 'opsFor' in c.scriptRuns
+      ? /** @type {{ opsFor: (id: string) => Array<any> }} */ (/** @type {unknown} */ (c.scriptRuns)).opsFor(runId)
+      : [];
     /** @type {(() => void) | undefined} */
     let onAbort;
     try {
@@ -233,11 +251,14 @@ export const scriptTool = {
         });
       }
       const result = await jsOffscreenClient.execHeadless(args.code, opts);
+      addActorDeliveryIds(result.actorDeliveryIds);
+      addActorDeliveryIds(mirroredOps().map((op) => op?.actorDeliveryId));
       const importPolicyMessage = moduleImportPolicyMessage(result.errorCode);
       if (importPolicyMessage) {
         return {
           ok: false,
           error: `${result.errorCode}: ${importPolicyMessage}`,
+          ...custody(),
         };
       }
       // Value spill (run cache): when the serialized [VALUE] overflows its cap,
@@ -271,16 +292,15 @@ export const scriptTool = {
       if (oncePerSession(sid, 'js-pitfalls')) {
         content += `\n\n${JS_PITFALLS_NOTE}\n\n${SCRIPT_BUILTINS_NOTE}`;
       }
-      return { ok: true, content };
+      return { ok: true, content, ...custody() };
     } catch (e) {
       const err = /** @type {{ name?: string, message?: string }} */ (e);
       // The offscreen heap died mid-run (doc evicted / channel death) — the
       // worker-held trace died with it, but the SW-side mirror survived:
       // report which delegations were already dispatched so the orchestrator
       // doesn't blind-re-send goals actors may have already acted on.
-      const mirrored = runId && c.scriptRuns && 'opsFor' in c.scriptRuns
-        ? /** @type {{ opsFor: (id: string) => Array<any> }} */ (/** @type {unknown} */ (c.scriptRuns)).opsFor(runId)
-        : [];
+      const mirrored = mirroredOps();
+      addActorDeliveryIds(mirrored.map((op) => op?.actorDeliveryId));
       const dispatched = mirrored.length
         ? `\n[DELEGATIONS dispatched before the failure]\n${renderTraceLines(mirrored).join('\n')}`
         : '';
@@ -300,9 +320,14 @@ export const scriptTool = {
         return {
           ok: false,
           error: `script_failed: actor orchestration transport failed${dispatched}\n${fenced}`,
+          ...custody(),
         };
       }
-      return { ok: false, error: `script_failed: ${err?.name ?? 'Error'}: ${err?.message ?? String(e)}` };
+      return {
+        ok: false,
+        error: `script_failed: ${err?.name ?? 'Error'}: ${err?.message ?? String(e)}`,
+        ...custody(),
+      };
     } finally {
       // Release ABORTS first (script-runs.js): any ask still pending SW-side
       // is an orphan whose actor turn dies with the run — the non-Stop exits

--- a/extension/peerd-runtime/tools/dispatcher.js
+++ b/extension/peerd-runtime/tools/dispatcher.js
@@ -545,11 +545,24 @@ export const dispatchToolCall = async (call, ctx) => {
         outcomeKind: /** @type {{ outcomeKind?: any }} */ (result)?.outcomeKind,
       }).catch(() => null);
     }
-    // A rewrite replaces the failure shape wholesale (it only ever fires on
-    // an already-failed result) so the discriminated ok:false stays literal.
+    // A rewrite replaces the model-facing failure shape, but custody metadata
+    // is not presentation. An awaited actor reply may already exist and its
+    // mailbox row cannot be acknowledged unless these host-only ids reach the
+    // durable tool-result block.
+    const actorDeliveryId = typeof result?.actorDeliveryId === 'string'
+      ? result.actorDeliveryId : undefined;
+    const actorDeliveryIds = Array.isArray(result?.actorDeliveryIds)
+      ? [...new Set(result.actorDeliveryIds.filter(
+        (id) => typeof id === 'string' && id.length > 0))]
+      : [];
     /** @type {ToolResult} */
     const settled = recoveryRewrite
-      ? { ok: false, error: recoveryRewrite.error }
+      ? {
+        ok: false,
+        error: recoveryRewrite.error,
+        ...(actorDeliveryId ? { actorDeliveryId } : {}),
+        ...(actorDeliveryIds.length > 0 ? { actorDeliveryIds } : {}),
+      }
       : result;
     /** @type {ToolResult} */
     const enriched = {

--- a/extension/peerd-runtime/tools/exposure.js
+++ b/extension/peerd-runtime/tools/exposure.js
@@ -309,9 +309,9 @@ export const actorTargetIdField = (name) =>
  * a possibly-injected worker — supplied), and lock edit_file to the actor's kind.
  * The gate's pin check is the defense-in-depth backstop; this is the
  * normalization that makes it pass. Mutates call.args in place. Pure logic,
- * shared by the in-SW actor turn (turn-driver) AND the offscreen actor tool
- * relay (SW re-pins the worker's call — never trusts it). Moved here from
- * turn-driver so both use ONE implementation (no drift on a security seam).
+ * shared by every dedicated-worker host. The privileged relay re-pins the
+ * worker's call and never trusts it. One implementation prevents drift at this
+ * security seam.
  * @param {any} call @param {string|undefined} actorType @param {string|undefined} instanceId
  */
 export const pinActorCall = (call, actorType, instanceId) => {

--- a/extension/peerd-runtime/tools/gates.js
+++ b/extension/peerd-runtime/tools/gates.js
@@ -52,6 +52,7 @@ import {
   DEFAULT_CONFIRM_ACTIONS,
   normalizeMode,
 } from '../permissions/index.js';
+import { ACTOR_ISOLATION_UNAVAILABLE_TOOLS, actorIsolationAvailable } from '../actor/isolation.js';
 
 /** @typedef {import('/shared/tool-types.js').Tool} Tool */
 /** @typedef {import('/shared/tool-types.js').ToolContext} ToolContext */
@@ -73,6 +74,7 @@ import {
  *   actorType?: string,
  *   backing?: 'tab' | 'api',
  *   actorSurface?: 'tools' | 'code',
+ *   actorIsolation?: import('../actor/isolation.js').ActorIsolationCapability,
  * }} GateContext
  */
 
@@ -225,6 +227,11 @@ export const actorTierGate = (tool, args, ctx) => {
  * @returns {Omit<GateResult, 'name'>}
  */
 export const exposureGate = (tool, args, ctx) => {
+  if (ctx?.actorIsolation
+      && !actorIsolationAvailable(ctx.actorIsolation)
+      && ACTOR_ISOLATION_UNAVAILABLE_TOOLS.has(tool.name)) {
+    return { allowed: false, reason: `actor isolation ${ctx.actorIsolation.status}: '${tool.name}' was not run` };
+  }
   if (ctx?.exposure === 'main') {
     if (isHiddenFromMain(tool.name)) {
       return { allowed: false, reason: `'${tool.name}' is actor-only — message a tab's actor to reach the page` };

--- a/extension/shared/tool-types.js
+++ b/extension/shared/tool-types.js
@@ -97,6 +97,11 @@
  * @property {any} [structured]        optional host-only structured twin of a
  *   presentation-oriented `content` string. The model loop ignores it; trusted
  *   relays may consume it without parsing human-formatted text.
+ * @property {string} [actorDeliveryId] internal durable mailbox correlation.
+ *   Preserved into the persisted tool-result block and removed from the mailbox
+ *   only after that message commits. Provider formatters ignore this field.
+ * @property {string[]} [actorDeliveryIds] internal durable mailbox correlations
+ *   for a tool that consumed multiple actor replies, such as script.
  */
 
 /**
@@ -112,6 +117,10 @@
  *   failed stamps this so the recovery decision is deterministic instead of
  *   string-matched. Optional — unstamped failures take the heuristic path.
  * @property {ToolMeta} [meta]
+ * @property {string} [actorDeliveryId] internal durable mailbox correlation;
+ *   never serialized to a provider.
+ * @property {string[]} [actorDeliveryIds] internal durable mailbox correlations;
+ *   never serialized to a provider.
  */
 
 /** @typedef {ToolResultOk | ToolResultErr} ToolResult */

--- a/extension/sidepanel/chat-reducer.js
+++ b/extension/sidepanel/chat-reducer.js
@@ -25,7 +25,7 @@
  * @property {string} [thinking]
  * @property {boolean} [streaming]
  * @property {boolean} [synthetic]
- * @property {{ kind: string, instanceId: string, name?: string, failed?: boolean }} [actorReply]
+ * @property {{ kind: string, instanceId: string, name?: string, failed?: boolean, outcomeKnown?: boolean, performed?: boolean }} [actorReply]
  * @property {string} [stopReason]
  * @property {string} [error]
  * @property {unknown[]} [toolResults]
@@ -83,6 +83,7 @@
  * @property {{ initialized: boolean, locked: boolean, unlockedAt: number, prfEnrolled: boolean, hasRecovery: boolean }} vault
  * @property {SessionState} session
  * @property {{ current: string, hasKey: boolean, model: string }} providers
+ * @property {{ actorExecution?: { status: string, host: string|null, reason: string|null, retryable: boolean } }} [capabilities]
  * @property {{ id: string, peerName: string, onboardingComplete: boolean }} profile
  * @property {SettingsState} settings
  * @property {any} pendingConfirm
@@ -95,7 +96,7 @@
  * @property {ReadonlyArray<any>} agentTabEvents
  * @property {Readonly<Record<string, { stdout: string, stderr: string }>>} vmStreams
  * @property {{ byToolUse: Record<string, string>, sessions: Record<string, SpawnedSession> }} spawned
- * @property {Readonly<Record<string, { sessionId?: string, kind?: string, instanceId?: string, name?: string, fromIndex?: number, messages?: any[], streaming?: boolean, error?: string|null, aborted?: boolean, cost?: any }>>} actors
+ * @property {Readonly<Record<string, { sessionId?: string, kind?: string, instanceId?: string, name?: string, fromIndex?: number, messages?: any[], streaming?: boolean, error?: string|null, aborted?: boolean, outcomeKnown?: boolean, cost?: any }>>} actors
  * @property {Record<string, Array<{ seq: number, method: string, to?: string, goalPreview?: string, phase: string, ms?: number|null, failed?: boolean, cancelled?: boolean }>>} scriptOps  live delegation feed per script toolUseId
  * @property {Readonly<Record<string, unknown>>} asyncTasks
  * @property {Readonly<Record<string, { active: boolean, sessionId: string, iteration: number, maxIterations: number, goal: string, phase: string, summary: string|null }>>} goalRuns
@@ -408,7 +409,11 @@ export const reduceChat = (state, msg) => {
       return putActorCard(state, /** @type {string} */ (msg.parentToolUseId), { ...seed, messages });
     }
     case 'turn/actor-error':
-      return putActorCard(state, /** @type {string} */ (msg.parentToolUseId), { error: msg.error, streaming: false });
+      return putActorCard(state, /** @type {string} */ (msg.parentToolUseId), {
+        error: msg.error,
+        streaming: false,
+        ...(msg.outcomeKnown === false ? { outcomeKnown: false } : {}),
+      });
     case 'turn/actor-done': {
       // An ABORT (Stop cascade) → 'cancelled' card; a clean failure with no error
       // already folded → mark failed; else just stop the spinner. Short-circuit when

--- a/extension/sidepanel/components/actor-isolation-banner.js
+++ b/extension/sidepanel/components/actor-isolation-banner.js
@@ -1,0 +1,80 @@
+// @ts-check
+
+import m from '/vendor/mithril/mithril.js';
+
+/** @typedef {(msg: object) => Promise<any>} Send */
+
+// Persistent capability failure. It is not dismissible because hiding it would
+// leave both the user and model with a false picture of what peerd can do.
+export const ActorIsolationBanner = {
+  /** @param {{ state: { retrying?: boolean, retryFailed?: boolean, retryRequested?: boolean, recoveryAnnounced?: boolean, recoveryDismissed?: boolean }, attrs: { capability?: { status?: string, reason?: string|null, retryable?: boolean }, send: Send } }} vnode */
+  view(vnode) {
+    const { capability, send } = vnode.attrs;
+    if (!capability) return null;
+    if (capability.status === 'available') {
+      if (!vnode.state.retryRequested || vnode.state.recoveryDismissed) return null;
+      const focusRecovery = (/** @type {{ dom: HTMLElement }} */ recoveryVnode) => {
+        if (vnode.state.recoveryAnnounced) return;
+        vnode.state.recoveryAnnounced = true;
+        recoveryVnode.dom.focus();
+      };
+      return m('.actor-isolation-banner.is-recovered', {
+        tabindex: '-1',
+        oncreate: focusRecovery,
+        onupdate: focusRecovery,
+        onblur: () => {
+          vnode.state.recoveryDismissed = true;
+          m.redraw();
+        },
+      }, m('.actor-isolation-copy', [
+        m('strong', 'Actor work is ready'),
+        m('span', 'The isolated worker is available again.'),
+      ]));
+    }
+    const temporary = capability.status === 'temporarily_unavailable';
+    const retrying = vnode.state.retrying === true;
+    const retryFailed = vnode.state.retryFailed === true;
+    const retry = async () => {
+      if (vnode.state.retrying === true) return;
+      vnode.state.retrying = true;
+      vnode.state.retryFailed = false;
+      vnode.state.retryRequested = true;
+      vnode.state.recoveryAnnounced = false;
+      vnode.state.recoveryDismissed = false;
+      // why: render the busy and disabled state before a fast worker probe can
+      // resolve, so repeated clicks and assistive technology see the transition.
+      m.redraw.sync();
+      try {
+        const response = await send({ type: 'actor-isolation/retry' });
+        if (response?.capability && capability) Object.assign(capability, response.capability);
+        else vnode.state.retryFailed = true;
+      }
+      catch { vnode.state.retryFailed = true; }
+      finally { vnode.state.retrying = false; m.redraw(); }
+    };
+    return m('.actor-isolation-banner', {
+      role: 'status',
+      'aria-live': 'polite',
+      'aria-atomic': 'true',
+      'aria-busy': String(retrying),
+    }, [
+      m('.actor-isolation-copy', [
+        m('strong', temporary
+          ? retryFailed ? 'Actor work is still paused' : 'Actor work is paused'
+          : 'Actors are unavailable'),
+        m('span', temporary
+          ? retryFailed
+            ? 'Actor execution could not be restored. Try again in a moment. If it keeps failing, restart the browser, then use Try again.'
+            : 'Actor execution is paused because its isolation state could not be confirmed. Use Try again before retrying an actor request.'
+          : 'This browser could not create the isolated worker actors require. Actor requests will not run.'),
+      ]),
+      temporary && capability.retryable
+        ? m('button.secondary', {
+            type: 'button',
+            disabled: retrying,
+            onclick: retry,
+          }, retrying ? 'Retrying actor worker…' : 'Try again')
+        : null,
+    ]);
+  },
+};

--- a/extension/sidepanel/components/app.js
+++ b/extension/sidepanel/components/app.js
@@ -10,6 +10,7 @@ import m from '/vendor/mithril/mithril.js';
 import { VaultGate } from './vault-gate.js';
 import { ChatView } from './chat-view.js';
 import { SessionsView } from './sessions-view.js';
+import { ActorIsolationBanner } from './actor-isolation-banner.js';
 import { openOptions } from '/shared/open-options.js';
 import { openHome } from '/shared/open-home.js';
 import { CHANNEL } from '/shared/channel-config.js';
@@ -60,10 +61,14 @@ export const App = {
     const notices = unlocked && state.notices?.length
       ? m(NoticeBar, { notices: state.notices, uiActions })
       : null;
+    const actorIsolation = unlocked
+      ? m(ActorIsolationBanner, { capability: state.capabilities?.actorExecution, send })
+      : null;
 
     return m('div', { class: 'app-shell' }, [
       unlocked ? m(TopBar, { state, send, optionsActive }) : null,
       notices,
+      actorIsolation,
       m('.body', unlocked
         ? [
             view === 'chat'   ? m(ChatView, { state, send, voiceManager, uiActions, surface: 'sidepanel', activeTabIsWeb })

--- a/extension/sidepanel/components/chat-view.js
+++ b/extension/sidepanel/components/chat-view.js
@@ -42,6 +42,9 @@ const saveJsonFile = (payload, filename) => {
  * @typedef {Object} ChatViewState
  * @property {boolean} goalArmed             the Goal toggle's arm state (UI-only)
  * @property {string|null|undefined} _sid    which chat the arm state belongs to
+ * @property {boolean} hadMessages           whether this chat already mounted a transcript
+ * @property {boolean} hasObservedSession    whether initial session hydration has completed
+ * @property {Map<string|undefined, Set<string>>} seenRecoveryIdsBySession recovery announcements already heard per chat
  * @property {boolean} [debugMenuOpen]       the debug-export flyout's open state
  * @property {boolean} [inspectorOpen]       the context-inspector modal's open state
  * @property {Array<Record<string, any>>|null} [snapshots]  the inspector's fetched snapshots (null = loading)
@@ -64,14 +67,21 @@ export const ChatView = {
     // InputBar's per-session draft swap.
     vnode.state.goalArmed = false;
     vnode.state._sid = vnode.attrs.state?.session?.sessionId;
+    vnode.state.hadMessages = (vnode.attrs.state?.session?.messages?.length ?? 0) > 0;
+    vnode.state.hasObservedSession = vnode.state._sid != null;
+    vnode.state.seenRecoveryIdsBySession = new Map();
   },
 
   /** @param {ChatViewVnode} vnode */
   view: ({ attrs: { state, send, voiceManager, uiActions, surface, activeTabIsWeb }, state: ui }) => {
     const sid = state.session?.sessionId;
+    const messages = state.session?.messages ?? [];
+    const changedSession = sid !== ui._sid;
+    const isUserVisibleSwitch = changedSession && ui.hasObservedSession && sid != null;
     if (sid !== ui._sid) {
       ui._sid = sid;
       ui.goalArmed = false;
+      ui.hadMessages = messages.length > 0;
       // The debug surface is per-session UI: a flyout or inspector left open
       // on chat A must not survive a switch to chat B (B would silently show
       // A's snapshots).
@@ -79,7 +89,10 @@ export const ChatView = {
       ui.inspectorOpen = false;
       ui.snapshots = null;
     }
-    const messages = state.session?.messages ?? [];
+    if (sid != null) ui.hasObservedSession = true;
+    const announceOnMount = messages.length > 0
+      && (isUserVisibleSwitch || !ui.hadMessages);
+    if (messages.length > 0) ui.hadMessages = true;
     const hasKey = state.providers?.hasKey;
     // Fingerprint of the settings that shape the model-picker options. The
     // side panel gets live settings pushes (e.g. editing the OpenRouter
@@ -154,8 +167,14 @@ export const ChatView = {
 
       showVoiceOnboarding ? m(VoiceOnboardingCard, { send }) : null,
 
-      messages.length === 0 ? m(EmptyState, { hasKey, send, surface, activeTabIsWeb })
+      messages.length === 0 ? m(EmptyState, {
+        hasKey, send, surface, activeTabIsWeb,
+        actorExecution: state.capabilities?.actorExecution,
+      })
         : m(MessageList, {
+            sessionId: state.session?.sessionId,
+            announceOnMount,
+            seenRecoveryIdsBySession: ui.seenRecoveryIdsBySession,
             messages,
             vmStreams: state.vmStreams,
             // The AI peer's display name (default profile, set during
@@ -521,7 +540,7 @@ export const PATH_TYPE = { ms: 18, start: 980, cascade: 90 };
  * @property {boolean[]} started
  */
 
-/** @typedef {{ state: EmptyState_State, attrs: { hasKey?: boolean, send: Send, surface?: string, activeTabIsWeb?: boolean } }} EmptyStateVnode */
+/** @typedef {{ state: EmptyState_State, attrs: { hasKey?: boolean, send: Send, surface?: string, activeTabIsWeb?: boolean, actorExecution?: { status?: string } } }} EmptyStateVnode */
 
 // Arm the one-shot type-in (step 3) for every card. Idempotent via
 // `ui.armed`, so the redraw-driven onupdate can't re-trigger it; only runs
@@ -597,6 +616,7 @@ const EmptyState = {
       ? m('.path-menu', { class: isHome ? 'path-menu--home' : '' }, prompts.map((p, i) => {
           const shown = ui.shown?.[i] ?? Infinity;
           const done = shown >= p.text.length;
+          const actorUnavailable = attrs.actorExecution && attrs.actorExecution.status !== 'available' && p.type !== 'ask';
           // cursor shows only once this tile has STARTED typing and isn't done
           const typing = (ui.started?.[i] ?? true) && !done;
           return m('button.path-card', {
@@ -605,9 +625,12 @@ const EmptyState = {
             // hexes in JS). The glyph + label carry that color permanently;
             // the tile background + outline stay grey.
             'data-path': p.type,
-            title: p.text,
+            title: actorUnavailable ? 'Unavailable until the isolated actor worker recovers' : p.text,
             // a11y reads the full prompt even mid-type
-            'aria-label': `${p.label}: ${p.text}`,
+            'aria-label': actorUnavailable
+              ? `${p.label}: unavailable while actor work is paused`
+              : `${p.label}: ${p.text}`,
+            disabled: actorUnavailable,
             // Fire-and-forget: the SW pushes turn state, which flips the
             // view out of the empty state into the live transcript.
             onclick: () => send({ type: 'agent/send', text: p.text }),

--- a/extension/sidepanel/components/message-list.js
+++ b/extension/sidepanel/components/message-list.js
@@ -26,8 +26,27 @@ import m from '/vendor/mithril/mithril.js';
 import { renderMarkdown } from '/shared/markdown.js';
 import { stripUntrustedFences } from '/shared/util.js';
 import {
-  ACTOR_CREDENTIAL_BOUNDARY_USER_FAILURE, classifyFailure, formatBytes,
+  ACTOR_CREDENTIAL_BOUNDARY_USER_FAILURE, ACTOR_ISOLATION_TEMPORARY_USER_FAILURE,
+  ACTOR_ISOLATION_UNSUPPORTED_USER_FAILURE, classifyFailure, formatBytes,
 } from '/peerd-runtime/index.js';
+
+/** @param {string} text @returns {string|null} */
+const actorUserFailure = (text) => {
+  if (/actor-provider-boundary-blocked|model request was not run/i.test(text)) {
+    return ACTOR_CREDENTIAL_BOUNDARY_USER_FAILURE;
+  }
+  if (/actor_isolation_temporarily_unavailable|isolated worker is temporarily unavailable/i.test(text)) {
+    return ACTOR_ISOLATION_TEMPORARY_USER_FAILURE;
+  }
+  if (/actor_isolation_unavailable|cannot provide the required isolated worker/i.test(text)) {
+    return ACTOR_ISOLATION_UNSUPPORTED_USER_FAILURE;
+  }
+  return null;
+};
+
+/** @param {string} _text @returns {string} */
+const actorOutcomeUnknownFailure = (_text) =>
+  'peerd cannot confirm whether the actor ran or completed. Check the target before trying again.';
 
 /** @typedef {import('../chat-reducer.js').ChatMessage} ChatMessage */
 /** @typedef {import('../chat-reducer.js').SpawnedSession} SpawnedSession */
@@ -76,6 +95,9 @@ import {
  * @property {number} [depth]
  * @property {TabEvent[]} [tabEvents]
  * @property {UiActions} [uiActions]
+ * @property {string} [sessionId]
+ * @property {boolean} [announceOnMount]
+ * @property {Map<string|undefined, Set<string>>} [seenRecoveryIdsBySession]
  */
 
 // Auto-scroll heuristic: if the user is reading near the bottom, keep
@@ -157,18 +179,141 @@ const renderTranscript = ({ messages, vmStreams, spawned, actors, scriptOps, loa
   return out;
 };
 
+/** @param {ChatMessage} message @returns {Array<{ id: string, announcement: string }>} */
+const recoveryReceiptsForMessage = (message) => {
+  /** @type {Array<{ id: string, announcement: string }>} */
+  const receipts = [];
+  const messageId = typeof message.id === 'string' ? message.id : null;
+  if (message.actorReply?.outcomeKnown === false) {
+    if (messageId) receipts.push({
+      id: `${messageId}:actor-reply`,
+      announcement: 'Actor outcome unknown. Check the target before trying again.',
+    });
+  } else if (message.actorReply?.performed === false) {
+    if (messageId) receipts.push({
+      id: `${messageId}:actor-reply`,
+      announcement: 'Actor request not run. Re-issue it if it still matters.',
+    });
+  }
+  for (const rawResult of Array.isArray(message.toolResults) ? message.toolResults : []) {
+    const result = /** @type {any} */ (rawResult);
+    const content = typeof result?.content === 'string'
+      ? result.content
+      : JSON.stringify(result?.content ?? '');
+    if (result?.is_error === true
+      && /outcome is unknown|outcome unknown/i.test(content)
+      && messageId
+      && typeof result?.tool_use_id === 'string') {
+      receipts.push({
+        id: `${messageId}:tool-result:${result.tool_use_id}`,
+        announcement: 'Actor outcome unknown. Check the target before trying again.',
+      });
+    }
+  }
+  return receipts;
+};
+
+/** @param {ChatMessage[]|undefined} messages */
+const recoveryReceipts = (messages) => (messages ?? []).flatMap(recoveryReceiptsForMessage);
+
+/** @param {any} state @param {string} announcement */
+const replaceRecoveryAnnouncement = (state, announcement) => {
+  if (state.recoveryAnnouncementTimer) {
+    clearTimeout(state.recoveryAnnouncementTimer);
+    state.recoveryAnnouncementTimer = null;
+  }
+  state.recoveryAnnouncement = announcement;
+};
+
+/** @param {any} state */
+const scheduleRecoveryAnnouncementClear = (state) => {
+  const announced = state.recoveryAnnouncement;
+  if (!announced || state.recoveryAnnouncementTimer) return;
+  state.recoveryAnnouncementTimer = setTimeout(() => {
+    state.recoveryAnnouncementTimer = null;
+    if (state.recoveryAnnouncement === announced) {
+      state.recoveryAnnouncement = '';
+      m.redraw();
+    }
+  }, 1_000);
+};
+
 export const MessageList = {
+  /** @param {{ attrs: TranscriptArgs, state: any }} vnode */
+  oninit(vnode) {
+    vnode.state.sessionId = vnode.attrs.sessionId;
+    // Existing history on the initial mount is a visual receipt, not a new
+    // alert. Keep the baseline per session after that: a receipt first
+    // encountered when the user switches chats is new to this surface and must
+    // be announced, while switching back must not announce it again.
+    vnode.state.seenRecoveryIdsBySession = vnode.attrs.seenRecoveryIdsBySession ?? new Map();
+    const receipts = recoveryReceipts(vnode.attrs.messages);
+    const existing = vnode.state.seenRecoveryIdsBySession.get(vnode.attrs.sessionId);
+    const fresh = existing
+      ? receipts.filter((receipt) => !existing.has(receipt.id))
+      : vnode.attrs.announceOnMount ? receipts : [];
+    const seen = existing ?? new Set();
+    for (const receipt of receipts) seen.add(receipt.id);
+    vnode.state.seenRecoveryIdsBySession.set(vnode.attrs.sessionId, seen);
+    vnode.state.recoveryAnnouncement = fresh.map((receipt) => receipt.announcement).join(' ');
+    vnode.state.recoveryAnnouncementTimer = null;
+  },
+  /** @param {{ attrs: TranscriptArgs, state: any }} vnode */
+  onbeforeupdate(vnode) {
+    if (vnode.state.sessionId !== vnode.attrs.sessionId) {
+      vnode.state.sessionId = vnode.attrs.sessionId;
+      const receipts = recoveryReceipts(vnode.attrs.messages);
+      const existing = vnode.state.seenRecoveryIdsBySession.get(vnode.attrs.sessionId);
+      const fresh = existing
+        ? receipts.filter((receipt) => !existing.has(receipt.id))
+        : receipts;
+      const seen = existing ?? new Set();
+      for (const receipt of receipts) seen.add(receipt.id);
+      vnode.state.seenRecoveryIdsBySession.set(vnode.attrs.sessionId, seen);
+      replaceRecoveryAnnouncement(vnode.state, fresh
+        .map((receipt) => receipt.announcement)
+        .join(' '));
+      return true;
+    }
+    const seen = vnode.state.seenRecoveryIdsBySession.get(vnode.attrs.sessionId) ?? new Set();
+    const receipts = recoveryReceipts(vnode.attrs.messages);
+    const fresh = receipts.filter((receipt) => !seen.has(receipt.id));
+    for (const receipt of receipts) seen.add(receipt.id);
+    vnode.state.seenRecoveryIdsBySession.set(vnode.attrs.sessionId, seen);
+    if (fresh.length > 0) {
+      replaceRecoveryAnnouncement(vnode.state, fresh
+        .map((receipt) => receipt.announcement)
+        .join(' '));
+    }
+    return true;
+  },
   // Initial mount: jump to the bottom so existing-session render starts
   // with the latest turn visible, not the first message.
-  /** @param {{ dom: HTMLElement }} vnode */
-  oncreate(vnode) { vnode.dom.scrollTop = vnode.dom.scrollHeight; },
-  /** @param {{ dom: HTMLElement }} vnode */
-  onupdate(vnode) { scrollIfNearBottom(vnode.dom); },
+  /** @param {{ dom: HTMLElement, state: any }} vnode */
+  oncreate(vnode) {
+    vnode.dom.scrollTop = vnode.dom.scrollHeight;
+    scheduleRecoveryAnnouncementClear(vnode.state);
+  },
+  /** @param {{ dom: HTMLElement, state: any }} vnode */
+  onupdate(vnode) {
+    scrollIfNearBottom(vnode.dom);
+    scheduleRecoveryAnnouncementClear(vnode.state);
+  },
+  /** @param {{ state: any }} vnode */
+  onremove(vnode) {
+    if (vnode.state.recoveryAnnouncementTimer) clearTimeout(vnode.state.recoveryAnnouncementTimer);
+  },
 
-  /** @param {{ attrs: TranscriptArgs }} vnode */
-  view: ({ attrs: { messages, vmStreams, spawned, actors, scriptOps, loadActor, peerName, tabEvents, uiActions } }) =>
-    m('.message-list',
-      renderTranscript({ messages, vmStreams, spawned, actors, scriptOps, loadActor, peerName, depth: 0, tabEvents, uiActions })),
+  /** @param {{ attrs: TranscriptArgs, state: any }} vnode */
+  view: ({ attrs: { messages, vmStreams, spawned, actors, scriptOps, loadActor, peerName, tabEvents, uiActions }, state }) =>
+    m('.message-list', [
+      renderTranscript({ messages, vmStreams, spawned, actors, scriptOps, loadActor, peerName, depth: 0, tabEvents, uiActions }),
+      state.recoveryAnnouncement
+        ? m('span.sr-only.actor-recovery-announcement', {
+            role: 'status', 'aria-live': 'polite', 'aria-atomic': 'true',
+          }, state.recoveryAnnouncement)
+        : null,
+    ]),
 };
 
 // Inline "peerd opened a tab" notice — anchored at the turn it happened so it
@@ -296,9 +441,12 @@ const ActorReplyMessage = {
     // Drop replyText()'s one-line lead ("The <kind> actor … has replied:") —
     // the role label above the bubble already says who this is.
     const body = content.includes('\n\n') ? content.slice(content.indexOf('\n\n') + 2) : content;
-    const notRun = reply.failed === true
-      && /actor-provider-boundary-blocked|model request was not run/i.test(body);
-    const displayBody = notRun ? ACTOR_CREDENTIAL_BOUNDARY_USER_FAILURE : body;
+    const userFailure = reply.failed === true ? actorUserFailure(body) : null;
+    const outcomeUnknown = reply.outcomeKnown === false;
+    const notRun = !outcomeUnknown && (reply.performed === false || userFailure !== null);
+    const displayBody = outcomeUnknown
+      ? actorOutcomeUnknownFailure(body)
+      : (userFailure ?? body);
     // A `via:'script'` reply came from a fire-and-forget delegation inside an
     // earlier script run — it can land minutes later, so name its origin or the
     // bubble is unexplainable to a user who never saw the fan-out happen.
@@ -307,10 +455,10 @@ const ActorReplyMessage = {
       m('.role', [
         label,
         via === 'script' ? ' · delegated by an earlier script' : '',
-        reply.failed ? ` · ${notRun ? 'Not run' : 'failed'}` : '',
+        reply.failed ? ` · ${outcomeUnknown ? 'Outcome unknown' : notRun ? 'Not run' : 'failed'}` : '',
       ]),
       m('.bubble', renderText(stripUntrustedFences(displayBody))),
-    ]);
+      ]);
   },
 };
 
@@ -646,13 +794,15 @@ const ToolCall = {
 const renderSpawnedCard = ({ toolUse, toolResult, interrupted, spawned, actors, loadActor, peerName, depth, ui }) => {
   const meta = toolResult?.meta ?? null;
   const status = toolResult ? (toolResult.is_error ? 'failed' : 'ok') : (interrupted ? 'cancelled' : 'pending');
+  const resultText = toolResult ? formatResultContent(toolResult) : '';
+  const outcomeUnknown = status === 'failed' && /outcome is unknown|outcome unknown/i.test(resultText);
   const childId = resolveChildSessionId(toolUse, toolResult, spawned);
   const childSession = childId ? spawned?.sessions?.[childId] : null;
   const task = childSession?.task ?? toolUse.input?.task ?? '';
   const tooDeep = depth + 1 > MAX_NESTED_DEPTH;
   const terminalLabel = status === 'pending' ? 'running…'
     : status === 'cancelled' ? 'cancelled'
-    : status === 'failed' ? 'failed'
+    : status === 'failed' ? (outcomeUnknown ? 'Outcome unknown' : 'failed')
     : 'done';
 
   const onToggle = () => {
@@ -668,7 +818,7 @@ const renderSpawnedCard = ({ toolUse, toolResult, interrupted, spawned, actors, 
     }, [
       m('span.disclosure', ui.expanded ? '▼' : '▶'),
       m(`span.tool-status-dot.dot-${status}`,
-        { title: status === 'failed' ? 'failed' : status === 'pending' ? 'running' : status === 'cancelled' ? 'cancelled' : 'ok' }),
+        { title: status === 'failed' ? (outcomeUnknown ? 'outcome unknown' : 'failed') : status === 'pending' ? 'running' : status === 'cancelled' ? 'cancelled' : 'ok' }),
       m('span.tool-name', 'actor_create'),
       m('span.tool-args', `"${truncate(String(task), 48)}"`),
       m('.spacer'),
@@ -677,7 +827,9 @@ const renderSpawnedCard = ({ toolUse, toolResult, interrupted, spawned, actors, 
     ]),
     ui.expanded ? m('.actor-body', [
       status === 'failed' && toolResult
-        ? m('p.error-line', formatResultContent(toolResult))
+        ? m('p.error-line', outcomeUnknown
+          ? actorOutcomeUnknownFailure(resultText)
+          : formatResultContent(toolResult))
         : null,
       tooDeep
         ? m('p.muted', `nested ${MAX_NESTED_DEPTH} levels deep — deeper transcripts are inspectable via session navigation`)
@@ -686,7 +838,9 @@ const renderSpawnedCard = ({ toolUse, toolResult, interrupted, spawned, actors, 
               renderTranscript({ messages: childSession.messages, spawned, actors, loadActor, peerName, depth: depth + 1 }))
           : childId
             ? m('p.muted', status === 'pending' ? 'actor running…' : status === 'cancelled' ? 'actor cancelled' : 'loading transcript…')
-            : m('p.muted', 'no child transcript recorded'),
+            : m('p.muted', outcomeUnknown
+              ? 'No reliable actor transcript is available.'
+              : 'no child transcript recorded'),
     ]) : null,
   ]);
 };
@@ -721,9 +875,13 @@ const renderActorCard = ({ toolUse, toolResult, interrupted, actors, spawned, lo
     : card ? 'ok'
     : (toolResult ? (toolResult.is_error ? 'failed' : 'ok') : (interrupted ? 'cancelled' : 'pending'));
   const resultText = toolResult ? formatResultContent(toolResult) : '';
-  const notRun = status === 'failed'
-    && /not run|actor-provider-boundary-blocked|actor isolation|isolated worker.*(did not|unavailable)/i
-      .test(`${card?.error ?? ''} ${resultText}`);
+  const failureText = `${card?.error ?? ''} ${resultText}`;
+  const outcomeUnknown = card?.outcomeKnown === false
+    || /outcome is unknown|outcome unknown/i.test(failureText);
+  const userFailure = actorUserFailure(failureText);
+  const notRun = status === 'failed' && !outcomeUnknown
+    && (userFailure !== null
+      || /not run|no work was started|actor isolation|isolated worker.*(did not|unavailable)/i.test(failureText));
   const handedOff = !card && toolUse.input?.await === true
     && /is still working; its reply will arrive as a fenced note on a later turn/i.test(resultText);
   const acceptedAsync = !card && !!toolResult && toolResult.is_error !== true
@@ -732,7 +890,7 @@ const renderActorCard = ({ toolUse, toolResult, interrupted, actors, spawned, lo
     && toolUse.input?.await === true && !handedOff;
   const terminalLabel = status === 'pending' ? 'working…'
     : status === 'cancelled' ? 'cancelled'
-    : status === 'failed' ? (notRun ? 'Not run' : 'failed')
+    : status === 'failed' ? (outcomeUnknown ? 'Outcome unknown' : notRun ? 'Not run' : 'failed')
     : handedOff ? 'handed off'
     : acceptedAsync ? 'accepted'
     : 'done';
@@ -744,7 +902,7 @@ const renderActorCard = ({ toolUse, toolResult, interrupted, actors, spawned, lo
     }, [
       m('span.disclosure', ui.expanded ? '▼' : '▶'),
       m(`span.tool-status-dot.dot-${status}`,
-        { title: status === 'failed' ? 'failed' : status === 'pending' ? 'working' : status === 'cancelled' ? 'cancelled' : 'ok' }),
+        { title: status === 'failed' ? (outcomeUnknown ? 'outcome unknown' : 'failed') : status === 'pending' ? 'working' : status === 'cancelled' ? 'cancelled' : 'ok' }),
       m('span.tool-name', 'message_actor'),
       m('span.tool-args', `${cardLabel}: "${truncate(task, 40)}"`),
       m('.spacer'),
@@ -754,10 +912,12 @@ const renderActorCard = ({ toolUse, toolResult, interrupted, actors, spawned, lo
     ]),
     ui.expanded ? m('.actor-body', [
       card?.error
-        ? m('p.error-line', notRun ? ACTOR_CREDENTIAL_BOUNDARY_USER_FAILURE : String(card.error))
+        ? m('p.error-line', outcomeUnknown
+          ? actorOutcomeUnknownFailure(String(card.error))
+          : (userFailure ?? String(card.error)))
         : null,
       !card?.error && toolResult?.is_error
-        ? m('p.error-line', notRun ? ACTOR_CREDENTIAL_BOUNDARY_USER_FAILURE : resultText)
+        ? m('p.error-line', userFailure ?? resultText)
         : null,
       card?.error || toolResult?.is_error
         ? null
@@ -768,9 +928,11 @@ const renderActorCard = ({ toolUse, toolResult, interrupted, actors, spawned, lo
               renderTranscript({ messages: card.messages, actors, spawned, loadActor, peerName, depth: depth + 1 }))
           : completedAwait
             ? m('pre.tool-result-content', resultText)
-            : handedOff
-              ? m('p.muted', 'the actor is still working; check later messages for the reply')
+          : handedOff
+            ? m('p.muted', 'the actor is still working; check later messages for the reply')
           : m('p.muted', card?.streaming ? 'actor working…'
+              // Historical success proves acceptance, not delivery. A reload may
+              // have lost the live card while the reply is still pending.
               : (!card && toolResult && !toolResult.is_error) ? 'request accepted; check later messages for the reply'
               : 'no actor activity yet — its reply will arrive on a later turn'),
     ]) : null,

--- a/extension/sidepanel/error-display.js
+++ b/extension/sidepanel/error-display.js
@@ -21,6 +21,7 @@ export const mapError = (e) => {
   if (e === 'provider-key-missing') return 'No API key yet — add one in Settings.';
   if (e === 'unknown-provider') return 'No provider registered yet.';
   if (e === 'session-not-found') return 'Session was reset mid-turn.';
+  if (e === 'actor-recovery-pending') return 'Actor recovery is still being recorded. Wait a moment, then send again.';
   if (e === 'spend-limit-reached') return 'Spend limit reached — the agent was halted. Raise the limit in Settings to continue.';
 
   // Hard account limit (out of credit / over a spend or usage cap). The SW's

--- a/extension/sidepanel/styles.css
+++ b/extension/sidepanel/styles.css
@@ -123,6 +123,18 @@
 
 * { box-sizing: border-box; }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 html, body, #app {
   height: 100%;
   margin: 0;
@@ -940,6 +952,45 @@ button.icon.is-active {
 }
 .error-banner button { padding: 4px 10px; font-size: 12px; }
 
+.actor-isolation-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--elev);
+  color: var(--text);
+}
+.actor-isolation-copy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+  flex: 1;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.actor-isolation-copy strong { color: var(--fg); }
+.actor-isolation-banner.is-recovered .actor-isolation-copy strong { color: var(--fg); }
+.actor-isolation-banner.is-recovered:focus {
+  outline: 2px solid var(--fg);
+  outline-offset: -2px;
+}
+.actor-isolation-copy small {
+  color: var(--muted);
+  overflow-wrap: anywhere;
+}
+.actor-isolation-banner button {
+  flex: 0 0 auto;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 5px 9px;
+  font-size: 12px;
+}
+.actor-isolation-banner button:focus-visible {
+  outline: 2px solid var(--fg);
+  outline-offset: 2px;
+}
+
 /* Rate-limit retry indicator — amber, calmer than the error banner. */
 .rate-limit-banner {
   display: flex;
@@ -1269,6 +1320,17 @@ button.tool-call-header:focus-visible {
 }
 .tool-call-header .spacer { flex: 1; min-width: 8px; }
 .tool-duration { color: var(--fg-muted); font-size: 11px; flex-shrink: 0; }
+.actor-unknown-announcement {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 .tool-pending { color: var(--accent); font-size: 11px; font-style: italic; flex-shrink: 0; }
 
 /* Expanded detail body — the §02 lineage + result live here now, so the
@@ -2630,6 +2692,14 @@ button.tool-call-header:focus-visible {
   /* outline stays monochrome — color lives on the glyph + label */
   background: var(--bg);
 }
+/* The reveal animation owns `opacity`, so the global button:disabled opacity
+ * cannot visually win after the card settles. A non-animated filter keeps the
+ * actor-only starters visibly unavailable while Ask remains active. */
+.path-card:disabled {
+  filter: grayscale(1) opacity(0.5);
+  cursor: not-allowed;
+}
+.path-card:disabled:hover { background: var(--elev); }
 /* Per-tile cascade = 90ms. Step 1 (container) starts at 40ms + i*90ms. */
 .path-card:nth-child(1) { animation-delay: 40ms; }
 .path-card:nth-child(2) { animation-delay: 130ms; }

--- a/extension/tests/fixtures/actor-isolation.html
+++ b/extension/tests/fixtures/actor-isolation.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Actor isolation fixture</title>
+  <link rel="stylesheet" href="/sidepanel/styles.css">
+  <style>
+    body { min-width: 0; background: var(--bg); color: var(--fg); }
+    .actor-isolation-fixture { width: 400px; min-height: 900px; margin: 0 auto; }
+  </style>
+</head>
+<body>
+  <main id="app"></main>
+  <script type="module" src="/tests/fixtures/actor-isolation.js"></script>
+</body>
+</html>

--- a/extension/tests/fixtures/actor-isolation.js
+++ b/extension/tests/fixtures/actor-isolation.js
@@ -1,0 +1,114 @@
+// @ts-check
+// Real-component fixture for the paused actor-execution UI.
+
+import m from '/vendor/mithril/mithril.js';
+import { ActorIsolationBanner } from '/sidepanel/components/actor-isolation-banner.js';
+import { ChatView } from '/sidepanel/components/chat-view.js';
+
+// why: settle the starter cards immediately so the screenshot checks layout,
+// not the one-time typewriter animation.
+window.matchMedia = () => /** @type {MediaQueryList} */ ({ matches: true });
+
+/** @type {{ status: string, host: string|null, reason: string|null, retryable: boolean }} */
+let capability = {
+  status: 'temporarily_unavailable',
+  host: 'background-page-worker',
+  reason: 'fixture-private-worker-error',
+  retryable: true,
+};
+let retryAttempts = 0;
+
+/** @param {{ type?: string }} message */
+const send = async (message) => {
+  if (message.type === 'models/options') return { ok: true, options: [] };
+  if (message.type === 'actor-isolation/retry') {
+    retryAttempts += 1;
+    if (retryAttempts === 1) return { ok: false, code: 'actor_worker_start_timeout' };
+    capability = {
+      status: 'available', host: 'background-page-worker', reason: null, retryable: false,
+    };
+    state.capabilities.actorExecution = capability;
+    m.redraw();
+    return { ok: true, capability };
+  }
+  return { ok: true };
+};
+
+const state = {
+  session: {
+    sessionId: null,
+    messages: [],
+    permission: { mode: 'act', confirmActions: false },
+  },
+  providers: { current: 'ollama', hasKey: true, model: '' },
+  settings: { providerName: 'ollama', voiceOnboardingDismissed: true, voiceEnabled: false },
+  capabilities: { actorExecution: capability },
+  goalRuns: {},
+  agentTabEvents: [],
+  actors: {},
+};
+
+/** @type {any} */ (globalThis).actorIsolationFixtureShowUnknownOutcome = () => {
+  const fixtureState = /** @type {any} */ (state);
+  const messages = [
+      {
+        role: 'assistant', id: 'assistant-unknown', content: '',
+        toolUses: [{ id: 'tool-unknown', name: 'message_actor', input: { to: 'web', message: 'submit the form' } }],
+      },
+      {
+        role: 'user', id: 'result-unknown', content: '',
+        toolResults: [{ tool_use_id: 'tool-unknown', is_error: false, content: 'Message delivered.' }],
+      },
+      {
+        role: 'user', id: 'reply-unknown', synthetic: true,
+        actorReply: { kind: 'web', instanceId: 'web', failed: true, outcomeKnown: false },
+        content: 'The web actor did not complete cleanly. Its outcome is unknown. Do not retry automatically:\n\n<untrusted_web_content>peerd cannot confirm whether the previous request ran before the background host restarted. Check whether the requested action completed before trying again.</untrusted_web_content>',
+      },
+      {
+        role: 'user', id: 'actor-recovery:chat-unknown-outcome:queued-1', synthetic: true,
+        actorReply: {
+          kind: 'app', instanceId: 'app-1', name: 'orders', failed: true,
+          outcomeKnown: true, performed: false,
+        },
+        content: 'The app actor orders (app-1) could not complete your request:\n\n<untrusted_web_content>The background host restarted before this actor request was dispatched. It was not run. Re-issue it if it still matters.</untrusted_web_content>',
+      },
+      {
+        role: 'assistant', id: 'assistant-spawn-unknown', content: '',
+        toolUses: [{ id: 'spawn-unknown', name: 'actor_create', input: { task: 'update the record', sync: true } }],
+      },
+      {
+        role: 'user', id: 'result-spawn-unknown', content: '',
+        toolResults: [{
+          tool_use_id: 'spawn-unknown', is_error: true,
+          content: 'Actor execution did not complete. Its outcome is unknown. Do not retry automatically.',
+        }],
+      },
+    ];
+  // First mount the destination chat as ordinary history. Recovery receipts
+  // then arrive on that same live chat, which is the event the transient status
+  // is meant to announce. Reopening this finished history stays silent.
+  fixtureState.session = {
+    ...fixtureState.session,
+    sessionId: 'chat-unknown-outcome',
+    messages: messages.slice(0, 2),
+  };
+  m.redraw.sync();
+  fixtureState.session = { ...fixtureState.session, messages };
+  fixtureState.actors = {
+    'tool-unknown': {
+      kind: 'web', instanceId: 'web', streaming: false,
+      error: 'The actor worker stopped. Its outcome is unknown.',
+      outcomeKnown: false,
+    },
+  };
+  m.redraw();
+};
+
+const Fixture = {
+  view: () => m('.actor-isolation-fixture', [
+    m(ActorIsolationBanner, { capability, send }),
+    m(ChatView, { state, send, surface: 'sidepanel', activeTabIsWeb: false }),
+  ]),
+};
+
+m.mount(document.getElementById('app'), Fixture);

--- a/extension/tests/index.js
+++ b/extension/tests/index.js
@@ -111,6 +111,7 @@ import './unit/sidepanel/tools-chip.test.js';
 import './unit/sidepanel/attachments.test.js';
 import './unit/sidepanel/message-list.test.js';
 import './unit/sidepanel/failure-chip.test.js';
+import './unit/sidepanel/actor-isolation.test.js';
 import './unit/sidepanel/confirm-note.test.js';
 import './unit/sidepanel/learned-origins-view.test.js';
 import './unit/options/activity-origin-events.test.js';

--- a/extension/tests/unit/background/state-get.test.js
+++ b/extension/tests/unit/background/state-get.test.js
@@ -40,6 +40,7 @@ const HAVE_LIVE_SW = typeof globalThis.chrome?.runtime?.sendMessage === 'functio
  * @property {object} settings
  * @property {{ hasKey: boolean }} providers
  * @property {{ permission: { mode: string, confirmActions: boolean }, messages?: unknown }} session
+ * @property {{ actorExecution: { status: string, host: string|null, reason: string|null, retryable: boolean } }} capabilities
  *
  * @typedef {{ ok?: boolean, state: StateSnapshot }} StateReply
  */
@@ -114,6 +115,15 @@ describe('background/state-get — one-shot snapshot route', () => {
     const { state } = await getState();
     expect(typeof state.session.permission.mode).toBe('string');
     expect(typeof state.session.permission.confirmActions).toBe('boolean');
+  });
+
+  it('reports one actor execution capability in both locked and unlocked state', async () => {
+    const { state } = await getState();
+    expect(['available', 'unsupported', 'temporarily_unavailable'].includes(state.capabilities.actorExecution.status)).toBe(true);
+    expect(typeof state.capabilities.actorExecution.retryable).toBe('boolean');
+    if (state.capabilities.actorExecution.status === 'available') {
+      expect(['offscreen-document-worker', 'background-page-worker'].includes(state.capabilities.actorExecution.host ?? '')).toBe(true);
+    }
   });
 
   it('carries no key material anywhere in the snapshot', async () => {

--- a/extension/tests/unit/offscreen/job-runner.test.js
+++ b/extension/tests/unit/offscreen/job-runner.test.js
@@ -522,6 +522,30 @@ throw new Error('unrelated failure');`,
     expect(c.payload.runId).toBe('run-1');
   });
 
+  it('actors: collects delivery custody outside the worker-visible call result', async () => {
+    const r = await runJob(
+      {
+        code: [
+          'const one = await actors.call("vm-1", "one");',
+          'const two = await actors.call("vm-2", "two");',
+          'return [one.reply, two.reply, Object.keys(one)];',
+        ].join('\n'),
+        actors: true, ownerSessionId: 'chat-1', runId: 'run-custody',
+      },
+      {
+        sendToSW: async (_type, payload) => ({
+          ok: true,
+          actorDeliveryId: `delivery-${/** @type {any} */ (payload).args.to}`,
+          value: { reply: /** @type {any} */ (payload).args.to, failed: false },
+        }),
+      },
+    );
+
+    expect(r.error).toBe(null);
+    expect(r.value).toEqual(['vm-1', 'vm-2', ['reply', 'failed']]);
+    expect(r.actorDeliveryIds).toEqual(['delivery-vm-1', 'delivery-vm-2']);
+  });
+
   it('actors: the DELEGATIONS trace records every op with outcome + timing, and usedActors flags the run', async () => {
     const r = await runJob(
       {

--- a/extension/tests/unit/offscreen/job-runner.test.js
+++ b/extension/tests/unit/offscreen/job-runner.test.js
@@ -546,6 +546,29 @@ throw new Error('unrelated failure');`,
     expect(r.actorDeliveryIds).toEqual(['delivery-vm-1', 'delivery-vm-2']);
   });
 
+  it('actors: preserves delivery custody when a later self import terminates on policy', async () => {
+    const r = await runJob(
+      {
+        code: [
+          'await actors.call("vm-1", "one");',
+          'return await peerd.self.import("bad.js");',
+        ].join('\n'),
+        actors: true, ownerSessionId: 'chat-1', runId: 'run-policy-custody',
+      },
+      {
+        sendToSW: async () => ({
+          ok: true,
+          actorDeliveryId: 'delivery-before-import',
+          value: { reply: 'done', failed: false },
+        }),
+      },
+    );
+
+    expect(r.errorCode).toBe(UNSUPPORTED_NATIVE_MODULE_IMPORT_CODE);
+    expect(String(r.error)).toContain('cannot run this import form');
+    expect(r.actorDeliveryIds).toEqual(['delivery-before-import']);
+  });
+
   it('actors: the DELEGATIONS trace records every op with outcome + timing, and usedActors flags the run', async () => {
     const r = await runJob(
       {

--- a/extension/tests/unit/peerd-runtime/actor-spawn.test.js
+++ b/extension/tests/unit/peerd-runtime/actor-spawn.test.js
@@ -9,6 +9,9 @@ import { describe, it, expect } from '../../framework.js';
 import {
   makeSpawnActor, createSessionStore, runUserTurn,
 } from '/peerd-runtime/index.js';
+import {
+  makeInMemorySessions, makeRelayedCallModel, makeRelayedToolDispatch, runActorLoop,
+} from '/peerd-runtime/actor/actor-worker-core.js';
 import { makeMockIdb } from '../../mocks/idb.js';
 
 /** @typedef {import('/peerd-provider/format/from-anthropic.js').ProviderEvent} ProviderEvent */
@@ -37,17 +40,35 @@ const buildDeps = (overrides = {}) => {
   /** @type {any[]} */
   const audits = [];
   let t = 0;
+  const callModel = (/** @type {any} */ _args) => mockTextStream('child result text');
   /** @type {SpawnDeps} */
   const deps = /** @type {SpawnDeps} */ (/** @type {unknown} */ ({
     sessions,
-    runUserTurn,
-    callModel: () => mockTextStream('child result text'),
-    getSecret: async () => 'sk-test',
-    safeFetch: async () => new Response('ok'),
     appendAudit: async (/** @type {any} */ e) => { audits.push(e); },
-    buildToolContext: async () => ({ session: {}, audit: async () => {} }),
-    dispatchToolCall: async () => ({ ok: true, content: 'ran' }),
-    renderSystemPrompt: async () => 'system prompt',
+    renderSystemPromptForChild: async () => 'system prompt',
+    runChildOffscreen: async (/** @type {any} */ job, /** @type {any} */ opts = {}) => {
+      const workerSessions = makeInMemorySessions({
+        sessionId: job.sessionId, provider: job.provider, model: job.model, depth: job.depth,
+      });
+      const result = await runActorLoop({
+        runUserTurn,
+        sessions: workerSessions,
+        callModel: makeRelayedCallModel(async (args) => {
+          const events = [];
+          for await (const event of callModel(args)) events.push(event);
+          return { events };
+        }, job.maxOutputTokens),
+        toolDispatch: makeRelayedToolDispatch(async () => ({ ok: true, result: { ok: true, content: 'ran' } })),
+        getSystemPrompt: () => job.systemPrompt,
+        appendAudit: async () => {},
+        onEvent: opts.onEvent,
+        tools: job.tools ?? [],
+      }, {
+        sessionId: job.sessionId, userText: job.task, maxSteps: job.maxSteps,
+        signal: opts.signal,
+      });
+      return { ok: true, started: true, ...result };
+    },
     getToolDescriptors: () => [],
     now: () => (t += 10),
     ...overrides,
@@ -95,15 +116,13 @@ describe('actor orchestrator — e2e with real loop', () => {
     expect(all.length).toBe(1);
   });
 
-  it('tags loop audits with parentage so the trail reads from any level', async () => {
+  it('tags lifecycle audits with parentage so the trail reads from any level', async () => {
     const { sessions, deps, audits } = buildDeps();
     const parent = await sessions.create();
     const spawn = makeSpawnActor(deps);
     const out = await spawn({ task: 't', parentSessionId: parent.sessionId });
 
-    // The loop's own session_started audit flows through the tagged
-    // appendAudit, so it carries parentSessionId + depth.
-    const started = audits.find((a) => a.type === 'session_started');
+    const started = audits.find((a) => a.type === 'actor_ran_isolated');
     expect(started?.details?.parentSessionId).toBe(parent.sessionId);
     expect(started?.details?.actorSessionId).toBe(out.sessionId);
     expect(started?.details?.depth).toBe(1);

--- a/extension/tests/unit/peerd-runtime/turn-driver-credentials.test.js
+++ b/extension/tests/unit/peerd-runtime/turn-driver-credentials.test.js
@@ -1,20 +1,16 @@
 // @ts-check
-// Browser-runtime proof for the bound-actor fallback custody shape. This runs
-// the production turn driver, session store, and agent loop in a page realm,
-// with injected shell dependencies and a fake provider. Live service-worker
-// wiring still needs a packaged Firefox actor smoke test.
+// Browser-runtime proof that a bound actor cannot enter the privileged turn
+// driver. Live service-worker wiring is covered by the packaged Firefox smoke.
 
 import { describe, it, expect } from '../../framework.js';
-import {
-  ACTOR_CREDENTIAL_BOUNDARY_FAILURE, createSessionStore, makeTurnDriver, runUserTurn,
-} from '/peerd-runtime/index.js';
+import { createSessionStore, makeTurnDriver } from '/peerd-runtime/index.js';
 import { makeMockIdb } from '../../mocks/idb.js';
 
 /** @param {any} value */
 const identity = (value) => value;
 
-describe('bound actor fallback credential custody', () => {
-  it('keeps credentials out of the real loop and restores them at the model boundary', async () => {
+describe('bound actor background-heap refusal', () => {
+  it('refuses before the real loop or provider can run', async () => {
     const sessions = createSessionStore({
       idb: makeMockIdb(),
       now: () => 1_000,
@@ -31,8 +27,8 @@ describe('bound actor fallback credential custody', () => {
     /** @type {Record<string, any>[]} */
     const modelCalls = [];
     /** @type {Record<string, any>[]} */
-    const broadcasts = [];
-    let tripBoundary = false;
+    const audits = [];
+    let releases = 0;
     const settings = {
       reasoningEnabled: false,
       reasoningEffort: 'medium',
@@ -52,7 +48,7 @@ describe('bound actor fallback credential custody', () => {
       sessions,
       sessionState: { set: () => {} },
       turnSlots: {
-        claim: () => ({ controller: new AbortController(), release: () => {} }),
+        claim: () => ({ controller: new AbortController(), release: () => { releases++; } }),
         isBusy: () => false,
       },
       buildTemporalBlock: () => '',
@@ -81,9 +77,9 @@ describe('bound actor fallback credential custody', () => {
       listProviders: () => [],
       costOf: () => ({ usd: 0, known: true }),
       makeTurnCostTracker: () => ({ onUsage: async () => {}, maybeHalt: () => {} }),
-      uiConnected: () => true,
-      uiPorts: { broadcast: (/** @type {any} */ message) => broadcasts.push(message) },
-      auditLog: { append: async () => {} },
+      uiConnected: () => false,
+      uiPorts: { broadcast: () => {} },
+      auditLog: { append: async (/** @type {any} */ entry) => { audits.push(entry); } },
       postChatNote: () => {},
       /** @param {any} start */
       resolveFailoverChain: (start) => [start],
@@ -96,19 +92,7 @@ describe('bound actor fallback credential custody', () => {
         yield { type: 'text-delta', text: 'actor completed' };
         yield { type: 'message-stop', stopReason: 'end_turn' };
       },
-      /** @param {any} ctx */
-      runUserTurn: (ctx) => {
-        loopCtx = ctx;
-        if (tripBoundary) {
-          return runUserTurn({
-            ...ctx,
-            async *callModel() {
-              await ctx.getSecret('anthropic');
-            },
-          });
-        }
-        return runUserTurn(ctx);
-      },
+      runUserTurn: (/** @type {any} */ ctx) => { loopCtx = ctx; return /** @type {any} */ ([]); },
       getSecret: liveGetSecret,
       safeFetch: liveSafeFetch,
       REASONING_BUDGET_TOKENS: 0,
@@ -126,37 +110,13 @@ describe('bound actor fallback credential custody', () => {
       sessionId: actor.sessionId,
       userText: 'inspect the page',
     });
-    expect(result).toEqual({ ok: true, stopReason: 'end_turn' });
-    expect(modelCalls.length).toBe(1);
-    expect(modelCalls[0].getSecret).toBe(liveGetSecret);
-    expect(modelCalls[0].safeFetch).toBe(liveSafeFetch);
-    const captured = /** @type {Record<string, any>} */ (/** @type {unknown} */ (loopCtx));
-    await expect(() => captured.getSecret('anthropic'))
-      .toThrow((error) => error?.name === 'ActorCredentialBoundaryError'
-        && error?.capability === 'secret');
-    await expect(() => captured.safeFetch('https://example.com'))
-      .toThrow((error) => error?.name === 'ActorCredentialBoundaryError'
-        && error?.capability === 'provider-network');
+    expect(result).toBe(undefined);
+    expect(modelCalls.length).toBe(0);
+    expect(loopCtx).toBe(null);
+    expect(releases).toBe(1);
+    expect(audits.some((entry) => entry.type === 'actor_background_turn_refused'
+      && entry.details?.performed === false)).toBe(true);
     const stored = await sessions.get(actor.sessionId);
-    expect(stored?.messages.at(-1)?.content).toBe('actor completed');
-
-    // Production-path regression: runUserTurn consumes the model iterator and
-    // catches the named error itself. The refusal must be mapped before that
-    // event crosses into the driver, and the driver must report a failed turn.
-    tripBoundary = true;
-    const refused = await driver.runAgentTurn({
-      sessionId: actor.sessionId,
-      userText: 'try direct credential access',
-      display: { parentToolUseId: 'boundary-tool', kind: 'web', instanceId: 'web' },
-    });
-    expect(refused).toEqual({ ok: false, stopReason: undefined });
-    expect(broadcasts.some((message) => message.type === 'turn/error'
-      && message.error === ACTOR_CREDENTIAL_BOUNDARY_FAILURE)).toBe(true);
-    expect(broadcasts.some((message) => message.type === 'turn/actor-done'
-      && message.parentToolUseId === 'boundary-tool' && message.ok === false)).toBe(true);
-    const afterRefusal = await sessions.get(actor.sessionId);
-    expect(String((/** @type {any} */ (afterRefusal?.messages.at(-1)))?.error))
-      .toContain('model request was not run');
-    expect(JSON.stringify(afterRefusal).includes('refused direct secret access')).toBe(false);
+    expect(stored?.messages.length).toBe(0);
   });
 });

--- a/extension/tests/unit/sidepanel/actor-isolation.test.js
+++ b/extension/tests/unit/sidepanel/actor-isolation.test.js
@@ -1,0 +1,479 @@
+// @ts-check
+
+import m from '/vendor/mithril/mithril.js';
+import { describe, it, expect } from '../../framework.js';
+import { ActorIsolationBanner } from '/sidepanel/components/actor-isolation-banner.js';
+import { MessageList } from '/sidepanel/components/message-list.js';
+
+const flush = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  m.redraw.sync();
+};
+
+describe('sidepanel actor isolation UX', () => {
+  it('shows a persistent polite status and offers retry only for a temporary host failure', async () => {
+    /** @type {Array<Record<string, unknown>>} */
+    const sent = [];
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    m.mount(root, {
+      view: () => m(ActorIsolationBanner, {
+        capability: { status: 'temporarily_unavailable', reason: 'worker import failed', retryable: true },
+        send: async (/** @type {Record<string, unknown>} */ message) => { sent.push(message); },
+      }),
+    });
+    try {
+      await flush();
+      expect(root.querySelector('[role="status"][aria-live="polite"]')).toBeTruthy();
+      expect(root.textContent).toContain('Use Try again before retrying an actor request');
+      expect(root.textContent).toContain('isolation state could not be confirmed');
+      expect(root.textContent.includes('worker import failed')).toBe(false);
+      const retry = /** @type {HTMLButtonElement} */ (root.querySelector('button'));
+      retry.click();
+      expect(sent).toEqual([{ type: 'actor-isolation/retry' }]);
+      const busy = /** @type {HTMLElement} */ (root.querySelector('.actor-isolation-banner'));
+      const busyButton = /** @type {HTMLButtonElement} */ (busy.querySelector('button'));
+      expect(busy.getAttribute('aria-busy')).toBe('true');
+      expect(busyButton.disabled).toBe(true);
+      expect(busyButton.textContent).toContain('Retrying actor worker');
+    } finally { m.mount(root, null); root.remove(); }
+  });
+
+  it('announces a failed retry without exposing transport details', async () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    m.mount(root, {
+      view: () => m(ActorIsolationBanner, {
+        capability: { status: 'temporarily_unavailable', reason: 'private worker stack', retryable: true },
+        send: async () => { throw new Error('private runtime messaging failure'); },
+      }),
+    });
+    try {
+      await flush();
+      /** @type {HTMLButtonElement} */ (root.querySelector('button')).click();
+      await flush();
+      expect(root.textContent).toContain('Actor work is still paused');
+      expect(root.textContent).toContain('Actor execution could not be restored');
+      expect(root.textContent.includes('private runtime messaging failure')).toBe(false);
+      expect(root.textContent.includes('private worker stack')).toBe(false);
+    } finally { m.mount(root, null); root.remove(); }
+  });
+
+  it('does not offer a retry when the browser cannot provide actor isolation', async () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    m.mount(root, {
+      view: () => m(ActorIsolationBanner, {
+        capability: { status: 'unsupported', reason: 'missing worker API', retryable: false },
+        send: async () => {},
+      }),
+    });
+    try {
+      await flush();
+      expect(root.textContent).toContain('Actors are unavailable');
+      expect(root.querySelector('button')).toBe(null);
+      expect(root.textContent.includes('missing worker API')).toBe(false);
+    } finally { m.mount(root, null); root.remove(); }
+  });
+
+  it('moves focus to a recovery status after retry succeeds', async () => {
+    /** @type {{ status: string, reason: string|null, retryable: boolean }} */
+    const capability = { status: 'temporarily_unavailable', reason: 'worker failed', retryable: true };
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    m.mount(root, {
+      view: () => m(ActorIsolationBanner, {
+        capability,
+        send: async () => ({
+          ok: true,
+          capability: { status: 'available', reason: null, retryable: false },
+        }),
+      }),
+    });
+    try {
+      await flush();
+      /** @type {HTMLButtonElement} */ (root.querySelector('button')).click();
+      await flush();
+      const recovered = /** @type {HTMLElement} */ (root.querySelector('.actor-isolation-banner.is-recovered'));
+      expect(recovered).toBeTruthy();
+      expect(recovered.textContent).toContain('Actor work is ready');
+      expect(document.activeElement).toBe(recovered);
+    } finally { m.mount(root, null); root.remove(); }
+  });
+
+  it('renders a failed message_actor call as an accessible Not run disclosure', async () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    m.mount(root, { view: () => m(MessageList, { messages: [
+      { role: 'assistant', id: 'a1', content: '', toolUses: [{ id: 't1', name: 'message_actor', input: { to: 'web', message: 'click submit' } }] },
+      { role: 'user', id: 'u1', content: '', toolResults: [{ tool_use_id: 't1', is_error: true, content: 'actor_isolation_unavailable: Actors were not run' }] },
+    ] }) });
+    try {
+      await flush();
+      const toggle = /** @type {HTMLButtonElement} */ (root.querySelector('.tool-actor > button.tool-call-header'));
+      expect(toggle).toBeTruthy();
+      expect(toggle.getAttribute('aria-expanded')).toBe('false');
+      expect(toggle.textContent).toContain('Not run');
+      toggle.click();
+      await flush();
+      expect(toggle.getAttribute('aria-expanded')).toBe('true');
+      expect(root.textContent).toContain('actor_isolation_unavailable');
+      expect(root.textContent).toContain('cannot provide the required isolated worker');
+      expect(root.textContent.includes('Do not retry automatically')).toBe(false);
+      expect(root.textContent.includes('reply will arrive')).toBe(false);
+    } finally { m.mount(root, null); root.remove(); }
+  });
+
+  it('labels a post-start bound actor failure Outcome unknown, never Not run', async () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    m.mount(root, { view: () => m(MessageList, {
+      messages: [
+        { role: 'assistant', id: 'a-unknown', content: '', toolUses: [{ id: 't-unknown', name: 'message_actor', input: { to: 'web', message: 'submit it' } }] },
+        { role: 'user', id: 'u-unknown', content: '', toolResults: [{ tool_use_id: 't-unknown', is_error: false, content: 'Message delivered.' }] },
+        {
+          role: 'user', id: 'reply-unknown', synthetic: true,
+          actorReply: { kind: 'web', instanceId: 'web', failed: true, outcomeKnown: false },
+          content: 'The web actor did not complete cleanly. Its outcome is unknown. Do not retry automatically:\n\n<untrusted_web_content>peerd cannot confirm whether the previous request ran before the background host restarted. Check whether the requested action completed before trying again.</untrusted_web_content>',
+        },
+      ],
+      actors: {
+        't-unknown': {
+          kind: 'web', instanceId: 'web', streaming: false,
+          error: 'the actor worker stopped after execution began; the outcome is unknown',
+          outcomeKnown: false,
+        },
+      },
+    }) });
+    try {
+      await flush();
+      const card = /** @type {HTMLButtonElement} */ (root.querySelector('.tool-actor > button.tool-call-header'));
+      const replyRole = root.querySelector('.message-actor-reply .role');
+      expect(card.textContent).toContain('Outcome unknown');
+      expect(card.textContent.includes('Not run')).toBe(false);
+      expect(replyRole?.textContent).toContain('Outcome unknown');
+      expect(replyRole?.textContent?.includes('Not run')).toBe(false);
+      const reply = root.querySelector('.message-actor-reply');
+      expect(reply?.getAttribute('role')).toBe(null);
+      expect(reply?.getAttribute('aria-live')).toBe(null);
+      expect(root.querySelector('.actor-recovery-announcement')).toBe(null);
+      expect(root.textContent).toContain('peerd cannot confirm whether the actor ran or completed');
+      expect(root.textContent).toContain('Check the target before trying again');
+      expect(root.textContent.includes('Do not retry automatically')).toBe(false);
+    } finally { m.mount(root, null); root.remove(); }
+  });
+
+  it('renders a historical queued recovery receipt without reannouncing it', async () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    m.mount(root, { view: () => m(MessageList, {
+      messages: [{
+        role: 'user', id: 'actor-recovery:chat-1:app-1:1', synthetic: true,
+        actorReply: {
+          kind: 'app', instanceId: 'app-1', name: 'orders', failed: true,
+          outcomeKnown: true, performed: false,
+        },
+        content: 'The app actor orders (app-1) could not complete your request:\n\n<untrusted_web_content>The background host restarted before this actor request was dispatched. It was not run. Re-issue it if it still matters.</untrusted_web_content>',
+      }],
+    }) });
+    try {
+      await flush();
+      const reply = root.querySelector('.message-actor-reply');
+      expect(reply).toBeTruthy();
+      expect(reply?.querySelector('.role')?.textContent).toContain('Not run');
+      expect(reply?.querySelector('.role')?.textContent?.includes('failed')).toBe(false);
+      expect(reply?.getAttribute('role')).toBe(null);
+      expect(reply?.getAttribute('aria-live')).toBe(null);
+      expect(root.querySelectorAll('[role="status"]').length).toBe(0);
+      expect(root.textContent).toContain('before this actor request was dispatched');
+    } finally { m.mount(root, null); root.remove(); }
+  });
+
+  it('announces newly arriving recovery receipts once, but not after remounting history', async () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    /** @type {any[]} */
+    const messages = [{ role: 'user', id: 'human-1', content: 'status?', when: 1 }];
+    const component = { view: () => m(MessageList, { sessionId: 'chat-live', messages }) };
+    m.mount(root, component);
+    try {
+      await flush();
+      expect(root.querySelector('.actor-recovery-announcement')).toBe(null);
+      messages.push({
+        role: 'user', id: 'actor-recovery:chat-live:queued-1', synthetic: true,
+        actorReply: {
+          kind: 'app', instanceId: 'app-1', failed: true,
+          outcomeKnown: true, performed: false,
+        },
+        content: 'The app actor did not run the request:\n\n<untrusted_web_content>The request was not run.</untrusted_web_content>',
+      });
+      m.redraw.sync();
+      const status = root.querySelector('.actor-recovery-announcement[role="status"]');
+      expect(status?.getAttribute('aria-live')).toBe('polite');
+      expect(status?.getAttribute('aria-atomic')).toBe('true');
+      expect(status?.textContent).toContain('Actor request not run');
+      expect(root.querySelectorAll('[role="status"]').length).toBe(1);
+
+      m.mount(root, null);
+      m.mount(root, component);
+      await flush();
+      expect(root.querySelector('.actor-recovery-announcement')).toBe(null);
+      expect(root.querySelectorAll('[role="status"]').length).toBe(0);
+    } finally { m.mount(root, null); root.remove(); }
+  });
+
+  it('announces a receipt first encountered after an empty chat without repeating it', async () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    const seenRecoveryIdsBySession = new Map();
+    let sessionId = 'chat-empty';
+    /** @type {any[]} */
+    let messages = [];
+    const component = {
+      view: () => messages.length === 0
+        ? m('p', 'empty chat')
+        : m(MessageList, {
+          sessionId, messages, announceOnMount: true, seenRecoveryIdsBySession,
+        }),
+    };
+    m.mount(root, component);
+    try {
+      await flush();
+      sessionId = 'chat-recovery';
+      messages = [{
+        role: 'user', id: 'actor-recovery:chat-recovery:started-1', synthetic: true,
+        actorReply: { kind: 'web', instanceId: 'web', failed: true, outcomeKnown: false },
+        content: 'The web actor outcome is unknown.',
+      }];
+      m.redraw.sync();
+      expect(root.querySelector('.actor-recovery-announcement')?.textContent)
+        .toContain('Actor outcome unknown');
+
+      sessionId = 'chat-empty';
+      messages = [];
+      m.redraw.sync();
+      sessionId = 'chat-recovery';
+      messages = [{
+        role: 'user', id: 'actor-recovery:chat-recovery:started-1', synthetic: true,
+        actorReply: { kind: 'web', instanceId: 'web', failed: true, outcomeKnown: false },
+        content: 'The web actor outcome is unknown.',
+      }];
+      m.redraw.sync();
+      expect(root.querySelector('.actor-recovery-announcement')).toBe(null);
+    } finally { m.mount(root, null); root.remove(); }
+  });
+
+  it('announces a recovery receipt first encountered after switching chats only once', async () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    let sessionId = 'chat-a';
+    /** @type {any[]} */
+    let messages = [{ role: 'user', id: 'human-a', content: 'status?', when: 1 }];
+    const component = { view: () => m(MessageList, { sessionId, messages }) };
+    m.mount(root, component);
+    try {
+      await flush();
+      expect(root.querySelector('.actor-recovery-announcement')).toBe(null);
+
+      sessionId = 'chat-b';
+      messages = [{
+        role: 'user', id: 'actor-recovery:chat-b:started-1', synthetic: true,
+        actorReply: {
+          kind: 'web', instanceId: 'web', failed: true, outcomeKnown: false,
+        },
+        content: 'The web actor did not complete cleanly. Its outcome is unknown.',
+      }];
+      m.redraw.sync();
+      expect(root.querySelector('.actor-recovery-announcement')?.textContent)
+        .toContain('Actor outcome unknown');
+
+      sessionId = 'chat-a';
+      messages = [{ role: 'user', id: 'human-a', content: 'status?', when: 1 }];
+      m.redraw.sync();
+      expect(root.querySelector('.actor-recovery-announcement')).toBe(null);
+
+      sessionId = 'chat-b';
+      messages = [{
+        role: 'user', id: 'actor-recovery:chat-b:started-1', synthetic: true,
+        actorReply: {
+          kind: 'web', instanceId: 'web', failed: true, outcomeKnown: false,
+        },
+        content: 'The web actor did not complete cleanly. Its outcome is unknown.',
+      }];
+      m.redraw.sync();
+      expect(root.querySelector('.actor-recovery-announcement')).toBe(null);
+    } finally { m.mount(root, null); root.remove(); }
+  });
+
+  it('restarts the clear timer when recovery announcements overlap', async () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    /** @type {any[]} */
+    const messages = [{ role: 'user', id: 'human-1', content: 'status?', when: 1 }];
+    m.mount(root, { view: () => m(MessageList, { sessionId: 'chat-live', messages }) });
+    try {
+      await flush();
+      messages.push({
+        role: 'user', id: 'actor-recovery:chat-live:started-1', synthetic: true,
+        actorReply: {
+          kind: 'web', instanceId: 'web', failed: true, outcomeKnown: false,
+        },
+        content: 'The web actor did not complete cleanly. Its outcome is unknown.',
+      });
+      m.redraw.sync();
+      expect(root.querySelector('.actor-recovery-announcement')?.textContent)
+        .toContain('Actor outcome unknown');
+
+      messages.push({
+        role: 'user', id: 'actor-recovery:chat-live:queued-2', synthetic: true,
+        actorReply: {
+          kind: 'app', instanceId: 'app-1', failed: true,
+          outcomeKnown: true, performed: false,
+        },
+        content: 'The app actor did not run the request.',
+      });
+      m.redraw.sync();
+      expect(root.querySelector('.actor-recovery-announcement')?.textContent)
+        .toContain('Actor request not run');
+
+      await new Promise((resolve) => setTimeout(resolve, 1_100));
+      m.redraw.sync();
+      expect(root.querySelector('.actor-recovery-announcement')).toBe(null);
+    } finally { m.mount(root, null); root.remove(); }
+  });
+
+  it('keeps a historical awaited message_actor warning visible but out of a live region', async () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    m.mount(root, { view: () => m(MessageList, {
+      messages: [
+        {
+          role: 'assistant', id: 'a-awaited-unknown', content: '',
+          toolUses: [{
+            id: 't-awaited-unknown', name: 'message_actor',
+            input: { to: 'web', message: 'submit it', await: true },
+          }],
+        },
+        {
+          role: 'user', id: 'u-awaited-unknown', content: '',
+          toolResults: [{
+            tool_use_id: 't-awaited-unknown', is_error: true,
+            content: 'Actor execution did not complete. Its outcome is unknown. Do not retry automatically.',
+          }],
+        },
+      ],
+      actors: {
+        't-awaited-unknown': {
+          kind: 'web', instanceId: 'web', streaming: false,
+          error: 'the actor host stopped; the outcome is unknown',
+          outcomeKnown: false,
+        },
+      },
+    }) });
+    try {
+      await flush();
+      const toggle = /** @type {HTMLButtonElement} */ (root.querySelector('.tool-actor > button.tool-call-header'));
+      expect(toggle.textContent).toContain('Outcome unknown');
+      expect(root.querySelector('.actor-unknown-announcement')).toBe(null);
+      expect(root.querySelector('.actor-recovery-announcement')).toBe(null);
+      expect(root.querySelectorAll('[role="status"]').length).toBe(0);
+      expect(root.textContent.includes('Do not retry automatically')).toBe(false);
+    } finally { m.mount(root, null); root.remove(); }
+  });
+
+  it('announces a newly arriving awaited actor unknown outcome once', async () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    /** @type {any[]} */
+    const messages = [{
+      role: 'assistant', id: 'a-awaited-live', content: '',
+      toolUses: [{
+        id: 't-awaited-live', name: 'message_actor',
+        input: { to: 'web', message: 'submit it', await: true },
+      }],
+    }];
+    m.mount(root, { view: () => m(MessageList, { sessionId: 'chat-live', messages }) });
+    try {
+      await flush();
+      messages.push({
+        role: 'user', id: 'u-awaited-live', content: '',
+        toolResults: [{
+          tool_use_id: 't-awaited-live', is_error: true,
+          content: 'Actor execution did not complete. Its outcome is unknown.',
+        }],
+      });
+      m.redraw.sync();
+      const status = root.querySelector('.actor-recovery-announcement[role="status"]');
+      expect(status?.getAttribute('aria-live')).toBe('polite');
+      expect(status?.textContent).toContain('Actor outcome unknown');
+      expect(root.querySelectorAll('[role="status"]').length).toBe(1);
+      m.redraw.sync();
+      expect(root.querySelectorAll('[role="status"]').length).toBe(1);
+    } finally { m.mount(root, null); root.remove(); }
+  });
+
+  it('describes a historical success as accepted, not delivered', async () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    m.mount(root, { view: () => m(MessageList, { messages: [
+      { role: 'assistant', id: 'a2', content: '', toolUses: [{ id: 't2', name: 'message_actor', input: { to: 'web', message: 'read it' } }] },
+      { role: 'user', id: 'u2', content: '', toolResults: [{ tool_use_id: 't2', is_error: false, content: 'Message delivered to the web actor.' }] },
+    ] }) });
+    try {
+      await flush();
+      /** @type {HTMLButtonElement} */ (root.querySelector('.tool-actor > button.tool-call-header')).click();
+      await flush();
+      expect(root.textContent).toContain('request accepted; check later messages');
+      expect(root.textContent.includes('reply delivered')).toBe(false);
+    } finally { m.mount(root, null); root.remove(); }
+  });
+
+  it('renders actor_create as a keyboard-operable disclosure', async () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    m.mount(root, { view: () => m(MessageList, { messages: [
+      { role: 'assistant', id: 'a3', content: '', toolUses: [{ id: 't3', name: 'actor_create', input: { task: 'check it' } }] },
+      { role: 'user', id: 'u3', content: '', toolResults: [{ tool_use_id: 't3', is_error: true, content: 'not run' }] },
+    ] }) });
+    try {
+      await flush();
+      const toggle = /** @type {HTMLButtonElement} */ (root.querySelector('.tool-actor > button.tool-call-header'));
+      expect(toggle).toBeTruthy();
+      expect(toggle.getAttribute('aria-expanded')).toBe('false');
+      toggle.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      toggle.click();
+      await flush();
+      expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    } finally { m.mount(root, null); root.remove(); }
+  });
+
+  it('labels a sync actor_create post-start failure Outcome unknown', async () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    m.mount(root, { view: () => m(MessageList, { messages: [
+      { role: 'assistant', id: 'a4', content: '', toolUses: [{ id: 't4', name: 'actor_create', input: { task: 'change it' } }] },
+      {
+        role: 'user', id: 'u4', content: '',
+        toolResults: [{
+          tool_use_id: 't4', is_error: true,
+          content: 'Actor execution did not complete. Its outcome is unknown. Do not retry automatically.',
+        }],
+      },
+    ] }) });
+    try {
+      await flush();
+      const toggle = /** @type {HTMLButtonElement} */ (root.querySelector('.tool-actor > button.tool-call-header'));
+      expect(toggle.textContent).toContain('Outcome unknown');
+      expect(toggle.textContent.includes('done')).toBe(false);
+      expect(toggle.title === 'Not run').toBe(false);
+      expect(root.querySelector('.actor-unknown-announcement')).toBe(null);
+      expect(root.querySelector('.actor-recovery-announcement')).toBe(null);
+      expect(root.querySelectorAll('[role="status"]').length).toBe(0);
+      toggle.click();
+      await flush();
+      const body = root.querySelector('.tool-actor .actor-body');
+      expect(body?.textContent).toContain('Check the target before trying again');
+      expect(body?.textContent?.includes('Do not retry automatically')).toBe(false);
+    } finally { m.mount(root, null); root.remove(); }
+  });
+});

--- a/packaging/check-firefox.ts
+++ b/packaging/check-firefox.ts
@@ -42,8 +42,8 @@ import { REPO_ROOT, ARTIFACTS_DIR } from './lib.ts';
  * once the guard exists.
  */
 const GUARDED_CHROME_ONLY: readonly { api: string; file: string; why: string }[] = [
-  // The heap split needs the offscreen API; Firefox has none, so actorClient is
-  // null and the actor turn falls back to the in-SW loop (THREAT-MODEL R1).
+  // Chrome uses this for the actor-worker host and other document-only jobs.
+  // Firefox starts the actor Worker directly from its extension background page.
   { api: 'offscreen.createDocument', file: 'background/service-worker.js', why: 'guarded by offscreenAvailable' },
   { api: 'runtime.getContexts', file: 'background/offscreen-contexts.js', why: 'one capability-checked offscreen liveness probe' },
   // CDP. The `debugger` permission is STRIPPED from every Firefox manifest

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -93,6 +93,9 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // 545/547 → 548: the learned-origins un-learn surface (#262) and the Activity
 // origin-lock rows (#282) land together — both ledgers are kept and the floor
 // is their union, the same shape as the 505/506 → 510 merge above.
+// 648 → 653: Firefox actor isolation adds the direct background host, worker
+// protocol, browser-neutral capability, shared capability banner, and browser
+// UX test.
 // 548 → 549: the in-page activity indicator's two checked cores (#259) —
 // actor/activity-label.js and background/page-activity.js. The injected
 // overlay body itself is ES5 and exempt, so it does not count.
@@ -144,7 +147,11 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // 635 → 636: the recoverable publish transaction is shared by dweb hosts.
 // 636 → 639: dweb reseed, content ownership, and share rollback are checked.
 // 650 → 651: Firefox actor credential-custody browser coverage is checked.
-const COVERED_FLOOR = 652;
+// 651 → 657: the direct host, worker protocol, isolation policy, banner,
+// rendered fixture, and UI test are checked.
+// 657 → 658: durable actor isolation failure state is checked.
+// 659 → 660: the remote module import policy is checked.
+const COVERED_FLOOR = 660;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/scripts/cdp/states.mjs
+++ b/scripts/cdp/states.mjs
@@ -2241,9 +2241,9 @@ export const STATES = [
   },
 
   // --- functional: an offscreen actor DELEGATES to its own web actor ------
-  // Heap-split phase 4, the deepest chain — two isolated heaps stacked. The
+  // Heap-split phase 4, the deepest chain, with two isolated heaps stacked. The
   // orchestrator spawns a sync actor granted message_actor; that actor's loop
-  // runs in its OWN isolated Worker heap and calls message_actor({to:'web'}) — which relays
+  // runs in its OWN isolated Worker heap and calls message_actor({to:'web'}), which relays
   // to the SW, dispatches actorMessaging from the child's restricted ctx, and (because
   // the sender is an actor) AWAITS the web actor's fenced reply into the child's tool
   // result. The web actor is ITSELF an isolated Worker heap (phase 3). Proof: the child
@@ -2291,7 +2291,7 @@ export const STATES = [
       const entries = (await auditEntries(ctx)).filter((entry) => !priorAuditIds.has(entry.id));
       const isolation = actorIsolationEvidence(entries);
       const msgActorRan = entries.some((e) => e.type === 'tool_executed' && e.details && e.details.tool === 'message_actor');
-      rec.check('the actor looped in isolation (message_actor emitted, then answered) — 2 child calls', actorDelegatesState.childCalls >= 2, `childCalls=${actorDelegatesState.childCalls}`);
+      rec.check('the actor looped in isolation (message_actor emitted, then answered), 2 child calls', actorDelegatesState.childCalls >= 2, `childCalls=${actorDelegatesState.childCalls}`);
       rec.check('the actor ran in a dedicated Worker with a verified realm', isolation.exactProof === true, `isolated=${isolation.isolated.length}`);
       rec.check('the actor delegated via message_actor from its heap (tool_executed audit)', msgActorRan === true, `msgActorRan=${msgActorRan}`);
       rec.check('a WEB-ACTOR sub-loop ran (its own heap) for the child delegation', actorDelegatesState.webCalls >= 1, `webCalls=${actorDelegatesState.webCalls}`);

--- a/scripts/cdp/states.mjs
+++ b/scripts/cdp/states.mjs
@@ -19,7 +19,7 @@
 
 import { createServer } from 'node:http';
 import { createSocket } from 'node:dgram';
-import { rpc, evalIn, waitFor, sseText, sseToolCall, openExtPage, openWidePage, sleep, PASSPHRASE } from './e2e-harness.mjs';
+import { rpc, evalIn, waitFor, sseText, sseToolCall, openExtPage, openWidePage, sleep, setEmulatedTheme, PASSPHRASE } from './e2e-harness.mjs';
 
 // A compact transcript probe shared by the functional states.
 const probe = (ctx) => evalIn(ctx.page, `(() => {
@@ -40,6 +40,23 @@ const probe = (ctx) => evalIn(ctx.page, `(() => {
 
 const SMOKE_TEXT = 'e2e-smoke-ok';
 const TRANSFER_EXPORT_VERSION = 2;
+
+const auditEntries = async (ctx, limit = 800) => {
+  const audit = await rpc(ctx.page, { type: 'audit/list', limit });
+  return (audit && audit.entries) || [];
+};
+
+const actorIsolationEvidence = (entries) => {
+  const isolated = entries.filter((entry) => entry.type === 'actor_ran_isolated');
+  return {
+    isolated,
+    exactProof: isolated.length > 0 && isolated.every((entry) =>
+      entry.details?.workerType === 'dedicated'
+        && entry.details?.realmVerified === true),
+    backgroundRefused: entries.some((entry) => entry.type === 'actor_background_turn_refused'),
+    isolationFailed: entries.some((entry) => entry.type === 'actor_isolation_failure'),
+  };
+};
 
 // Transfer routes require the exact options-page Port. Keep the live E2E on
 // that production boundary instead of calling the generic dispatcher.
@@ -1255,6 +1272,198 @@ export const STATES = [
     },
   },
 
+  // Functional + rendered coverage for the actor-execution failure posture.
+  // It uses the real banner and chat components without forcing a worker crash
+  // into the shared live extension state.
+  {
+    name: 'actor-isolation-ui', kind: 'functional', phase: 'post-unlock',
+    responder: null,
+    async run(ctx, rec) {
+      const page = await openExtPage(ctx, 'tests/fixtures/actor-isolation.html');
+      try {
+        await page.send('Emulation.setDeviceMetricsOverride', {
+          width: 400,
+          height: 900,
+          deviceScaleFactor: 1,
+          mobile: false,
+        });
+        const rendered = await waitFor(() => evalIn(page, `(() => {
+          const banner = document.querySelector('.actor-isolation-banner');
+          const retry = banner?.querySelector('button');
+          const cards = [...document.querySelectorAll('button.path-card')];
+          if (!banner || !retry || cards.length !== 6) return null;
+          retry.focus();
+          const rect = retry.getBoundingClientRect();
+          return {
+            role: banner.getAttribute('role'),
+            live: banner.getAttribute('aria-live'),
+            text: banner.textContent ?? '',
+            retryFocused: document.activeElement === retry,
+            retryWidth: rect.width,
+            retryHeight: rect.height,
+            askDisabled: cards[0].disabled,
+            actorCardsDisabled: cards.slice(1).every((card) => card.disabled),
+            actorCardFilters: cards.slice(1).map((card) => getComputedStyle(card).filter),
+            actorLabels: cards.slice(1).map((card) => card.getAttribute('aria-label') ?? ''),
+          };
+        })()`), { budgetMs: 5_000, pollMs: 50 });
+
+        rec.check('paused actor work is a polite persistent status',
+          rendered?.role === 'status'
+            && rendered?.live === 'polite'
+            && rendered?.text.includes('Actor work is paused'));
+        rec.check('the user-facing notice hides the raw worker failure',
+          !!rendered && !rendered.text.includes('fixture-private-worker-error'));
+        rec.check('retry is keyboard focusable with a 44px target',
+          rendered?.retryFocused === true
+            && rendered?.retryWidth >= 44
+            && rendered?.retryHeight >= 44,
+          JSON.stringify(rendered));
+        rec.check('Ask remains available while every actor starter is unavailable and named honestly',
+          rendered?.askDisabled === false
+            && rendered?.actorCardsDisabled === true
+            && rendered?.actorCardFilters.every((filter) => filter !== 'none')
+            && rendered?.actorLabels.every((label) => label.includes('unavailable while actor work is paused')),
+          JSON.stringify(rendered));
+        // The real starter cards have a one-time staggered reveal. Let its
+        // longest icon/label delay settle so the screenshot captures the
+        // disabled state, not an intermediate animation frame.
+        await sleep(1_200);
+        await setEmulatedTheme(page, 'light');
+        await sleep(80);
+        await rec.shotPage('paused.light', page);
+        await setEmulatedTheme(page, 'dark');
+        await sleep(80);
+        await rec.shotPage('paused.dark', page);
+
+        await evalIn(page, `document.querySelector('.actor-isolation-banner button')?.click()`);
+        const retryFailed = await waitFor(() => evalIn(page, `(() => {
+          const status = document.querySelector('.actor-isolation-banner');
+          return status?.textContent?.includes('Actor work is still paused')
+            ? { text: status.textContent ?? '', live: status.getAttribute('aria-live') }
+            : null;
+        })()`), { budgetMs: 5_000, pollMs: 50 });
+        rec.check('failed retry is announced without raw worker details',
+          retryFailed?.live === 'polite'
+            && retryFailed?.text.includes('Actor execution could not be restored')
+            && !retryFailed?.text.includes('actor_worker_start_timeout'),
+          JSON.stringify(retryFailed));
+        await rec.shotPage('retry-failed.dark', page);
+
+        await evalIn(page, `document.querySelector('.actor-isolation-banner button')?.click()`);
+        const recovered = await waitFor(() => evalIn(page, `(() => {
+          const status = document.querySelector('.actor-isolation-banner.is-recovered');
+          return status ? {
+            text: status.textContent ?? '',
+            focused: document.activeElement === status,
+            retryPresent: !!status.querySelector('button'),
+          } : null;
+        })()`), { budgetMs: 5_000, pollMs: 50 });
+        rec.check('successful retry moves focus to an honest recovery status',
+          recovered?.focused === true
+            && recovered?.retryPresent === false
+            && recovered?.text.includes('Actor work is ready'),
+          JSON.stringify(recovered));
+        await rec.shotPage('recovered.dark', page);
+
+        await evalIn(page, `document.querySelector('textarea')?.focus()`);
+        const recoveryDismissed = await waitFor(() => evalIn(page,
+          `!document.querySelector('.actor-isolation-banner')`),
+        { budgetMs: 2_000, pollMs: 50 });
+        rec.check('the recovery status clears after the user moves focus onward', recoveryDismissed === true);
+
+        await evalIn(page, `globalThis.actorIsolationFixtureShowUnknownOutcome()`);
+        const unknownOutcome = await waitFor(() => evalIn(page, `(() => {
+          const card = document.querySelector('.tool-actor > button.tool-call-header');
+          const reply = document.querySelector('.message-actor-reply');
+          const announcement = document.querySelector('.actor-recovery-announcement[role="status"]');
+          if (!card || !reply) return null;
+          return {
+            card: card.textContent ?? '',
+            role: reply.querySelector('.role')?.textContent ?? '',
+            body: reply.querySelector('.bubble')?.textContent ?? '',
+            liveRole: announcement?.getAttribute('role') ?? null,
+            live: announcement?.getAttribute('aria-live') ?? null,
+            atomic: announcement?.getAttribute('aria-atomic') ?? null,
+            announcement: announcement?.textContent ?? '',
+            replyLive: reply.getAttribute('aria-live'),
+          };
+        })()`), { budgetMs: 5_000, pollMs: 50 });
+        rec.check('a post-start failure is labeled Outcome unknown, never Not run or done',
+          unknownOutcome?.card.includes('Outcome unknown')
+            && unknownOutcome?.role.includes('Outcome unknown')
+            && !unknownOutcome?.card.includes('Not run')
+            && !unknownOutcome?.card.includes('done'),
+          JSON.stringify(unknownOutcome));
+        rec.check('unknown-outcome recovery guidance remains visible to the user',
+          unknownOutcome?.body.includes('peerd cannot confirm whether the actor ran or completed')
+            && unknownOutcome?.body.includes('Check the target before trying again')
+            && !unknownOutcome?.body.includes('Do not retry automatically'),
+          JSON.stringify(unknownOutcome));
+        const queuedRecovery = await evalIn(page, `(() => {
+          const replies = [...document.querySelectorAll('.message-actor-reply')];
+          const reply = replies.find((node) => node.querySelector('.role')?.textContent?.includes('Not run'));
+          return reply ? {
+            role: reply.querySelector('.role')?.textContent ?? '',
+            body: reply.querySelector('.bubble')?.textContent ?? '',
+            replyLive: reply.getAttribute('aria-live'),
+            nestedStatuses: reply.querySelectorAll('[role="status"]').length,
+          } : null;
+        })()`);
+        rec.check('a queued recovery receipt is labeled Not run, never failed or unknown',
+          queuedRecovery?.role.includes('Not run')
+            && !queuedRecovery?.role.includes('failed')
+            && !queuedRecovery?.role.includes('Outcome unknown')
+            && queuedRecovery?.body.includes('before this actor request was dispatched'),
+          JSON.stringify(queuedRecovery));
+        rec.check('recovery receipts use one transient polite atomic announcement',
+          unknownOutcome?.liveRole === 'status'
+            && unknownOutcome?.live === 'polite'
+            && unknownOutcome?.atomic === 'true'
+            && unknownOutcome?.announcement.includes('Actor outcome unknown')
+            && unknownOutcome?.announcement.includes('Actor request not run')
+            && unknownOutcome?.replyLive === null
+            && queuedRecovery?.replyLive === null
+            && queuedRecovery?.nestedStatuses === 0,
+          JSON.stringify(unknownOutcome));
+        const spawnedUnknown = await evalIn(page, `(() => {
+          const cards = [...document.querySelectorAll('.tool-actor')];
+          const card = cards.find((node) => node.querySelector('.tool-name')?.textContent === 'actor_create');
+          const header = card?.querySelector('button.tool-call-header');
+          header?.click();
+          const announcement = document.querySelector('.actor-recovery-announcement[role="status"]');
+          return {
+            label: header?.textContent ?? '',
+            permanentStatuses: card?.querySelectorAll('[role="status"]').length ?? 0,
+            live: announcement?.getAttribute('aria-live'),
+            atomic: announcement?.getAttribute('aria-atomic'),
+            liveLabel: announcement?.textContent ?? '',
+          };
+        })()`);
+        const spawnedUnknownBody = await waitFor(() => evalIn(page, `(() => {
+          const cards = [...document.querySelectorAll('.tool-actor')];
+          const card = cards.find((node) => node.querySelector('.tool-name')?.textContent === 'actor_create');
+          return card?.querySelector('.actor-body')?.textContent ?? '';
+        })()`), { budgetMs: 2_000, pollMs: 50 });
+        rec.check('sync actor_create also labels the failure Outcome unknown',
+          spawnedUnknown?.label.includes('Outcome unknown')
+            && !spawnedUnknown?.label.includes('done'),
+          JSON.stringify(spawnedUnknown));
+        rec.check('sync actor_create shows only the human recovery step',
+          spawnedUnknownBody?.includes('Check the target before trying again')
+            && !spawnedUnknownBody?.includes('Do not retry automatically'),
+          JSON.stringify({ ...spawnedUnknown, body: spawnedUnknownBody }));
+        rec.check('sync actor_create uses the shared transient unknown-outcome announcement',
+          spawnedUnknown?.permanentStatuses === 0
+            && spawnedUnknown?.live === 'polite'
+            && spawnedUnknown?.atomic === 'true'
+            && spawnedUnknown?.liveLabel?.includes('Actor outcome unknown'),
+          JSON.stringify(spawnedUnknown));
+        await rec.shotPage('outcome-unknown.dark', page);
+      } finally { try { page.close(); } catch { /* */ } }
+    },
+  },
+
   // --- visual (WIDE): the full-tab options / settings page --------------------
   {
     name: 'options-fulltab', kind: 'visual', phase: 'post-unlock',
@@ -1864,13 +2073,13 @@ export const STATES = [
     },
   },
 
-  // --- functional: a pure-reasoning actor runs in its OWN offscreen heap ---
+  // --- functional: a pure-reasoning actor runs in its OWN isolated heap ---
   // Heap-split phase 1. The orchestrator spawns a sync tools:[] actor; that
-  // child's loop runs in a dedicated offscreen Worker (its own heap, no key),
+  // child's loop runs in a dedicated Worker (its own heap, no key),
   // relaying its model call back to the SW. Proof: the child model call happens
   // (its prompt carries the EPHEMERAL ACTOR block), the result round-trips into
-  // the orchestrator's final answer, AND the actor_ran_offscreen audit marker
-  // is present (it fired only on the offscreen path, never the in-SW fallback).
+  // the orchestrator's final answer, AND the host-neutral actor_ran_isolated
+  // audit carries the dedicated-worker and verified-realm proof fields.
   {
     name: 'reasoning-offscreen', kind: 'functional', phase: 'post-unlock',
     responder: (callIndex, request) => {
@@ -1887,6 +2096,7 @@ export const STATES = [
     },
     async run(ctx, rec) {
       reasoningState = { spawned: 0, childCalls: 0 };
+      const priorAuditIds = new Set((await auditEntries(ctx)).map((entry) => entry.id));
       const sent = await rpc(ctx.page, { type: 'agent/send', text: 'reason about the answer to life' });
       rec.check('agent/send accepted', !!sent?.ok, JSON.stringify(sent));
       let out = {};
@@ -1899,30 +2109,25 @@ export const STATES = [
         return (out.bubbles || []).includes('FINAL-ANSWER-42') && !out.busy;
       }, { budgetMs: 30_000 });
 
-      // The offscreen PROOF: the child ran in its own worker heap (this audit
-      // type is appended ONLY on the offscreen path; the in-SW fallback appends
-      // actor_offscreen_fallback instead).
-      const audit = await rpc(ctx.page, { type: 'audit/list', limit: 500 });
-      const entries = (audit && audit.entries) || [];
-      const ranOffscreen = entries.some((e) => e.type === 'actor_ran_offscreen');
-      const fellBack = entries.some((e) => e.type === 'actor_offscreen_fallback');
+      const entries = (await auditEntries(ctx)).filter((entry) => !priorAuditIds.has(entry.id));
+      const isolation = actorIsolationEvidence(entries);
       const actorTypes = entries.filter((e) => String(e.type).startsWith('spawned')).map((e) => e.type);
       rec.check('the child sub-loop ran (EPHEMERAL ACTOR prompt seen)', reasoningState.childCalls >= 1, `childCalls=${reasoningState.childCalls}`);
-      rec.check('the pure-reasoning child ran in its OWN offscreen heap (actor_ran_offscreen audit)', ranOffscreen === true, `offscreen=${ranOffscreen} fellBack=${fellBack} bubbles=${JSON.stringify(out.bubbles)} actorAudits=${JSON.stringify(actorTypes)}`);
-      rec.check('it did NOT silently fall back to the in-SW loop', fellBack === false);
+      rec.check('the pure-reasoning child ran in a dedicated Worker with a verified realm', isolation.exactProof === true, `isolated=${isolation.isolated.length} backgroundRefused=${isolation.backgroundRefused} isolationFailed=${isolation.isolationFailed} bubbles=${JSON.stringify(out.bubbles)} actorAudits=${JSON.stringify(actorTypes)}`);
+      rec.check('it did NOT enter the background turn driver or fail isolation', isolation.backgroundRefused === false && isolation.isolationFailed === false);
       rec.check('the child result round-tripped into the orchestrator final answer', (out.bubbles || []).includes('FINAL-ANSWER-42'));
       rec.check('the turn settles idle', out.busy === false);
       await rec.shot('final');
     },
   },
 
-  // --- functional: a TOOL-BEARING actor runs in its OWN offscreen heap ---
+  // --- functional: a TOOL-BEARING actor runs in its OWN isolated heap ---
   // Heap-split phase 4. The orchestrator spawns a sync actor GRANTED script;
-  // that child's loop runs in a dedicated offscreen Worker (its own heap, no key)
+  // that child's loop runs in a dedicated Worker (its own heap, no key)
   // and RELAYS its script call back to the SW, which rebuilds the child's restricted
   // ctx from the persisted grantedTools and dispatches script in the offscreen
   // job-runner. Proof: the child looped (two model calls: emit script, then answer),
-  // the actor_ran_offscreen audit fired (offscreen path, not the in-SW fallback),
+  // the actor_ran_isolated audit carries the dedicated-worker realm proof,
   // AND a tool_executed audit for script is present (the relayed tool actually ran).
   {
     name: 'actor-tools-offscreen', kind: 'functional', phase: 'post-unlock',
@@ -1944,6 +2149,7 @@ export const STATES = [
     },
     async run(ctx, rec) {
       actorToolsState = { spawned: 0, childCalls: 0 };
+      const priorAuditIds = new Set((await auditEntries(ctx)).map((entry) => entry.id));
       const sent = await rpc(ctx.page, { type: 'agent/send', text: 'use an actor to compute six times seven' });
       rec.check('agent/send accepted', !!sent?.ok, JSON.stringify(sent));
       let out = {};
@@ -1956,15 +2162,13 @@ export const STATES = [
         return (out.bubbles || []).includes('FINAL-WITH-CHILD') && !out.busy;
       }, { budgetMs: 30_000 });
 
-      const audit = await rpc(ctx.page, { type: 'audit/list', limit: 500 });
-      const entries = (audit && audit.entries) || [];
-      const ranOffscreen = entries.some((e) => e.type === 'actor_ran_offscreen');
-      const fellBack = entries.some((e) => e.type === 'actor_offscreen_fallback');
+      const entries = (await auditEntries(ctx)).filter((entry) => !priorAuditIds.has(entry.id));
+      const isolation = actorIsolationEvidence(entries);
       const jsRan = entries.some((e) => e.type === 'tool_executed' && e.details && e.details.tool === 'script');
       rec.check('the tool-bearing child looped in its heap (script emitted, then answered) — 2 child calls', actorToolsState.childCalls >= 2, `childCalls=${actorToolsState.childCalls}`);
-      rec.check('the child ran in its OWN offscreen heap (actor_ran_offscreen audit)', ranOffscreen === true, `offscreen=${ranOffscreen} fellBack=${fellBack}`);
+      rec.check('the child ran in a dedicated Worker with a verified realm', isolation.exactProof === true, `isolated=${isolation.isolated.length}`);
       rec.check('script actually executed via the SW-gated relay (tool_executed audit)', jsRan === true, `jsRan=${jsRan}`);
-      rec.check('it did NOT fall back to the in-SW loop', fellBack === false);
+      rec.check('it did NOT enter the background turn driver or fail isolation', isolation.backgroundRefused === false && isolation.isolationFailed === false);
       rec.check('the child result round-tripped into the orchestrator final answer', (out.bubbles || []).includes('FINAL-WITH-CHILD'));
       rec.check('the turn settles idle', out.busy === false);
       await rec.shot('final');
@@ -2010,6 +2214,7 @@ export const STATES = [
       actorCodeDelegatesState = {
         spawned: 0, childCalls: 0, webCalls: 0, sawComposedResult: false,
       };
+      const priorAuditIds = new Set((await auditEntries(ctx)).map((entry) => entry.id));
       const sent = await rpc(ctx.page, { type: 'agent/send', text: 'use an actor script to ask the web actor for the price' });
       rec.check('agent/send accepted', !!sent?.ok, JSON.stringify(sent));
       let out = {};
@@ -2022,15 +2227,13 @@ export const STATES = [
         return (out.bubbles || []).includes('FINAL-VIA-ACTOR-CODE') && !out.busy;
       }, { budgetMs: 45_000 });
 
-      const audit = await rpc(ctx.page, { type: 'audit/list', limit: 800 });
-      const entries = (audit && audit.entries) || [];
-      const ranOffscreen = entries.some((e) => e.type === 'actor_ran_offscreen');
-      const fellBack = entries.some((e) => e.type === 'actor_offscreen_fallback');
+      const entries = (await auditEntries(ctx)).filter((entry) => !priorAuditIds.has(entry.id));
+      const isolation = actorIsolationEvidence(entries);
       const jsRan = entries.some((e) => e.type === 'tool_executed' && e.details && e.details.tool === 'script');
       rec.check('the actor script ran through the SW-gated relay', jsRan === true, `jsRan=${jsRan}`);
       rec.check('the actor looped after code received the web reply', actorCodeDelegatesState.childCalls >= 2 && actorCodeDelegatesState.sawComposedResult, `childCalls=${actorCodeDelegatesState.childCalls} composed=${actorCodeDelegatesState.sawComposedResult}`);
       rec.check('actors.call reached a real web-actor heap', actorCodeDelegatesState.webCalls >= 1, `webCalls=${actorCodeDelegatesState.webCalls}`);
-      rec.check('the actor stayed in its isolated offscreen heap', ranOffscreen === true && fellBack === false, `offscreen=${ranOffscreen} fellBack=${fellBack}`);
+      rec.check('the actor stayed in a dedicated Worker with a verified realm', isolation.exactProof === true && isolation.backgroundRefused === false && isolation.isolationFailed === false, `isolated=${isolation.isolated.length} backgroundRefused=${isolation.backgroundRefused} isolationFailed=${isolation.isolationFailed}`);
       rec.check('the composed result reached the orchestrator', (out.bubbles || []).includes('FINAL-VIA-ACTOR-CODE'));
       rec.check('the turn settles idle', out.busy === false);
       await rec.shot('final');
@@ -2040,11 +2243,11 @@ export const STATES = [
   // --- functional: an offscreen actor DELEGATES to its own web actor ------
   // Heap-split phase 4, the deepest chain — two isolated heaps stacked. The
   // orchestrator spawns a sync actor granted message_actor; that actor's loop
-  // runs in its OWN offscreen heap and calls message_actor({to:'web'}) — which relays
+  // runs in its OWN isolated Worker heap and calls message_actor({to:'web'}) — which relays
   // to the SW, dispatches actorMessaging from the child's restricted ctx, and (because
   // the sender is an actor) AWAITS the web actor's fenced reply into the child's tool
-  // result. The web actor is ITSELF an offscreen heap (phase 3). Proof: the child looped
-  // offscreen, a web-actor sub-loop ran, message_actor executed via the relay, and the
+  // result. The web actor is ITSELF an isolated Worker heap (phase 3). Proof: the child
+  // looped in isolation, a web-actor sub-loop ran, message_actor executed via the relay, and the
   // web reply round-tripped up through the child into the orchestrator's answer. This is
   // the delegation-from-a-heap path the unit tests can only stub.
   {
@@ -2072,6 +2275,7 @@ export const STATES = [
     },
     async run(ctx, rec) {
       actorDelegatesState = { spawned: 0, childCalls: 0, webCalls: 0 };
+      const priorAuditIds = new Set((await auditEntries(ctx)).map((entry) => entry.id));
       const sent = await rpc(ctx.page, { type: 'agent/send', text: 'use an actor to ask the web actor for the price' });
       rec.check('agent/send accepted', !!sent?.ok, JSON.stringify(sent));
       let out = {};
@@ -2084,16 +2288,14 @@ export const STATES = [
         return (out.bubbles || []).includes('FINAL-VIA-ACTOR') && !out.busy;
       }, { budgetMs: 40_000 });
 
-      const audit = await rpc(ctx.page, { type: 'audit/list', limit: 800 });
-      const entries = (audit && audit.entries) || [];
-      const ranOffscreen = entries.some((e) => e.type === 'actor_ran_offscreen');
-      const fellBack = entries.some((e) => e.type === 'actor_offscreen_fallback');
+      const entries = (await auditEntries(ctx)).filter((entry) => !priorAuditIds.has(entry.id));
+      const isolation = actorIsolationEvidence(entries);
       const msgActorRan = entries.some((e) => e.type === 'tool_executed' && e.details && e.details.tool === 'message_actor');
-      rec.check('the actor looped offscreen (message_actor emitted, then answered) — 2 child calls', actorDelegatesState.childCalls >= 2, `childCalls=${actorDelegatesState.childCalls}`);
-      rec.check('the actor ran in its OWN offscreen heap (actor_ran_offscreen audit)', ranOffscreen === true, `offscreen=${ranOffscreen} fellBack=${fellBack}`);
+      rec.check('the actor looped in isolation (message_actor emitted, then answered) — 2 child calls', actorDelegatesState.childCalls >= 2, `childCalls=${actorDelegatesState.childCalls}`);
+      rec.check('the actor ran in a dedicated Worker with a verified realm', isolation.exactProof === true, `isolated=${isolation.isolated.length}`);
       rec.check('the actor delegated via message_actor from its heap (tool_executed audit)', msgActorRan === true, `msgActorRan=${msgActorRan}`);
       rec.check('a WEB-ACTOR sub-loop ran (its own heap) for the child delegation', actorDelegatesState.webCalls >= 1, `webCalls=${actorDelegatesState.webCalls}`);
-      rec.check('it did NOT fall back to the in-SW loop', fellBack === false);
+      rec.check('it did NOT enter the background turn driver or fail isolation', isolation.backgroundRefused === false && isolation.isolationFailed === false);
       rec.check('the web reply round-tripped up through the actor into the final answer', (out.bubbles || []).includes('FINAL-VIA-ACTOR'));
       rec.check('the turn settles idle', out.busy === false);
       await rec.shot('final');

--- a/scripts/firefox/outcome-unknown-oracle.mjs
+++ b/scripts/firefox/outcome-unknown-oracle.mjs
@@ -1,0 +1,17 @@
+// Pure semantic oracles for Firefox's packaged unknown-outcome test. The
+// lifecycle marker is stable; the user-facing explanation is free to change
+// wording while preserving the warning and recovery action.
+
+export const hasOutcomeUnknownState = (text) =>
+  String(text ?? '').includes('outcome_unknown:');
+
+export const hasAmbiguousOutcomeWarning = (text) =>
+  /may have completed|cannot confirm whether[^.]*\b(?:ran|completed)\b|outcome is unknown/i
+    .test(String(text ?? ''));
+
+export const advisesCheckingBeforeRetry = (text) => {
+  const value = String(text ?? '');
+  return /\b(?:check|verify)\b/i.test(value)
+    && /\b(?:target|external state|requested action)\b/i.test(value)
+    && /\b(?:retry(?:ing)?|repeat(?:ing)?|try(?:ing)?\s+again)\b/i.test(value);
+};

--- a/scripts/firefox/run-runtime-tests.mjs
+++ b/scripts/firefox/run-runtime-tests.mjs
@@ -2053,15 +2053,22 @@ const runBrokenWorkerSmoke = async ({ providerServer, fixturePort }) => {
       && accessible?.expanded === 'false',
     'the failed message_actor card is a collapsed Not run disclosure', JSON.stringify(accessible));
 
-    const expanded = await driver.execute(`
+    const disclosureClicked = await driver.execute(`
       const header = [...document.querySelectorAll('.tool-call.tool-actor button.tool-call-header')]
         .find((node) => node.querySelector('.tool-name')?.textContent === 'message_actor');
       header?.click();
-      return {
+      return !!header;
+    `);
+    assert(disclosureClicked === true, 'the Not run disclosure accepts its expand action');
+    const expanded = await waitFor(() => driver.execute(`
+      const header = [...document.querySelectorAll('.tool-call.tool-actor button.tool-call-header')]
+        .find((node) => node.querySelector('.tool-name')?.textContent === 'message_actor');
+      const state = {
         expanded: header?.getAttribute('aria-expanded') ?? null,
         error: header?.parentElement?.querySelector('.actor-body .error-line')?.textContent ?? null,
       };
-    `);
+      return state.expanded === 'true' && typeof state.error === 'string' ? state : null;
+    `), { budgetMs: 5_000, pollMs: 100 });
     assert(expanded?.expanded === 'true' && typeof expanded?.error === 'string'
       && expanded.error.includes('actor_isolation_temporarily_unavailable')
       && !/Do not retry automatically|Use the Try again control/i.test(expanded.error),

--- a/scripts/firefox/run-runtime-tests.mjs
+++ b/scripts/firefox/run-runtime-tests.mjs
@@ -646,6 +646,17 @@ const createBrokenWorkerArtifact = () => {
   const staging = join(directory, 'staging');
   const artifact = join(directory, `peerd-${VERSION}-store-firefox-broken-worker.xpi`);
   cpSync(join(ROOT, 'artifacts', 'staging', 'store-firefox'), staging, { recursive: true });
+  const probe = join(staging, 'background', 'firefox-broken-worker-probe.js');
+  writeFileSync(probe, `const bootId = crypto.randomUUID();
+browser.runtime.onMessage.addListener((message) =>
+  message?.type === 'firefox-broken-worker/boot-id'
+    ? Promise.resolve({ ok: true, bootId })
+    : undefined);
+`, { flag: 'wx', mode: 0o600 });
+  const serviceWorker = join(staging, 'background', 'service-worker.js');
+  const serviceWorkerSource = readFileSync(serviceWorker, 'utf8');
+  overwriteRegularFile(serviceWorker,
+    `import './firefox-broken-worker-probe.js';\n${serviceWorkerSource}`);
   const worker = join(staging, 'offscreen', 'actor-worker.js');
   overwriteRegularFile(worker, `await fetch('https://api.anthropic.com${WORKER_PROBE_PATH}', { method: 'POST', cache: 'no-store' });
 throw new Error('Firefox runtime test fault: actor worker failed before ready');
@@ -1788,8 +1799,11 @@ const runBrokenWorkerSmoke = async ({ providerServer, fixturePort }) => {
         const provider = await send({
           type: 'provider/setKey', provider: 'anthropic', plaintext: ${JSON.stringify(PROVIDER_KEY_CANARY)},
         });
+        const boot = await send({ type: 'firefox-broken-worker/boot-id' });
         return {
-          ok: before?.ok === true && vault?.ok === true && provider?.ok === true,
+          ok: before?.ok === true && vault?.ok === true && provider?.ok === true
+            && typeof boot?.bootId === 'string',
+          bootId: boot?.bootId ?? null,
           capability: before?.state?.capabilities?.actorExecution ?? null,
         };
       })().then(done, (error) => done({ ok: false, error: error?.message || String(error) }));
@@ -1944,29 +1958,66 @@ const runBrokenWorkerSmoke = async ({ providerServer, fixturePort }) => {
       'the broken-worker state, audit, and session diagnostics contain no credential canaries');
 
     const probesBeforeReload = providerServer.workerStartupProbes;
-    try { await driver.execute('browser.runtime.reload(); return true;'); }
-    catch { /* the page can disconnect before WebDriver receives the return */ }
-    const reloaded = await waitFor(async () => {
+    // Use Firefox's real event-page lifecycle here too. runtime.reload removes
+    // the temporary add-on document from under WebDriver and can make its
+    // moz-extension origin unavailable for the remainder of the command budget.
+    const extensionHandle = await driver.windowHandle();
+    const survivor = await driver.newWindow('tab');
+    assert(typeof survivor?.handle === 'string',
+      'the failure restart keeps a plain browser context alive',
+      JSON.stringify(survivor));
+    await driver.switchToWindow(survivor.handle);
+    await driver.navigate('about:blank');
+    await driver.switchToWindow(extensionHandle);
+    await driver.closeWindow();
+    await driver.switchToWindow(survivor.handle);
+    const openHandles = await driver.windowHandles();
+    assert(Array.isArray(openHandles) && !openHandles.includes(extensionHandle),
+      'the failure proof physically closes the extension UI context',
+      JSON.stringify(openHandles));
+    await new Promise((resolveWait) => setTimeout(resolveWait,
+      FIREFOX_EVENT_PAGE_IDLE_MS + FIREFOX_EVENT_PAGE_RESTART_MARGIN_MS));
+    let lastRestartObserved = null;
+    let lastRestartError = null;
+    const restarted = await waitFor(async () => {
       try {
         await driver.navigate(`${EXTENSION_ORIGIN}/sidepanel/sidepanel.html`);
-        return await driver.execute(`return chrome.runtime.id === ${JSON.stringify(ADDON_ID)}
-          && !!document.querySelector('#app');`);
-      } catch { return false; }
+        const observed = await driver.executeAsync(`
+          const done = arguments[arguments.length - 1];
+          Promise.all([
+            browser.runtime.sendMessage({ type: 'state/get' }),
+            browser.runtime.sendMessage({ type: 'firefox-broken-worker/boot-id' }),
+          ]).then(([state, boot]) => done({
+            mounted: !!document.querySelector('#app'),
+            capability: state?.state?.capabilities?.actorExecution ?? null,
+            bootId: boot?.bootId ?? null,
+          }), (error) => done({ error: error?.message || String(error) }));
+        `);
+        lastRestartObserved = observed;
+        return observed?.mounted === true
+          && observed?.bootId !== initialized.bootId
+          && observed?.capability?.status === 'temporarily_unavailable'
+          && observed?.capability?.host === 'background-page-worker'
+          && observed?.capability?.retryable === true
+          ? observed
+          : null;
+      } catch (error) {
+        lastRestartError = {
+          name: typeof error?.name === 'string' ? error.name : null,
+          message: error?.message ?? String(error),
+        };
+        return null;
+      }
     }, { budgetMs: 30_000, pollMs: 250 });
-    assert(reloaded === true, 'the side panel reconnects after the Firefox background reload');
-    const persistedCapability = await waitFor(() => driver.executeAsync(`
-      const done = arguments[arguments.length - 1];
-      browser.runtime.sendMessage({ type: 'state/get' })
-        .then((reply) => {
-          const capability = reply?.state?.capabilities?.actorExecution ?? null;
-          done(capability?.retryable === true ? capability : null);
-        },
-          (error) => done({ error: error?.message || String(error) }));
-    `), { budgetMs: 30_000, pollMs: 250 });
+    assert(typeof restarted?.bootId === 'string'
+      && restarted.bootId !== initialized.bootId,
+    'the side panel reconnects to a new Firefox event-page generation',
+    JSON.stringify({ previousBootId: initialized.bootId, lastRestartObserved, lastRestartError }));
+    const persistedCapability = restarted.capability;
     assert(persistedCapability?.status === 'temporarily_unavailable'
       && persistedCapability?.host === 'background-page-worker'
       && persistedCapability?.retryable === true,
-    'the worker failure remains fail-closed after the Firefox background reload',
+    'the worker failure remains fail-closed after the Firefox event-page restart',
     JSON.stringify(persistedCapability));
     assert(providerServer.workerStartupProbes === probesBeforeReload,
       'background restart does not clear or automatically probe the stored failure',

--- a/scripts/firefox/run-runtime-tests.mjs
+++ b/scripts/firefox/run-runtime-tests.mjs
@@ -2065,13 +2065,13 @@ const runBrokenWorkerSmoke = async ({ providerServer, fixturePort }) => {
         .find((node) => node.querySelector('.tool-name')?.textContent === 'message_actor');
       const state = {
         expanded: header?.getAttribute('aria-expanded') ?? null,
-        error: header?.parentElement?.querySelector('.actor-body .error-line')?.textContent ?? null,
+        detail: header?.parentElement?.querySelector('.actor-body .error-line')?.textContent ?? null,
       };
-      return state.expanded === 'true' && typeof state.error === 'string' ? state : null;
+      return state.expanded === 'true' && typeof state.detail === 'string' ? state : null;
     `), { budgetMs: 5_000, pollMs: 100 });
-    assert(expanded?.expanded === 'true' && typeof expanded?.error === 'string'
-      && expanded.error.includes('actor_isolation_temporarily_unavailable')
-      && !/Do not retry automatically|Use the Try again control/i.test(expanded.error),
+    assert(expanded?.expanded === 'true' && typeof expanded?.detail === 'string'
+      && expanded.detail.includes('actor_isolation_temporarily_unavailable')
+      && !/Do not retry automatically|Use the Try again control/i.test(expanded.detail),
     'the Not run disclosure exposes the failure reason without relying on color',
     JSON.stringify(expanded));
   } finally {

--- a/scripts/firefox/run-runtime-tests.mjs
+++ b/scripts/firefox/run-runtime-tests.mjs
@@ -51,6 +51,7 @@ const LIFETIME_ACTOR_PROMPT = 'Return the Firefox background lifetime proof toke
 const LIFETIME_HEARTBEAT_KEY = 'peerdActorHostKeepAlive';
 const LIFETIME_RESPONSE_DELAY_MS = 65_000;
 const FIREFOX_EVENT_PAGE_IDLE_MS = 30_000;
+const FIREFOX_EVENT_PAGE_RESTART_MARGIN_MS = 15_000;
 const LIFETIME_QUIET_MS = 12_000;
 const LIFETIME_FAILURE_SCREENSHOT = 'lifetime-failure.png';
 const LIFETIME_FAILURE_LOG = 'lifetime-geckodriver.log';
@@ -1516,7 +1517,7 @@ const runActorKeepaliveLossSmoke = async ({ providerServer, fixturePort }) => {
 };
 
 const runActorRecoverySmoke = async ({ providerServer }) => {
-  console.log('Firefox actor recovery smoke: reload twice without replaying durable mailbox work');
+  console.log('Firefox actor recovery smoke: idle-restart twice without replaying durable mailbox work');
   const { artifact, directory } = createRecoveryArtifact();
   let driver = null;
   try {
@@ -1622,22 +1623,32 @@ const runActorRecoverySmoke = async ({ providerServer }) => {
       }, (error) => done({ ok: false, error: error?.message || String(error) }));
     `, [prepared.sessionId, expectedReceiptIds]);
 
-    const reloadAndRecover = async (previousBoot) => {
-      // runtime.reload invalidates the extension document that issued it. Keep a
-      // neutral WebDriver context alive so the session has somewhere valid to
-      // land before navigating back into the reloaded extension.
+    const idleRestartAndRecover = async (previousBoot) => {
+      // Exercise Firefox's real event-page lifecycle. runtime.reload tears down
+      // the temporary add-on's moz-extension document and Gecko may reject
+      // navigation back to that origin for the whole WebDriver command budget,
+      // which tests add-on reinstallation rather than product recovery. Closing
+      // the last extension UI releases its port; after Firefox's idle window the
+      // event page is discarded and the survivor tab can wake a fresh generation.
       const extensionHandle = await driver.windowHandle();
       const survivor = await driver.newWindow('tab');
       assert(typeof survivor?.handle === 'string',
-        'the recovery reload keeps a plain browser context alive',
+        'the recovery restart keeps a plain browser context alive',
         JSON.stringify(survivor));
       await driver.switchToWindow(survivor.handle);
       await driver.navigate('about:blank');
       await driver.switchToWindow(extensionHandle);
-      try { await driver.execute('browser.runtime.reload(); return true;'); }
-      catch { /* the extension page can disconnect before the command returns */ }
+      await driver.closeWindow();
       await driver.switchToWindow(survivor.handle);
+      const openHandles = await driver.windowHandles();
+      assert(Array.isArray(openHandles) && !openHandles.includes(extensionHandle),
+        'the recovery proof physically closes the extension UI context',
+        JSON.stringify(openHandles));
+      await new Promise((resolveWait) => setTimeout(resolveWait,
+        FIREFOX_EVENT_PAGE_IDLE_MS + FIREFOX_EVENT_PAGE_RESTART_MARGIN_MS));
+
       let lastObserved = null;
+      let lastThrownError = null;
       const ready = await waitFor(async () => {
         try {
           await driver.navigate(`${EXTENSION_ORIGIN}/sidepanel/sidepanel.html`);
@@ -1658,12 +1669,18 @@ const runActorRecoverySmoke = async ({ providerServer }) => {
             && observed.boot.bootId !== previousBoot.bootId
             ? observed
             : null;
-        } catch { return null; }
+        } catch (error) {
+          lastThrownError = {
+            name: typeof error?.name === 'string' ? error.name : null,
+            message: error?.message ?? String(error),
+          };
+          return null;
+        }
       }, { budgetMs: 30_000, pollMs: 250 });
       assert(typeof ready?.boot?.bootId === 'string'
         && ready.boot.bootId !== previousBoot.bootId,
       'the recovery XPI starts a new background generation',
-      JSON.stringify({ previousBoot, lastObserved }));
+      JSON.stringify({ previousBoot, lastObserved, lastThrownError }));
       if (ready.state?.vault?.locked === true) {
         const unlocked = await driver.executeAsync(`
           const [passphrase] = arguments;
@@ -1690,7 +1707,7 @@ const runActorRecoverySmoke = async ({ providerServer }) => {
       return recovered;
     };
 
-    const first = await reloadAndRecover(prepared.boot);
+    const first = await idleRestartAndRecover(prepared.boot);
     assert(first.receipts.some((receipt) => receipt.id.endsWith(':firefox-recovery-queued')
       && receipt.outcomeKnown === true && receipt.performed === false
       && receipt.content.includes('It was not run')),
@@ -1707,7 +1724,7 @@ const runActorRecoverySmoke = async ({ providerServer }) => {
       'first background recovery performs no provider or actor request',
       JSON.stringify(providerServer.records.slice(recordStart)));
 
-    const second = await reloadAndRecover(first.boot);
+    const second = await idleRestartAndRecover(first.boot);
     await new Promise((resolveWait) => setTimeout(resolveWait, 1_500));
     const finalState = await readRecoveryState();
     assert(finalState?.mailboxKeys?.length === 0

--- a/scripts/firefox/run-runtime-tests.mjs
+++ b/scripts/firefox/run-runtime-tests.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-// Firefox runtime gate, first slice.
+// Firefox packaged parity and runtime gate.
 //
 // This installs the real staged Store XPI as a temporary add-on, boots its
 // background page and primary UI pages, and exercises the real Firefox
@@ -9,7 +9,10 @@
 // diagnostic.
 
 import { execFileSync } from 'node:child_process';
-import { createReadStream, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import {
+  closeSync, constants, cpSync, createReadStream, existsSync, fstatSync, mkdirSync,
+  mkdtempSync, openSync, readFileSync, rmSync, statSync, writeFileSync,
+} from 'node:fs';
 import { createServer } from 'node:http';
 import { createServer as createHttpsServer } from 'node:https';
 import { connect as connectSocket } from 'node:net';
@@ -18,6 +21,11 @@ import { delimiter, dirname, extname, join, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { packageArtifact } from '../../packaging/package.ts';
 import { startGeckodriver, waitFor } from './webdriver.mjs';
+import {
+  advisesCheckingBeforeRetry,
+  hasAmbiguousOutcomeWarning,
+  hasOutcomeUnknownState,
+} from './outcome-unknown-oracle.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(HERE, '..', '..');
@@ -28,6 +36,7 @@ const ADDON_ID = 'peerd@peerd.ai';
 const TEST_UUID = '7d12f198-31fc-4e95-9184-e954123981a6';
 const EXTENSION_ORIGIN = `moz-extension://${TEST_UUID}`;
 const FIXTURE_PATH = '/__firefox-runtime-fixture';
+const WORKER_PROBE_PATH = '/__firefox-worker-startup-probe';
 const MODULE_IMPORT_PROBE_PATH = '/__firefox-module-import-probe.js';
 const RESULT_BUDGET_MS = 180_000;
 const PROVIDER_PATH = '/v1/messages';
@@ -36,6 +45,29 @@ const PROVIDER_KEY_CANARY = 'sk-ant-firefox-provider-canary-7d12f198';
 const ACTOR_REPLY_CANARY = 'firefox-bound-actor-reply-7d12f198';
 const FINAL_REPLY_CANARY = 'firefox-parent-final-reply-7d12f198';
 const ACTOR_PROMPT = 'Return the Firefox bound actor proof token.';
+const LIFETIME_ACTOR_REPLY_CANARY = 'firefox-lifetime-actor-reply-7d12f198';
+const LIFETIME_FINAL_REPLY_CANARY = 'firefox-lifetime-parent-final-7d12f198';
+const LIFETIME_ACTOR_PROMPT = 'Return the Firefox background lifetime proof token.';
+const LIFETIME_HEARTBEAT_KEY = 'peerdActorHostKeepAlive';
+const LIFETIME_RESPONSE_DELAY_MS = 65_000;
+const FIREFOX_EVENT_PAGE_IDLE_MS = 30_000;
+const LIFETIME_QUIET_MS = 12_000;
+const LIFETIME_FAILURE_SCREENSHOT = 'lifetime-failure.png';
+const LIFETIME_FAILURE_LOG = 'lifetime-geckodriver.log';
+const LIFETIME_FAILURE_DIAGNOSTIC = 'lifetime-failure.json';
+const KEEPALIVE_LOSS_ACTOR_PROMPT = 'Click the Firefox parity action, then report its status.';
+const KEEPALIVE_LOSS_TOOL_ID = 'firefox-keepalive-loss-click';
+const KEEPALIVE_LOSS_FINAL_CANARY = 'firefox-keepalive-loss-final-7d12f198';
+const KEEPALIVE_LOSS_LATE_CANARY = 'firefox-keepalive-loss-late-response-7d12f198';
+const KEEPALIVE_LOSS_RESPONSE_DELAY_MS = 20_000;
+const KEEPALIVE_LOSS_SCREENSHOT = 'keepalive-loss.png';
+const KEEPALIVE_LOSS_LOG = 'keepalive-loss-geckodriver.log';
+const KEEPALIVE_LOSS_DIAGNOSTIC = 'keepalive-loss.json';
+const RECOVERY_SEED_KEY = 'peerdFirefoxActorRecoverySeed';
+const RECOVERY_BOOT_KEY = 'peerdFirefoxActorRecoveryBoot';
+const FAILURE_FINAL_CANARY = 'firefox-actor-not-run-final-7d12f198';
+const FAILURE_ACTOR_PROMPT = 'Click the Firefox parity action and report the page status.';
+const BROKEN_WORKER_SCREENSHOT = 'broken-worker.png';
 
 const onPath = (name) => (process.env.PATH ?? '').split(delimiter)
   .map((directory) => join(directory, name))
@@ -52,6 +84,17 @@ const geckodriverBinary = process.env.GECKODRIVER_PATH || onPath('geckodriver');
 const assert = (condition, message, detail = '') => {
   if (!condition) throw new Error(`${message}${detail ? `: ${detail}` : ''}`);
   console.log(`  ✓ ${message}`);
+};
+
+const overwriteRegularFile = (path, contents) => {
+  const descriptor = openSync(path,
+    constants.O_WRONLY | constants.O_TRUNC | constants.O_NOFOLLOW);
+  try {
+    if (!fstatSync(descriptor).isFile()) throw new Error(`refusing to overwrite non-file: ${path}`);
+    writeFileSync(descriptor, contents);
+  } finally {
+    closeSync(descriptor);
+  }
 };
 
 const TYPES = {
@@ -78,6 +121,7 @@ const startTestServer = async () => {
   <script>
     document.getElementById('firefox-action').addEventListener('click', () => {
       document.body.dataset.clicked = 'yes';
+      document.body.dataset.clickCount = String(Number(document.body.dataset.clickCount ?? 0) + 1);
     });
     document.getElementById('firefox-input').addEventListener('input', (event) => {
       document.getElementById('firefox-status').textContent = event.target.value;
@@ -116,6 +160,10 @@ const startTestServer = async () => {
 
 const sse = (event, data) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
 
+const requestSystemText = (request) => Array.isArray(request?.system)
+  ? request.system.map((block) => String(block?.text ?? '')).join('\n')
+  : String(request?.system ?? '');
+
 const textResponse = (text) => [
   sse('message_start', { type: 'message_start' }),
   sse('content_block_start', {
@@ -131,13 +179,13 @@ const textResponse = (text) => [
   sse('message_stop', { type: 'message_stop' }),
 ].join('');
 
-const delegationResponse = () => {
-  const input = JSON.stringify({ to: 'web', message: ACTOR_PROMPT, await: true });
+const delegationResponse = ({ to = 'web', message = ACTOR_PROMPT, toolUseId = 'firefox-actor-tool' } = {}) => {
+  const input = JSON.stringify({ to, message, await: true });
   return [
     sse('message_start', { type: 'message_start' }),
     sse('content_block_start', {
       type: 'content_block_start', index: 0,
-      content_block: { type: 'tool_use', id: 'firefox-actor-tool', name: 'message_actor', input: {} },
+      content_block: { type: 'tool_use', id: toolUseId, name: 'message_actor', input: {} },
     }),
     sse('content_block_delta', {
       type: 'content_block_delta', index: 0,
@@ -149,6 +197,29 @@ const delegationResponse = () => {
   ].join('');
 };
 
+const toolUseResponse = ({ id, name, input }) => [
+  sse('message_start', { type: 'message_start' }),
+  sse('content_block_start', {
+    type: 'content_block_start', index: 0,
+    content_block: { type: 'tool_use', id, name, input: {} },
+  }),
+  sse('content_block_delta', {
+    type: 'content_block_delta', index: 0,
+    delta: { type: 'input_json_delta', partial_json: JSON.stringify(input) },
+  }),
+  sse('content_block_stop', { type: 'content_block_stop', index: 0 }),
+  sse('message_delta', { type: 'message_delta', delta: { stop_reason: 'tool_use' } }),
+  sse('message_stop', { type: 'message_stop' }),
+].join('');
+
+// Evaluate the loss-lane tool response before any browser starts. This keeps a
+// malformed helper scope from spending the long lifetime runner before failing.
+const KEEPALIVE_LOSS_CLICK_RESPONSE = toolUseResponse({
+  id: KEEPALIVE_LOSS_TOOL_ID,
+  name: 'click',
+  input: { selector: '#firefox-action', expectedCount: 1 },
+});
+
 // why a browser-level TLS proxy: the production adapter's endpoint is fixed,
 // and safeFetch correctly rejects HTTP redirects. The proxy leaves the URL as
 // https://api.anthropic.com/v1/messages, so the real adapter and egress policy
@@ -159,6 +230,12 @@ const startProviderServer = async () => {
   const records = [];
   const connections = [];
   const tlsErrors = [];
+  let workerStartupProbes = 0;
+  let lifetimeActorResponses = 0;
+  let lifetimeActorResponseAt = 0;
+  let lifetimeActorAborts = 0;
+  let keepaliveLossActorAborts = 0;
+  let scenario = { mode: 'happy', actorTarget: 'web' };
   const certificateDirectory = mkdtempSync(join(tmpdir(), 'peerd-firefox-provider-'));
   const certificatePath = join(certificateDirectory, 'provider-cert.pem');
   const keyPath = join(certificateDirectory, 'provider-key.pem');
@@ -176,6 +253,15 @@ const startProviderServer = async () => {
   }
 
   const providerRequestHandler = (request, response) => {
+    if (request.method === 'POST' && request.url === WORKER_PROBE_PATH) {
+      workerStartupProbes += 1;
+      response.writeHead(204, {
+        'access-control-allow-origin': '*',
+        'cache-control': 'no-store',
+      });
+      response.end();
+      return;
+    }
     if (request.method !== 'POST' || request.url !== PROVIDER_PATH) {
       response.writeHead(404);
       response.end('not found');
@@ -196,17 +282,101 @@ const startProviderServer = async () => {
         return;
       }
       const body = Buffer.concat(chunks).toString('utf8');
-      records.push({ method: request.method, url: request.url, headers: { ...request.headers }, body });
-      const payload = body.includes('<actor_agent>')
-        ? textResponse(ACTOR_REPLY_CANARY)
-        : body.includes(ACTOR_REPLY_CANARY)
-          ? textResponse(FINAL_REPLY_CANARY)
-          : delegationResponse();
+      const requestScenario = { ...scenario };
+      const record = {
+        method: request.method,
+        url: request.url,
+        headers: { ...request.headers },
+        body,
+        scenario: requestScenario.mode,
+        receivedAt: Date.now(),
+        responseAttemptedAt: null,
+        respondedAt: null,
+      };
+      records.push(record);
+      const actorRequest = body.includes('<actor_agent>');
+      const priorLifetimeParentRequest = requestScenario.mode === 'lifetime'
+        && !actorRequest
+        && records.slice(0, -1).some((entry) =>
+          entry.scenario === 'lifetime' && !entry.body.includes('<actor_agent>'));
+      const failureContinuation = body.includes('Actors were not run')
+        || body.includes('actor_isolation_temporarily_unavailable')
+        || body.includes('isolated worker host is temporarily unavailable');
+      const keepaliveLossActorContinuation = requestScenario.mode === 'keepalive-loss'
+        && actorRequest && body.includes(KEEPALIVE_LOSS_TOOL_ID);
+      const payload = requestScenario.mode === 'lifetime'
+        ? actorRequest
+          ? textResponse(LIFETIME_ACTOR_REPLY_CANARY)
+          : body.includes(LIFETIME_ACTOR_REPLY_CANARY)
+            ? textResponse(LIFETIME_FINAL_REPLY_CANARY)
+            : priorLifetimeParentRequest
+              ? textResponse('Firefox lifetime fixture: actor reply was unavailable.')
+              : delegationResponse({ message: LIFETIME_ACTOR_PROMPT, toolUseId: 'firefox-lifetime-actor-tool' })
+        : requestScenario.mode === 'keepalive-loss'
+          ? actorRequest
+            ? keepaliveLossActorContinuation
+              ? textResponse(KEEPALIVE_LOSS_LATE_CANARY)
+              : KEEPALIVE_LOSS_CLICK_RESPONSE
+            : hasOutcomeUnknownState(body)
+              ? textResponse(KEEPALIVE_LOSS_FINAL_CANARY)
+              : delegationResponse({
+                to: requestScenario.actorTarget,
+                message: KEEPALIVE_LOSS_ACTOR_PROMPT,
+                toolUseId: 'firefox-keepalive-loss-actor-tool',
+              })
+        : actorRequest
+          ? textResponse(ACTOR_REPLY_CANARY)
+          : requestScenario.mode === 'broken-worker'
+          ? failureContinuation
+            ? textResponse(FAILURE_FINAL_CANARY)
+            : delegationResponse({
+              to: requestScenario.actorTarget,
+              message: FAILURE_ACTOR_PROMPT,
+              toolUseId: 'firefox-broken-worker-tool',
+            })
+          : body.includes(ACTOR_REPLY_CANARY)
+            ? textResponse(FINAL_REPLY_CANARY)
+            : delegationResponse();
       response.writeHead(200, {
         'content-type': 'text/event-stream; charset=utf-8',
         'cache-control': 'no-store',
       });
-      response.end(payload);
+      if ((requestScenario.mode === 'lifetime' && actorRequest) || keepaliveLossActorContinuation) {
+        // why: Firefox does not resolve this proxied fetch on flushed headers
+        // alone. Send one ignored SSE comment so the connect timeout clears,
+        // then leave the stream silent while the lifetime heartbeat is tested.
+        response.write(': connected\n\n');
+        let abortRecorded = false;
+        response.once('close', () => {
+          if (!response.writableFinished && !abortRecorded) {
+            abortRecorded = true;
+            if (keepaliveLossActorContinuation) keepaliveLossActorAborts += 1;
+            else lifetimeActorAborts += 1;
+          }
+        });
+        setTimeout(() => {
+          if (response.destroyed) {
+            if (!abortRecorded) {
+              abortRecorded = true;
+              if (keepaliveLossActorContinuation) keepaliveLossActorAborts += 1;
+              else lifetimeActorAborts += 1;
+            }
+            return;
+          }
+          record.responseAttemptedAt = Date.now();
+          response.end(payload, () => {
+            record.respondedAt = Date.now();
+            if (!keepaliveLossActorContinuation) {
+              lifetimeActorResponses += 1;
+              lifetimeActorResponseAt = Date.now();
+            }
+          });
+        }, keepaliveLossActorContinuation
+          ? KEEPALIVE_LOSS_RESPONSE_DELAY_MS
+          : Number(requestScenario.lifetimeDelayMs) || LIFETIME_RESPONSE_DELAY_MS);
+      } else {
+        response.end(payload, () => { record.respondedAt = Date.now(); });
+      }
     });
   };
 
@@ -280,6 +450,12 @@ const startProviderServer = async () => {
   }
   return {
     port, records, connections, tlsErrors,
+    get workerStartupProbes() { return workerStartupProbes; },
+    get lifetimeActorResponses() { return lifetimeActorResponses; },
+    get lifetimeActorResponseAt() { return lifetimeActorResponseAt; },
+    get lifetimeActorAborts() { return lifetimeActorAborts; },
+    get keepaliveLossActorAborts() { return keepaliveLossActorAborts; },
+    setScenario: (next) => { scenario = { ...scenario, ...next }; },
     close: async () => {
       for (const socket of sockets) socket.destroy();
       await Promise.all([
@@ -403,10 +579,28 @@ const runBoundActorSmoke = async (driver, providerServer) => {
   assert(actorProof.bundle.session.messages.some((message) => message.role === 'assistant'
     && typeof message.content === 'string' && message.content.includes(FINAL_REPLY_CANARY)),
     'the parent chat receives the actor result and returns a final reply');
-  assert(actorProof.bundle.contextSnapshots.some((snapshot) => snapshot.label === 'actor web (in-SW)'),
-    'the installed Firefox actor uses the in-service-worker route');
-  assert(!actorProof.audit.some((entry) => entry.type === 'actor_ran_offscreen'),
-    'Firefox does not claim offscreen heap isolation');
+  const actorExecution = actorProof.state?.capabilities?.actorExecution;
+  assert(actorExecution?.status === 'available'
+    && actorExecution?.host === 'background-page-worker'
+    && actorExecution?.retryable === false,
+  'the installed Firefox package reports the dedicated-worker actor host as available',
+  JSON.stringify(actorExecution));
+  assert(actorProof.bundle.contextSnapshots.some((snapshot) => snapshot.label === 'actor:web'),
+    'the installed Firefox path labels model context as the isolated actor relay');
+  const isolatedAudit = actorProof.audit.find((entry) => entry.type === 'actor_ran_isolated');
+  assert(isolatedAudit?.details?.host === 'background-page-worker'
+    && isolatedAudit?.details?.workerType === 'dedicated'
+    && isolatedAudit?.details?.realmVerified === true
+    && isolatedAudit?.details?.extensionApisPresent === false
+    && isolatedAudit?.details?.kind === 'web'
+    && isolatedAudit?.details?.ok === true,
+  'the audit proves the Firefox actor ran in a verified extension-API-free dedicated worker',
+  JSON.stringify(isolatedAudit?.details));
+  assert(!actorProof.audit.some((entry) => entry.type === 'actor_background_turn_refused'),
+    'the successful Firefox actor turn has no background-turn refusal');
+  assert(!actorProof.audit.some((entry) => entry.type === 'actor_isolation_failure'
+    || entry.type === 'actor_isolation_unavailable'),
+  'the successful Firefox actor turn has no isolation fallback or failure');
   const storedProof = JSON.stringify({
     bundle: actorProof.bundle, audit: actorProof.audit, state: actorProof.state,
   });
@@ -444,6 +638,1385 @@ const runBoundActorSmoke = async (driver, providerServer) => {
     'the awaited actor reply re-enters as the matching fenced tool result');
   assert(providerRequests.every((record) => !record.body.includes(PROVIDER_KEY_CANARY)),
     'provider request bodies contain no key canary');
+};
+
+const createBrokenWorkerArtifact = () => {
+  const directory = mkdtempSync(join(tmpdir(), 'peerd-firefox-broken-worker-'));
+  const staging = join(directory, 'staging');
+  const artifact = join(directory, `peerd-${VERSION}-store-firefox-broken-worker.xpi`);
+  cpSync(join(ROOT, 'artifacts', 'staging', 'store-firefox'), staging, { recursive: true });
+  const worker = join(staging, 'offscreen', 'actor-worker.js');
+  overwriteRegularFile(worker, `await fetch('https://api.anthropic.com${WORKER_PROBE_PATH}', { method: 'POST', cache: 'no-store' });
+throw new Error('Firefox runtime test fault: actor worker failed before ready');
+`);
+  execFileSync('zip', ['-q', '-X', '-r', artifact, '.'], {
+    cwd: staging,
+    env: { ...process.env, TZ: 'UTC' },
+  });
+  return { artifact, directory };
+};
+
+const createLifetimeArtifact = () => {
+  const directory = mkdtempSync(join(tmpdir(), 'peerd-firefox-lifetime-'));
+  const staging = join(directory, 'staging');
+  const artifact = join(directory, `peerd-${VERSION}-store-firefox-lifetime.xpi`);
+  cpSync(join(ROOT, 'artifacts', 'staging', 'store-firefox'), staging, { recursive: true });
+  const probe = join(staging, 'background', 'firefox-lifetime-probe.js');
+  writeFileSync(probe, `const bootId = crypto.randomUUID();
+const heartbeats = [];
+globalThis.peerdFirefoxLifetimeProbe = {
+  record(changes) {
+    const change = changes?.[${JSON.stringify(LIFETIME_HEARTBEAT_KEY)}];
+    if (!change) return;
+    heartbeats.push({ at: Date.now(), value: change.newValue ?? null });
+  },
+};
+browser.runtime.onMessage.addListener((message) =>
+  message?.type === 'firefox-lifetime/boot-id'
+    ? Promise.resolve({ ok: true, bootId, heartbeats: heartbeats.slice() })
+    : undefined);
+`, { flag: 'wx', mode: 0o600 });
+  const serviceWorker = join(staging, 'background', 'service-worker.js');
+  const source = readFileSync(serviceWorker, 'utf8');
+  const listenerLine = '    actorHostKeepAlive.onChanged(changes);';
+  if (source.split(listenerLine).length !== 2) {
+    throw new Error('Firefox lifetime probe seam no longer matches service-worker.js');
+  }
+  overwriteRegularFile(serviceWorker, `import './firefox-lifetime-probe.js';\n${source.replace(
+    listenerLine,
+    `    globalThis.peerdFirefoxLifetimeProbe?.record(changes);\n${listenerLine}`,
+  )}`);
+  execFileSync('zip', ['-q', '-X', '-r', artifact, '.'], {
+    cwd: staging,
+    env: { ...process.env, TZ: 'UTC' },
+  });
+  return { artifact, directory };
+};
+
+const createKeepaliveLossArtifact = () => {
+  const directory = mkdtempSync(join(tmpdir(), 'peerd-firefox-keepalive-loss-'));
+  const staging = join(directory, 'staging');
+  const artifact = join(directory, `peerd-${VERSION}-store-firefox-keepalive-loss.xpi`);
+  cpSync(join(ROOT, 'artifacts', 'staging', 'store-firefox'), staging, { recursive: true });
+  const probe = join(staging, 'background', 'firefox-keepalive-loss-probe.js');
+  writeFileSync(probe, `let armed = false;
+globalThis.peerdFirefoxKeepaliveLossFault = {
+  consume() {
+    if (!armed) return false;
+    armed = false;
+    return true;
+  },
+};
+browser.runtime.onMessage.addListener((message) => {
+  if (message?.type !== 'firefox-keepalive-loss/arm') return undefined;
+  armed = true;
+  return Promise.resolve({ ok: true });
+});
+`, { flag: 'wx', mode: 0o600 });
+  const directHost = join(staging, 'background', 'direct-actor-host.js');
+  const source = readFileSync(directHost, 'utf8');
+  const writeLine = '    const write = storage.set({ [key]: value });';
+  if (source.split(writeLine).length !== 2) {
+    throw new Error('Firefox keepalive fault seam no longer matches direct-actor-host.js');
+  }
+  overwriteRegularFile(directHost, source.replace(writeLine, `    const write = globalThis.peerdFirefoxKeepaliveLossFault?.consume()
+      ? Promise.reject(new Error('Firefox runtime test fault: keepalive heartbeat failed'))
+      : storage.set({ [key]: value });`));
+  const serviceWorker = join(staging, 'background', 'service-worker.js');
+  const serviceWorkerSource = readFileSync(serviceWorker, 'utf8');
+  overwriteRegularFile(serviceWorker, `import './firefox-keepalive-loss-probe.js';\n${serviceWorkerSource}`);
+  execFileSync('zip', ['-q', '-X', '-r', artifact, '.'], {
+    cwd: staging,
+    env: { ...process.env, TZ: 'UTC' },
+  });
+  return { artifact, directory };
+};
+
+const createRecoveryArtifact = () => {
+  const directory = mkdtempSync(join(tmpdir(), 'peerd-firefox-recovery-'));
+  const staging = join(directory, 'staging');
+  const artifact = join(directory, `peerd-${VERSION}-store-firefox-recovery.xpi`);
+  cpSync(join(ROOT, 'artifacts', 'staging', 'store-firefox'), staging, { recursive: true });
+  const probe = join(staging, 'background', 'firefox-recovery-probe.js');
+  writeFileSync(probe, `const bootId = crypto.randomUUID();
+const stored = await browser.storage.local.get([
+  ${JSON.stringify(RECOVERY_SEED_KEY)},
+  ${JSON.stringify(RECOVERY_BOOT_KEY)},
+]);
+const previousBoot = stored?.[${JSON.stringify(RECOVERY_BOOT_KEY)}];
+const boot = {
+  bootId,
+  count: Number(previousBoot?.count ?? 0) + 1,
+};
+await browser.storage.local.set({ ${JSON.stringify(RECOVERY_BOOT_KEY)}: boot });
+const seed = stored?.[${JSON.stringify(RECOVERY_SEED_KEY)}];
+if (seed?.active === true && Array.isArray(seed.entries)) {
+  const mailbox = Object.fromEntries(seed.entries
+    .filter((entry) => entry && typeof entry.id === 'string')
+    .map((entry) => [entry.id, entry]));
+  await browser.storage.session.set({ actorMailbox: mailbox });
+}
+browser.runtime.onMessage.addListener((message) =>
+  message?.type === 'firefox-recovery/probe'
+    ? Promise.resolve({ ok: true, boot })
+    : undefined);
+`, { flag: 'wx', mode: 0o600 });
+  const serviceWorker = join(staging, 'background', 'service-worker.js');
+  const source = readFileSync(serviceWorker, 'utf8');
+  overwriteRegularFile(serviceWorker, `import './firefox-recovery-probe.js';\n${source}`);
+  execFileSync('zip', ['-q', '-X', '-r', artifact, '.'], {
+    cwd: staging,
+    env: { ...process.env, TZ: 'UTC' },
+  });
+  return { artifact, directory };
+};
+
+const runActorLifetimeSmoke = async ({ providerServer }) => {
+  console.log('Firefox actor lifetime smoke: keep a long Worker turn alive with every UI port closed');
+  const { artifact, directory } = createLifetimeArtifact();
+  const recordStart = providerServer.records.length;
+  const responseStart = providerServer.lifetimeActorResponses;
+  const abortStart = providerServer.lifetimeActorAborts;
+  let driver = null;
+  try {
+    driver = await startGeckodriver({
+      binary: geckodriverBinary,
+      firefoxBinary,
+      acceptInsecureCerts: true,
+      proxy: {
+        proxyType: 'manual',
+        sslProxy: `127.0.0.1:${providerServer.port}`,
+        noProxy: ['localhost', '127.0.0.1'],
+      },
+      prefs: {
+        'extensions.webextensions.uuids': JSON.stringify({ [ADDON_ID]: TEST_UUID }),
+      },
+    });
+    const installedId = await driver.installAddon(resolve(artifact));
+    assert(installedId === ADDON_ID, 'the lifetime diagnostic XPI keeps the Store add-on id', String(installedId));
+    await driver.navigate(`${EXTENSION_ORIGIN}/sidepanel/sidepanel.html`);
+    const prepared = await driver.executeAsync(`
+      const [passphrase, providerKey] = arguments;
+      const done = arguments[arguments.length - 1];
+      const send = (message) => browser.runtime.sendMessage(message);
+      (async () => {
+        const vault = await send({ type: 'vault/initialize', passphrase });
+        const provider = await send({ type: 'provider/setKey', provider: 'anthropic', plaintext: providerKey });
+        const boot = await send({ type: 'firefox-lifetime/boot-id' });
+        return {
+          ok: vault?.ok === true && provider?.ok === true && typeof boot?.bootId === 'string',
+          bootId: boot?.bootId ?? null,
+        };
+      })().then(done, (error) => done({ ok: false, error: error?.message || String(error) }));
+    `, [PASSPHRASE_CANARY, PROVIDER_KEY_CANARY]);
+    assert(prepared?.ok === true,
+      'the lifetime profile initializes without a test-owned keepalive listener', JSON.stringify(prepared));
+
+    const lifetimeDelayMs = LIFETIME_RESPONSE_DELAY_MS;
+    providerServer.setScenario({ mode: 'lifetime', actorTarget: 'web', lifetimeDelayMs });
+    const started = await driver.executeAsync(`
+      const done = arguments[arguments.length - 1];
+      browser.runtime.sendMessage({
+        type: 'agent/send',
+        text: 'Delegate the Firefox background lifetime proof and return its exact result.',
+      }).then(done, (error) => done({ ok: false, error: error?.message || String(error) }));
+    `);
+    assert(started?.ok === true, 'the long Firefox actor turn starts', JSON.stringify(started));
+
+    const actorRequestStarted = await waitFor(() => providerServer.records
+      .slice(recordStart)
+      .some((record) => record.scenario === 'lifetime' && record.body.includes('<actor_agent>')),
+    { budgetMs: 30_000, pollMs: 100 });
+    assert(actorRequestStarted === true, 'the isolated actor reaches the delayed provider response');
+
+    const extensionHandle = await driver.windowHandle();
+    const plainContext = await driver.newWindow('tab');
+    assert(typeof plainContext?.handle === 'string',
+      'the lifetime test opens a plain browser context before closing the extension UI',
+      JSON.stringify(plainContext));
+    await driver.switchToWindow(plainContext.handle);
+    await driver.navigate('about:blank');
+    await driver.switchToWindow(extensionHandle);
+    await driver.closeWindow();
+    await driver.switchToWindow(plainContext.handle);
+    const openHandles = await driver.windowHandles();
+    assert(Array.isArray(openHandles) && !openHandles.includes(extensionHandle),
+      'the extension UI context is physically closed for the lifetime proof',
+      JSON.stringify(openHandles));
+    const actorResponseFinished = await waitFor(() => {
+      if (providerServer.lifetimeActorResponses > responseStart) return 'completed';
+      const parentRequests = providerServer.records.slice(recordStart)
+        .filter((record) => record.scenario === 'lifetime'
+          && !record.body.includes('<actor_agent>'));
+      return parentRequests.length > 1 ? 'actor-ended-without-reply' : null;
+    },
+      { budgetMs: lifetimeDelayMs + 30_000, pollMs: 250 });
+    assert(actorResponseFinished === 'completed',
+      'the actor Worker survives while every extension UI port is closed',
+      String(actorResponseFinished));
+
+    const parentContinuationFinished = await waitFor(() => providerServer.records
+      .slice(recordStart)
+      .some((record) => record.scenario === 'lifetime'
+        && !record.body.includes('<actor_agent>')
+        && record.body.includes(LIFETIME_ACTOR_REPLY_CANARY)
+        && typeof record.respondedAt === 'number'),
+    { budgetMs: 30_000, pollMs: 100 });
+    assert(parentContinuationFinished === true,
+      'the parent continuation finishes while every extension UI port remains closed');
+
+    await driver.navigate(`${EXTENSION_ORIGIN}/sidepanel/sidepanel.html`);
+    const proof = await waitFor(() => driver.executeAsync(`
+      const [finalCanary, actorCanary, actorPrompt, heartbeatKey] = arguments;
+      const done = arguments[arguments.length - 1];
+      const send = (message) => browser.runtime.sendMessage(message);
+      (async () => {
+        const [listed, heartbeat, audit, boot] = await Promise.all([
+          send({ type: 'session/list' }),
+          browser.storage.session.get(heartbeatKey),
+          send({ type: 'audit/list', limit: 500 }),
+          send({ type: 'firefox-lifetime/boot-id' }),
+        ]);
+        let parentBundle = null;
+        let actorSessionId = null;
+        for (const session of listed?.sessions ?? []) {
+          if (!session?.sessionId || session.kind === 'actor') continue;
+          const debug = await send({ type: 'session/debugBundle', sessionId: session.sessionId });
+          const complete = debug?.bundle?.session?.messages?.some((message) =>
+            message.role === 'assistant'
+              && typeof message.content === 'string'
+              && message.content.includes(finalCanary));
+          if (!complete) continue;
+          const actor = (debug?.bundle?.childSessions ?? []).find((child) =>
+            child.kind === 'actor'
+              && child.messages?.some((message) =>
+              message.role === 'user'
+                && typeof message.content === 'string'
+                && message.content.includes(actorPrompt))
+              && child.messages?.some((message) =>
+                message.role === 'assistant'
+                  && typeof message.content === 'string'
+                  && message.content.includes(actorCanary)));
+          if (!actor?.sessionId) continue;
+          parentBundle = debug.bundle;
+          actorSessionId = actor.sessionId;
+          break;
+        }
+        return parentBundle && actorSessionId ? {
+          heartbeats: boot?.heartbeats ?? [],
+          heartbeat: heartbeat?.[heartbeatKey] ?? null,
+          bundle: parentBundle,
+          actorSessionId,
+          bootId: boot?.bootId ?? null,
+          audit: audit?.entries ?? [],
+        } : null;
+      })().then(done, (error) => done({ error: error?.message || String(error) }));
+    `, [
+      LIFETIME_FINAL_REPLY_CANARY,
+      LIFETIME_ACTOR_REPLY_CANARY,
+      LIFETIME_ACTOR_PROMPT,
+      LIFETIME_HEARTBEAT_KEY,
+    ]), {
+      budgetMs: 60_000,
+      pollMs: 250,
+    });
+    assert(proof?.bundle && Array.isArray(proof?.heartbeats),
+      'the session heartbeat runs and the parent turn completes with no UI open',
+      JSON.stringify(proof));
+    assert(proof.bootId === prepared.bootId,
+      'the same Firefox background heap owns actor start, product heartbeats, and completion',
+      JSON.stringify({ prepared: prepared.bootId, completed: proof.bootId }));
+    const isolatedRuns = proof.audit.filter((entry) => entry.type === 'actor_ran_isolated'
+      && entry.details?.host === 'background-page-worker'
+      && entry.details?.actorSessionId === proof.actorSessionId);
+    assert(isolatedRuns.length === 1
+      && isolatedRuns[0]?.details?.ok === true
+      && isolatedRuns[0]?.details?.realmVerified === true,
+      'the heartbeat-retained lifetime turn keeps the verified background-page Worker boundary',
+      JSON.stringify(isolatedRuns.map((entry) => entry.details)));
+    const lifetimeParentContinuations = providerServer.records.slice(recordStart)
+      .filter((record) => record.scenario === 'lifetime'
+        && !record.body.includes('<actor_agent>')
+        && record.body.includes(LIFETIME_ACTOR_REPLY_CANARY));
+    assert(lifetimeParentContinuations.length === 1
+      && typeof lifetimeParentContinuations[0].respondedAt === 'number',
+    'the parent continuation completes exactly once without a UI-triggered replay',
+    JSON.stringify(lifetimeParentContinuations.map((record) => ({
+      receivedAt: record.receivedAt,
+      respondedAt: record.respondedAt,
+    }))));
+    const lifetimeActorRequests = providerServer.records.slice(recordStart)
+      .filter((record) => record.scenario === 'lifetime'
+        && record.body.includes('<actor_agent>')
+        && record.body.includes(LIFETIME_ACTOR_PROMPT));
+    const pulseTimes = proof.heartbeats
+      .filter((entry) => entry?.value?.leaseId && Number.isInteger(entry?.value?.sequence))
+      .map((entry) => entry.at);
+    const heartbeatAfterIdle = pulseTimes.some((at) =>
+      at >= lifetimeActorRequests[0]?.receivedAt + FIREFOX_EVENT_PAGE_IDLE_MS
+        && at <= providerServer.lifetimeActorResponseAt);
+    const heartbeatOverlapsRequest = pulseTimes.some((at) =>
+      at >= lifetimeActorRequests[0]?.receivedAt
+        && at <= providerServer.lifetimeActorResponseAt);
+    assert(lifetimeActorRequests.length === 1
+      && pulseTimes.length >= 2
+      && pulseTimes.at(-1) > pulseTimes[0]
+      && heartbeatAfterIdle === true
+      && heartbeatOverlapsRequest === true,
+    'the product Firefox session heartbeat runs after the idle window during the delayed actor request',
+    JSON.stringify({
+      requestAt: lifetimeActorRequests[0]?.receivedAt,
+      idleThresholdAt: lifetimeActorRequests[0]?.receivedAt + FIREFOX_EVENT_PAGE_IDLE_MS,
+      heartbeats: proof.heartbeats,
+      actorResponseAt: providerServer.lifetimeActorResponseAt,
+    }));
+    assert(lifetimeActorRequests.length === 1
+      && providerServer.lifetimeActorResponses - responseStart === 1
+      && providerServer.lifetimeActorAborts - abortStart === 0,
+    'the original actor request completes exactly once without an aborted replay',
+    JSON.stringify({
+      requests: lifetimeActorRequests.length,
+      responses: providerServer.lifetimeActorResponses - responseStart,
+      aborts: providerServer.lifetimeActorAborts - abortStart,
+    }));
+    // Let the final session-key removal settle before sampling. The actor run
+    // is complete now, so the product lease must be gone and no later heartbeat
+    // may advance the in-memory diagnostic count.
+    await new Promise((resolveWait) => setTimeout(resolveWait, 500));
+    const quietBefore = await driver.executeAsync(`
+      const [heartbeatKey] = arguments;
+      const done = arguments[arguments.length - 1];
+      Promise.all([
+        browser.storage.session.get(heartbeatKey),
+        browser.runtime.sendMessage({ type: 'firefox-lifetime/boot-id' }),
+      ]).then(([heartbeat, boot]) => done({
+        heartbeat: heartbeat?.[heartbeatKey] ?? null,
+        count: boot?.heartbeats?.length ?? 0,
+      }), (error) => done({ error: error?.message || String(error) }));
+    `, [LIFETIME_HEARTBEAT_KEY]);
+    await new Promise((resolveWait) => setTimeout(resolveWait, LIFETIME_QUIET_MS));
+    const quietAfter = await driver.executeAsync(`
+      const [heartbeatKey] = arguments;
+      const done = arguments[arguments.length - 1];
+      Promise.all([
+        browser.storage.session.get(heartbeatKey),
+        browser.runtime.sendMessage({ type: 'firefox-lifetime/boot-id' }),
+      ]).then(([heartbeat, boot]) => done({
+        heartbeat: heartbeat?.[heartbeatKey] ?? null,
+        count: boot?.heartbeats?.length ?? 0,
+      }), (error) => done({ error: error?.message || String(error) }));
+    `, [LIFETIME_HEARTBEAT_KEY]);
+    assert(quietBefore?.heartbeat === null && quietAfter?.heartbeat === null,
+      'the product Firefox session heartbeat is gone after the last actor run',
+      JSON.stringify({ before: quietBefore, after: quietAfter }));
+    assert(Number(quietBefore?.count) === Number(quietAfter?.count),
+    'the keepalive marker stays unchanged beyond another heartbeat interval',
+    JSON.stringify({ quietMs: LIFETIME_QUIET_MS, before: quietBefore, after: quietAfter }));
+    const stored = JSON.stringify({ heartbeats: proof.heartbeats, bundle: proof.bundle, audit: proof.audit });
+    assert(!stored.includes(PROVIDER_KEY_CANARY) && !stored.includes(PASSPHRASE_CANARY),
+      'the lifetime proof stores no credential canaries');
+  } catch (error) {
+    try {
+      if (driver) {
+        const screenshot = await driver.screenshot();
+        writeFileSync(join(OUTPUT, LIFETIME_FAILURE_SCREENSHOT), Buffer.from(screenshot, 'base64'));
+      }
+    } catch { /* the browser may already be gone */ }
+    const geckoLog = driver?.logs.join('') ?? '';
+    if (geckoLog) writeFileSync(join(OUTPUT, LIFETIME_FAILURE_LOG), geckoLog);
+    writeFileSync(join(OUTPUT, LIFETIME_FAILURE_DIAGNOSTIC), JSON.stringify({
+      error: error?.message ?? String(error),
+      records: providerServer.records.slice(recordStart).map((record) => ({
+        scenario: record.scenario,
+        actor: record.body.includes('<actor_agent>'),
+        receivedAt: record.receivedAt,
+        respondedAt: record.respondedAt,
+      })),
+      actorResponses: providerServer.lifetimeActorResponses - responseStart,
+      actorAborts: providerServer.lifetimeActorAborts - abortStart,
+    }, null, 2));
+    throw error;
+  } finally {
+    await driver?.close();
+    providerServer.setScenario({ mode: 'happy', actorTarget: 'web', lifetimeDelayMs: 0 });
+    rmSync(directory, { recursive: true, force: true });
+  }
+};
+
+const runActorKeepaliveLossSmoke = async ({ providerServer, fixturePort }) => {
+  console.log('Firefox actor keepalive-loss smoke: fail a product heartbeat after a real side effect');
+  const { artifact, directory } = createKeepaliveLossArtifact();
+  const recordStart = providerServer.records.length;
+  const abortStart = providerServer.keepaliveLossActorAborts;
+  let driver = null;
+  let fixtureTabId = null;
+  try {
+    driver = await startGeckodriver({
+      binary: geckodriverBinary,
+      firefoxBinary,
+      acceptInsecureCerts: true,
+      proxy: {
+        proxyType: 'manual',
+        sslProxy: `127.0.0.1:${providerServer.port}`,
+        noProxy: ['localhost', '127.0.0.1'],
+      },
+      prefs: {
+        'extensions.webextensions.uuids': JSON.stringify({ [ADDON_ID]: TEST_UUID }),
+      },
+    });
+    await driver.setWindowRect({ width: 400, height: 900, x: 0, y: 0 });
+    const installedId = await driver.installAddon(resolve(artifact));
+    assert(installedId === ADDON_ID,
+      'the keepalive-loss diagnostic XPI keeps the Store add-on id', String(installedId));
+    await driver.navigate(`${EXTENSION_ORIGIN}/sidepanel/sidepanel.html`);
+    const prepared = await driver.executeAsync(`
+      const [passphrase, providerKey, fixtureUrl] = arguments;
+      const done = arguments[arguments.length - 1];
+      const send = (message) => browser.runtime.sendMessage(message);
+      (async () => {
+        const vault = await send({ type: 'vault/initialize', passphrase });
+        const provider = await send({ type: 'provider/setKey', provider: 'anthropic', plaintext: providerKey });
+        const tab = await browser.tabs.create({ url: fixtureUrl, active: true });
+        for (let attempt = 0; attempt < 200; attempt += 1) {
+          try {
+            const [probe] = await browser.scripting.executeScript({
+              target: { tabId: tab.id },
+              func: () => document.readyState === 'complete'
+                && document.getElementById('firefox-action') !== null,
+            });
+            if (probe?.result === true) {
+              return { ok: vault?.ok === true && provider?.ok === true, tabId: tab.id };
+            }
+          } catch { /* navigation is still in flight */ }
+          await new Promise((resolveWait) => setTimeout(resolveWait, 100));
+        }
+        return { ok: false, tabId: tab.id, error: 'fixture tab did not become scriptable' };
+      })().then(done, (error) => done({ ok: false, error: error?.message || String(error) }));
+    `, [
+      PASSPHRASE_CANARY,
+      PROVIDER_KEY_CANARY,
+      `http://127.0.0.1:${fixturePort}${FIXTURE_PATH}`,
+    ]);
+    fixtureTabId = prepared?.tabId ?? null;
+    assert(prepared?.ok === true && Number.isInteger(fixtureTabId),
+      'the keepalive-loss profile initializes a concrete actor target', JSON.stringify(prepared));
+
+    providerServer.setScenario({ mode: 'keepalive-loss', actorTarget: String(fixtureTabId) });
+    const started = await driver.executeAsync(`
+      const done = arguments[arguments.length - 1];
+      browser.runtime.sendMessage({
+        type: 'agent/send',
+        text: 'Delegate the Firefox keepalive-loss proof and report its exact outcome.',
+      }).then(done, (error) => done({ ok: false, error: error?.message || String(error) }));
+    `);
+    assert(started?.ok === true, 'the keepalive-loss actor turn starts', JSON.stringify(started));
+
+    const sideEffectAndContinuation = await waitFor(async () => {
+      const actorContinuation = providerServer.records.slice(recordStart).find((record) =>
+        record.scenario === 'keepalive-loss'
+          && record.body.includes('<actor_agent>')
+          && record.body.includes(KEEPALIVE_LOSS_TOOL_ID)
+          && record.respondedAt === null);
+      const observed = await driver.executeAsync(`
+        const [tabId] = arguments;
+        const done = arguments[arguments.length - 1];
+        browser.scripting.executeScript({
+          target: { tabId },
+          func: () => ({
+            clicked: document.body.dataset.clicked ?? null,
+            clickCount: document.body.dataset.clickCount ?? '0',
+          }),
+        }).then(([entry]) => done(entry?.result ?? null), () => done(null));
+      `, [fixtureTabId]);
+      return actorContinuation && observed?.clicked === 'yes'
+        ? {
+          actorRequestAt: actorContinuation.receivedAt,
+          clicked: observed.clicked,
+          clickCount: observed.clickCount,
+        }
+        : null;
+    }, { budgetMs: 30_000, pollMs: 100 });
+    assert(sideEffectAndContinuation?.clicked === 'yes'
+      && Number.parseInt(sideEffectAndContinuation?.clickCount ?? '0', 10) > 0,
+      'the actor side effect commits before the keepalive fault is armed',
+      JSON.stringify(sideEffectAndContinuation));
+
+    const faultArmed = await driver.executeAsync(`
+      const done = arguments[arguments.length - 1];
+      browser.runtime.sendMessage({ type: 'firefox-keepalive-loss/arm' })
+        .then((result) => done(result?.ok === true),
+          (error) => done({ error: error?.message || String(error) }));
+    `);
+    assert(faultArmed === true, 'the packaged lane arms only the next product heartbeat');
+
+    const extensionHandle = await driver.windowHandle();
+    const plainContext = await driver.newWindow('tab');
+    assert(typeof plainContext?.handle === 'string',
+      'the keepalive-loss test opens a plain context before closing the extension UI',
+      JSON.stringify(plainContext));
+    await driver.switchToWindow(plainContext.handle);
+    await driver.navigate('about:blank');
+    await driver.switchToWindow(extensionHandle);
+    await driver.closeWindow();
+    await driver.switchToWindow(plainContext.handle);
+    const extensionUiClosedAt = Date.now();
+    const openHandles = await driver.windowHandles();
+    assert(Array.isArray(openHandles) && !openHandles.includes(extensionHandle),
+      'the heartbeat fails with the extension UI physically closed',
+      JSON.stringify(openHandles));
+
+    const lossSettledWhileClosed = await waitFor(() => {
+      const records = providerServer.records.slice(recordStart)
+        .filter((record) => record.scenario === 'keepalive-loss');
+      const interrupted = records.find((record) =>
+        record.body.includes('<actor_agent>')
+          && record.receivedAt === sideEffectAndContinuation.actorRequestAt);
+      const outcomeUnknown = records.find((record) =>
+        !record.body.includes('<actor_agent>')
+          && hasOutcomeUnknownState(record.body));
+      return interrupted && outcomeUnknown ? {
+        actorContinuationReceivedAt: interrupted.receivedAt,
+        actorContinuationRespondedAt: interrupted.respondedAt,
+        unknownContinuationReceivedAt: outcomeUnknown.receivedAt,
+      } : null;
+    }, { budgetMs: 15_000, pollMs: 100 });
+    assert(lossSettledWhileClosed?.actorContinuationRespondedAt === null
+      && lossSettledWhileClosed?.unknownContinuationReceivedAt >= extensionUiClosedAt,
+      'the failed heartbeat settles Outcome unknown before the delayed provider response with every UI closed',
+      JSON.stringify({ extensionUiClosedAt, ...lossSettledWhileClosed }));
+
+    await driver.navigate(`${EXTENSION_ORIGIN}/sidepanel/sidepanel.html`);
+
+    const proof = await waitFor(() => driver.executeAsync(`
+      const [finalCanary, rootToolUseId, heartbeatKey] = arguments;
+      const done = arguments[arguments.length - 1];
+      const send = (message) => browser.runtime.sendMessage(message);
+      (async () => {
+        const [listed, audit, heartbeat, mailbox, state] = await Promise.all([
+          send({ type: 'session/list' }),
+          send({ type: 'audit/list', limit: 500 }),
+          browser.storage.session.get(heartbeatKey),
+          browser.storage.session.get('actorMailbox'),
+          send({ type: 'state/get' }),
+        ]);
+        let bundle = null;
+        for (const session of listed?.sessions ?? []) {
+          if (!session?.sessionId || session.kind === 'actor') continue;
+          const debug = await send({ type: 'session/debugBundle', sessionId: session.sessionId });
+          const doneMessage = debug?.bundle?.session?.messages?.some((message) =>
+            message.role === 'assistant'
+              && typeof message.content === 'string'
+              && message.content.includes(finalCanary));
+          if (doneMessage) { bundle = debug.bundle; break; }
+        }
+        if (!bundle) return null;
+        const toolResult = bundle.session.messages
+          .flatMap((message) => message.toolResults ?? [])
+          .find((result) => result.tool_use_id === rootToolUseId);
+        return {
+          bundle,
+          toolResult: toolResult ?? null,
+          audit: audit?.entries ?? [],
+          heartbeat: heartbeat?.[heartbeatKey] ?? null,
+          mailboxKeys: Object.keys(mailbox?.actorMailbox ?? {}),
+          actorExecution: state?.state?.capabilities?.actorExecution ?? null,
+        };
+      })().then(done, (error) => done({ error: error?.message || String(error) }));
+    `, [KEEPALIVE_LOSS_FINAL_CANARY, 'firefox-keepalive-loss-actor-tool', LIFETIME_HEARTBEAT_KEY]), {
+      budgetMs: 60_000,
+      pollMs: 250,
+    });
+    assert(proof?.bundle && proof?.toolResult,
+      'the post-start keepalive loss reaches one visible parent terminal state', JSON.stringify(proof));
+    const resultText = String(proof.toolResult?.content ?? '');
+    assert(proof.toolResult?.is_error === true
+      && hasOutcomeUnknownState(resultText),
+    'the awaited actor result is Outcome unknown rather than Not run', resultText);
+    const failedRun = proof.audit.find((entry) => entry.type === 'actor_ran_isolated'
+      && entry.details?.host === 'background-page-worker'
+      && entry.details?.ok === false);
+    assert(failedRun?.details?.performed === true
+      && failedRun?.details?.outcomeKnown === false,
+    'the audit records a post-start ambiguous outcome', JSON.stringify(failedRun));
+    assert(proof.heartbeat === null && proof.mailboxKeys.length === 0,
+      'the failed lease and committed actor receipt leave no heartbeat or mailbox row',
+      JSON.stringify({ heartbeat: proof.heartbeat, mailboxKeys: proof.mailboxKeys }));
+    assert(proof.actorExecution?.status === 'temporarily_unavailable'
+      && proof.actorExecution?.retryable === true,
+    'the failed heartbeat pauses actor execution until an explicit retry',
+    JSON.stringify(proof.actorExecution));
+
+    const preGuardRequests = providerServer.records.slice(recordStart)
+      .filter((record) => record.scenario === 'keepalive-loss');
+    const preGuardActorRequests = preGuardRequests
+      .filter((record) => record.body.includes('<actor_agent>'));
+    const preGuardRootRequests = preGuardRequests.filter((record) =>
+      !record.body.includes('<actor_agent>')
+        && !hasOutcomeUnknownState(record.body));
+    const preGuardUnknownContinuations = preGuardRequests.filter((record) =>
+      !record.body.includes('<actor_agent>')
+        && hasOutcomeUnknownState(record.body));
+    const interruptedActorContinuation = preGuardActorRequests.find((record) =>
+      record.body.includes(KEEPALIVE_LOSS_TOOL_ID)
+        && record.receivedAt === sideEffectAndContinuation.actorRequestAt);
+    assert(preGuardRootRequests.length === 1
+      && preGuardActorRequests.length === 2
+      && preGuardUnknownContinuations.length === 1,
+    'the ambiguous turn makes exactly one root request, two actor requests, and one terminal continuation',
+    JSON.stringify({
+      rootRequests: preGuardRootRequests.length,
+      actorRequests: preGuardActorRequests.length,
+      unknownContinuations: preGuardUnknownContinuations.length,
+    }));
+    assert(interruptedActorContinuation
+      && preGuardUnknownContinuations[0].receivedAt < (interruptedActorContinuation.respondedAt ?? Infinity),
+    'the failed heartbeat settles Outcome unknown before any delayed upstream continuation can return',
+    JSON.stringify({
+      actorContinuationReceivedAt: interruptedActorContinuation?.receivedAt,
+      actorContinuationRespondedAt: interruptedActorContinuation?.respondedAt,
+      unknownContinuationReceivedAt: preGuardUnknownContinuations[0]?.receivedAt,
+    }));
+
+    const guardStart = providerServer.records.length;
+    const guardTurn = await driver.executeAsync(`
+      const done = arguments[arguments.length - 1];
+      browser.runtime.sendMessage({
+        type: 'agent/send',
+        text: 'Report whether actor work is available. Do not retry the previous action.',
+      }).then(done, (error) => done({ ok: false, error: error?.message || String(error) }));
+    `);
+    assert(guardTurn?.ok === true, 'the model-facing paused-capability proof starts', JSON.stringify(guardTurn));
+    const guardedRequest = await waitFor(() => providerServer.records.slice(guardStart)
+      .find((record) => record.scenario === 'keepalive-loss'
+        && !record.body.includes('<actor_agent>')
+        && typeof record.respondedAt === 'number'),
+    { budgetMs: 30_000, pollMs: 100 });
+    let guardedPayload = null;
+    try { guardedPayload = JSON.parse(guardedRequest?.body ?? ''); }
+    catch { /* assertion below reports the malformed body */ }
+    const guardedTools = (guardedPayload?.tools ?? []).map((tool) => tool?.name);
+    const guardedSystem = requestSystemText(guardedPayload);
+    assert(guardedSystem.includes('status="temporarily_unavailable"')
+      && !guardedTools.some((name) =>
+        ['message_actor', 'actor_create', 'request_review'].includes(name)),
+    'the next model turn names the pause and removes actor execution tools',
+    JSON.stringify({ guardedSystem, guardedTools }));
+
+    const requestCount = providerServer.records.slice(recordStart)
+      .filter((record) => record.scenario === 'keepalive-loss').length;
+    assert(requestCount === preGuardRequests.length + 1,
+      'the guarded follow-up adds exactly one deliberate parent request',
+      JSON.stringify({ beforeGuard: preGuardRequests.length, afterGuard: requestCount }));
+    const lateResponseEvent = await waitFor(() => {
+      const interrupted = providerServer.records.slice(recordStart).find((record) =>
+        record.scenario === 'keepalive-loss'
+          && record.body.includes('<actor_agent>')
+          && record.receivedAt === sideEffectAndContinuation.actorRequestAt);
+      const actorAborts = providerServer.keepaliveLossActorAborts - abortStart;
+      if (actorAborts === 1) {
+        return { actorAborts, responseAttemptedAt: interrupted?.responseAttemptedAt ?? null };
+      }
+      if (actorAborts === 0 && typeof interrupted?.responseAttemptedAt === 'number') {
+        return { actorAborts, responseAttemptedAt: interrupted.responseAttemptedAt };
+      }
+      return null;
+    }, { budgetMs: KEEPALIVE_LOSS_RESPONSE_DELAY_MS + 5_000, pollMs: 100 });
+    assert(lateResponseEvent,
+      'the interrupted provider stream is either closed or attempts its delayed response',
+      JSON.stringify(lateResponseEvent));
+    await new Promise((resolveWait) => setTimeout(resolveWait, LIFETIME_QUIET_MS));
+    const settledRequests = providerServer.records.slice(recordStart)
+      .filter((record) => record.scenario === 'keepalive-loss');
+    const settledActorRequests = settledRequests
+      .filter((record) => record.body.includes('<actor_agent>'));
+    const actorAborts = providerServer.keepaliveLossActorAborts - abortStart;
+    const settledInterruptedContinuation = settledActorRequests.find((record) =>
+      record.body.includes(KEEPALIVE_LOSS_TOOL_ID)
+        && record.receivedAt === sideEffectAndContinuation.actorRequestAt);
+    // why: AbortSignal revocation is the product boundary. Firefox may either
+    // close the proxied HTTP stream or drain it without delivering its result;
+    // both are safe when the retired relay cannot dispatch or replay anything.
+    assert(settledActorRequests.length === 2
+      && settledRequests.length === requestCount,
+    'the post-start loss produces no actor or parent replay beyond a full heartbeat interval', JSON.stringify({
+      quietMs: LIFETIME_QUIET_MS,
+      actorRequests: settledActorRequests.length,
+      actorAborts,
+      actorContinuationResponseAttemptedAt: settledInterruptedContinuation?.responseAttemptedAt,
+      actorContinuationRespondedAt: settledInterruptedContinuation?.respondedAt,
+      requestsBeforeQuiet: requestCount,
+      requestsAfterQuiet: settledRequests.length,
+    }));
+    const lateResponseProof = await driver.executeAsync(`
+      const [sessionId, tabId, lateCanary] = arguments;
+      const done = arguments[arguments.length - 1];
+      Promise.all([
+        browser.runtime.sendMessage({ type: 'session/debugBundle', sessionId }),
+        browser.runtime.sendMessage({ type: 'state/get' }),
+        browser.scripting.executeScript({
+          target: { tabId },
+          func: () => ({
+            clicked: document.body.dataset.clicked ?? null,
+            clickCount: document.body.dataset.clickCount ?? '0',
+          }),
+        }),
+      ]).then(([debug, state, [page]]) => done({
+        bundleOk: debug?.ok === true && !!debug?.bundle,
+        lateCanaryPresent: JSON.stringify(debug?.bundle ?? {}).includes(lateCanary),
+        actorExecution: state?.state?.capabilities?.actorExecution ?? null,
+        page: page?.result ?? null,
+      }), (error) => done({ error: error?.message || String(error) }));
+    `, [proof.bundle.session.sessionId, fixtureTabId, KEEPALIVE_LOSS_LATE_CANARY]);
+    assert(lateResponseProof?.bundleOk === true
+      && lateResponseProof?.lateCanaryPresent === false
+      && lateResponseProof?.actorExecution?.status === 'temporarily_unavailable'
+      && lateResponseProof?.page?.clicked === 'yes'
+      && lateResponseProof?.page?.clickCount === sideEffectAndContinuation.clickCount,
+    'late provider bytes have no authority to change the terminal result or repeat the side effect',
+    JSON.stringify(lateResponseProof));
+
+    await driver.navigate(`${EXTENSION_ORIGIN}/sidepanel/sidepanel.html`);
+    const rendered = await waitFor(() => driver.execute(`
+      const header = [...document.querySelectorAll('.tool-call.tool-actor button.tool-call-header')]
+        .find((node) => node.querySelector('.tool-name')?.textContent === 'message_actor');
+      const banner = document.querySelector('.actor-isolation-banner');
+      const retryButtons = [...(banner?.querySelectorAll('button') ?? [])]
+        .filter((button) => button.textContent?.trim() === 'Try again');
+      if (!header || !header.innerText.includes('Outcome unknown')
+          || !banner || retryButtons.length !== 1) return null;
+      return {
+        header: header.innerText,
+        banner: banner.innerText,
+        bannerRole: banner.getAttribute('role'),
+        retryLabel: retryButtons[0]?.textContent?.trim() ?? '',
+      };
+    `), { budgetMs: 30_000, pollMs: 250 });
+    assert(rendered?.bannerRole === 'status'
+      && rendered?.banner?.includes('Actor work is paused')
+      && rendered?.retryLabel === 'Try again',
+    'the packaged UI persistently exposes one labeled recovery control', JSON.stringify(rendered));
+    const actorHeaderClicked = await driver.execute(`
+      const header = [...document.querySelectorAll('.tool-call.tool-actor button.tool-call-header')]
+        .find((node) => node.querySelector('.tool-name')?.textContent === 'message_actor');
+      if (!header) return false;
+      header.click();
+      return true;
+    `);
+    assert(actorHeaderClicked === true, 'the ambiguous actor result exposes an expandable detail control');
+    const expandedActorResult = await waitFor(() => driver.execute(`
+      const header = [...document.querySelectorAll('.tool-call.tool-actor button.tool-call-header')]
+        .find((node) => node.querySelector('.tool-name')?.textContent === 'message_actor');
+      if (!header || header.getAttribute('aria-expanded') !== 'true') return null;
+      return {
+        header: header.innerText,
+        expanded: header.getAttribute('aria-expanded'),
+        body: header.parentElement?.querySelector('.actor-body')?.innerText ?? '',
+      };
+    `), { budgetMs: 10_000, pollMs: 100 });
+    assert(expandedActorResult?.expanded === 'true'
+      && expandedActorResult?.header?.includes('Outcome unknown')
+      && !expandedActorResult?.header?.includes('Not run'),
+    'the packaged UI distinguishes Outcome unknown without relying on color',
+    JSON.stringify(expandedActorResult));
+    assert(hasAmbiguousOutcomeWarning(expandedActorResult?.body),
+      'the ambiguous actor detail warns that the action may have completed',
+      JSON.stringify(expandedActorResult));
+    assert(advisesCheckingBeforeRetry(expandedActorResult?.body),
+      'the ambiguous actor detail tells the user to check before retrying',
+      JSON.stringify(expandedActorResult));
+
+    const requestsBeforeRetry = providerServer.records.length;
+    const recoveryStarted = await driver.execute(`
+      const retry = [...document.querySelectorAll('.actor-isolation-banner button')]
+        .find((button) => button.textContent?.trim() === 'Try again');
+      if (!retry) return null;
+      retry.click();
+      const banner = document.querySelector('.actor-isolation-banner');
+      const busyButton = banner?.querySelector('button');
+      return {
+        ariaBusy: banner?.getAttribute('aria-busy') ?? null,
+        disabled: busyButton?.disabled ?? false,
+        label: busyButton?.textContent?.trim() ?? '',
+      };
+    `);
+    assert(recoveryStarted?.ariaBusy === 'true'
+      && recoveryStarted?.disabled === true
+      && recoveryStarted?.label === 'Retrying actor worker…',
+    'the visible retry control enters an announced, disabled busy state',
+    JSON.stringify(recoveryStarted));
+    const recovered = await waitFor(() => driver.executeAsync(`
+      const [heartbeatKey] = arguments;
+      const done = arguments[arguments.length - 1];
+      Promise.all([
+        browser.runtime.sendMessage({ type: 'state/get' }),
+        browser.storage.session.get(heartbeatKey),
+      ]).then(([state, heartbeat]) => {
+        const receipts = [...document.querySelectorAll('.actor-isolation-banner.is-recovered')];
+        const proof = {
+          state: state?.state?.capabilities?.actorExecution ?? null,
+          heartbeat: heartbeat?.[heartbeatKey] ?? null,
+          receiptCount: receipts.length,
+          receipt: receipts[0]?.innerText ?? '',
+          focused: receipts.length === 1 && document.activeElement === receipts[0],
+        };
+        done(proof.state?.status === 'available'
+          && proof.heartbeat === null
+          && proof.receiptCount === 1
+          && proof.receipt.includes('Actor work is ready')
+          && proof.focused === true
+          ? proof
+          : null);
+      }, (error) => done({ error: error?.message || String(error) }));
+    `, [LIFETIME_HEARTBEAT_KEY]), { budgetMs: 30_000, pollMs: 100 });
+    assert(recovered?.state?.status === 'available'
+      && recovered?.heartbeat === null
+      && recovered?.receiptCount === 1
+      && recovered?.receipt?.includes('Actor work is ready')
+      && recovered?.focused === true,
+    'the visible retry restores actor work, clears its heartbeat, and focuses one recovery receipt',
+    JSON.stringify(recovered));
+    await new Promise((resolveWait) => setTimeout(resolveWait, LIFETIME_QUIET_MS));
+    assert(providerServer.records.length === requestsBeforeRetry,
+      'restoring actor work does not replay the ambiguous request beyond a full heartbeat interval',
+      JSON.stringify({ before: requestsBeforeRetry, after: providerServer.records.length }));
+  } catch (error) {
+    const geckoLog = driver?.logs.join('') ?? '';
+    if (geckoLog) writeFileSync(join(OUTPUT, KEEPALIVE_LOSS_LOG), geckoLog);
+    writeFileSync(join(OUTPUT, KEEPALIVE_LOSS_DIAGNOSTIC), JSON.stringify({
+      error: error?.message ?? String(error),
+      records: providerServer.records.slice(recordStart).map((record) => ({
+        scenario: record.scenario,
+        actor: record.body.includes('<actor_agent>'),
+        outcomeUnknown: hasOutcomeUnknownState(record.body),
+        receivedAt: record.receivedAt,
+        responseAttemptedAt: record.responseAttemptedAt,
+        respondedAt: record.respondedAt,
+      })),
+      actorAborts: providerServer.keepaliveLossActorAborts - abortStart,
+    }, null, 2));
+    throw error;
+  } finally {
+    try {
+      if (driver) {
+        const screenshot = await driver.screenshot();
+        writeFileSync(join(OUTPUT, KEEPALIVE_LOSS_SCREENSHOT), Buffer.from(screenshot, 'base64'));
+      }
+    } catch { /* the browser may already be gone */ }
+    if (fixtureTabId != null && driver) {
+      await driver.executeAsync(`
+        const [tabId] = arguments;
+        const done = arguments[arguments.length - 1];
+        browser.tabs.remove(tabId).then(() => done(true), () => done(false));
+      `, [fixtureTabId]).catch(() => {});
+    }
+    await driver?.close();
+    providerServer.setScenario({ mode: 'happy', actorTarget: 'web' });
+    rmSync(directory, { recursive: true, force: true });
+  }
+};
+
+const runActorRecoverySmoke = async ({ providerServer }) => {
+  console.log('Firefox actor recovery smoke: reload twice without replaying durable mailbox work');
+  const { artifact, directory } = createRecoveryArtifact();
+  let driver = null;
+  try {
+    driver = await startGeckodriver({
+      binary: geckodriverBinary,
+      firefoxBinary,
+      acceptInsecureCerts: true,
+      proxy: {
+        proxyType: 'manual',
+        sslProxy: `127.0.0.1:${providerServer.port}`,
+        noProxy: ['localhost', '127.0.0.1'],
+      },
+      prefs: {
+        'extensions.webextensions.uuids': JSON.stringify({ [ADDON_ID]: TEST_UUID }),
+      },
+    });
+    const installedId = await driver.installAddon(resolve(artifact));
+    assert(installedId === ADDON_ID, 'the recovery diagnostic XPI keeps the Store add-on id', String(installedId));
+    await driver.navigate(`${EXTENSION_ORIGIN}/sidepanel/sidepanel.html`);
+
+    const prepared = await driver.executeAsync(`
+      const [passphrase, providerKey, seedKey] = arguments;
+      const done = arguments[arguments.length - 1];
+      const send = (message) => browser.runtime.sendMessage(message);
+      (async () => {
+        const vault = await send({ type: 'vault/initialize', passphrase });
+        const provider = await send({ type: 'provider/setKey', provider: 'anthropic', plaintext: providerKey });
+        const command = await send({ type: 'agent/send', text: '/system Firefox recovery fixture' });
+        let sessionId = null;
+        for (let attempt = 0; attempt < 200; attempt += 1) {
+          const listed = await send({ type: 'session/list' });
+          sessionId = listed?.sessions?.[0]?.sessionId ?? null;
+          if (sessionId) break;
+          await new Promise((resolveWait) => setTimeout(resolveWait, 50));
+        }
+        if (!sessionId) throw new Error('recovery parent session was not created');
+        const createdAt = Date.now();
+        const provenance = { rootSessionId: sessionId, lineagePath: [sessionId] };
+        const entries = [
+          {
+            id: 'firefox-recovery-queued', senderSessionId: sessionId,
+            to: 'web', message: 'queued recovery request', createdAt,
+            state: 'queued', kind: 'web', provenance,
+          },
+          {
+            id: 'firefox-recovery-started', senderSessionId: sessionId,
+            to: 'web', message: 'started recovery request', createdAt: createdAt + 1,
+            state: 'started', startedAt: createdAt + 2, kind: 'web', provenance,
+          },
+          {
+            id: 'firefox-recovery-legacy', senderSessionId: sessionId,
+            to: 'web', message: 'legacy recovery request', createdAt: createdAt + 3,
+            kind: 'web', provenance,
+          },
+        ];
+        await browser.storage.session.remove('actorMailbox');
+        await browser.storage.local.set({ [seedKey]: { active: true, entries } });
+        const probe = await send({ type: 'firefox-recovery/probe' });
+        return {
+          ok: vault?.ok === true && provider?.ok === true
+            && command?.ok === true && typeof probe?.boot?.bootId === 'string',
+          sessionId,
+          entryIds: entries.map((entry) => entry.id),
+          boot: probe?.boot ?? null,
+        };
+      })().then(done, (error) => done({ ok: false, error: error?.message || String(error) }));
+    `, [PASSPHRASE_CANARY, PROVIDER_KEY_CANARY, RECOVERY_SEED_KEY]);
+    assert(prepared?.ok === true, 'the recovery profile creates one durable parent and three mailbox seeds',
+      JSON.stringify(prepared));
+
+    providerServer.setScenario({ mode: 'recovery', actorTarget: 'web' });
+    const recordStart = providerServer.records.length;
+    const expectedReceiptIds = prepared.entryIds
+      .map((id) => `actor-recovery:${prepared.sessionId}:${id}`)
+      .sort();
+
+    const readRecoveryState = () => driver.executeAsync(`
+      const [sessionId, expectedIds] = arguments;
+      const done = arguments[arguments.length - 1];
+      const send = (message) => browser.runtime.sendMessage(message);
+      Promise.all([
+        send({ type: 'session/get', sessionId }),
+        browser.storage.session.get('actorMailbox'),
+        send({ type: 'firefox-recovery/probe' }),
+        send({ type: 'audit/list', limit: 500 }),
+      ]).then(([sessionReply, mailboxStored, probe, audit]) => {
+        const messages = sessionReply?.session?.messages ?? [];
+        const expected = new Set(expectedIds);
+        const receipts = messages.filter((message) => expected.has(message?.id));
+        done({
+          ok: sessionReply?.ok === true,
+          boot: probe?.boot ?? null,
+          mailboxKeys: Object.keys(mailboxStored?.actorMailbox ?? {}),
+          messageIds: messages.map((message) => message?.id ?? null),
+          receipts: receipts.map((message) => ({
+            id: message.id,
+            content: message.content,
+            outcomeKnown: message.actorReply?.outcomeKnown,
+            performed: message.actorReply?.performed,
+          })),
+          audit: audit?.entries ?? [],
+        });
+      }, (error) => done({ ok: false, error: error?.message || String(error) }));
+    `, [prepared.sessionId, expectedReceiptIds]);
+
+    const reloadAndRecover = async (previousBoot) => {
+      // runtime.reload invalidates the extension document that issued it. Keep a
+      // neutral WebDriver context alive so the session has somewhere valid to
+      // land before navigating back into the reloaded extension.
+      const extensionHandle = await driver.windowHandle();
+      const survivor = await driver.newWindow('tab');
+      assert(typeof survivor?.handle === 'string',
+        'the recovery reload keeps a plain browser context alive',
+        JSON.stringify(survivor));
+      await driver.switchToWindow(survivor.handle);
+      await driver.navigate('about:blank');
+      await driver.switchToWindow(extensionHandle);
+      try { await driver.execute('browser.runtime.reload(); return true;'); }
+      catch { /* the extension page can disconnect before the command returns */ }
+      await driver.switchToWindow(survivor.handle);
+      let lastObserved = null;
+      const ready = await waitFor(async () => {
+        try {
+          await driver.navigate(`${EXTENSION_ORIGIN}/sidepanel/sidepanel.html`);
+          const observed = await driver.executeAsync(`
+            const done = arguments[arguments.length - 1];
+            Promise.all([
+              browser.runtime.sendMessage({ type: 'state/get' }),
+              browser.runtime.sendMessage({ type: 'firefox-recovery/probe' }),
+            ]).then(([state, probe]) => done({
+              stateOk: state?.ok === true,
+              state: state?.state ?? null,
+              boot: probe?.boot ?? null,
+            }), (error) => done({ error: error?.message || String(error) }));
+          `);
+          lastObserved = observed;
+          return observed?.stateOk === true
+            && typeof observed.boot?.bootId === 'string'
+            && observed.boot.bootId !== previousBoot.bootId
+            ? observed
+            : null;
+        } catch { return null; }
+      }, { budgetMs: 30_000, pollMs: 250 });
+      assert(typeof ready?.boot?.bootId === 'string'
+        && ready.boot.bootId !== previousBoot.bootId,
+      'the recovery XPI starts a new background generation',
+      JSON.stringify({ previousBoot, lastObserved }));
+      if (ready.state?.vault?.locked === true) {
+        const unlocked = await driver.executeAsync(`
+          const [passphrase] = arguments;
+          const done = arguments[arguments.length - 1];
+          browser.runtime.sendMessage({ type: 'vault/unlock', passphrase })
+            .then(done, (error) => done({ ok: false, error: error?.message || String(error) }));
+        `, [PASSPHRASE_CANARY]);
+        assert(unlocked?.ok === true, 'the recovery profile unlocks for transcript inspection',
+          JSON.stringify(unlocked));
+      }
+      const recovered = await waitFor(async () => {
+        const state = await readRecoveryState();
+        return state?.ok === true
+          && typeof state.boot?.bootId === 'string'
+          && state.boot.bootId !== previousBoot.bootId
+          && state.mailboxKeys?.length === 0
+          && state.receipts?.length === expectedReceiptIds.length
+          ? state
+          : null;
+      }, { budgetMs: 30_000, pollMs: 250 });
+      assert(recovered?.receipts?.length === expectedReceiptIds.length,
+        'queued, started, and legacy recovery receipts commit before mailbox removal',
+        JSON.stringify(recovered));
+      return recovered;
+    };
+
+    const first = await reloadAndRecover(prepared.boot);
+    assert(first.receipts.some((receipt) => receipt.id.endsWith(':firefox-recovery-queued')
+      && receipt.outcomeKnown === true && receipt.performed === false
+      && receipt.content.includes('It was not run')),
+    'queued mailbox work becomes one durable Not run receipt', JSON.stringify(first.receipts));
+    assert(first.receipts.filter((receipt) =>
+      receipt.id.endsWith(':firefox-recovery-started')
+        || receipt.id.endsWith(':firefox-recovery-legacy'))
+      .every((receipt) => receipt.outcomeKnown === false
+        && receipt.content.includes('cannot confirm whether the previous request ran')),
+    'started and legacy mailbox work become durable Outcome unknown receipts',
+    JSON.stringify(first.receipts));
+    await new Promise((resolveWait) => setTimeout(resolveWait, 1_500));
+    assert(providerServer.records.length === recordStart,
+      'first background recovery performs no provider or actor request',
+      JSON.stringify(providerServer.records.slice(recordStart)));
+
+    const second = await reloadAndRecover(first.boot);
+    await new Promise((resolveWait) => setTimeout(resolveWait, 1_500));
+    const finalState = await readRecoveryState();
+    assert(finalState?.mailboxKeys?.length === 0
+      && finalState?.messageIds?.length === expectedReceiptIds.length
+      && JSON.stringify(finalState.messageIds.slice().sort()) === JSON.stringify(expectedReceiptIds),
+    'the second recovery removes its mailbox seeds without duplicating stable receipts',
+    JSON.stringify(finalState));
+    assert(new Set([prepared.boot.bootId, first.boot.bootId, second.boot.bootId]).size === 3,
+      'the recovery proof observes three distinct background boot identities',
+      JSON.stringify([prepared.boot, first.boot, second.boot]));
+    const replayAudit = finalState.audit.filter((entry) => entry.type === 'actor_ran_isolated'
+      || entry.type === 'actor_message');
+    assert(providerServer.records.length === recordStart && replayAudit.length === 0,
+      'two background recoveries produce zero model calls and zero actor executions',
+      JSON.stringify({ requests: providerServer.records.slice(recordStart), replayAudit }));
+  } finally {
+    await driver?.close();
+    providerServer.setScenario({ mode: 'happy', actorTarget: 'web' });
+    rmSync(directory, { recursive: true, force: true });
+  }
+};
+
+const runBrokenWorkerSmoke = async ({ providerServer, fixturePort }) => {
+  console.log('Firefox actor failure smoke: install a copy with the dedicated worker removed');
+  const { artifact, directory } = createBrokenWorkerArtifact();
+  const workerProbeStart = providerServer.workerStartupProbes;
+  let driver = null;
+  let fixtureTabId = null;
+  try {
+    driver = await startGeckodriver({
+      binary: geckodriverBinary,
+      firefoxBinary,
+      acceptInsecureCerts: true,
+      proxy: {
+        proxyType: 'manual',
+        sslProxy: `127.0.0.1:${providerServer.port}`,
+        noProxy: ['localhost', '127.0.0.1'],
+      },
+      prefs: {
+        'extensions.webextensions.uuids': JSON.stringify({ [ADDON_ID]: TEST_UUID }),
+      },
+    });
+    await driver.setWindowRect({ width: 400, height: 900, x: 0, y: 0 });
+    const installedId = await driver.installAddon(resolve(artifact));
+    assert(installedId === ADDON_ID, 'the broken-worker diagnostic XPI keeps the Store add-on id', String(installedId));
+
+    await driver.navigate(`${EXTENSION_ORIGIN}/sidepanel/sidepanel.html`);
+    const mounted = await waitFor(() => driver.execute(
+      "return document.readyState === 'complete' && (document.getElementById('app')?.childElementCount || 0) > 0;",
+    ), { budgetMs: 30_000 });
+    assert(mounted === true, 'the broken-worker package still mounts the Firefox side panel');
+
+    const initialized = await driver.executeAsync(`
+      const done = arguments[arguments.length - 1];
+      const send = (message) => browser.runtime.sendMessage(message);
+      (async () => {
+        const before = await send({ type: 'state/get' });
+        const vault = await send({
+          type: 'vault/initialize', passphrase: ${JSON.stringify(PASSPHRASE_CANARY)},
+        });
+        const provider = await send({
+          type: 'provider/setKey', provider: 'anthropic', plaintext: ${JSON.stringify(PROVIDER_KEY_CANARY)},
+        });
+        return {
+          ok: before?.ok === true && vault?.ok === true && provider?.ok === true,
+          capability: before?.state?.capabilities?.actorExecution ?? null,
+        };
+      })().then(done, (error) => done({ ok: false, error: error?.message || String(error) }));
+    `);
+    assert(initialized?.ok === true, 'the broken-worker package initializes the real vault and provider',
+      JSON.stringify(initialized));
+    assert(initialized?.capability?.status === 'available'
+      && initialized?.capability?.host === 'background-page-worker',
+    'Firefox reports the actor host available before the worker is first started',
+    JSON.stringify(initialized?.capability));
+
+    const fixture = await driver.executeAsync(`
+      const [fixtureUrl] = arguments;
+      const done = arguments[arguments.length - 1];
+      (async () => {
+        const tab = await browser.tabs.create({ url: fixtureUrl, active: true });
+        for (let attempt = 0; attempt < 200; attempt += 1) {
+          try {
+            const [probe] = await browser.scripting.executeScript({
+              target: { tabId: tab.id },
+              func: () => document.readyState === 'complete'
+                && document.getElementById('firefox-action') !== null,
+            });
+            if (probe?.result === true) {
+              return { ok: true, tabId: tab.id };
+            }
+          } catch { /* navigation is still in flight */ }
+          await new Promise((resolveWait) => setTimeout(resolveWait, 100));
+        }
+        return { ok: false, tabId: tab.id, error: 'fixture tab did not become scriptable' };
+      })().then(done, (error) => done({ ok: false, error: error?.message || String(error) }));
+    `, [`http://127.0.0.1:${fixturePort}${FIXTURE_PATH}`]);
+    fixtureTabId = fixture?.tabId ?? null;
+    assert(fixture?.ok === true && Number.isInteger(fixtureTabId),
+      'the failure lane has a concrete actor target', JSON.stringify(fixture));
+    providerServer.setScenario({ mode: 'broken-worker', actorTarget: String(fixtureTabId) });
+
+    const started = await driver.executeAsync(`
+      const done = arguments[arguments.length - 1];
+      browser.runtime.sendMessage({
+        type: 'agent/send',
+        text: 'Ask the specified Firefox actor to click its action and report the page status.',
+      }).then(done, (error) => done({ ok: false, error: error?.message || String(error) }));
+    `);
+    assert(started?.ok === true, 'Firefox accepts the turn that will exercise the broken worker',
+      JSON.stringify(started));
+
+    const proof = await waitFor(() => driver.executeAsync(`
+      const [finalCanary] = arguments;
+      const done = arguments[arguments.length - 1];
+      const send = (message) => browser.runtime.sendMessage(message);
+      (async () => {
+        const [listed, audit, state] = await Promise.all([
+          send({ type: 'session/list' }),
+          send({ type: 'audit/list', limit: 500 }),
+          send({ type: 'state/get' }),
+        ]);
+        if (state?.state?.capabilities?.actorExecution?.status !== 'temporarily_unavailable') return null;
+        let bundle = null;
+        for (const session of listed?.sessions ?? []) {
+          if (!session?.sessionId || session.kind === 'actor') continue;
+          const debug = await send({ type: 'session/debugBundle', sessionId: session.sessionId });
+          if (debug?.bundle?.session?.messages?.some((message) =>
+            message.role === 'assistant'
+              && typeof message.content === 'string'
+              && message.content.includes(finalCanary))) {
+            bundle = debug.bundle;
+            break;
+          }
+        }
+        if (!bundle) return null;
+        return {
+          bundle,
+          audit: audit?.entries ?? [],
+          state: state?.state ?? null,
+        };
+      })().then(done, (error) => done({ error: error?.message || String(error) }));
+    `, [FAILURE_FINAL_CANARY]), { budgetMs: 60_000, pollMs: 250 });
+    assert(proof?.state && proof?.bundle, 'the failed actor turn reaches a visible terminal state',
+      JSON.stringify(proof));
+
+    const capability = proof.state.capabilities?.actorExecution;
+    assert(capability?.status === 'temporarily_unavailable'
+      && capability?.host === 'background-page-worker'
+      && capability?.retryable === true,
+    'a worker startup failure makes actor execution temporarily unavailable and retryable',
+    JSON.stringify(capability));
+
+    const unavailable = proof.audit.filter((entry) => entry.type === 'actor_isolation_unavailable');
+    const failures = proof.audit.filter((entry) => entry.type === 'actor_isolation_failure');
+    const workerStartupAttempts = providerServer.workerStartupProbes - workerProbeStart;
+    assert(workerStartupAttempts === 2,
+      'the packaged host makes one initial worker start and exactly one automatic retry',
+      String(workerStartupAttempts));
+    assert(unavailable.length === 1
+      && unavailable[0]?.details?.host === 'background-page-worker'
+      && unavailable[0]?.details?.retryable === true,
+    'the bounded automatic startup retry ends in one persistent unavailability transition',
+    JSON.stringify(unavailable));
+    assert(failures.length === 1 && failures[0]?.details?.performed === false,
+      'the failed actor turn is audited as not performed', JSON.stringify(failures));
+    assert(!proof.audit.some((entry) => entry.type === 'actor_ran_isolated'),
+      'the broken-worker package never claims an isolated actor run');
+    assert(!proof.audit.some((entry) => entry.type === 'actor_background_turn_refused'),
+      'the broken-worker failure is not misreported as a background-turn refusal');
+
+    const observedTarget = await driver.executeAsync(`
+      const [tabId] = arguments;
+      const done = arguments[arguments.length - 1];
+      browser.scripting.executeScript({
+        target: { tabId },
+        func: () => ({
+          clicked: document.body.dataset.clicked ?? null,
+          value: document.getElementById('firefox-input')?.value ?? null,
+          status: document.getElementById('firefox-status')?.textContent ?? null,
+        }),
+      }).then(([entry]) => done(entry?.result ?? null),
+        (error) => done({ error: error?.message || String(error) }));
+    `, [fixtureTabId]);
+    assert(observedTarget?.clicked === null
+      && observedTarget?.value === ''
+      && observedTarget?.status === 'ready',
+    'the unavailable actor leaves its concrete target unchanged', JSON.stringify(observedTarget));
+
+    const failureRequests = providerServer.records.filter((record) => record.scenario === 'broken-worker');
+    const actorRequests = failureRequests.filter((record) => record.body.includes('<actor_agent>'));
+    const parsedFailureRequests = failureRequests.map((record) => {
+      try { return JSON.parse(record.body); }
+      catch { return null; }
+    });
+    const failureContinuation = parsedFailureRequests.find((request) =>
+      request?.messages?.some((message) => Array.isArray(message.content)
+        && message.content.some((block) => block?.type === 'tool_result'
+          && block.tool_use_id === 'firefox-broken-worker-tool')));
+    const failureToolNames = (failureContinuation?.tools ?? []).map((tool) => tool?.name);
+    const failureSystem = requestSystemText(failureContinuation);
+    assert(failureRequests.length >= 2, 'the parent model receives the terminal actor refusal',
+      String(failureRequests.length));
+    assert(actorRequests.length === 0, 'the worker startup failure makes no actor model request',
+      String(actorRequests.length));
+    assert(failureSystem.includes('status="temporarily_unavailable"')
+      && !failureToolNames.some((name) =>
+        ['message_actor', 'actor_create', 'request_review'].includes(name)),
+    'the continuation tells the model actors are unavailable and removes actor execution tools',
+    JSON.stringify({ failureSystem, failureToolNames }));
+    assert(failureRequests.every((record) => record.headers['x-api-key'] === PROVIDER_KEY_CANARY)
+      && failureRequests.every((record) => !record.body.includes(PROVIDER_KEY_CANARY)),
+    'the broken-worker lane keeps the provider key at the provider boundary');
+
+    const storedProof = JSON.stringify({ bundle: proof.bundle, audit: proof.audit, state: proof.state });
+    assert(!storedProof.includes(PROVIDER_KEY_CANARY) && !storedProof.includes(PASSPHRASE_CANARY),
+      'the broken-worker state, audit, and session diagnostics contain no credential canaries');
+
+    const probesBeforeReload = providerServer.workerStartupProbes;
+    try { await driver.execute('browser.runtime.reload(); return true;'); }
+    catch { /* the page can disconnect before WebDriver receives the return */ }
+    const reloaded = await waitFor(async () => {
+      try {
+        await driver.navigate(`${EXTENSION_ORIGIN}/sidepanel/sidepanel.html`);
+        return await driver.execute(`return chrome.runtime.id === ${JSON.stringify(ADDON_ID)}
+          && !!document.querySelector('#app');`);
+      } catch { return false; }
+    }, { budgetMs: 30_000, pollMs: 250 });
+    assert(reloaded === true, 'the side panel reconnects after the Firefox background reload');
+    const persistedCapability = await waitFor(() => driver.executeAsync(`
+      const done = arguments[arguments.length - 1];
+      browser.runtime.sendMessage({ type: 'state/get' })
+        .then((reply) => {
+          const capability = reply?.state?.capabilities?.actorExecution ?? null;
+          done(capability?.retryable === true ? capability : null);
+        },
+          (error) => done({ error: error?.message || String(error) }));
+    `), { budgetMs: 30_000, pollMs: 250 });
+    assert(persistedCapability?.status === 'temporarily_unavailable'
+      && persistedCapability?.host === 'background-page-worker'
+      && persistedCapability?.retryable === true,
+    'the worker failure remains fail-closed after the Firefox background reload',
+    JSON.stringify(persistedCapability));
+    assert(providerServer.workerStartupProbes === probesBeforeReload,
+      'background restart does not clear or automatically probe the stored failure',
+      `${providerServer.workerStartupProbes} probes after ${probesBeforeReload}`);
+
+    await driver.navigate(`${EXTENSION_ORIGIN}/home/home.html`);
+    await driver.navigate(`${EXTENSION_ORIGIN}/sidepanel/sidepanel.html`);
+    const accessible = await waitFor(() => driver.execute(`
+      const statuses = [...document.querySelectorAll('.actor-isolation-banner[role="status"]')];
+      const header = [...document.querySelectorAll('.tool-call.tool-actor button.tool-call-header')]
+        .find((node) => node.querySelector('.tool-name')?.textContent === 'message_actor');
+      if (statuses.length !== 1 || !header) return null;
+      return {
+        statusCount: statuses.length,
+        live: statuses[0].getAttribute('aria-live'),
+        atomic: statuses[0].getAttribute('aria-atomic'),
+        bannerText: statuses[0].innerText,
+        retryText: statuses[0].querySelector('button')?.textContent ?? null,
+        headerText: header.innerText,
+        headerTag: header.tagName,
+        expanded: header.getAttribute('aria-expanded'),
+      };
+    `), { budgetMs: 30_000, pollMs: 250 });
+    assert(accessible?.statusCount === 1
+      && accessible?.live === 'polite'
+      && accessible?.atomic === 'true'
+      && accessible?.bannerText.includes('Actor work is paused')
+      && accessible?.bannerText.includes('Use Try again before retrying an actor request.')
+      && accessible?.retryText === 'Try again',
+    'the persistent live status explains impact and offers a retry', JSON.stringify(accessible));
+    assert(accessible?.headerTag === 'BUTTON'
+      && accessible?.headerText.includes('Not run')
+      && accessible?.expanded === 'false',
+    'the failed message_actor card is a collapsed Not run disclosure', JSON.stringify(accessible));
+
+    const expanded = await driver.execute(`
+      const header = [...document.querySelectorAll('.tool-call.tool-actor button.tool-call-header')]
+        .find((node) => node.querySelector('.tool-name')?.textContent === 'message_actor');
+      header?.click();
+      return {
+        expanded: header?.getAttribute('aria-expanded') ?? null,
+        error: header?.parentElement?.querySelector('.actor-body .error-line')?.textContent ?? null,
+      };
+    `);
+    assert(expanded?.expanded === 'true' && typeof expanded?.error === 'string'
+      && expanded.error.includes('actor_isolation_temporarily_unavailable')
+      && !/Do not retry automatically|Use the Try again control/i.test(expanded.error),
+    'the Not run disclosure exposes the failure reason without relying on color',
+    JSON.stringify(expanded));
+  } finally {
+    try {
+      if (driver) {
+        const screenshot = await driver.screenshot();
+        writeFileSync(join(OUTPUT, BROKEN_WORKER_SCREENSHOT), Buffer.from(screenshot, 'base64'));
+      }
+    } catch { /* the browser may already be gone */ }
+    if (fixtureTabId != null && driver) {
+      await driver.executeAsync(`
+        const [tabId] = arguments;
+        const done = arguments[arguments.length - 1];
+        browser.tabs.remove(tabId).then(() => done(true), () => done(false));
+      `, [fixtureTabId]).catch(() => {});
+    }
+    await driver?.close();
+    providerServer.setScenario({ mode: 'happy', actorTarget: 'web' });
+    rmSync(directory, { recursive: true, force: true });
+  }
 };
 
 const runModuleImportPolicySmoke = async (driver, server) => {
@@ -534,7 +2107,12 @@ const main = async () => {
   if (!firefoxBinary) throw new Error('Firefox not found. Set FIREFOX_PATH.');
   if (!geckodriverBinary) throw new Error('geckodriver not found. Set GECKODRIVER_PATH.');
   mkdirSync(OUTPUT, { recursive: true });
-  for (const diagnostic of ['failure.png', 'geckodriver.log', 'sidepanel.png']) {
+  for (const diagnostic of [
+    'failure.png', 'geckodriver.log', 'sidepanel.png',
+    BROKEN_WORKER_SCREENSHOT, KEEPALIVE_LOSS_SCREENSHOT,
+    KEEPALIVE_LOSS_LOG, KEEPALIVE_LOSS_DIAGNOSTIC,
+    LIFETIME_FAILURE_SCREENSHOT, LIFETIME_FAILURE_LOG, LIFETIME_FAILURE_DIAGNOSTIC,
+  ]) {
     rmSync(join(OUTPUT, diagnostic), { force: true });
   }
 
@@ -669,6 +2247,9 @@ const main = async () => {
 
     await runModuleImportPolicySmoke(driver, server);
     await runBoundActorSmoke(driver, providerServer);
+    await runActorLifetimeSmoke({ providerServer });
+    await runActorKeepaliveLossSmoke({ providerServer, fixturePort: server.port });
+    await runActorRecoverySmoke({ providerServer });
 
     const scriptingFlow = await driver.executeAsync(`
       const done = arguments[arguments.length - 1];
@@ -774,6 +2355,8 @@ const main = async () => {
     await new Promise((resolveWait) => setTimeout(resolveWait, 1_700));
     const screenshot = await driver.screenshot();
     writeFileSync(join(OUTPUT, 'sidepanel.png'), Buffer.from(screenshot, 'base64'));
+
+    await runBrokenWorkerSmoke({ providerServer, fixturePort: server.port });
 
     console.log('Firefox Gecko web-platform suite: run shared browser tests');
     const only = process.env.FIREFOX_TEST_ONLY ?? '';

--- a/scripts/firefox/webdriver.mjs
+++ b/scripts/firefox/webdriver.mjs
@@ -135,6 +135,11 @@ export const startGeckodriver = async ({
       execute: (script, args = []) => command('POST', '/execute/sync', { script, args }),
       executeAsync: (script, args = []) => command('POST', '/execute/async', { script, args }),
       setWindowRect: (rect) => command('POST', '/window/rect', rect),
+      windowHandle: () => command('GET', '/window'),
+      windowHandles: () => command('GET', '/window/handles'),
+      newWindow: (type = 'tab') => command('POST', '/window/new', { type }),
+      switchToWindow: (handle) => command('POST', '/window', { handle }),
+      closeWindow: () => command('DELETE', '/window'),
       screenshot: () => command('GET', '/screenshot'),
       close: async () => {
         try {

--- a/tests/background/actor-isolation-state.test.ts
+++ b/tests/background/actor-isolation-state.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  actorIsolationFailureKey, makeActorIsolationStateStore,
+} from '../../extension/background/actor-isolation-state.js';
+
+const capability = { host: 'background-page-worker' };
+
+const memoryStorage = () => {
+  const values: Record<string, any> = {};
+  return {
+    values,
+    storage: {
+      get: async (key: string) => ({ [key]: values[key] }),
+      set: async (items: Record<string, any>) => { Object.assign(values, items); },
+      remove: async (key: string) => { delete values[key]; },
+    },
+  };
+};
+
+describe('actor isolation failure state', () => {
+  test('persists a retryable failure for the exact host and protocol', async () => {
+    const memory = memoryStorage();
+    const store = makeActorIsolationStateStore({ storage: memory.storage, protocol: 3, now: () => 42 });
+
+    await store.markUnavailable(capability, 'worker import failed', 'actor_worker_crashed');
+
+    expect(await store.load(capability)).toEqual({
+      status: 'temporarily_unavailable',
+      host: 'background-page-worker',
+      reason: 'worker import failed',
+      retryable: true,
+    });
+    expect(memory.values[actorIsolationFailureKey(capability, 3)]).toMatchObject({
+      protocol: 3, code: 'actor_worker_crashed', recordedAt: 42,
+    });
+  });
+
+  test('a protocol or host change does not inherit a stale failure', async () => {
+    const memory = memoryStorage();
+    const oldStore = makeActorIsolationStateStore({ storage: memory.storage, protocol: 2 });
+    await oldStore.markUnavailable(capability, 'old failure', 'actor_worker_crashed');
+
+    const currentStore = makeActorIsolationStateStore({ storage: memory.storage, protocol: 3 });
+    expect(await currentStore.load(capability)).toBeNull();
+    expect(await oldStore.load({ host: 'offscreen-document-worker' })).toBeNull();
+  });
+
+  test('only an explicit clear removes the matching failure', async () => {
+    const memory = memoryStorage();
+    const store = makeActorIsolationStateStore({ storage: memory.storage, protocol: 3 });
+    await store.markUnavailable(capability, 'failed', 'actor_worker_crashed');
+
+    expect(await store.load(capability)).not.toBeNull();
+    await store.clear(capability);
+    expect(await store.load(capability)).toBeNull();
+  });
+});

--- a/tests/background/actor-recovery-gate.test.ts
+++ b/tests/background/actor-recovery-gate.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  actorDeliveryIdsFromMessage,
+  makeActorRecoveryGate,
+} from '../../extension/background/actor-recovery-gate.js';
+
+describe('actor delivery custody', () => {
+  test('collects live and script delivery ids once from committed user messages', () => {
+    expect(actorDeliveryIdsFromMessage({
+      role: 'user',
+      actorReply: { actorDeliveryId: 'live-1' },
+      toolResults: [
+        { actorDeliveryId: 'awaited-1' },
+        { actorDeliveryIds: ['script-1', 'live-1', '', 42] },
+      ],
+    })).toEqual(['live-1', 'awaited-1', 'script-1']);
+  });
+
+  test('ignores non-user messages and invalid or oversized ids', () => {
+    expect(actorDeliveryIdsFromMessage({
+      role: 'assistant', actorReply: { actorDeliveryId: 'not-committed-here' },
+    })).toEqual([]);
+    expect(actorDeliveryIdsFromMessage({
+      role: 'user',
+      toolResults: [{ actorDeliveryIds: ['x'.repeat(513), null] }],
+    })).toEqual([]);
+  });
+});
+
+describe('actor recovery gate', () => {
+  test('automatic work waits until passive recovery has committed', async () => {
+    let release = () => {};
+    const recovery = new Promise<{ redrained: number; retained: number }>((resolve) => {
+      release = () => resolve({ redrained: 0, retained: 0 });
+    });
+    const events: string[] = [];
+    const gate = makeActorRecoveryGate({
+      redrain: async () => {
+        events.push('recovery-started');
+        return recovery;
+      },
+    });
+
+    const running = gate.runWhenReady('model-work', () => { events.push('model-work'); });
+    await Promise.resolve();
+    expect(events).toEqual(['recovery-started']);
+    release();
+    expect(await running).toBe(true);
+    expect(events).toEqual(['recovery-started', 'model-work']);
+  });
+
+  test('a retained receipt blocks work and schedules a same-lifetime retry', async () => {
+    const scheduled: Array<() => void> = [];
+    let attempts = 0;
+    const events: string[] = [];
+    const gate = makeActorRecoveryGate({
+      redrain: async () => ({ redrained: 0, retained: ++attempts === 1 ? 1 : 0 }),
+      schedule: (fn) => { scheduled.push(fn); },
+    });
+
+    expect(await gate.runWhenReady('model-work', () => { events.push('model-work'); })).toBe(false);
+    expect(events).toEqual([]);
+    expect(scheduled).toHaveLength(1);
+
+    scheduled[0]();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(attempts).toBe(2);
+    expect(events).toEqual(['model-work']);
+  });
+
+  test('repeated blocked nudges collapse to one pending action', async () => {
+    const scheduled: Array<() => void> = [];
+    let attempts = 0;
+    const events: string[] = [];
+    const gate = makeActorRecoveryGate({
+      redrain: async () => ({ redrained: 0, retained: ++attempts < 3 ? 1 : 0 }),
+      schedule: (fn) => { scheduled.push(fn); },
+    });
+
+    expect(await gate.runWhenReady('schedules', () => { events.push('old'); })).toBe(false);
+    expect(await gate.runWhenReady('schedules', () => { events.push('latest'); })).toBe(false);
+    expect(events).toEqual([]);
+    expect(scheduled).toHaveLength(1);
+
+    scheduled[0]!();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(events).toEqual(['latest']);
+  });
+
+  test('ready reports recovery state without queueing user work', async () => {
+    const scheduled: Array<() => void> = [];
+    const gate = makeActorRecoveryGate({
+      redrain: async () => ({ redrained: 0, retained: 1 }),
+      schedule: (fn) => { scheduled.push(fn); },
+    });
+
+    expect(await gate.ready()).toBe(false);
+    expect(scheduled).toHaveLength(1);
+  });
+
+  test('a recovery exception fails closed and remains retryable', async () => {
+    const scheduled: Array<() => void> = [];
+    const logs: unknown[] = [];
+    const gate = makeActorRecoveryGate({
+      redrain: async () => { throw new Error('storage unavailable'); },
+      schedule: (fn) => { scheduled.push(fn); },
+      log: (error) => { logs.push(error); },
+    });
+
+    expect(await gate.runWhenReady('model-work', () => { throw new Error('must not run'); })).toBe(false);
+    expect(logs).toHaveLength(1);
+    expect(scheduled).toHaveLength(1);
+  });
+});

--- a/tests/background/direct-actor-host.test.ts
+++ b/tests/background/direct-actor-host.test.ts
@@ -1,0 +1,665 @@
+import { describe, expect, test } from 'bun:test';
+import { makeDirectActorHost, makeStorageSessionKeepAlive } from '../../extension/background/direct-actor-host.js';
+
+describe('Firefox actor host storage.session heartbeat', () => {
+  test('changes a session key until the active lease stops', async () => {
+    const calls: Array<{ set: { leaseId: string, sequence: number } } | { remove: string }> = [];
+    let tick = () => {};
+    let cleared = 0;
+    let keepAlive: ReturnType<typeof makeStorageSessionKeepAlive>;
+    keepAlive = makeStorageSessionKeepAlive({
+      key: 'keepalive',
+      intervalMs: 10_000,
+      ackTimeoutMs: 1_000,
+      makeLeaseId: () => 'lease-1',
+      storage: {
+        set: async (items) => {
+          const value = items.keepalive as { leaseId: string, sequence: number };
+          calls.push({ set: value });
+          queueMicrotask(() => keepAlive.onChanged({ keepalive: { newValue: value } }));
+        },
+        remove: async (key) => { calls.push({ remove: key }); },
+      },
+      setIntervalFn: ((callback: () => void) => { tick = callback; return 7; }) as typeof setInterval,
+      clearIntervalFn: ((id: number) => { expect(id).toBe(7); cleared += 1; }) as typeof clearInterval,
+    });
+
+    await keepAlive.start();
+    expect(calls).toEqual([
+      { remove: 'keepalive' },
+      { set: { leaseId: 'lease-1', sequence: 1 } },
+    ]);
+    expect(keepAlive.onChanged({ other: { newValue: 1 } })).toBe(false);
+
+    tick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(calls.at(-1)).toEqual({ set: { leaseId: 'lease-1', sequence: 2 } });
+
+    await keepAlive.stop();
+    expect(calls.at(-1)).toEqual({ remove: 'keepalive' });
+    expect(cleared).toBe(1);
+  });
+
+  test('an active heartbeat failure ends the lease and reports it', async () => {
+    let writes = 0;
+    let tick = () => {};
+    const losses: string[] = [];
+    let cleared = 0;
+    let keepAlive: ReturnType<typeof makeStorageSessionKeepAlive>;
+    keepAlive = makeStorageSessionKeepAlive({
+      key: 'keepalive',
+      intervalMs: 10_000,
+      ackTimeoutMs: 1_000,
+      makeLeaseId: () => 'lease-1',
+      onLost: (error) => { losses.push(error.message); },
+      storage: {
+        remove: async () => {},
+        set: async (items) => {
+          writes += 1;
+          if (writes === 2) throw new Error('session storage stopped');
+          const value = items.keepalive as { leaseId: string, sequence: number };
+          queueMicrotask(() => keepAlive.onChanged({ keepalive: { newValue: value } }));
+        },
+      },
+      setIntervalFn: ((callback: () => void) => { tick = callback; return 7; }) as typeof setInterval,
+      clearIntervalFn: (() => { cleared += 1; }) as typeof clearInterval,
+    });
+
+    await keepAlive.start();
+    tick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(losses).toEqual(['session storage stopped']);
+    expect(cleared).toBe(1);
+  });
+
+  test('an unexpected heartbeat generation fails the active lease', async () => {
+    const losses: string[] = [];
+    let keepAlive: ReturnType<typeof makeStorageSessionKeepAlive>;
+    keepAlive = makeStorageSessionKeepAlive({
+      key: 'keepalive',
+      intervalMs: 10_000,
+      ackTimeoutMs: 1_000,
+      makeLeaseId: () => 'lease-1',
+      onLost: (error) => { losses.push(error.message); },
+      storage: {
+        remove: async () => {},
+        set: async (items) => {
+          const value = items.keepalive as { leaseId: string, sequence: number };
+          queueMicrotask(() => keepAlive.onChanged({ keepalive: { newValue: value } }));
+        },
+      },
+      setIntervalFn: (() => 7) as unknown as typeof setInterval,
+      clearIntervalFn: (() => {}) as typeof clearInterval,
+    });
+
+    await keepAlive.start();
+    expect(keepAlive.onChanged({
+      keepalive: { newValue: { leaseId: 'other', sequence: 99 } },
+    })).toBe(false);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(losses).toEqual(['actor host storage heartbeat changed unexpectedly']);
+  });
+
+  test('ignores a delayed owned deletion from an older lease generation', async () => {
+    const losses: string[] = [];
+    let nextLease = 0;
+    let keepAlive: ReturnType<typeof makeStorageSessionKeepAlive>;
+    keepAlive = makeStorageSessionKeepAlive({
+      key: 'keepalive',
+      intervalMs: 10_000,
+      ackTimeoutMs: 1_000,
+      makeLeaseId: () => `lease-${nextLease += 1}`,
+      onLost: (error) => { losses.push(error.message); },
+      storage: {
+        remove: async () => {},
+        set: async (items) => {
+          const value = items.keepalive as { leaseId: string, sequence: number };
+          queueMicrotask(() => keepAlive.onChanged({ keepalive: { newValue: value } }));
+        },
+      },
+      setIntervalFn: (() => 7) as unknown as typeof setInterval,
+      clearIntervalFn: (() => {}) as typeof clearInterval,
+    });
+
+    await keepAlive.start();
+    await keepAlive.stop();
+    await keepAlive.start();
+    expect(keepAlive.onChanged({
+      keepalive: { oldValue: { leaseId: 'lease-1', sequence: 1 } },
+    })).toBe(false);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(losses).toEqual([]);
+    expect(keepAlive.onChanged({
+      keepalive: { oldValue: { leaseId: 'lease-2', sequence: 1 } },
+    })).toBe(false);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(losses).toEqual(['actor host storage heartbeat changed unexpectedly']);
+  });
+
+  test('reports a lost lease before best-effort removal finishes', async () => {
+    let tick = () => {};
+    let removes = 0;
+    let finishRemoval = () => {};
+    const blockedRemoval = new Promise<void>((resolve) => { finishRemoval = resolve; });
+    const losses: string[] = [];
+    let writes = 0;
+    let keepAlive: ReturnType<typeof makeStorageSessionKeepAlive>;
+    keepAlive = makeStorageSessionKeepAlive({
+      key: 'keepalive',
+      intervalMs: 10_000,
+      ackTimeoutMs: 1_000,
+      makeLeaseId: () => 'lease-1',
+      onLost: (error) => { losses.push(error.message); },
+      storage: {
+        remove: async () => {
+          removes += 1;
+          if (removes > 1) await blockedRemoval;
+        },
+        set: async (items) => {
+          writes += 1;
+          if (writes === 2) throw new Error('heartbeat failed');
+          const value = items.keepalive as { leaseId: string, sequence: number };
+          queueMicrotask(() => keepAlive.onChanged({ keepalive: { newValue: value } }));
+        },
+      },
+      setIntervalFn: ((callback: () => void) => { tick = callback; return 7; }) as typeof setInterval,
+      clearIntervalFn: (() => {}) as typeof clearInterval,
+    });
+
+    await keepAlive.start();
+    tick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(losses).toEqual(['heartbeat failed']);
+    expect(removes).toBe(2);
+    finishRemoval();
+  });
+
+  test('waits for a late heartbeat write before removing its generation', async () => {
+    let tick = () => {};
+    let writes = 0;
+    let removes = 0;
+    let finishLateWrite = () => {};
+    const lateWrite = new Promise<void>((resolve) => { finishLateWrite = resolve; });
+    const timers = new Map<number, () => void>();
+    let nextTimer = 0;
+    const losses: string[] = [];
+    let keepAlive: ReturnType<typeof makeStorageSessionKeepAlive>;
+    keepAlive = makeStorageSessionKeepAlive({
+      key: 'keepalive',
+      intervalMs: 10_000,
+      ackTimeoutMs: 1_000,
+      makeLeaseId: () => 'lease-1',
+      onLost: (error) => { losses.push(error.message); },
+      storage: {
+        remove: async () => { removes += 1; },
+        set: async (items) => {
+          writes += 1;
+          if (writes === 2) return lateWrite;
+          const value = items.keepalive as { leaseId: string, sequence: number };
+          queueMicrotask(() => keepAlive.onChanged({ keepalive: { newValue: value } }));
+        },
+      },
+      setIntervalFn: ((callback: () => void) => { tick = callback; return 7; }) as typeof setInterval,
+      clearIntervalFn: (() => {}) as typeof clearInterval,
+      setTimeoutFn: ((callback: () => void) => {
+        nextTimer += 1;
+        timers.set(nextTimer, callback);
+        return nextTimer;
+      }) as typeof setTimeout,
+      clearTimeoutFn: ((id: number) => { timers.delete(id); }) as typeof clearTimeout,
+    });
+
+    await keepAlive.start();
+    expect(removes).toBe(1);
+    tick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    timers.get(Math.max(...timers.keys()))?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(losses).toEqual(['actor host storage heartbeat was not acknowledged']);
+    expect(removes).toBe(1);
+
+    finishLateWrite();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(removes).toBe(2);
+  });
+
+  test('a stopped lease ignores a queued heartbeat', async () => {
+    let tick = () => {};
+    let writes = 0;
+    let keepAlive: ReturnType<typeof makeStorageSessionKeepAlive>;
+    keepAlive = makeStorageSessionKeepAlive({
+      key: 'keepalive',
+      intervalMs: 10_000,
+      ackTimeoutMs: 1_000,
+      makeLeaseId: () => 'lease-1',
+      storage: {
+        remove: async () => {},
+        set: async (items) => {
+          writes += 1;
+          const value = items.keepalive as { leaseId: string, sequence: number };
+          queueMicrotask(() => keepAlive.onChanged({ keepalive: { newValue: value } }));
+        },
+      },
+      setIntervalFn: ((callback: () => void) => { tick = callback; return 7; }) as typeof setInterval,
+      clearIntervalFn: (() => {}) as typeof clearInterval,
+    });
+
+    await keepAlive.start();
+    tick();
+    await keepAlive.stop();
+    expect(writes).toBe(1);
+  });
+
+  test('refuses startup when the initial heartbeat event is not acknowledged', async () => {
+    const scheduled = new Map<number, () => void>();
+    let nextTimer = 0;
+    let intervals = 0;
+    const keepAlive = makeStorageSessionKeepAlive({
+      key: 'keepalive',
+      intervalMs: 10_000,
+      ackTimeoutMs: 1_000,
+      makeLeaseId: () => 'lease-1',
+      storage: {
+        remove: async () => {},
+        set: async () => {},
+      },
+      setIntervalFn: (() => { intervals += 1; return 7; }) as unknown as typeof setInterval,
+      clearIntervalFn: (() => {}) as typeof clearInterval,
+      setTimeoutFn: ((callback: () => void) => {
+        nextTimer += 1;
+        scheduled.set(nextTimer, callback);
+        return nextTimer;
+      }) as typeof setTimeout,
+      clearTimeoutFn: ((id: number) => { scheduled.delete(id); }) as typeof clearTimeout,
+    });
+
+    const start = keepAlive.start();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    scheduled.get(Math.max(...scheduled.keys()))?.();
+    await expect(start).rejects.toThrow('was not acknowledged');
+    expect(intervals).toBe(0);
+  });
+
+  test('bounds startup when cold-start heartbeat cleanup never settles', async () => {
+    const scheduled = new Map<number, () => void>();
+    let nextTimer = 0;
+    let writes = 0;
+    const keepAlive = makeStorageSessionKeepAlive({
+      key: 'keepalive',
+      intervalMs: 10_000,
+      ackTimeoutMs: 1_000,
+      storage: {
+        remove: () => new Promise<void>(() => {}),
+        set: async () => { writes += 1; },
+      },
+      setTimeoutFn: ((callback: () => void) => {
+        nextTimer += 1;
+        scheduled.set(nextTimer, callback);
+        return nextTimer;
+      }) as typeof setTimeout,
+      clearTimeoutFn: ((id: number) => { scheduled.delete(id); }) as typeof clearTimeout,
+    });
+
+    const start = keepAlive.start();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    scheduled.get(Math.max(...scheduled.keys()))?.();
+
+    await expect(start).rejects.toThrow('cleanup is still pending');
+    expect(writes).toBe(0);
+  });
+});
+
+describe('direct actor host', () => {
+  test('keeps run and relays in-process behind an object-identity sender', async () => {
+    let accepted = false;
+    let runJob: any = null;
+    const host = makeDirectActorHost({
+      workerUrl: 'moz-extension://id/offscreen/actor-worker.js',
+      run: async (job: any, deps: any) => {
+        runJob = job;
+        return deps.sendToSW('actor/model-call', { relayToken: 'grant', args: {} });
+      },
+      abort: () => {},
+    });
+    host.bindRelayRoutes({
+      'actor/model-call': (_message: any, sender: unknown) => {
+        accepted = host.isRelaySender(sender);
+        return { ok: true, events: [] };
+      },
+    });
+
+    const result = await host.sendMessage({ type: 'actor/run', job: { actorSessionId: 'actor-1' } });
+    expect(result.ok).toBe(true);
+    expect(runJob.actorSessionId).toBe('actor-1');
+    expect(accepted).toBe(true);
+    expect(host.isRelaySender({})).toBe(false);
+  });
+
+  test('refuses a run until relay routes are bound', async () => {
+    let ran = false;
+    const host = makeDirectActorHost({
+      workerUrl: 'worker.js',
+      run: async () => { ran = true; return { ok: true }; },
+      abort: () => {},
+    });
+    expect(await host.sendMessage({ type: 'actor/run', job: {} })).toMatchObject({
+      ok: false, started: false, code: 'actor_host_not_ready',
+    });
+    expect(ran).toBe(false);
+  });
+
+  test('routes abort directly without exposing a runtime route', async () => {
+    const aborted: string[] = [];
+    const host = makeDirectActorHost({
+      workerUrl: 'worker.js',
+      run: async () => ({ ok: true }),
+      abort: (runId: string) => { aborted.push(runId); },
+    });
+    expect(await host.sendMessage({ type: 'actor/abort', runId: 'run-1' })).toEqual({ ok: true });
+    expect(aborted).toEqual(['run-1']);
+  });
+
+  test('keeps one refcounted event-page lease while any actor run is active', async () => {
+    const releases: Array<() => void> = [];
+    let starts = 0;
+    let stops = 0;
+    const host = makeDirectActorHost({
+      workerUrl: 'worker.js',
+      run: () => new Promise((resolve) => { releases.push(() => resolve({ ok: true })); }),
+      abort: () => {},
+      startKeepAlive: () => { starts += 1; },
+      stopKeepAlive: () => { stops += 1; },
+    });
+    host.bindRelayRoutes({});
+
+    const first = host.sendMessage({ type: 'actor/run', job: { actorSessionId: 'a' } });
+    const second = host.sendMessage({ type: 'actor/run', job: { actorSessionId: 'b' } });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(starts).toBe(1);
+
+    releases[0]();
+    await first;
+    expect(stops).toBe(0);
+    releases[1]();
+    await second;
+    expect(stops).toBe(1);
+  });
+
+  test('fails closed before actor execution when the event-page lease cannot start', async () => {
+    let ran = false;
+    let stops = 0;
+    const host = makeDirectActorHost({
+      workerUrl: 'worker.js',
+      run: async () => { ran = true; return { ok: true }; },
+      abort: () => {},
+      startKeepAlive: () => { throw new Error('session storage unavailable'); },
+      stopKeepAlive: () => { stops += 1; },
+    });
+    host.bindRelayRoutes({});
+
+    expect(await host.sendMessage({ type: 'actor/run', job: {} })).toMatchObject({
+      ok: false,
+      started: false,
+      code: 'actor_host_keepalive_failed',
+    });
+    expect(ran).toBe(false);
+    expect(stops).toBe(1);
+  });
+
+  test('can start a later lease after a failed lease is cleaned up', async () => {
+    let starts = 0;
+    let stops = 0;
+    let runs = 0;
+    const host = makeDirectActorHost({
+      workerUrl: 'worker.js',
+      run: async () => { runs += 1; return { ok: true }; },
+      abort: () => {},
+      startKeepAlive: () => {
+        starts += 1;
+        if (starts === 1) throw new Error('first start failed');
+      },
+      stopKeepAlive: () => { stops += 1; },
+    });
+    host.bindRelayRoutes({});
+
+    expect(await host.sendMessage({ type: 'actor/run', job: {} })).toMatchObject({
+      ok: false,
+      started: false,
+      code: 'actor_host_keepalive_failed',
+    });
+    expect(await host.sendMessage({ type: 'actor/run', job: {} })).toEqual({ ok: true });
+    expect({ starts, stops, runs }).toEqual({ starts: 2, stops: 2, runs: 1 });
+  });
+
+  test('serializes a new lease after the previous asynchronous clear', async () => {
+    const runReleases = new Map<string, () => void>();
+    let starts = 0;
+    let stops = 0;
+    let finishFirstStop = () => {};
+    const firstStop = new Promise<void>((resolve) => { finishFirstStop = resolve; });
+    const host = makeDirectActorHost({
+      workerUrl: 'worker.js',
+      run: (job: any) => new Promise((resolve) => {
+        runReleases.set(job.actorSessionId, () => resolve({ ok: true }));
+      }),
+      abort: () => {},
+      startKeepAlive: () => { starts += 1; },
+      stopKeepAlive: () => {
+        stops += 1;
+        return stops === 1 ? firstStop : undefined;
+      },
+    });
+    host.bindRelayRoutes({});
+
+    const first = host.sendMessage({ type: 'actor/run', job: { actorSessionId: 'a' } });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    runReleases.get('a')?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect({ starts, stops }).toEqual({ starts: 1, stops: 1 });
+
+    const second = host.sendMessage({ type: 'actor/run', job: { actorSessionId: 'b' } });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(starts).toBe(1);
+    finishFirstStop();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(starts).toBe(2);
+    runReleases.get('b')?.();
+
+    await Promise.all([first, second]);
+    expect(stops).toBe(2);
+  });
+
+  test('aborts and reports an unknown outcome if the event-page lease is lost', async () => {
+    const aborted: string[] = [];
+    const host = makeDirectActorHost({
+      workerUrl: 'worker.js',
+      run: () => new Promise(() => {}),
+      abort: (runId: string) => { aborted.push(runId); },
+      startKeepAlive: () => {},
+      stopKeepAlive: () => {},
+    });
+    host.bindRelayRoutes({});
+
+    const result = host.sendMessage({
+      type: 'actor/run',
+      job: { runId: 'run-lost', actorSessionId: 'actor-lost' },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    host.failKeepAlive(new Error('session heartbeat stopped'));
+
+    expect(await result).toMatchObject({
+      ok: false,
+      started: true,
+      code: 'actor_host_keepalive_lost',
+      outcomeKnown: false,
+    });
+    expect(aborted).toEqual(['run-lost']);
+  });
+
+  test('settles unknown without waiting for a stuck heartbeat write or cleanup', async () => {
+    let intervalTick = () => {};
+    const timers = new Map<number, () => void>();
+    let nextTimer = 0;
+    let writes = 0;
+    let host: ReturnType<typeof makeDirectActorHost>;
+    let keepAlive: ReturnType<typeof makeStorageSessionKeepAlive>;
+    keepAlive = makeStorageSessionKeepAlive({
+      key: 'keepalive',
+      intervalMs: 10_000,
+      ackTimeoutMs: 1_000,
+      makeLeaseId: () => 'lease-1',
+      onLost: (error) => host.failKeepAlive(error),
+      storage: {
+        remove: async () => {},
+        set: async (items) => {
+          writes += 1;
+          if (writes === 2) return new Promise<void>(() => {});
+          const value = items.keepalive as { leaseId: string, sequence: number };
+          queueMicrotask(() => keepAlive.onChanged({ keepalive: { newValue: value } }));
+        },
+      },
+      setIntervalFn: ((callback: () => void) => { intervalTick = callback; return 7; }) as typeof setInterval,
+      clearIntervalFn: (() => {}) as typeof clearInterval,
+      setTimeoutFn: ((callback: () => void) => {
+        nextTimer += 1;
+        timers.set(nextTimer, callback);
+        return nextTimer;
+      }) as typeof setTimeout,
+      clearTimeoutFn: ((id: number) => { timers.delete(id); }) as typeof clearTimeout,
+    });
+    const aborted: string[] = [];
+    let runs = 0;
+    host = makeDirectActorHost({
+      workerUrl: 'worker.js',
+      run: () => { runs += 1; return new Promise(() => {}); },
+      abort: (runId: string) => { aborted.push(runId); },
+      startKeepAlive: keepAlive.start,
+      stopKeepAlive: keepAlive.stop,
+    });
+    host.bindRelayRoutes({});
+
+    const result = host.sendMessage({
+      type: 'actor/run', job: { runId: 'run-stuck', actorSessionId: 'actor-stuck' },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    intervalTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    timers.get(Math.max(...timers.keys()))?.();
+
+    expect(await Promise.race([
+      result,
+      new Promise((_, reject) => setTimeout(() => reject(new Error('loss did not settle')), 100)),
+    ])).toMatchObject({
+      ok: false, started: true, code: 'actor_host_keepalive_lost', outcomeKnown: false,
+    });
+    expect(aborted).toEqual(['run-stuck']);
+    expect(runs).toBe(1);
+
+    const probe = host.sendMessage({
+      type: 'actor/run', job: { actorSessionId: '__probe__', probeOnly: true },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    timers.get(Math.max(...timers.keys()))?.();
+    expect(await probe).toMatchObject({
+      ok: false, started: false, code: 'actor_host_keepalive_failed',
+    });
+    expect(runs).toBe(1);
+  });
+
+  test('settles a successful run while normal heartbeat cleanup is stuck', async () => {
+    const timers = new Map<number, () => void>();
+    let nextTimer = 0;
+    let removes = 0;
+    let runs = 0;
+    let keepAlive: ReturnType<typeof makeStorageSessionKeepAlive>;
+    keepAlive = makeStorageSessionKeepAlive({
+      key: 'keepalive',
+      intervalMs: 10_000,
+      ackTimeoutMs: 1_000,
+      makeLeaseId: () => 'lease-1',
+      storage: {
+        remove: () => {
+          removes += 1;
+          return removes === 1 ? Promise.resolve() : new Promise<void>(() => {});
+        },
+        set: async (items) => {
+          const value = items.keepalive as { leaseId: string, sequence: number };
+          queueMicrotask(() => keepAlive.onChanged({ keepalive: { newValue: value } }));
+        },
+      },
+      setIntervalFn: (() => 7) as unknown as typeof setInterval,
+      clearIntervalFn: (() => {}) as typeof clearInterval,
+      setTimeoutFn: ((callback: () => void) => {
+        nextTimer += 1;
+        timers.set(nextTimer, callback);
+        return nextTimer;
+      }) as typeof setTimeout,
+      clearTimeoutFn: ((id: number) => { timers.delete(id); }) as typeof clearTimeout,
+    });
+    const host = makeDirectActorHost({
+      workerUrl: 'worker.js',
+      run: async () => { runs += 1; return { ok: true }; },
+      abort: () => {},
+      startKeepAlive: keepAlive.start,
+      stopKeepAlive: keepAlive.stop,
+    });
+    host.bindRelayRoutes({});
+
+    expect(await Promise.race([
+      host.sendMessage({ type: 'actor/run', job: { actorSessionId: 'actor-1' } }),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('successful run did not settle')), 100)),
+    ])).toEqual({ ok: true });
+    expect(removes).toBe(2);
+
+    const later = host.sendMessage({ type: 'actor/run', job: { actorSessionId: 'actor-2' } });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const cleanupTimeout = Math.max(...timers.keys());
+    timers.get(cleanupTimeout)?.();
+    expect(await later).toMatchObject({
+      ok: false, started: false, code: 'actor_host_keepalive_failed',
+    });
+    expect(runs).toBe(1);
+  });
+
+  test('keeps a lost lease latched until an explicit probe reestablishes it', async () => {
+    let runs = 0;
+    let starts = 0;
+    const host = makeDirectActorHost({
+      workerUrl: 'worker.js',
+      run: async (job: any) => {
+        runs += 1;
+        return job.probeOnly === true ? { ok: true, probe: true } : new Promise(() => {});
+      },
+      abort: () => {},
+      startKeepAlive: () => { starts += 1; },
+      stopKeepAlive: () => {},
+    });
+    host.bindRelayRoutes({});
+
+    const first = host.sendMessage({
+      type: 'actor/run',
+      job: { runId: 'run-1', actorSessionId: 'actor-1' },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    host.failKeepAlive(new Error('heartbeat lost'));
+
+    expect(await host.sendMessage({
+      type: 'actor/run', job: { runId: 'run-2', actorSessionId: 'actor-2' },
+    })).toMatchObject({ ok: false, started: false, code: 'actor_host_keepalive_failed' });
+    expect(await first).toMatchObject({
+      ok: false, started: true, code: 'actor_host_keepalive_lost', outcomeKnown: false,
+    });
+    expect(await host.sendMessage({
+      type: 'actor/run', job: { runId: 'run-3', actorSessionId: 'actor-3' },
+    })).toMatchObject({ ok: false, started: false, code: 'actor_host_keepalive_failed' });
+    expect(runs).toBe(1);
+
+    expect(await host.sendMessage({
+      type: 'actor/run', job: { actorSessionId: '__probe__', probeOnly: true },
+    })).toEqual({ ok: true, probe: true });
+    expect({ runs, starts }).toEqual({ runs: 2, starts: 2 });
+  });
+});

--- a/tests/background/offscreen-actor-client.test.ts
+++ b/tests/background/offscreen-actor-client.test.ts
@@ -3,6 +3,7 @@
 // 'actor/tool-dispatch' route (SW-side pin + gate + the web actor's owned-tab thread).
 import { describe, test, expect } from 'bun:test';
 import { makeOffscreenActorClient } from '../../extension/background/offscreen-actor-client.js';
+import { makeDirectActorHost } from '../../extension/background/direct-actor-host.js';
 import { DWEB_INBOUND_TOOL_NAMES } from '../../extension/peerd-runtime/actor/capability-manifest.js';
 
 // Stand-ins for the two senders that matter. The relay routes must accept only the
@@ -157,7 +158,7 @@ describe('run() — Stop-cascade aborted stamping', () => {
     const relayResult: any = await relay;
     expect(result.aborted).toBe(true);
     expect(relaySignal?.aborted).toBe(true);
-    expect(relayResult.result.error).toContain('cancelled');
+    expect(relayResult).toEqual({ ok: false, error: 'aborted' });
   });
 
   test('runner settlement aborts an already-admitted SW model relay', async () => {
@@ -192,6 +193,70 @@ describe('run() — Stop-cascade aborted stamping', () => {
     expect(result.aborted).toBe(true);
     expect(modelSignal?.aborted).toBe(true);
     expect(relayResult).toEqual({ ok: false, error: 'aborted' });
+  });
+
+  test('Firefox lease loss revokes a pending model relay before late bytes arrive', async () => {
+    let modelStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => { modelStarted = resolve; });
+    let releaseModel: (() => void) | undefined;
+    const modelRelease = new Promise<void>((resolve) => { releaseModel = resolve; });
+    let modelSignal: AbortSignal | undefined;
+    let relayResult: Promise<any> | null = null;
+    let relayToken = '';
+    let relayAgain: ((type: string, payload: any) => Promise<any>) | null = null;
+    const workerAborts: string[] = [];
+    const host = makeDirectActorHost({
+      workerUrl: 'worker.js',
+      run: async (job: any, { sendToSW }: any) => {
+        relayToken = job.relayToken;
+        relayAgain = sendToSW;
+        relayResult = sendToSW('actor/model-call', {
+          relayToken,
+          args: { provider: 'anthropic', model: 'm' },
+        });
+        await relayResult;
+        return { ok: true, started: true, finalText: 'late response' };
+      },
+      abort: (runId: string) => { workerAborts.push(runId); },
+    });
+    const client = makeOffscreenActorClient(baseDeps({
+      ensureHost: async () => {},
+      isRelaySender: host.isRelaySender,
+      sendMessage: host.sendMessage,
+      callModel: async function* ({ signal }: any) {
+        modelSignal = signal;
+        modelStarted?.();
+        await modelRelease;
+        yield { type: 'text_delta', text: 'late provider bytes' };
+      },
+    }));
+    host.bindRelayRoutes(client.routes);
+
+    const run = client.run({
+      actorSessionId: 'a', message: 'm', systemPrompt: 's', provider: 'anthropic', model: 'm',
+    } as any);
+    await started;
+    host.failKeepAlive(new Error('session heartbeat stopped'));
+
+    expect(await run).toEqual(expect.objectContaining({
+      ok: false,
+      started: true,
+      code: 'actor_host_keepalive_lost',
+      outcomeKnown: false,
+    }));
+    expect(workerAborts).toHaveLength(1);
+    expect(modelSignal?.aborted).toBe(true);
+    expect(relayAgain).not.toBeNull();
+    const replayResult = await (relayAgain as unknown as (type: string, payload: any) => Promise<any>)(
+      'actor/model-call', {
+      relayToken,
+      args: { provider: 'anthropic', model: 'm' },
+      });
+    expect(replayResult).toEqual({ ok: false, error: 'actor/model-call: unauthorized relay' });
+
+    releaseModel?.();
+    expect(relayResult).not.toBeNull();
+    expect(await (relayResult as unknown as Promise<any>)).toEqual({ ok: false, error: 'aborted' });
   });
 });
 
@@ -527,6 +592,127 @@ describe('actor/model-call — spend-limit preflight', () => {
     const out: any = await during((relayToken) => client.routes['actor/model-call']({ relayToken, args: {} }, OFFSCREEN), 'actor-A');
     expect(out.ok).toBe(true);
     expect(asked).toEqual(['actor-A']);
+  });
+});
+
+describe('actor/model-call — trusted run metadata wins over worker args', () => {
+  test('pins provider, model, and Ollama host at the key-bearing boundary', async () => {
+    let seen: any = null;
+    const { client, during } = clientWithRelay({
+      callModel: async function* (args: any) { seen = args; yield { type: 'text', text: 'ok' }; },
+      sendMessage: undefined,
+    });
+    // The helper's job is anthropic/model m. The worker-controlled payload tries
+    // to switch all three fields; the live grant must overwrite it.
+    const out: any = await during((relayToken) => client.routes['actor/model-call']({
+      relayToken,
+      args: { provider: 'openai', model: 'expensive-unknown', ollamaHost: 'http://attacker.test' },
+    }, OFFSCREEN));
+    expect(out.ok).toBe(true);
+    expect(seen.provider).toBe('anthropic');
+    expect(seen.model).toBe('m');
+    expect(seen.ollamaHost).toBeUndefined();
+  });
+});
+
+describe('run() — relay lifetime', () => {
+  test('aborts the SW-side relay signal whenever the host settles', async () => {
+    let relaySignal: AbortSignal | null = null;
+    let client: any;
+    client = makeOffscreenActorClient(baseDeps({
+      sessions: { get: async () => ({ kind: 'spawned', grantedTools: ['script'] }) },
+      restrictCtxCapabilities: (ctx: any) => ctx,
+      buildToolContext: async () => ({}),
+      dispatchToolCall: async (_call: any, ctx: any) => {
+        relaySignal = ctx.abortSignal;
+        return { ok: true };
+      },
+      sendMessage: async (message: any) => {
+        if (message.type === 'actor/run') {
+          await client.routes['actor/tool-dispatch']({
+            relayToken: message.job.relayToken,
+            call: { name: 'script', args: {} },
+          }, OFFSCREEN);
+          return { ok: true, started: true, finalText: 'done' };
+        }
+        return { ok: true };
+      },
+    }));
+
+    await client.run({ actorSessionId: 's1', message: 'm', systemPrompt: 's', provider: 'anthropic', model: 'm' });
+    await Promise.resolve();
+    expect(relaySignal).not.toBeNull();
+    expect((relaySignal as unknown as AbortSignal).aborted).toBe(true);
+  });
+
+  test('a model relay suspended in preflight cannot start after its host settles', async () => {
+    let releasePreflight!: () => void;
+    const preflightGate = new Promise<void>((resolve) => { releasePreflight = resolve; });
+    let enteredPreflight!: () => void;
+    const preflightEntered = new Promise<void>((resolve) => { enteredPreflight = resolve; });
+    let routeResult: Promise<any> = Promise.resolve(null);
+    let modelCalled = false;
+    let client: any;
+    client = makeOffscreenActorClient(baseDeps({
+      spendRefusalFor: async () => {
+        enteredPreflight();
+        await preflightGate;
+        return null;
+      },
+      callModel: async function* () { modelCalled = true; yield { type: 'text', text: 'forbidden' }; },
+      sendMessage: async (message: any) => {
+        if (message.type === 'actor/run') {
+          routeResult = client.routes['actor/model-call']({
+            relayToken: message.job.relayToken,
+            args: {},
+          }, OFFSCREEN);
+          await preflightEntered;
+          return { ok: true, started: true, finalText: 'host settled' };
+        }
+        return { ok: true };
+      },
+    }));
+
+    await client.run({ actorSessionId: 's1', message: 'm', systemPrompt: 's', provider: 'anthropic', model: 'm' });
+    releasePreflight();
+    expect(await routeResult).toEqual({ ok: false, error: 'aborted' });
+    expect(modelCalled).toBe(false);
+  });
+
+  test('a tool relay suspended in session lookup cannot dispatch after its host settles', async () => {
+    let releaseSession!: () => void;
+    const sessionGate = new Promise<void>((resolve) => { releaseSession = resolve; });
+    let enteredSession!: () => void;
+    const sessionEntered = new Promise<void>((resolve) => { enteredSession = resolve; });
+    let routeResult: Promise<any> = Promise.resolve(null);
+    let dispatched = false;
+    let client: any;
+    client = makeOffscreenActorClient(baseDeps({
+      sessions: {
+        get: async () => {
+          enteredSession();
+          await sessionGate;
+          return { kind: 'actor', actorType: 'webvm', instanceId: 'vm-1' };
+        },
+      },
+      dispatchToolCall: async () => { dispatched = true; return { ok: true }; },
+      sendMessage: async (message: any) => {
+        if (message.type === 'actor/run') {
+          routeResult = client.routes['actor/tool-dispatch']({
+            relayToken: message.job.relayToken,
+            call: { name: 'vm_exec', args: {} },
+          }, OFFSCREEN);
+          await sessionEntered;
+          return { ok: true, started: true, finalText: 'host settled' };
+        }
+        return { ok: true };
+      },
+    }));
+
+    await client.run({ actorSessionId: 's1', message: 'm', systemPrompt: 's', provider: 'anthropic', model: 'm' });
+    releaseSession();
+    expect(await routeResult).toEqual({ ok: false, error: 'aborted' });
+    expect(dispatched).toBe(false);
   });
 });
 

--- a/tests/background/offscreen-actor-client.test.ts
+++ b/tests/background/offscreen-actor-client.test.ts
@@ -595,7 +595,7 @@ describe('actor/model-call — spend-limit preflight', () => {
   });
 });
 
-describe('actor/model-call — trusted run metadata wins over worker args', () => {
+describe('actor/model-call: trusted run metadata wins over worker args', () => {
   test('pins provider, model, and Ollama host at the key-bearing boundary', async () => {
     let seen: any = null;
     const { client, during } = clientWithRelay({
@@ -615,7 +615,7 @@ describe('actor/model-call — trusted run metadata wins over worker args', () =
   });
 });
 
-describe('run() — relay lifetime', () => {
+describe('run(): relay lifetime', () => {
   test('aborts the SW-side relay signal whenever the host settles', async () => {
     let relaySignal: AbortSignal | null = null;
     let client: any;

--- a/tests/background/routes-actors.test.ts
+++ b/tests/background/routes-actors.test.ts
@@ -228,6 +228,25 @@ describe('actors/call — per-operation authority', () => {
     registry.release('run-1');
   });
 
+  test('an awaited actor reply keeps its delivery id outside the worker-visible value', async () => {
+    const h = makeHarness({
+      messageActor: async () => ({
+        ok: true, content: 'done', actorDeliveryId: 'delivery-1',
+      }),
+    });
+
+    expect(await h.call('call', { address: 'vm-1', message: 'run tests' }))
+      .toEqual({
+        ok: true,
+        actorDeliveryId: 'delivery-1',
+        value: { reply: 'done', failed: false },
+      });
+    expect(h.mirrored).toEqual([expect.objectContaining({
+      settled: true, actorDeliveryId: 'delivery-1',
+    })]);
+    expect(h.mirrored[0].actorDeliveryId).not.toBe(h.mirrored[0].goal);
+  });
+
   test('the SW-side run ceiling refuses work before dispatch', async () => {
     const h = makeHarness({ actorOpAllowed: false });
     expect(await h.call('ask', { to: 'web', goal: 'find it' }))

--- a/tests/background/routes-session-mutations.test.ts
+++ b/tests/background/routes-session-mutations.test.ts
@@ -27,7 +27,7 @@ const baseDeps = (over: any = {}) => {
       clear: () => { cache.current = null; calls.cacheCleared = true; },
     },
     autoMemory: { maybeExtract: async (id: string, reason: string) => { calls.extract.push([id, reason]); } },
-    maybeAutoResume: () => {},
+    maybeAutoResumeAfterRecovery: () => {},
     haltGoalRun: (sid: string) => { calls.halted.push(sid); },
     // session/reset stops the abandoned session's turn + cascades to its actors.
     // Defaults = "nothing in flight" so the other reset tests are unaffected.

--- a/tests/background/routes-sessions.test.ts
+++ b/tests/background/routes-sessions.test.ts
@@ -31,6 +31,7 @@ const baseDeps = (over: any = {}) => {
       startGoalRun: async (req: any) => { calls.goal.push(req); },
       haltGoalRun: (sid: string) => { calls.halted.push(sid); },
       ensureSession: async () => 'a',
+      actorRecoveryReady: async () => true,
       handleSystemCommand: async (a: string) => { calls.system.push(a); },
       handleToolsCommand: async (a: string) => { calls.tools.push(a); },
       postChatNote: () => {},
@@ -68,6 +69,17 @@ describe('agent/send slash-command routing', () => {
     expect(calls.goal).toEqual([{ sessionId: 'a', goal: 'build a drum machine' }]);
     expect(calls.turns.length).toBe(0);
   });
+  test('recovery pending refuses a goal before creating or starting it', async () => {
+    let ensured = false;
+    const { deps, calls } = baseDeps({
+      actorRecoveryReady: async () => false,
+      ensureSession: async () => { ensured = true; return 'a'; },
+    });
+    expect(await makeSessionRoutes(deps)['agent/send']({ text: 'build it', goal: true }))
+      .toEqual({ ok: false, error: 'actor-recovery-pending' });
+    expect(ensured).toBe(false);
+    expect(calls.goal).toEqual([]);
+  });
   test('a plain message halts an active goal run (steer-takeover)', async () => {
     const { deps, calls } = baseDeps();
     await makeSessionRoutes(deps)['agent/send']({ text: 'hello' });
@@ -87,6 +99,19 @@ describe('agent/send slash-command routing', () => {
     await makeSessionRoutes(deps)['agent/send']({ text: '/tools research' });
     expect(calls.system).toEqual(['be terse']);
     expect(calls.tools).toEqual(['research']);
+  });
+  test('recovery pending refuses a model turn without halting its goal', async () => {
+    const { deps, calls } = baseDeps({ actorRecoveryReady: async () => false });
+    expect(await makeSessionRoutes(deps)['agent/send']({ text: 'hello' }))
+      .toEqual({ ok: false, error: 'actor-recovery-pending' });
+    expect(calls.turns).toEqual([]);
+    expect(calls.halted).toEqual([]);
+  });
+  test('local slash commands remain available while recovery is pending', async () => {
+    const { deps, calls } = baseDeps({ actorRecoveryReady: async () => false });
+    expect(await makeSessionRoutes(deps)['agent/send']({ text: '/system be terse' }))
+      .toEqual({ ok: true, handled: 'system' });
+    expect(calls.system).toEqual(['be terse']);
   });
   test('plain message runs a turn with composer-expanded text', async () => {
     const { deps, calls } = baseDeps();

--- a/tests/background/routes-system.test.ts
+++ b/tests/background/routes-system.test.ts
@@ -35,6 +35,7 @@ const baseDeps = (over: any = {}) => ({
   onSettingsChanging: () => {},
   onSettingsChanged: async () => {},
   privateTransferAuthorization: PRIVATE_TRANSFER_AUTHORIZATION,
+  retryActorIsolation: async () => ({ ok: true, capability: { status: 'available' } }),
   ...over,
 });
 
@@ -42,6 +43,10 @@ describe('state/get + audit/list', () => {
   test('state/get wraps the snapshot', async () => {
     const r = makeSystemRoutes(baseDeps());
     expect(await r['state/get']()).toEqual({ ok: true, state: { vault: { locked: false }, session: {} } });
+  });
+  test('actor isolation retry delegates to the capability controller', async () => {
+    const r = makeSystemRoutes(baseDeps());
+    expect(await r['actor-isolation/retry']()).toEqual({ ok: true, capability: { status: 'available' } });
   });
   test('audit/list newest-first, capped, with total', async () => {
     const r = makeSystemRoutes(baseDeps());

--- a/tests/background/routes-vault.test.ts
+++ b/tests/background/routes-vault.test.ts
@@ -41,7 +41,7 @@ const makeDeps = (vaultOver: Record<string, any> = {}) => {
     pushState: () => { calls.pushState.push(1); },
     purgeVaultBlob: async () => {},
     sessionCache: { sessionGet: async () => null },
-    maybeAutoResume: () => {},
+    maybeAutoResumeAfterRecovery: () => {},
     confirmCoordinator: { resolve: (id: string, answer: string) => { calls.resolve = [id, answer]; } },
     VaultAlreadyInitializedError, WrongPassphraseError, VaultNotInitializedError,
     RecoveryPassphraseNotSetError, PrfNotEnrolledError, PrfUnlockFailedError, VaultLockedError,
@@ -162,7 +162,7 @@ describe('vault unlock — goal resume ordering (#60)', () => {
     base64ToBytes: () => new Uint8Array([1]),
     sessionCache: { sessionGet: async () => 'cur' },
     resumeGoalRuns: async () => { await new Promise((r) => setTimeout(r, 30)); order.push('resume'); },
-    maybeAutoResume: () => { order.push('autoresume'); },
+    maybeAutoResumeAfterRecovery: () => { order.push('autoresume'); },
     WrongPassphraseError, VaultNotInitializedError, RecoveryPassphraseNotSetError,
     PrfNotEnrolledError, PrfUnlockFailedError, VaultLockedError,
   });

--- a/tests/firefox/outcome-unknown-oracle.test.ts
+++ b/tests/firefox/outcome-unknown-oracle.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  advisesCheckingBeforeRetry,
+  hasAmbiguousOutcomeWarning,
+  hasOutcomeUnknownState,
+} from '../../scripts/firefox/outcome-unknown-oracle.mjs';
+
+describe('Firefox unknown-outcome runtime oracle', () => {
+  test('keys routing to the durable lifecycle state instead of prose', () => {
+    expect(hasOutcomeUnknownState('outcome_unknown: details')).toBe(true);
+    expect(hasOutcomeUnknownState(JSON.stringify({ content: 'outcome_unknown: details' }))).toBe(true);
+    expect(hasOutcomeUnknownState('This action may have completed.')).toBe(false);
+  });
+
+  test.each([
+    'This action may have completed, but peerd did not receive confirmation.',
+    'peerd cannot confirm whether the actor ran or completed.',
+    'The actor did not complete cleanly. Its outcome is unknown.',
+  ])('recognizes ambiguous-outcome warning semantics: %s', (message) => {
+    expect(hasAmbiguousOutcomeWarning(message)).toBe(true);
+  });
+
+  test.each([
+    'Check the target before repeating it.',
+    'Check the requested action before trying again.',
+    'Verify the external state before retrying.',
+  ])('recognizes the recovery action without pinning one sentence: %s', (message) => {
+    expect(advisesCheckingBeforeRetry(message)).toBe(true);
+  });
+
+  test('does not mistake a definite not-run result for an ambiguous outcome', () => {
+    const message = 'This operation was not run. It is safe to retry.';
+    expect(hasOutcomeUnknownState(message)).toBe(false);
+    expect(hasAmbiguousOutcomeWarning(message)).toBe(false);
+    expect(advisesCheckingBeforeRetry(message)).toBe(false);
+  });
+});

--- a/tests/offscreen/actor-runner.test.ts
+++ b/tests/offscreen/actor-runner.test.ts
@@ -1,74 +1,298 @@
 import { describe, test, expect } from 'bun:test';
 import { abortActor, runActor } from '../../extension/offscreen/actor-runner.js';
+import { ACTOR_WORKER_PROTOCOL } from '../../extension/offscreen/actor-worker-protocol.js';
 
-describe('runActor — inbound provenance hop', () => {
-  test('posts only a strict inbound boolean into the dedicated Worker', async () => {
-    const originalWorker = globalThis.Worker;
-    const posted: any[] = [];
+const REALM = {
+  dedicatedWorker: true,
+  window: false,
+  document: false,
+  browser: false,
+  chrome: false,
+};
 
-    class FakeWorker {
-      listeners = new Map<string, (event: any) => void>();
+class FakeWorker {
+  listeners = new Map<string, Array<(event: any) => void>>();
+  posted: any[] = [];
+  terminated = false;
+  onPost: ((message: any) => void) | null = null;
 
-      addEventListener(type: string, listener: (event: any) => void) {
-        this.listeners.set(type, listener);
+  addEventListener(type: string, listener: (event: any) => void) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  postMessage(message: any) {
+    this.posted.push(message);
+    this.onPost?.(message);
+  }
+
+  emit(type: string, event: any) {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+
+  terminate() { this.terminated = true; }
+}
+
+const job = {
+  runId: 'run-1',
+  actorSessionId: 'actor-1',
+  message: 'inspect the page',
+  systemPrompt: 'system',
+  provider: 'anthropic',
+  model: 'model',
+};
+
+describe('actor worker startup proof', () => {
+  test('posts the run only after readiness and host-canary separation', async () => {
+    const worker = new FakeWorker();
+    worker.onPost = (message) => {
+      if (message.type === 'probe') {
+        queueMicrotask(() => worker.emit('message', { data: {
+          type: 'probe-response',
+          protocol: ACTOR_WORKER_PROTOCOL,
+          rid: message.rid,
+          canaryAbsent: true,
+        } }));
       }
-
-      postMessage(message: any) {
-        posted.push(message);
-        if (message.type === 'run') {
-          queueMicrotask(() => this.listeners.get('message')?.({
-            data: { type: 'done', result: { finalText: 'observed', toolCalls: 0 } },
-          }));
-        }
+      if (message.type === 'run') {
+        queueMicrotask(() => worker.emit('message', { data: {
+          type: 'done', result: { finalText: 'done', newMessages: [] },
+        } }));
       }
+    };
+    const relays: string[] = [];
+    const resultPromise = runActor(job, {
+      workerUrl: '/worker.js',
+      createWorker: () => {
+        queueMicrotask(() => worker.emit('message', { data: {
+          type: 'ready', protocol: ACTOR_WORKER_PROTOCOL, realm: REALM,
+        } }));
+        return worker as unknown as Worker;
+      },
+      sendToSW: async (type) => { relays.push(type); return { ok: true }; },
+    });
 
-      terminate() {}
-    }
-
-    globalThis.Worker = FakeWorker as any;
-    try {
-      const base = {
-        actorSessionId: 'dweb', message: 'peer bytes', systemPrompt: 's',
-        provider: 'anthropic', model: 'm', actorType: 'dweb',
-      };
-      await runActor({ ...base, inbound: true }, {
-        workerUrl: '/offscreen/actor-worker.js',
-        sendToSW: async () => ({ ok: true }),
-      });
-      await runActor({ ...base, inbound: 'truthy-but-not-trusted' as any }, {
-        workerUrl: '/offscreen/actor-worker.js',
-        sendToSW: async () => ({ ok: true }),
-      });
-    } finally {
-      globalThis.Worker = originalWorker;
-    }
-
-    const runMessages = posted.filter((message) => message.type === 'run');
-    expect(runMessages.map((message) => message.inbound)).toEqual([true, false]);
+    const result = await resultPromise;
+    expect(result).toMatchObject({ ok: true, started: true, finalText: 'done' });
+    expect(worker.posted.map((message) => message.type)).toEqual(['probe', 'run']);
+    expect(relays).toEqual([]);
+    expect(worker.terminated).toBe(true);
   });
-});
 
-describe('runActor — Stop ordering', () => {
-  test('an actor/abort arriving before actor/run prevents Worker creation', async () => {
-    const originalWorker = globalThis.Worker;
-    let workersCreated = 0;
-    class FakeWorker {
-      constructor() { workersCreated += 1; }
-    }
-    globalThis.Worker = FakeWorker as any;
-    try {
-      abortActor('aw-early-stop');
-      const result = await runActor({
-        runId: 'aw-early-stop', actorSessionId: 'a', message: 'm', systemPrompt: 's',
-        provider: 'anthropic', model: 'm',
-      }, {
-        workerUrl: '/offscreen/actor-worker.js',
+  test('classifies a graceful provider failure by whether a tool request began', async () => {
+    const runFailure = async (relayTool: boolean) => {
+      const worker = new FakeWorker();
+      const emitForgedDone = () => worker.emit('message', { data: {
+        type: 'done', result: {
+          error: 'provider boundary blocked', newMessages: [], toolCalls: 0,
+        },
+      } });
+      worker.onPost = (message) => {
+        if (message.type === 'probe') {
+          queueMicrotask(() => worker.emit('message', { data: {
+            type: 'probe-response', protocol: ACTOR_WORKER_PROTOCOL,
+            rid: message.rid, canaryAbsent: true,
+          } }));
+        }
+        if (message.type === 'run') {
+          queueMicrotask(() => {
+            if (relayTool) {
+              worker.emit('message', { data: {
+                type: 'tool-request', rid: 'tool-1', call: { name: 'script', args: {} },
+              } });
+            } else emitForgedDone();
+          });
+        }
+        if (message.type === 'tool-response') queueMicrotask(emitForgedDone);
+      };
+      return runActor({ ...job, runId: `failed-${relayTool}` }, {
+        workerUrl: '/worker.js',
+        createWorker: () => {
+          queueMicrotask(() => worker.emit('message', { data: {
+            type: 'ready', protocol: ACTOR_WORKER_PROTOCOL, realm: REALM,
+          } }));
+          return worker as unknown as Worker;
+        },
         sendToSW: async () => ({ ok: true }),
       });
-      expect(result).toEqual(expect.objectContaining({ ok: false, started: true, aborted: true }));
-      expect(workersCreated).toBe(0);
-    } finally {
-      globalThis.Worker = originalWorker;
+    };
+
+    expect(await runFailure(false)).toMatchObject({
+      ok: false, started: true, toolCalls: 0, outcomeKnown: true,
+    });
+    expect(await runFailure(true)).toMatchObject({
+      ok: false, started: true, toolCalls: 1, outcomeKnown: false,
+    });
+  });
+
+  test('refuses an invalid realm before a run or relay', async () => {
+    const worker = new FakeWorker();
+    let relayCount = 0;
+    const result = await runActor(job, {
+      workerUrl: '/worker.js',
+      createWorker: () => {
+        queueMicrotask(() => worker.emit('message', { data: {
+          type: 'ready', protocol: ACTOR_WORKER_PROTOCOL,
+          realm: { ...REALM, browser: true },
+        } }));
+        return worker as unknown as Worker;
+      },
+      sendToSW: async () => { relayCount++; return { ok: true }; },
+    });
+
+    expect(result).toMatchObject({ ok: false, started: false, code: 'actor_worker_protocol_error' });
+    expect(worker.posted).toEqual([]);
+    expect(relayCount).toBe(0);
+  });
+
+  test('can re-prove the worker boundary without starting an actor turn', async () => {
+    const worker = new FakeWorker();
+    worker.onPost = (message) => {
+      if (message.type === 'probe') {
+        queueMicrotask(() => worker.emit('message', { data: {
+          type: 'probe-response', protocol: ACTOR_WORKER_PROTOCOL,
+          rid: message.rid, canaryAbsent: true,
+        } }));
+      }
+    };
+    const result = await runActor({ ...job, probeOnly: true }, {
+      workerUrl: '/worker.js',
+      createWorker: () => {
+        queueMicrotask(() => worker.emit('message', { data: {
+          type: 'ready', protocol: ACTOR_WORKER_PROTOCOL, realm: REALM,
+        } }));
+        return worker as unknown as Worker;
+      },
+      sendToSW: async () => { throw new Error('probe must not relay'); },
+    });
+
+    expect(result).toMatchObject({
+      ok: true, started: false, code: 'actor_worker_ready', realmVerified: true,
+    });
+    expect(worker.posted.map((message) => message.type)).toEqual(['probe']);
+  });
+
+  test('treats a pre-proof model request as a protocol failure', async () => {
+    const worker = new FakeWorker();
+    let relayCount = 0;
+    const result = await runActor(job, {
+      workerUrl: '/worker.js',
+      createWorker: () => {
+        queueMicrotask(() => worker.emit('message', { data: {
+          type: 'model-request', rid: 'forged', args: {},
+        } }));
+        return worker as unknown as Worker;
+      },
+      sendToSW: async () => { relayCount++; return { ok: true }; },
+    });
+
+    expect(result).toMatchObject({ ok: false, started: false, code: 'actor_worker_protocol_error' });
+    expect(relayCount).toBe(0);
+  });
+
+  test('does not accept a probe response before the versioned ready message', async () => {
+    const worker = new FakeWorker();
+    let relayCount = 0;
+    const result = await runActor(job, {
+      workerUrl: '/worker.js',
+      createWorker: () => {
+        queueMicrotask(() => worker.emit('message', { data: {
+          type: 'probe-response', protocol: ACTOR_WORKER_PROTOCOL,
+          rid: 'probe-run-1', canaryAbsent: true,
+        } }));
+        return worker as unknown as Worker;
+      },
+      sendToSW: async () => { relayCount++; return { ok: true }; },
+    });
+
+    expect(result).toMatchObject({ ok: false, started: false, code: 'actor_worker_protocol_error' });
+    expect(worker.posted).toEqual([]);
+    expect(relayCount).toBe(0);
+  });
+
+  test('rejects a duplicate ready message while the canary probe is pending', async () => {
+    const worker = new FakeWorker();
+    const result = await runActor(job, {
+      workerUrl: '/worker.js',
+      createWorker: () => {
+        queueMicrotask(() => {
+          worker.emit('message', { data: { type: 'ready', protocol: ACTOR_WORKER_PROTOCOL, realm: REALM } });
+          worker.emit('message', { data: { type: 'ready', protocol: ACTOR_WORKER_PROTOCOL, realm: REALM } });
+        });
+        return worker as unknown as Worker;
+      },
+      sendToSW: async () => ({ ok: true }),
+    });
+
+    expect(result).toMatchObject({ ok: false, started: false, code: 'actor_worker_protocol_error' });
+    expect(worker.posted.map((message) => message.type)).toEqual(['probe']);
+  });
+
+  test('reports constructor and startup timeout failures as never started', async () => {
+    const spawnFailure = await runActor(job, {
+      workerUrl: '/missing.js',
+      createWorker: () => { throw new Error('missing worker'); },
+      sendToSW: async () => ({ ok: true }),
+    });
+    expect(spawnFailure).toMatchObject({ ok: false, started: false, code: 'actor_worker_spawn_failed' });
+
+    const idleWorker = new FakeWorker();
+    const timeout = await runActor(job, {
+      workerUrl: '/worker.js',
+      createWorker: () => idleWorker as unknown as Worker,
+      startupMs: 5,
+      sendToSW: async () => ({ ok: true }),
+    });
+    expect(timeout).toMatchObject({ ok: false, started: false, code: 'actor_worker_start_timeout' });
+    expect(idleWorker.terminated).toBe(true);
+  });
+
+  test('posts only a strict inbound boolean after readiness succeeds', async () => {
+    const observed: boolean[] = [];
+    for (const [index, inbound] of [true, 'truthy-but-not-trusted' as any].entries()) {
+      const worker = new FakeWorker();
+      worker.onPost = (message) => {
+        if (message.type === 'probe') {
+          queueMicrotask(() => worker.emit('message', { data: {
+            type: 'probe-response', protocol: ACTOR_WORKER_PROTOCOL,
+            rid: message.rid, canaryAbsent: true,
+          } }));
+        }
+        if (message.type === 'run') {
+          observed.push(message.inbound);
+          queueMicrotask(() => worker.emit('message', { data: {
+            type: 'done', result: { finalText: 'observed', toolCalls: 0 },
+          } }));
+        }
+      };
+      await runActor({ ...job, runId: `inbound-${index}`, inbound }, {
+        workerUrl: '/worker.js',
+        createWorker: () => {
+          queueMicrotask(() => worker.emit('message', { data: {
+            type: 'ready', protocol: ACTOR_WORKER_PROTOCOL, realm: REALM,
+          } }));
+          return worker as unknown as Worker;
+        },
+        sendToSW: async () => ({ ok: true }),
+      });
     }
+    expect(observed).toEqual([true, false]);
+  });
+
+  test('an abort arriving before the run prevents Worker creation', async () => {
+    let workersCreated = 0;
+    abortActor('aw-early-stop');
+    const result = await runActor({
+      ...job, runId: 'aw-early-stop',
+    }, {
+      workerUrl: '/worker.js',
+      createWorker: () => { workersCreated++; return new FakeWorker() as unknown as Worker; },
+      sendToSW: async () => ({ ok: true }),
+    });
+    expect(result).toEqual(expect.objectContaining({
+      ok: false, started: true, phase: 'startup', code: 'actor_run_aborted', aborted: true,
+    }));
+    expect(workersCreated).toBe(0);
   });
 });

--- a/tests/peerd-provider/local-webgpu-adapter.test.ts
+++ b/tests/peerd-provider/local-webgpu-adapter.test.ts
@@ -76,6 +76,25 @@ describe('callLocalWebgpu', () => {
     expect(out.at(-1)).toMatchObject({ type: 'message-stop' });
     setLocalGenerate(null);
   });
+
+  test('projects messages before the local provider transport', async () => {
+    let received: any = null;
+    setLocalGenerate((request) => {
+      received = request;
+      return streamOf(['ok']);
+    });
+    await collect(callLocalWebgpu({
+      messages: [{
+        role: 'user', content: 'tool result', actorDeliveryId: 'actor:private',
+        actorReply: { actorDeliveryId: 'actor:private' },
+        toolResults: [{ content: 'done', actorDeliveryIds: ['actor:private'] }],
+      }],
+      system: 'sys',
+    } as any));
+    expect(received.messages).toEqual([{ role: 'user', content: 'tool result' }]);
+    expect(JSON.stringify(received)).not.toContain('actor:private');
+    setLocalGenerate(null);
+  });
 });
 
 describe('localWebgpuAdapter descriptor', () => {

--- a/tests/peerd-provider/openai-format.test.ts
+++ b/tests/peerd-provider/openai-format.test.ts
@@ -46,7 +46,10 @@ describe('to-openai message mapping', () => {
       },
       {
         role: 'user', content: '', id: '2', when: 0,
-        toolResults: [{ tool_use_id: 'call_1', content: '{"ok":true}' }],
+        toolResults: [{
+          tool_use_id: 'call_1', content: '{"ok":true}',
+          actorDeliveryId: 'delivery-one', actorDeliveryIds: ['delivery-two'],
+        }],
       },
     ]) as OpenAiMsg[];
     const asst = msgs.find((m) => m.role === 'assistant');
@@ -57,6 +60,8 @@ describe('to-openai message mapping', () => {
     const tool = msgs.find((m) => m.role === 'tool');
     if (!tool) throw new Error('expected tool message');
     expect(tool.tool_call_id).toBe('call_1');
+    expect(JSON.stringify(msgs)).not.toContain('delivery-one');
+    expect(JSON.stringify(msgs)).not.toContain('delivery-two');
   });
 
   test('orphan tool_calls get a synthesized tool message', () => {

--- a/tests/peerd-provider/to-anthropic.test.ts
+++ b/tests/peerd-provider/to-anthropic.test.ts
@@ -198,11 +198,16 @@ describe('toAnthropicMessages — orphan tool_result demotion', () => {
       asst('a1', 'toolu_A'),
       {
         role: 'user', content: '', id: 'u1', when: 0,
-        toolResults: [{ tool_use_id: 'toolu_A', content: 'ok' }],
+        toolResults: [{
+          tool_use_id: 'toolu_A', content: 'ok',
+          actorDeliveryId: 'delivery-one', actorDeliveryIds: ['delivery-two'],
+        }],
       },
     ]);
     const last = out[out.length - 1].content as any[];
     expect(last).toEqual([{ type: 'tool_result', tool_use_id: 'toolu_A', content: 'ok' }]);
+    expect(JSON.stringify(out)).not.toContain('delivery-one');
+    expect(JSON.stringify(out)).not.toContain('delivery-two');
   });
 });
 

--- a/tests/peerd-runtime/actor-create-tool.test.ts
+++ b/tests/peerd-runtime/actor-create-tool.test.ts
@@ -81,6 +81,43 @@ describe('actor_create tool — MED-1: the SYNC result is fenced as untrusted', 
     expect(r.content.indexOf('HIT WALL-CLOCK TIMEOUT')).toBeLessThan(r.content.indexOf('<untrusted_web_content'));
   });
 
+  test('a post-start execution failure is a trusted unknown-outcome error', async () => {
+    const r = await actorCreateTool.execute({ task: 'change it', sync: true }, syncCtx({
+      result: 'the target may have changed before the worker stopped',
+      stopped: true,
+      executionFailed: true,
+      outcomeKnown: false,
+    }) as any) as any;
+    expect(r).toMatchObject({ ok: false, performed: true, outcomeKnown: false, retryable: false });
+    expect(r.error).toContain('Its outcome is unknown. Do not retry automatically.');
+    expect(r.error).toContain('<untrusted_web_content');
+    expect(r.error.indexOf('Do not retry automatically')).toBeLessThan(r.error.indexOf('<untrusted_web_content'));
+  });
+
+  test('a post-start persistence exception preserves the unknown-outcome contract', async () => {
+    const failure = Object.assign(new Error('storage write failed'), {
+      performed: true, outcomeKnown: false, retryable: false, executionFailed: true,
+    });
+    const ctx = baseCtx({ spawnActor: async () => { throw failure; } });
+    const r = await actorCreateTool.execute({ task: 'change it', sync: true }, ctx as any) as any;
+    expect(r).toMatchObject({ ok: false, performed: true, outcomeKnown: false, retryable: false });
+    expect(r.error).toContain('Do not retry automatically');
+    expect(r.error).not.toContain('storage write failed');
+  });
+
+  test('a graceful pre-tool actor failure is Not run rather than outcome unknown', async () => {
+    const r = await actorCreateTool.execute({ task: 'change it', sync: true }, syncCtx({
+      result: 'actor-provider-boundary-blocked: The actor model request was not run.',
+      stopped: true,
+      executionFailed: true,
+      outcomeKnown: true,
+      toolCalls: 0,
+    }) as any) as any;
+    expect(r).toMatchObject({ ok: false, performed: false, outcomeKnown: true, retryable: true });
+    expect(r.error).toContain('FAILED BEFORE TARGET WORK RAN');
+    expect(r.error).not.toContain('Its outcome is unknown');
+  });
+
   test('a refusal is surfaced as an error, not a fenced result', async () => {
     const ctx = baseCtx({
       spawnActor: async () => ({ result: 'max depth 5 exceeded', sessionId: null, toolCalls: 0, durationMs: 0, depth: 6, refused: true }),

--- a/tests/peerd-runtime/actor-isolation.test.ts
+++ b/tests/peerd-runtime/actor-isolation.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  actorIsolationCapability,
+  actorIsolationForTurn,
+  actorIsolationRefusal,
+  actorIsolationSpawnRefusal,
+  actorIsolationTemporarilyUnavailable,
+  filterByActorIsolation,
+  actorIsolationPromptBlock,
+} from '../../extension/peerd-runtime/actor/isolation.js';
+
+describe('actor isolation capability', () => {
+  test('prefers the Chrome offscreen worker host', () => {
+    expect(actorIsolationCapability({ offscreenWorker: true, backgroundPageWorker: true })).toEqual({
+      status: 'available', host: 'offscreen-document-worker', reason: null, retryable: false,
+    });
+  });
+
+  test('uses a direct background-page worker on Firefox', () => {
+    expect(actorIsolationCapability({ offscreenWorker: false, backgroundPageWorker: true })).toEqual({
+      status: 'available', host: 'background-page-worker', reason: null, retryable: false,
+    });
+  });
+
+  test('fails closed with stable no-side-effect fields', () => {
+    const unsupported = actorIsolationCapability({ offscreenWorker: false, backgroundPageWorker: false });
+    expect(actorIsolationRefusal(unsupported)).toMatchObject({
+      ok: false,
+      code: 'actor_isolation_unavailable',
+      performed: false,
+      targetRead: false,
+      targetChanged: false,
+      retryable: false,
+    });
+  });
+
+  test('can report a binding that was resolved before startup failed', () => {
+    const unsupported = actorIsolationCapability({ offscreenWorker: false, backgroundPageWorker: false });
+    expect(actorIsolationRefusal(unsupported, { targetRead: true, targetChanged: true })).toMatchObject({
+      performed: false,
+      targetRead: true,
+      targetChanged: true,
+    });
+  });
+
+  test('shapes a spawn refusal without a child session or side effect', () => {
+    const unsupported = actorIsolationCapability({ offscreenWorker: false, backgroundPageWorker: false });
+    expect(actorIsolationSpawnRefusal(unsupported, 2)).toEqual({
+      result: 'Actors were not run because this browser cannot provide the required isolated worker.',
+      sessionId: null,
+      toolCalls: 0,
+      durationMs: 0,
+      depth: 3,
+      refused: true,
+    });
+  });
+
+  test('marks a host failure as a distinct retryable state', () => {
+    const available = actorIsolationCapability({ offscreenWorker: false, backgroundPageWorker: true });
+    const failed = actorIsolationTemporarilyUnavailable(available, new Error('worker import failed'));
+    expect(actorIsolationRefusal(failed)).toMatchObject({
+      code: 'actor_isolation_temporarily_unavailable', retryable: true,
+    });
+    expect(failed.host).toBe('background-page-worker');
+  });
+});
+
+describe('actor isolation exposure', () => {
+  const tools = ['message_actor', 'actor_create', 'request_review', 'actor_list', 'read_memory']
+    .map((name) => ({ name }));
+
+  test('removes actor execution tools but keeps inventory', () => {
+    const unavailable = actorIsolationCapability({ offscreenWorker: false, backgroundPageWorker: false });
+    expect(filterByActorIsolation(tools, unavailable).map((tool) => tool.name)).toEqual(['actor_list', 'read_memory']);
+    expect(actorIsolationPromptBlock(unavailable)).toContain('Do not open or resolve an actor target');
+    expect(actorIsolationPromptBlock(unavailable)).not.toContain('Try again');
+  });
+
+  test('leaves tools present without exposing host details when available', () => {
+    const available = actorIsolationCapability({ offscreenWorker: false, backgroundPageWorker: true });
+    expect(filterByActorIsolation(tools, available)).toEqual(tools);
+    expect(actorIsolationPromptBlock(available)).toBe('');
+  });
+
+  test('tells the model that only the user should retry a temporary failure', () => {
+    const available = actorIsolationCapability({ offscreenWorker: false, backgroundPageWorker: true });
+    const failed = actorIsolationTemporarilyUnavailable(available, new Error('worker import failed'));
+    expect(actorIsolationPromptBlock(failed)).toContain('Try again control');
+    expect(actorIsolationPromptBlock(failed)).not.toContain('worker import failed');
+  });
+
+  test('keeps an unavailable turn unavailable after recovery, but sees a live failure', () => {
+    const available = actorIsolationCapability({ offscreenWorker: false, backgroundPageWorker: true });
+    const unavailable = actorIsolationTemporarilyUnavailable(available, new Error('worker failed'));
+    expect(actorIsolationForTurn(unavailable, available)).toBe(unavailable);
+    expect(actorIsolationForTurn(available, unavailable)).toBe(unavailable);
+  });
+});

--- a/tests/peerd-runtime/actor-lifecycle.test.ts
+++ b/tests/peerd-runtime/actor-lifecycle.test.ts
@@ -83,6 +83,30 @@ const spawnDeps = (store: any, loop: any, extra: any = {}) => ({
   renderSystemPrompt: async ({ taskOverride }: any) => `sys task=${taskOverride}`,
   getToolDescriptors: () => [{ name: 'a', description: 'A', schema: {} }],
   now: (() => { let t = 1000; return () => (t += 25); })(),
+  // Lifecycle tests exercise the dedicated-worker contract through a portable
+  // fake host. The loop still receives the child's abort signal, but no test
+  // relies on the removed privileged-background fallback.
+  runChildOffscreen: async (job: any, opts: any = {}) => {
+    let stopReason: string | undefined;
+    let toolCalls = 0;
+    const usage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+    for await (const event of loop({
+      sessionId: job.sessionId,
+      userText: job.task,
+      sessions: store,
+      signal: opts.signal,
+    })) {
+      if (event.type === 'stop') stopReason = event.stopReason;
+      if (event.type === 'tool-use') toolCalls++;
+      if (event.type === 'usage' && event.usage) Object.assign(usage, event.usage);
+      opts.onEvent?.(event);
+    }
+    const session = await store.get(job.sessionId);
+    const finalText = [...(session?.messages ?? [])].reverse()
+      .find((message: any) => message.role === 'assistant' && typeof message.content === 'string')?.content ?? '';
+    return { ok: true, started: true, finalText, stopReason, toolCalls, usage };
+  },
+  renderSystemPromptForChild: (task: string) => `SYS:${task}`,
   ...extra,
 });
 
@@ -290,36 +314,81 @@ describe('heap split — routing a child offscreen (reasoning AND tool-bearing)'
     expect(offscreenJob.tools.map((t: any) => t.name)).toEqual(['script']);
   });
 
-  test('a NEVER-STARTED offscreen failure falls back to the in-SW loop (never dies on infra)', async () => {
+  test('a NEVER-STARTED worker failure fails closed without running in the background heap', async () => {
     const store = makeStore();
     const parent = await store.create({});
     const spawn = withOffscreen(store, async () => ({ ok: false, started: false, error: 'offscreen doc unavailable' }));
     const out = await spawn({ task: 'reason', tools: [], parentSessionId: parent.sessionId });
-    expect(out.result).toBe('IN-SW answer');           // fell back, didn't die
+    expect(out.result).toBe('offscreen doc unavailable');
+    expect(out.refused).toBe(true);
   });
 
-  test('a STARTED-but-errored offscreen run does NOT re-run in-SW (would double-bill)', async () => {
+  test('a tool side effect followed by a Worker error does not re-run in-SW', async () => {
     const store = makeStore();
     const parent = await store.create({});
     let inSwRan = false;
     const inSwLoop = async function* (ctx: any) { inSwRan = true; await ctx.sessions.appendMessage(ctx.sessionId, { role: 'assistant', content: 'IN-SW answer' }); yield { type: 'stop', stopReason: 'end_turn' }; };
     const spawn = makeSpawnActor(spawnDeps(store, inSwLoop, {
-      runChildOffscreen: async () => ({ ok: false, started: true, error: 'provider-http-500', finalText: '' }),
+      runChildOffscreen: async () => ({
+        ok: false,
+        started: true,
+        error: 'provider-http-500',
+        finalText: '',
+        toolCalls: 1,
+        newMessages: [
+          { role: 'user', content: 'change the target' },
+          { role: 'assistant', content: '', toolUses: [{ id: 'side-effect-1', name: 'script', input: { code: 'return 42' } }] },
+          { role: 'user', content: '', toolResults: [{ tool_use_id: 'side-effect-1', is_error: false, content: '42' }] },
+        ],
+      }),
       renderSystemPromptForChild: (t: string) => `SYS:${t}`,
     }) as any);
     const out = await spawn({ task: 'reason', tools: [], parentSessionId: parent.sessionId });
     expect(inSwRan).toBe(false);                        // did NOT double-run
-    expect(out.result).toBe('');                        // surfaced the (empty) offscreen result
+    expect(out.result).toContain('provider-http-500');  // surfaced the worker failure
+    expect(out.result).toContain('outcome is unknown');
+    expect(out.result).toContain('must not be retried automatically');
+    expect(out.stopped).toBe(true);
+    expect(out.executionFailed).toBe(true);
+    expect(out.outcomeKnown).toBe(false);
+    expect(out.toolCalls).toBe(1);
+  });
+
+  test('a transcript write failure after an isolated run throws structured unknown-outcome metadata', async () => {
+    const store = makeStore();
+    const parent = await store.create({});
+    store.appendMessage = async () => { throw new Error('storage unavailable'); };
+    const spawn = withOffscreen(store, async () => ({
+      ok: true,
+      started: true,
+      finalText: 'target changed',
+      newMessages: [{ role: 'assistant', content: 'target changed' }],
+      toolCalls: 1,
+    }));
+    try {
+      await spawn({ task: 'change it', tools: [], parentSessionId: parent.sessionId });
+      throw new Error('expected persistence failure');
+    } catch (error) {
+      expect(error).toMatchObject({
+        name: 'ActorPersistenceError',
+        performed: true,
+        outcomeKnown: false,
+        retryable: false,
+        executionFailed: true,
+      });
+    }
   });
 });
 
 // ---- actor-messaging: the lineage gate + arbitration ------------------------
 
 type Reenter = { userText: string; sessionId: string; synthetic: boolean };
+type RecoveryNotice = Reenter & { recoveryId: string };
 type Hop = { sessionId: string; parentSessionId: string | null; spawnedTrusted: boolean };
 
 const gateHarness = (over: Partial<Parameters<typeof makeActorMessaging>[0]> = {}) => {
   const reentries: Reenter[] = [];
+  const recoveryNotices: RecoveryNotice[] = [];
   const turnsRun: Array<{ actorSessionId: string; message: string }> = [];
   const appended: any[] = [];
   const deps = {
@@ -332,6 +401,7 @@ const gateHarness = (over: Partial<Parameters<typeof makeActorMessaging>[0]> = {
       return { result: 'built the thing' };
     },
     reenter: async (r: Reenter) => { reentries.push(r); },
+    recordRecovery: async (r: RecoveryNotice) => { recoveryNotices.push(r); return true; },
     turnSlots: { runWhenIdle: (_sid: string, fn: () => void) => fn() },
     getActiveSessionId: async () => 'chat-1',
     isVaultLocked: () => false,
@@ -342,7 +412,7 @@ const gateHarness = (over: Partial<Parameters<typeof makeActorMessaging>[0]> = {
     log: () => {},
     ...over,
   } as Parameters<typeof makeActorMessaging>[0];
-  return { ...makeActorMessaging(deps), reentries, turnsRun, appended };
+  return { ...makeActorMessaging(deps), reentries, recoveryNotices, turnsRun, appended };
 };
 
 // A trusted direct child of the active chat.
@@ -753,50 +823,49 @@ describe('message_actor — envelope provenance + redrain reroute (phase 7)', ()
     expect(appended[0].senderSessionId).toBe('sub-1');
   });
 
-  test('a redrained reply whose sender was an ephemeral actor is rerouted to the ROOT', async () => {
+  test('a recovery notice whose sender was an ephemeral actor is rerouted to the ROOT', async () => {
     const audits: any[] = [];
-    const { redrain, reentries } = gateHarness({
+    const { redrain, reentries, recoveryNotices } = gateHarness({
       appendAudit: async (e: any) => { audits.push(e); },
       mailbox: {
         append: async () => {},
         remove: async () => {},
         load: async () => [{
           id: 'c-1', senderSessionId: 'sub-9', to: 'app-1', message: 'finish it',
-          createdAt: 1, provenance: { rootSessionId: 'chat-1', lineagePath: ['chat-1', 'sub-9'] },
+          createdAt: 1, state: 'started', kind: 'app',
+          provenance: { rootSessionId: 'chat-1', lineagePath: ['chat-1', 'sub-9'] },
         }],
       },
     });
     const r = await redrain();
-    expect(r.redrained).toBe(1);
+    expect(r.redrained).toBe(0);
     await tick();
-    // The wake reached the CHAT, not the dead child.
-    expect(reentries.length).toBe(1);
-    expect(reentries[0].sessionId).toBe('chat-1');
+    // The passive notice reached the CHAT, not the dead child, and no model turn ran.
+    expect(reentries).toEqual([]);
+    expect(recoveryNotices.length).toBe(1);
+    expect(recoveryNotices[0].sessionId).toBe('chat-1');
     expect(audits.some((a) => a.type === 'actor_reply_rerouted')).toBe(true);
   });
 
-  test('a redrained in-flight twin still counts against dedupe (#4 symmetry)', async () => {
-    // Hold every queued turn so the redrained turn stays in flight; its intent
-    // must be tracked so an identical fresh send is refused and — critically —
-    // the redrained turn's settle doesn't decrement a DIFFERENT send's refcount.
-    const queued: Array<() => void> = [];
-    const { messageActor, redrain } = gateHarness({
-      turnSlots: { runWhenIdle: (_sid: string, fn: () => void) => { queued.push(fn); } },
+  test('a queued recovery notice never creates an in-flight actor intent', async () => {
+    const { messageActor, redrain, turnsRun } = gateHarness({
       mailbox: {
         append: async () => {},
         remove: async () => {},
-        load: async () => [{ id: 'c-1', senderSessionId: 'chat-1', to: 'app-1', message: 'reprice', createdAt: 1 }],
+        load: async () => [{
+          id: 'c-1', senderSessionId: 'chat-1', to: 'app-1', message: 'reprice',
+          createdAt: 1, state: 'queued', kind: 'app',
+        }],
       },
     });
-    await redrain(); // re-queues (chat-1 → app-1, 'reprice'); intent now tracked
-    // An identical fresh send from the same chat is refused as a duplicate.
-    const dup = await messageActor({ to: 'app-1', message: 'reprice', senderSessionId: 'chat-1' });
-    expect(dup.ok).toBe(false);
-    expect(dup.error).toContain('already in flight');
+    await redrain();
+    expect(turnsRun).toEqual([]);
+    const retry = await messageActor({ to: 'app-1', message: 'reprice', senderSessionId: 'chat-1' });
+    expect(retry.ok).toBe(true);
   });
 
   test('a pre-#134 envelope (no provenance) keeps the sender-addressed wake', async () => {
-    const { redrain, reentries } = gateHarness({
+    const { redrain, reentries, recoveryNotices } = gateHarness({
       mailbox: {
         append: async () => {},
         remove: async () => {},
@@ -805,7 +874,8 @@ describe('message_actor — envelope provenance + redrain reroute (phase 7)', ()
     });
     await redrain();
     await tick();
-    expect(reentries.length).toBe(1);
-    expect(reentries[0].sessionId).toBe('chat-1');
+    expect(reentries).toEqual([]);
+    expect(recoveryNotices.length).toBe(1);
+    expect(recoveryNotices[0].sessionId).toBe('chat-1');
   });
 });

--- a/tests/peerd-runtime/actor-messaging.test.ts
+++ b/tests/peerd-runtime/actor-messaging.test.ts
@@ -74,7 +74,7 @@ describe('message_actor — the sender gate (fail closed)', () => {
   });
 });
 
-describe('message_actor — actor isolation wall', () => {
+describe('message_actor: actor isolation wall', () => {
   const unavailable = {
     status: 'unsupported' as const,
     host: null,

--- a/tests/peerd-runtime/actor-messaging.test.ts
+++ b/tests/peerd-runtime/actor-messaging.test.ts
@@ -8,11 +8,13 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
 
 type Reenter = {
   userText: string; sessionId: string; synthetic: boolean;
-  actorReply?: { kind: string; instanceId: string; name?: string; failed?: boolean };
+  actorReply?: { kind: string; instanceId: string; name?: string; failed?: boolean; outcomeKnown?: boolean; performed?: boolean; actorDeliveryId?: string };
 };
+type RecoveryNotice = Reenter & { recoveryId: string };
 
 const harness = (over: Partial<Parameters<typeof makeActorMessaging>[0]> = {}) => {
   const reentries: Reenter[] = [];
+  const recoveryNotices: RecoveryNotice[] = [];
   const turnsRun: Array<{ actorSessionId: string; message: string }> = [];
   const deps = {
     resolveActor: async (to: string) =>
@@ -24,6 +26,7 @@ const harness = (over: Partial<Parameters<typeof makeActorMessaging>[0]> = {}) =
       return { result: 'built the thing' };
     },
     reenter: async (r: Reenter) => { reentries.push(r); },
+    recordRecovery: async (r: RecoveryNotice) => { recoveryNotices.push(r); return true; },
     // Run queued work immediately (no real slot in the test).
     turnSlots: { runWhenIdle: (_sid: string, fn: () => void) => fn() },
     getActiveSessionId: async () => 'chat-1',
@@ -34,7 +37,7 @@ const harness = (over: Partial<Parameters<typeof makeActorMessaging>[0]> = {}) =
     log: () => {},
     ...over,
   } as Parameters<typeof makeActorMessaging>[0];
-  return { ...makeActorMessaging(deps), reentries, turnsRun };
+  return { ...makeActorMessaging(deps), reentries, recoveryNotices, turnsRun };
 };
 
 describe('message_actor — the sender gate (fail closed)', () => {
@@ -71,6 +74,84 @@ describe('message_actor — the sender gate (fail closed)', () => {
   });
 });
 
+describe('message_actor — actor isolation wall', () => {
+  const unavailable = {
+    status: 'unsupported' as const,
+    host: null,
+    reason: 'no dedicated worker host',
+    retryable: false,
+  };
+
+  test('refuses before target resolution, persistence, or actor work', async () => {
+    let resolved = 0;
+    let persisted = 0;
+    const { messageActor, turnsRun } = harness({
+      getActorIsolation: () => unavailable,
+      resolveActor: async () => { resolved++; return null; },
+      mailbox: {
+        append: async () => { persisted++; },
+        remove: async () => {},
+        load: async () => [],
+      },
+    });
+    const result: any = await messageActor({ to: 'app-1', message: 'click', senderSessionId: 'chat-1' });
+    expect(result).toMatchObject({
+      ok: false, code: 'actor_isolation_unavailable', performed: false,
+      targetRead: false, targetChanged: false, retryable: false,
+    });
+    expect(resolved).toBe(0);
+    expect(persisted).toBe(0);
+    expect(turnsRun).toEqual([]);
+  });
+
+  test('does not disclose isolation state to a sender the lineage gate refuses', async () => {
+    const { messageActor } = harness({ getActorIsolation: () => unavailable });
+    const result: any = await messageActor({ to: 'app-1', message: 'click', senderSessionId: 'other' });
+    expect(result.code).toBeUndefined();
+    expect(result.error).toContain('active foreground chat');
+  });
+
+  test('treats an old state-less mailbox entry as unknown without resolving its target', async () => {
+    const removed: string[] = [];
+    let resolved = 0;
+    const { redrain, reentries, recoveryNotices, turnsRun } = harness({
+      getActorIsolation: () => unavailable,
+      resolveActor: async () => { resolved++; return null; },
+      mailbox: {
+        append: async () => {},
+        remove: async (id: string) => { removed.push(id); },
+        load: async () => [{ id: 'old-1', senderSessionId: 'chat-1', to: 'app-1', message: 'click', createdAt: 1 }],
+      },
+    });
+    expect(await redrain()).toEqual({ redrained: 0, retained: 0 });
+    await tick();
+    expect(removed).toEqual(['old-1']);
+    expect(resolved).toBe(0);
+    expect(turnsRun).toEqual([]);
+    expect(reentries).toEqual([]);
+    expect(recoveryNotices[0].actorReply?.failed).toBe(true);
+    expect(recoveryNotices[0].actorReply?.outcomeKnown).toBe(false);
+    expect(recoveryNotices[0].userText).toContain('cannot confirm whether the previous request ran');
+  });
+
+  test('a mailbox write failure reports the prior target resolution but never queues the actor', async () => {
+    const { messageActor, turnsRun } = harness({
+      mailbox: {
+        append: async () => { throw new Error('storage down'); },
+        remove: async () => {},
+        load: async () => [],
+      },
+    });
+    const result: any = await messageActor({ to: 'app-1', message: 'click', senderSessionId: 'chat-1' });
+    expect(result).toMatchObject({
+      ok: false, code: 'actor_mailbox_unavailable', performed: false,
+      targetRead: true, targetChanged: true,
+    });
+    expect(result.error).toContain('target resolution may already have read or created');
+    expect(turnsRun).toEqual([]);
+  });
+});
+
 describe('message_actor — happy path + correlation', () => {
   test('runs the actor turn and re-enters the SENDER with a fenced synthetic reply', async () => {
     const { messageActor, reentries, turnsRun } = harness();
@@ -86,7 +167,8 @@ describe('message_actor — happy path + correlation', () => {
     expect(reentries[0].userText).toContain('<u origin="app-1">built the thing</u>');
     // The wake carries WHO replied so the chat can surface it as its own
     // attributed bubble (trickle-up) instead of hiding it as plumbing.
-    expect(reentries[0].actorReply).toEqual({ kind: 'app', instanceId: 'app-1', name: 'todo', failed: false });
+    expect(reentries[0].actorReply).toMatchObject({ kind: 'app', instanceId: 'app-1', name: 'todo', failed: false });
+    expect(typeof reentries[0].actorReply?.actorDeliveryId).toBe('string');
   });
 
   test('a FAILED reply wake carries actorReply.failed so the bubble can show the failure', async () => {
@@ -96,7 +178,58 @@ describe('message_actor — happy path + correlation', () => {
     await messageActor({ to: 'app-1', message: 'x', senderSessionId: 'chat-1' });
     await tick();
     expect(reentries[0].actorReply?.failed).toBe(true);
+    expect(reentries[0].actorReply?.outcomeKnown).toBe(false);
     expect(reentries[0].actorReply?.kind).toBe('app');
+  });
+
+  test('a post-start failure puts unknown-outcome guidance in trusted framing', async () => {
+    const { messageActor, reentries } = harness({
+      runActorTurn: async () => ({
+        result: 'the target may have changed before the worker stopped',
+        stopped: true,
+        executionFailed: true,
+        outcomeKnown: false,
+      }),
+    });
+    await messageActor({ to: 'app-1', message: 'change the target', senderSessionId: 'chat-1' });
+    await tick();
+    expect(reentries[0].actorReply).toMatchObject({ failed: true, outcomeKnown: false });
+    expect(reentries[0].userText).toContain('Its outcome is unknown. Do not retry automatically');
+    expect(reentries[0].userText.indexOf('Do not retry automatically'))
+      .toBeLessThan(reentries[0].userText.indexOf('<u origin="app-1">'));
+  });
+
+  test('an awaited post-start failure preserves non-retryable outcome metadata', async () => {
+    const { messageActor } = harness({
+      runActorTurn: async () => ({
+        result: 'a side effect may already have landed',
+        stopped: true,
+        executionFailed: true,
+        outcomeKnown: false,
+      }),
+    });
+    const result: any = await messageActor({
+      to: 'app-1', message: 'change the target', senderSessionId: 'chat-1', awaitReply: true,
+    });
+    expect(result).toMatchObject({ ok: false, performed: true, outcomeKnown: false, retryable: false });
+    expect(result.error).toContain('Do not retry automatically');
+  });
+
+  test('a graceful pre-tool failure stays Not run and does not gain replay warnings', async () => {
+    const { messageActor, reentries } = harness({
+      runActorTurn: async () => ({
+        result: 'actor-provider-boundary-blocked: The actor model request was not run.',
+        stopped: true,
+        executionFailed: true,
+        outcomeKnown: true,
+      }),
+    });
+    await messageActor({ to: 'app-1', message: 'change the target', senderSessionId: 'chat-1' });
+    await tick();
+    expect(reentries[0].actorReply).toMatchObject({ failed: true });
+    expect(reentries[0].actorReply?.outcomeKnown).toBeUndefined();
+    expect(reentries[0].userText).toContain('model request was not run');
+    expect(reentries[0].userText).not.toContain('Its outcome is unknown');
   });
 
   test('an async custody refusal reaches the later turn with its stable recovery guidance', async () => {
@@ -167,6 +300,27 @@ describe('message_actor — awaitReply (in-band reply mode)', () => {
     // …and it did NOT re-enter the sender on a later turn (that's the async path).
     await tick();
     expect(reentries.length).toBe(0);
+  });
+
+  test('an awaited reply keeps its mailbox row until the parent result is durably acknowledged', async () => {
+    const appended: any[] = [];
+    const removed: string[] = [];
+    const { messageActor } = harness({
+      mailbox: {
+        append: async (entry: any) => { appended.push(entry); },
+        markStarted: async () => {},
+        remove: async (id: string) => { removed.push(id); },
+        load: async () => [],
+      },
+    });
+
+    const result: any = await messageActor({
+      to: 'app-1', message: 'get the price', senderSessionId: 'chat-1', awaitReply: true,
+    });
+
+    expect(result.actorDeliveryId).toBe(appended[0].id);
+    expect(result.actorDeliveryId.length).toBeLessThanOrEqual(512);
+    expect(removed).toEqual([]);
   });
 
   test('await returns the custody refusal in-band without substituting Stop copy', async () => {
@@ -386,7 +540,8 @@ describe('message_actor — error path still wakes the sender', () => {
     expect(reentries.length).toBe(1);
     expect(reentries[0].sessionId).toBe('chat-1');
     expect(reentries[0].synthetic).toBe(true);
-    expect(reentries[0].userText).toContain('could not complete');
+    expect(reentries[0].userText).toContain('outcome is unknown');
+    expect(reentries[0].userText).toContain('Do not retry automatically');
     expect(reentries[0].userText).toContain('boom');
   });
 });
@@ -394,29 +549,77 @@ describe('message_actor — error path still wakes the sender', () => {
 describe('message_actor — durable mailbox (persist + redrain)', () => {
   const makeMailbox = () => {
     const appended: any[] = [];
+    const started: string[] = [];
     const removed: string[] = [];
     let loadReturns: any[] = [];
     return {
       mailbox: {
         append: async (e: any) => { appended.push(e); },
+        markStarted: async (id: string) => { started.push(id); },
         remove: async (id: string) => { removed.push(id); },
         load: async () => loadReturns,
       },
-      appended, removed,
+      appended, started, removed,
       setLoad: (arr: any[]) => { loadReturns = arr; },
     };
   };
 
-  test('an ENGINE message persists on accept and clears on settle', async () => {
+  test('an ENGINE message persists until the synthetic reply commits', async () => {
     const mb = makeMailbox();
     const { messageActor, reentries } = harness({ mailbox: mb.mailbox });
     await messageActor({ to: 'app-1', message: 'build', senderSessionId: 'chat-1' });
     expect(mb.appended.length).toBe(1);
-    expect(mb.appended[0]).toMatchObject({ senderSessionId: 'chat-1', to: 'app-1', message: 'build' });
+    expect(mb.appended[0]).toMatchObject({
+      senderSessionId: 'chat-1', to: 'app-1', message: 'build', state: 'queued', kind: 'app',
+    });
+    expect(mb.started).toEqual([mb.appended[0].id]);
     await tick();
-    // The reply delivered → the durable entry is cleared (same id).
+    // Reentry fulfillment is not the commit acknowledgement. The id rides the
+    // synthetic user message and the session post-commit hook clears it later.
     expect(reentries.length).toBe(1);
-    expect(mb.removed).toEqual([mb.appended[0].id]);
+    expect(reentries[0].actorReply?.actorDeliveryId).toBe(mb.appended[0].id);
+    expect(mb.removed).toEqual([]);
+  });
+
+  test('a live async reply keeps its mailbox row while the parent slot is busy', async () => {
+    const mb = makeMailbox();
+    const parentCallbacks: Array<() => void> = [];
+    const { messageActor, reentries } = harness({
+      mailbox: mb.mailbox,
+      turnSlots: {
+        runWhenIdle: (sessionId: string, fn: () => void) => {
+          if (sessionId === 'res-1') fn();
+          else parentCallbacks.push(fn);
+        },
+      },
+    });
+
+    await messageActor({ to: 'app-1', message: 'build', senderSessionId: 'chat-1' });
+    await tick();
+
+    expect(parentCallbacks).toHaveLength(1);
+    expect(reentries).toEqual([]);
+    expect(mb.removed).toEqual([]);
+
+    parentCallbacks[0]();
+    await tick();
+    expect(reentries).toHaveLength(1);
+    expect(reentries[0].actorReply?.actorDeliveryId).toBe(mb.appended[0].id);
+    expect(mb.removed).toEqual([]);
+  });
+
+  test('a live async reply keeps its mailbox row when parent reentry fails', async () => {
+    const mb = makeMailbox();
+    const { messageActor, reentries } = harness({
+      mailbox: mb.mailbox,
+      reenter: async () => { throw new Error('parent session write failed'); },
+    });
+
+    await messageActor({ to: 'app-1', message: 'build', senderSessionId: 'chat-1' });
+    await tick();
+
+    expect(reentries).toEqual([]);
+    expect(mb.removed).toEqual([]);
   });
 
   test('a WEB message IS persisted now (async like every kind)', async () => {
@@ -429,31 +632,199 @@ describe('message_actor — durable mailbox (persist + redrain)', () => {
     await messageActor({ to: '42', message: 'click', senderSessionId: 'chat-1' });
     await tick();
     expect(mb.appended.length).toBe(1);
-    expect(mb.removed).toEqual([mb.appended[0].id]);   // cleared on settle, same as engine
+    expect(mb.removed).toEqual([]);   // post-commit hook owns acknowledgement
   });
 
-  test('redrain re-queues a persisted engine message → actor runs, sender woken, entry cleared', async () => {
+  test('recovery never executes queued work and reports it as Not run', async () => {
     const mb = makeMailbox();
-    mb.setLoad([{ id: 'c1', senderSessionId: 'chat-1', to: 'app-1', message: 'resume me', createdAt: 1 }]);
-    const { redrain, reentries, turnsRun } = harness({ mailbox: mb.mailbox });
-    const r = await redrain();
-    expect(r.redrained).toBe(1);
-    await tick();
-    expect(turnsRun).toEqual([{ actorSessionId: 'res-1', message: 'resume me' }]);
-    expect(reentries.length).toBe(1);
-    expect(reentries[0].sessionId).toBe('chat-1');
-    expect(mb.removed).toEqual(['c1']);
-  });
-
-  test('redrain abandons an entry whose instance is gone — wakes the sender with a failure, clears it', async () => {
-    const mb = makeMailbox();
-    mb.setLoad([{ id: 'c2', senderSessionId: 'chat-1', to: 'gone-9', message: 'x', createdAt: 1 }]);
-    const { redrain, reentries } = harness({ mailbox: mb.mailbox });
+    mb.setLoad([{
+      id: 'c1', senderSessionId: 'chat-1', to: 'app-1', message: 'resume me',
+      createdAt: 1, state: 'queued', kind: 'app',
+    }]);
+    const { redrain, reentries, recoveryNotices, turnsRun } = harness({ mailbox: mb.mailbox });
     const r = await redrain();
     expect(r.redrained).toBe(0);
     await tick();
-    expect(reentries.length).toBe(1);
-    expect(reentries[0].userText).toContain('could not be reached');
+    expect(turnsRun).toEqual([]);
+    expect(reentries).toEqual([]);
+    expect(recoveryNotices).toHaveLength(1);
+    expect(recoveryNotices[0].sessionId).toBe('chat-1');
+    expect(recoveryNotices[0].actorReply?.outcomeKnown).toBe(true);
+    expect(recoveryNotices[0].actorReply?.performed).toBe(false);
+    expect(recoveryNotices[0].userText.split('\n\n')[0]).toContain('did not run the request');
+    expect(recoveryNotices[0].userText).toContain('It was not run');
+    expect(mb.removed).toEqual(['c1']);
+  });
+
+  test('redrain never replays a started message and reports its outcome as unknown', async () => {
+    const mb = makeMailbox();
+    mb.setLoad([{
+      id: 'started-1', senderSessionId: 'chat-1', to: 'app-1', message: 'submit it',
+      createdAt: 1, state: 'started', kind: 'app', name: 'orders',
+    }]);
+    const { redrain, reentries, recoveryNotices, turnsRun } = harness({ mailbox: mb.mailbox });
+
+    expect(await redrain()).toEqual({ redrained: 0, retained: 0 });
+    await tick();
+
+    expect(turnsRun).toEqual([]);
+    expect(mb.started).toEqual([]);
+    expect(mb.removed).toEqual(['started-1']);
+    expect(reentries).toEqual([]);
+    expect(recoveryNotices).toHaveLength(1);
+    expect(recoveryNotices[0].actorReply).toMatchObject({
+      kind: 'app', instanceId: 'app-1', name: 'orders', failed: true, outcomeKnown: false,
+    });
+    expect(recoveryNotices[0].userText).toContain('Its outcome is unknown. Do not retry automatically');
+    expect(recoveryNotices[0].userText).toContain('Check whether the requested action completed');
+  });
+
+  test('recovery removes an already committed delivery without adding a duplicate warning', async () => {
+    const mb = makeMailbox();
+    mb.setLoad([{
+      id: 'committed-1', senderSessionId: 'chat-1', to: 'app-1', message: 'submit it',
+      createdAt: 1, state: 'started', kind: 'app',
+    }]);
+    const checks: any[] = [];
+    const { redrain, recoveryNotices, turnsRun } = harness({
+      mailbox: mb.mailbox,
+      deliveryCommitted: async (query) => { checks.push(query); return true; },
+    });
+
+    expect(await redrain()).toEqual({ redrained: 0, retained: 0 });
+    expect(checks).toEqual([{ sessionId: 'chat-1', deliveryId: 'committed-1' }]);
+    expect(turnsRun).toEqual([]);
+    expect(recoveryNotices).toEqual([]);
+    expect(mb.removed).toEqual(['committed-1']);
+  });
+
+  test('recovery retains a row when committed-delivery inspection is unavailable', async () => {
+    const mb = makeMailbox();
+    mb.setLoad([{
+      id: 'commit-check-failed', senderSessionId: 'chat-1', to: 'app-1', message: 'submit it',
+      createdAt: 1, state: 'started', kind: 'app',
+    }]);
+    const { redrain, recoveryNotices } = harness({
+      mailbox: mb.mailbox,
+      deliveryCommitted: async () => { throw new Error('session storage unavailable'); },
+    });
+
+    expect(await redrain()).toEqual({ redrained: 0, retained: 1 });
+    expect(recoveryNotices).toEqual([]);
+    expect(mb.removed).toEqual([]);
+  });
+
+  test('a start-state write failure returns Not run and never enters the actor slot', async () => {
+    const mb = makeMailbox();
+    mb.mailbox.markStarted = async () => { throw new Error('storage unavailable'); };
+    const { messageActor, turnsRun } = harness({ mailbox: mb.mailbox });
+
+    const result: any = await messageActor({
+      to: 'app-1', message: 'submit it', senderSessionId: 'chat-1', awaitReply: true,
+    });
+
+    expect(result).toMatchObject({
+      ok: false, code: 'actor_mailbox_unavailable', performed: false, retryable: true,
+    });
+    expect(result.error).toContain('was not run');
+    expect(turnsRun).toEqual([]);
+    expect(mb.removed).toEqual([mb.appended[0].id]);
+  });
+
+  test('a failed start write and failed cleanup cannot replay after restart', async () => {
+    const appended: any[] = [];
+    const first = harness({
+      mailbox: {
+        append: async (entry: any) => { appended.push(entry); },
+        markStarted: async () => { throw new Error('storage unavailable'); },
+        remove: async () => { throw new Error('storage unavailable'); },
+        load: async () => [],
+      },
+    });
+    const result: any = await first.messageActor({
+      to: 'app-1', message: 'submit it', senderSessionId: 'chat-1', awaitReply: true,
+    });
+    expect(result).toMatchObject({ ok: false, performed: false, retryable: true });
+    expect(first.turnsRun).toEqual([]);
+
+    const removed: string[] = [];
+    const restarted = harness({
+      mailbox: {
+        append: async () => {},
+        markStarted: async () => {},
+        remove: async (id: string) => { removed.push(id); },
+        load: async () => appended,
+      },
+    });
+    await restarted.redrain();
+    expect(restarted.turnsRun).toEqual([]);
+    expect(restarted.reentries).toEqual([]);
+    expect(restarted.recoveryNotices[0].userText).toContain('It was not run');
+    expect(removed).toEqual([appended[0].id]);
+  });
+
+  test('recovery retains a started record until its passive notice is persisted', async () => {
+    let release = () => {};
+    const removed: string[] = [];
+    const recoveryNotices: RecoveryNotice[] = [];
+    const { redrain, reentries } = harness({
+      recordRecovery: (notice: RecoveryNotice) => new Promise<boolean>((resolve) => {
+        recoveryNotices.push(notice);
+        release = () => resolve(true);
+      }),
+      mailbox: {
+        append: async () => {}, markStarted: async () => {},
+        remove: async (id: string) => { removed.push(id); },
+        load: async () => [{
+          id: 'started-deferred', senderSessionId: 'chat-1', to: 'app-1', message: 'submit it',
+          createdAt: 1, state: 'started', kind: 'app',
+        }],
+      },
+    });
+
+    const pending = redrain();
+    await tick();
+    expect(recoveryNotices).toHaveLength(1);
+    expect(reentries).toEqual([]);
+    expect(removed).toEqual([]);
+    release();
+    await pending;
+    expect(reentries).toEqual([]);
+    expect(removed).toEqual(['started-deferred']);
+  });
+
+  test('recovery retains a started record when passive persistence fails', async () => {
+    const removed: string[] = [];
+    const { redrain, reentries, turnsRun } = harness({
+      recordRecovery: async () => { throw new Error('session write failed'); },
+      mailbox: {
+        append: async () => {}, markStarted: async () => {},
+        remove: async (id: string) => { removed.push(id); },
+        load: async () => [{
+          id: 'started-reject', senderSessionId: 'chat-1', to: 'app-1', message: 'submit it',
+          createdAt: 1, state: 'started', kind: 'app',
+        }],
+      },
+    });
+
+    const recovery = await redrain();
+    expect(recovery.retained).toBe(1);
+    expect(turnsRun).toEqual([]);
+    expect(reentries).toEqual([]);
+    expect(removed).toEqual([]);
+  });
+
+  test('legacy recovery does not resolve a missing instance and reports unknown outcome', async () => {
+    const mb = makeMailbox();
+    mb.setLoad([{ id: 'c2', senderSessionId: 'chat-1', to: 'gone-9', message: 'x', createdAt: 1 }]);
+    const { redrain, reentries, recoveryNotices } = harness({ mailbox: mb.mailbox });
+    const r = await redrain();
+    expect(r.redrained).toBe(0);
+    await tick();
+    expect(reentries).toEqual([]);
+    expect(recoveryNotices).toHaveLength(1);
+    expect(recoveryNotices[0].actorReply?.outcomeKnown).toBe(false);
+    expect(recoveryNotices[0].userText).toContain('cannot confirm whether the previous request ran');
     expect(mb.removed).toEqual(['c2']);
   });
 
@@ -579,7 +950,8 @@ describe('message_actor — web actor (now ASYNC, same path as engine)', () => {
     expect(r.ok).toBe(true);   // dispatched
     await tick();
     expect(reentries.length).toBe(1);
-    expect(reentries[0].userText).toContain('could not complete');
+    expect(reentries[0].userText).toContain('outcome is unknown');
+    expect(reentries[0].userText).toContain('Do not retry automatically');
     expect(reentries[0].userText).toContain('tab closed');
   });
 

--- a/tests/peerd-runtime/actor/async-actors.test.ts
+++ b/tests/peerd-runtime/actor/async-actors.test.ts
@@ -57,6 +57,57 @@ describe('makeAsyncActors', () => {
     expect(reenters).toHaveLength(0); // no synthetic wake after a user Stop
   });
 
+  test('a post-start Worker failure wakes the parent with unknown-outcome guidance', async () => {
+    const reenters: any[] = [];
+    const as = makeAsyncActors(baseDeps({
+      spawnActor: async () => ({
+        result: 'The actor worker crashed. Its outcome is unknown and must not be retried automatically.',
+        sessionId: 'c1', stopped: true, executionFailed: true, outcomeKnown: false,
+      }),
+      reenter: async (o: any) => { reenters.push(o); },
+    }));
+    await as.spawnActorAsync({ task: 'write once', parentSessionId: 'parent' });
+    await flush();
+    expect(reenters).toHaveLength(1);
+    expect(reenters[0].userText).toContain('execution failed after work began');
+    expect(reenters[0].userText).toContain('outcome unknown');
+    expect(reenters[0].userText).toContain('do not retry automatically');
+    expect(reenters[0].userText).toContain('[UNTRUSTED]');
+  });
+
+  test('a post-start persistence exception wakes the parent as outcome unknown', async () => {
+    const reenters: any[] = [];
+    const failure = Object.assign(new Error('transcript write failed'), {
+      executionFailed: true, performed: true, outcomeKnown: false, retryable: false,
+    });
+    const as = makeAsyncActors(baseDeps({
+      spawnActor: async () => { throw failure; },
+      reenter: async (o: any) => { reenters.push(o); },
+    }));
+    await as.spawnActorAsync({ task: 'write once', parentSessionId: 'parent' });
+    await flush();
+    expect(reenters).toHaveLength(1);
+    expect(reenters[0].userText).toContain('outcome is unknown');
+    expect(reenters[0].userText).toContain('Do not retry automatically');
+    expect(reenters[0].userText).not.toContain('has finished');
+  });
+
+  test('a graceful pre-tool failure is not described as an unknown outcome', async () => {
+    const reenters: any[] = [];
+    const as = makeAsyncActors(baseDeps({
+      spawnActor: async () => ({
+        result: 'The actor model request was not run.', sessionId: 'c1',
+        stopped: true, executionFailed: true, outcomeKnown: true,
+      }),
+      reenter: async (o: any) => { reenters.push(o); },
+    }));
+    await as.spawnActorAsync({ task: 'write once', parentSessionId: 'parent' });
+    await flush();
+    expect(reenters).toHaveLength(1);
+    expect(reenters[0].userText).toContain('failed before target work ran');
+    expect(reenters[0].userText).not.toContain('outcome unknown');
+  });
+
   // A TIMEOUT is different from a user Stop — the parent is still working and
   // wants the partial, so a timed-out child DOES reintegrate.
   test('a timed-out child still wakes the parent with its partial', async () => {

--- a/tests/peerd-runtime/loop/concurrent-dispatch.test.ts
+++ b/tests/peerd-runtime/loop/concurrent-dispatch.test.ts
@@ -144,6 +144,30 @@ describe('runUserTurn — concurrent tool dispatch', () => {
     expect(seq.length).toBe(4);
   });
 
+  test('persists singular and batched actor delivery custody on tool results', async () => {
+    const store = makeStore();
+    store.seed('s1');
+    const ctx = baseCtx(store, {
+      callModel: makeToolModel([{ id: 't_script', name: 'script' }]),
+      tools: [{ name: 'script', description: '', schema: {} }],
+      classifyToolCall: () => WRITE_VERDICT,
+      toolDispatch: async () => ({
+        ok: true,
+        content: 'done',
+        meta: {},
+        actorDeliveryId: 'delivery-one',
+        actorDeliveryIds: ['delivery-two', 'delivery-two', ''],
+      }),
+    });
+
+    await drain(runUserTurn(ctx));
+    const session = await store.get('s1');
+    const block = session.messages.find((m: any) => Array.isArray(m.toolResults))
+      .toolResults[0];
+    expect(block.actorDeliveryId).toBe('delivery-one');
+    expect(block.actorDeliveryIds).toEqual(['delivery-two']);
+  });
+
   test('a write is a barrier: [read, write, read] runs strictly in order', async () => {
     const store = makeStore();
     store.seed('s1');

--- a/tests/peerd-runtime/loop/turn-driver.test.ts
+++ b/tests/peerd-runtime/loop/turn-driver.test.ts
@@ -11,6 +11,7 @@
 import { describe, test, expect } from 'bun:test';
 import { inboundActorCallAllowed, makeTurnDriver } from '/peerd-runtime/loop/turn-driver.js';
 import { ACTOR_CREDENTIAL_BOUNDARY_FAILURE } from '/peerd-runtime/errors.js';
+import { runUserTurn } from '/peerd-runtime/loop/agent-loop.js';
 
 /** Minimal deps maybeAutoResume touches; the rest stay undefined (never invoked). */
 const deps = (/** @type {any} */ over: any = {}) => ({
@@ -111,6 +112,7 @@ const turnDeps = (kind: 'chat' | 'actor' | 'spawned', {
   failover = false, boundaryFailure = false, streamBoundaryFailure = false,
   waitForAbort = false, abortDuringFallback = false, uiDisconnected = false,
   waitForActorIsolation = async () => {},
+  dynamicIsolation = false,
 } = {}) => {
   const liveGetSecret = async () => 'sk-live';
   const liveSafeFetch = async () => new Response('ok');
@@ -118,7 +120,7 @@ const turnDeps = (kind: 'chat' | 'actor' | 'spawned', {
   const rogueSafeFetch = async () => new Response('rogue');
   const rogueSignal = new AbortController().signal;
   const turnAbortController = new AbortController();
-  const session = {
+  const session: any = {
     sessionId: 's1', kind, provider: 'anthropic', model: 'claude-test',
     messages: [],
     ...(kind === 'actor' ? { actorType: 'web', instanceId: 'web' } : {}),
@@ -132,6 +134,10 @@ const turnDeps = (kind: 'chat' | 'actor' | 'spawned', {
   const chatNotes: string[] = [];
   let lateProviderContinuation = 0;
   const audits: any[] = [];
+  let actorIsolation: any = {
+    status: 'available', host: 'background-page-worker', reason: null, retryable: false,
+  };
+  let systemPromptRenders = 0;
   let releases = 0;
   const settings = {
     reasoningEnabled: false,
@@ -151,6 +157,15 @@ const turnDeps = (kind: 'chat' | 'actor' | 'spawned', {
     },
     sessions: {
       get: async () => session,
+      appendMessage: async (_sessionId: string, message: any) => {
+        session.messages.push({ ...message });
+        return session;
+      },
+      updateAssistantMessage: async (_sessionId: string, messageId: string, patch: any) => {
+        const message = session.messages.find((entry: any) => entry.id === messageId);
+        if (message) Object.assign(message, patch);
+        return session;
+      },
       setCost: async () => {},
     },
     sessionState: { set: () => {} },
@@ -163,7 +178,10 @@ const turnDeps = (kind: 'chat' | 'actor' | 'spawned', {
     browser: { tabs: { query: async () => [] } },
     originOfTabUrl: () => '',
     skillRegistry: { describeForPrompt: async () => '' },
-    renderSystemPrompt: async () => 'system',
+    renderSystemPrompt: async () => {
+      systemPromptRenders++;
+      return 'system';
+    },
     resolveManifestAllow: () => null,
     buildToolContext: async (args: any) => {
       toolContextArgs = args;
@@ -173,14 +191,23 @@ const turnDeps = (kind: 'chat' | 'actor' | 'spawned', {
     filterByDwebEnabled: identity,
     filterDescriptorsByManifest: identity,
     mainAgentDescriptors: identity,
-    listTools: () => [],
+    listTools: () => dynamicIsolation
+      ? ['message_actor', 'actor_create', 'request_review', 'actor_list']
+        .map((name) => ({ name, description: `${name} test tool.`, schema: { type: 'object' } }))
+      : [],
     settingsStore: { get: () => settings },
     DWEB_ENABLED: false,
     filterByGoalActive: identity,
     goalActiveFor: () => false,
     dwebEngagedSessions: new Set(),
     markDwebEngaged: () => {},
-    dispatchToolCall: async () => ({ ok: true }),
+    dispatchToolCall: async () => {
+      actorIsolation = {
+        status: 'temporarily_unavailable', host: 'background-page-worker',
+        reason: 'worker startup failed', retryable: true,
+      };
+      return { ok: false, error: 'actor worker unavailable' };
+    },
     maybeNudgeDebuggerGrant: () => {},
     getTool: () => null,
     decideAction: () => null,
@@ -203,6 +230,16 @@ const turnDeps = (kind: 'chat' | 'actor' | 'spawned', {
     recordModelCall: (call: any) => recordedModelCalls.push(call),
     callModel: async function* (args: any) {
       modelCalls.push(args);
+      if (dynamicIsolation) {
+        if (modelCalls.length === 1) {
+          yield { type: 'tool-use-start', id: 'actor-tool', name: 'message_actor' };
+          yield { type: 'tool-use-stop', id: 'actor-tool' };
+          yield { type: 'message-stop', stopReason: 'tool_use' };
+        } else {
+          yield { type: 'message-stop', stopReason: 'end_turn' };
+        }
+        return;
+      }
       if (abortDuringFallback) {
         modelKeyReads.push(args.provider);
         await args.getSecret(args.provider);
@@ -223,7 +260,7 @@ const turnDeps = (kind: 'chat' | 'actor' | 'spawned', {
       }
       yield { type: 'message-stop', stopReason: 'end_turn' };
     },
-    runUserTurn: async function* (ctx: any) {
+    runUserTurn: dynamicIsolation ? runUserTurn : async function* (ctx: any) {
       loopCtx = ctx;
       if (boundaryFailure) {
         await ctx.safeFetch('https://provider.invalid');
@@ -259,6 +296,7 @@ const turnDeps = (kind: 'chat' | 'actor' | 'spawned', {
     currentAppScope: async () => null,
     checkpointMgr: { capture: async () => {} },
     detectInterruptedTurn: () => ({ resumable: false }),
+    getActorIsolation: () => actorIsolation,
     waitForActorIsolation,
   });
   return {
@@ -267,6 +305,7 @@ const turnDeps = (kind: 'chat' | 'actor' | 'spawned', {
     liveGetSecret, liveSafeFetch,
     rogueGetSecret, rogueSafeFetch, rogueSignal,
     audits,
+    systemPromptRenders: () => systemPromptRenders,
     releases: () => releases,
     loopCtx: () => loopCtx,
     toolContextArgs: () => toolContextArgs,
@@ -286,6 +325,21 @@ describe('runAgentTurn credential custody', () => {
     releaseReady();
     await running;
     expect(fixture.modelCalls).toHaveLength(1);
+  });
+
+  test('a mid-turn actor-host failure updates the next model prompt', async () => {
+    const fixture = turnDeps('chat', { dynamicIsolation: true });
+    expect(await fixture.driver.runAgentTurn({ sessionId: 's1', userText: 'delegate work' }))
+      .toEqual({ ok: true, stopReason: 'end_turn' });
+    expect(fixture.modelCalls).toHaveLength(2);
+    expect(fixture.modelCalls[0].system).not.toContain('<actor_execution');
+    expect(fixture.modelCalls[0].tools.map((tool: any) => tool.name))
+      .toEqual(['message_actor', 'actor_create', 'request_review', 'actor_list']);
+    expect(fixture.modelCalls[1].system)
+      .toContain('<actor_execution status="temporarily_unavailable">');
+    expect(fixture.modelCalls[1].system).toContain('Do not retry automatically');
+    expect(fixture.modelCalls[1].tools.map((tool: any) => tool.name)).toEqual(['actor_list']);
+    expect(fixture.systemPromptRenders()).toBe(1);
   });
 
   test('a bound actor session is refused before the background loop, tools, or model', async () => {

--- a/tests/peerd-runtime/loop/turn-driver.test.ts
+++ b/tests/peerd-runtime/loop/turn-driver.test.ts
@@ -10,9 +10,7 @@
 
 import { describe, test, expect } from 'bun:test';
 import { inboundActorCallAllowed, makeTurnDriver } from '/peerd-runtime/loop/turn-driver.js';
-import {
-  ACTOR_CREDENTIAL_BOUNDARY_FAILURE, ActorCredentialBoundaryError,
-} from '/peerd-runtime/errors.js';
+import { ACTOR_CREDENTIAL_BOUNDARY_FAILURE } from '/peerd-runtime/errors.js';
 
 /** Minimal deps maybeAutoResume touches; the rest stay undefined (never invoked). */
 const deps = (/** @type {any} */ over: any = {}) => ({
@@ -32,7 +30,7 @@ test('makeTurnDriver returns the two entry points', () => {
   expect(typeof d.maybeAutoResume).toBe('function');
 });
 
-test('the in-SW inbound dweb fallback rejects forged hidden/signing tool calls', () => {
+test('the inbound dweb policy rejects forged hidden/signing tool calls', () => {
   expect(inboundActorCallAllowed({
     isActor: true, inbound: true, actorType: 'dweb', name: 'dweb_peers',
   })).toBe(true);
@@ -109,9 +107,10 @@ test('maybeAutoResume does not resume a turn that is not resumable', async () =>
   expect(noted).toBe(false);
 });
 
-const turnDeps = (kind: 'chat' | 'actor', {
+const turnDeps = (kind: 'chat' | 'actor' | 'spawned', {
   failover = false, boundaryFailure = false, streamBoundaryFailure = false,
   waitForAbort = false, abortDuringFallback = false, uiDisconnected = false,
+  waitForActorIsolation = async () => {},
 } = {}) => {
   const liveGetSecret = async () => 'sk-live';
   const liveSafeFetch = async () => new Response('ok');
@@ -132,6 +131,8 @@ const turnDeps = (kind: 'chat' | 'actor', {
   const broadcasts: any[] = [];
   const chatNotes: string[] = [];
   let lateProviderContinuation = 0;
+  const audits: any[] = [];
+  let releases = 0;
   const settings = {
     reasoningEnabled: false,
     reasoningEffort: 'medium',
@@ -154,7 +155,7 @@ const turnDeps = (kind: 'chat' | 'actor', {
     },
     sessionState: { set: () => {} },
     turnSlots: {
-      claim: () => ({ controller: turnAbortController, release: () => {} }),
+      claim: () => ({ controller: turnAbortController, release: () => { releases++; } }),
       isBusy: () => false,
     },
     buildTemporalBlock: () => '',
@@ -188,7 +189,7 @@ const turnDeps = (kind: 'chat' | 'actor', {
     makeTurnCostTracker: () => ({ onUsage: async () => {}, maybeHalt: () => {} }),
     uiConnected: () => !uiDisconnected && (boundaryFailure || streamBoundaryFailure),
     uiPorts: { broadcast: (message: any) => broadcasts.push(message) },
-    auditLog: { append: async () => {} },
+    auditLog: { append: async (entry: any) => { audits.push(entry); } },
     postChatNote: (note: string) => { chatNotes.push(note); },
     resolveFailoverChain: (start: any) => abortDuringFallback
       ? [
@@ -258,12 +259,15 @@ const turnDeps = (kind: 'chat' | 'actor', {
     currentAppScope: async () => null,
     checkpointMgr: { capture: async () => {} },
     detectInterruptedTurn: () => ({ resumable: false }),
+    waitForActorIsolation,
   });
   return {
     driver, modelCalls, modelKeyReads, broadcasts, chatNotes, turnAbortController,
     recordedModelCalls,
     liveGetSecret, liveSafeFetch,
     rogueGetSecret, rogueSafeFetch, rogueSignal,
+    audits,
+    releases: () => releases,
     loopCtx: () => loopCtx,
     toolContextArgs: () => toolContextArgs,
     lateProviderContinuation: () => lateProviderContinuation,
@@ -271,88 +275,85 @@ const turnDeps = (kind: 'chat' | 'actor', {
 };
 
 describe('runAgentTurn credential custody', () => {
-  test('a bound actor loop gets stubs while the provider call gets live credentials', async () => {
+  test('a turn cannot snapshot actor isolation before durable host health is ready', async () => {
+    let releaseReady = () => {};
+    const ready = new Promise<void>((resolve) => { releaseReady = resolve; });
+    const fixture = turnDeps('chat', { waitForActorIsolation: () => ready });
+    const running = fixture.driver.runAgentTurn({ sessionId: 's1', userText: 'hello' });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fixture.modelCalls).toEqual([]);
+    expect(fixture.toolContextArgs()).toBeNull();
+    releaseReady();
+    await running;
+    expect(fixture.modelCalls).toHaveLength(1);
+  });
+
+  test('a bound actor session is refused before the background loop, tools, or model', async () => {
     const fixture = turnDeps('actor');
     expect(await fixture.driver.runAgentTurn({ sessionId: 's1', userText: 'inspect the page' }))
-      .toEqual({ ok: true, stopReason: 'end_turn' });
+      .toBeUndefined();
 
-    const ctx = fixture.loopCtx();
-    expect(ctx).not.toBeNull();
-    await expect(ctx.getSecret('anthropic')).rejects.toBeInstanceOf(ActorCredentialBoundaryError);
-    await expect(ctx.getSecret('anthropic')).rejects.toMatchObject({ capability: 'secret' });
-    await expect(ctx.safeFetch('https://example.com')).rejects.toMatchObject({
-      name: 'ActorCredentialBoundaryError', capability: 'provider-network',
-    });
-    expect(fixture.toolContextArgs()).toMatchObject({
-      exposure: 'actor', sessionId: 's1',
-      actorInstanceId: 'web', actorType: 'web',
-    });
-    expect(fixture.modelCalls).toHaveLength(1);
-    expect(fixture.modelCalls[0]).toMatchObject({
-      provider: 'anthropic',
-      model: 'claude-test',
-      ollamaHost: 'http://127.0.0.1:11434',
-    });
-    expect(fixture.modelCalls[0].signal).toBe(fixture.turnAbortController.signal);
-    expect(fixture.modelCalls[0].signal).not.toBe(fixture.rogueSignal);
-    expect(fixture.modelCalls[0].getSecret).toBe(fixture.liveGetSecret);
-    expect(fixture.modelCalls[0].safeFetch).toBe(fixture.liveSafeFetch);
-    expect(fixture.modelCalls[0].getSecret).not.toBe(fixture.rogueGetSecret);
-    expect(fixture.modelCalls[0].safeFetch).not.toBe(fixture.rogueSafeFetch);
-    expect(await fixture.modelCalls[0].getSecret('anthropic')).toBe('sk-live');
-    expect(fixture.recordedModelCalls).toHaveLength(1);
-    expect(fixture.recordedModelCalls[0]).toMatchObject({
-      provider: 'anthropic', model: 'claude-test',
-      sessionId: 's1', label: 'actor web (in-SW)',
+    expect(fixture.loopCtx()).toBeNull();
+    expect(fixture.toolContextArgs()).toBeNull();
+    expect(fixture.modelCalls).toEqual([]);
+    expect(fixture.recordedModelCalls).toEqual([]);
+    expect(fixture.releases()).toBe(1);
+    expect(fixture.audits).toContainEqual({
+      type: 'actor_background_turn_refused',
+      sessionId: 's1',
+      details: { reason: 'dedicated_worker_required', performed: false },
     });
   });
 
-  test('a custody trip maps to accurate not-run and recovery language', async () => {
-    const fixture = turnDeps('actor', { boundaryFailure: true });
-    expect(await fixture.driver.runAgentTurn({
-      sessionId: 's1', userText: 'inspect the page',
-      display: { parentToolUseId: 'tool-1', kind: 'web', instanceId: 'web' },
-    })).toEqual({ ok: false, stopReason: null });
+  test('a spawned actor session is refused before the background loop, tools, or model', async () => {
+    const fixture = turnDeps('spawned');
+    expect(await fixture.driver.runAgentTurn({ sessionId: 's1', userText: 'continue delegated work' }))
+      .toBeUndefined();
 
-    const errors = fixture.broadcasts.filter((message) =>
-      message.type === 'turn/error' || message.type === 'turn/actor-error');
-    expect(errors).toHaveLength(2);
-    expect(errors.every((message) => message.error === ACTOR_CREDENTIAL_BOUNDARY_FAILURE)).toBe(true);
+    expect(fixture.loopCtx()).toBeNull();
+    expect(fixture.toolContextArgs()).toBeNull();
+    expect(fixture.modelCalls).toEqual([]);
+    expect(fixture.recordedModelCalls).toEqual([]);
+    expect(fixture.releases()).toBe(1);
+    expect(fixture.audits).toContainEqual({
+      type: 'actor_background_turn_refused',
+      sessionId: 's1',
+      details: { reason: 'dedicated_worker_required', performed: false },
+    });
+  });
+
+  test('the custody refusal keeps stable model-facing recovery language', () => {
     expect(ACTOR_CREDENTIAL_BOUNDARY_FAILURE).toContain('model request was not run');
     expect(ACTOR_CREDENTIAL_BOUNDARY_FAILURE).toContain('Do not retry automatically');
     expect(ACTOR_CREDENTIAL_BOUNDARY_FAILURE).toContain('Ask the user to reload peerd');
     expect(ACTOR_CREDENTIAL_BOUNDARY_FAILURE).not.toContain('no egress');
   });
 
-  test('a production loop error event fails the turn and actor completion', async () => {
-    const fixture = turnDeps('actor', { streamBoundaryFailure: true });
+  test('a production loop error event fails a chat turn', async () => {
+    const fixture = turnDeps('chat', { streamBoundaryFailure: true });
     expect(await fixture.driver.runAgentTurn({
       sessionId: 's1', userText: 'inspect the page',
-      display: { parentToolUseId: 'tool-1', kind: 'web', instanceId: 'web' },
     })).toEqual({ ok: false, stopReason: undefined });
 
     expect(fixture.broadcasts).toContainEqual(expect.objectContaining({
       type: 'turn/error', error: ACTOR_CREDENTIAL_BOUNDARY_FAILURE,
     }));
-    expect(fixture.broadcasts).toContainEqual(expect.objectContaining({
-      type: 'turn/actor-done', ok: false,
-    }));
+    expect(fixture.broadcasts.some((message) => message.type === 'turn/actor-done')).toBe(false);
   });
 
   test('a production loop error fails a background turn with no UI broadcasts', async () => {
-    const fixture = turnDeps('actor', {
+    const fixture = turnDeps('chat', {
       streamBoundaryFailure: true,
       uiDisconnected: true,
     });
     expect(await fixture.driver.runAgentTurn({
       sessionId: 's1', userText: 'inspect the page',
-      display: { parentToolUseId: 'tool-1', kind: 'web', instanceId: 'web' },
     })).toEqual({ ok: false, stopReason: undefined });
     expect(fixture.broadcasts).toEqual([]);
   });
 
-  test('actor cancellation reaches the exact broker signal with no late provider continuation', async () => {
-    const fixture = turnDeps('actor', { waitForAbort: true });
+  test('chat cancellation reaches the exact broker signal with no late provider continuation', async () => {
+    const fixture = turnDeps('chat', { waitForAbort: true });
     const running = fixture.driver.runAgentTurn({ sessionId: 's1', userText: 'inspect the page' });
     for (let attempt = 0; attempt < 20 && fixture.modelCalls.length === 0; attempt += 1) {
       await new Promise((resolve) => setTimeout(resolve, 0));
@@ -365,7 +366,7 @@ describe('runAgentTurn credential custody', () => {
   });
 
   test('Stop on a fallback never calls or keys the next candidate', async () => {
-    const fixture = turnDeps('actor', { abortDuringFallback: true });
+    const fixture = turnDeps('chat', { abortDuringFallback: true });
     const running = fixture.driver.runAgentTurn({ sessionId: 's1', userText: 'inspect the page' });
     for (let attempt = 0; attempt < 20 && fixture.modelCalls.length < 2; attempt += 1) {
       await new Promise((resolve) => setTimeout(resolve, 0));
@@ -389,19 +390,11 @@ describe('runAgentTurn credential custody', () => {
     expect(fixture.modelCalls[0].safeFetch).toBe(fixture.liveSafeFetch);
   });
 
-  test('every actor failover candidate receives only the trusted broker credentials', async () => {
+  test('an actor session cannot reach a failover provider in the background heap', async () => {
     const fixture = turnDeps('actor', { failover: true });
     await fixture.driver.runAgentTurn({ sessionId: 's1', userText: 'inspect the page' });
 
-    expect(fixture.modelCalls).toHaveLength(2);
-    expect(fixture.modelCalls.map((call) => [call.provider, call.model]))
-      .toEqual([
-        ['anthropic', 'claude-test'],
-        ['openrouter', 'fallback-model'],
-      ]);
-    for (const call of fixture.modelCalls) {
-      expect(call.getSecret).toBe(fixture.liveGetSecret);
-      expect(call.safeFetch).toBe(fixture.liveSafeFetch);
-    }
+    expect(fixture.modelCalls).toEqual([]);
+    expect(fixture.recordedModelCalls).toEqual([]);
   });
 });

--- a/tests/peerd-runtime/sessions/custom-system-prompt.test.ts
+++ b/tests/peerd-runtime/sessions/custom-system-prompt.test.ts
@@ -15,7 +15,6 @@ import {
 } from '../../../extension/peerd-runtime/loop/system-prompt.js';
 import { makeSpawnActor } from '../../../extension/peerd-runtime/actor/spawn.js';
 import type { Session } from '../../../extension/peerd-runtime/sessions/types.js';
-import type { LoopEvent } from '../../../extension/peerd-runtime/loop/agent-loop.js';
 
 // ---- minimal in-memory IDB (keyed by sessionId, like the real wrapper) ----
 const makeIdb = () => {
@@ -192,15 +191,6 @@ describe('buildTemporalContext — ephemeral <active_tab> reorientation', () => 
 });
 
 describe('actor spawn — customSystemPrompt is NOT inherited', () => {
-  // Tiny loop stand-in: render the prompt (so the spy fires), finish.
-  async function* loop(ctx: any): AsyncGenerator<LoopEvent> {
-    await ctx.getSystemPrompt();
-    await ctx.sessions.appendMessage(ctx.sessionId, {
-      role: 'assistant', content: 'child done', id: 'a1', when: 2,
-    });
-    yield { type: 'stop', sessionId: ctx.sessionId, messageId: 'a1', stopReason: 'end_turn' };
-  }
-
   test('the child render gets taskOverride only — no parent session instructions', async () => {
     const store = makeStore();
     const parent = await store.create({ customSystemPrompt: 'parent-only secret style guide' });
@@ -208,14 +198,15 @@ describe('actor spawn — customSystemPrompt is NOT inherited', () => {
     const renderCalls: any[] = [];
     const spawn = makeSpawnActor({
       sessions: store,
-      runUserTurn: loop,
-      callModel: async function* () { yield { type: 'message-stop', stopReason: 'end_turn' }; },
-      getSecret: async () => 'sk',
-      safeFetch: async () => new Response('ok'),
       appendAudit: async () => {},
-      buildToolContext: async () => ({ audit: async () => {} }),
-      dispatchToolCall: async () => ({ ok: true, content: 'r' }),
-      renderSystemPrompt: async (opts: any) => { renderCalls.push(opts); return 'sys'; },
+      renderSystemPromptForChild: async (task: string) => {
+        renderCalls.push({ taskOverride: task });
+        return 'sys';
+      },
+      runChildOffscreen: async () => ({
+        ok: true, started: true, finalText: 'child done',
+        newMessages: [{ role: 'assistant', content: 'child done', id: 'a1', when: 2 }],
+      }),
       getToolDescriptors: () => [],
     });
 

--- a/tests/peerd-runtime/sessions/per-message-store.test.ts
+++ b/tests/peerd-runtime/sessions/per-message-store.test.ts
@@ -104,6 +104,104 @@ describe('session store v2 — per-message records', () => {
     expect(idb._tbl('session_messages').get('m2').sessionId).toBe(s.sessionId);
   });
 
+  test('appendMessage is idempotent for a stable message id', async () => {
+    const idb = makeIdb();
+    const store = makeStore(idb);
+    const s = await store.create();
+    const receipt = { role: 'user', content: 'Outcome unknown', id: 'actor-recovery:1', when: 1 } as any;
+
+    await store.appendMessage(s.sessionId, receipt);
+    const out = await store.appendMessage(s.sessionId, { ...receipt, when: 2 });
+
+    expect(out.messages.map((m: any) => m.id)).toEqual(['actor-recovery:1']);
+    expect(out.messages[0].when).toBe(1);
+    expect(idb._tbl('sessions').get(s.sessionId).msgIndex).toEqual(['actor-recovery:1']);
+  });
+
+  test('concurrent appends to one session preserve both ordered message ids', async () => {
+    const idb = makeIdb();
+    const store = makeStore(idb);
+    const s = await store.create();
+
+    await Promise.all([
+      store.appendMessage(s.sessionId, { role: 'user', content: 'one', id: 'm-concurrent-1', when: 1 } as any),
+      store.appendMessage(s.sessionId, { role: 'assistant', content: 'two', id: 'm-concurrent-2', when: 2 } as any),
+    ]);
+
+    expect(idb._tbl('sessions').get(s.sessionId).msgIndex).toEqual(['m-concurrent-1', 'm-concurrent-2']);
+    expect((await store.get(s.sessionId))!.messages.map((message: any) => message.id))
+      .toEqual(['m-concurrent-1', 'm-concurrent-2']);
+  });
+
+  test('a metadata update cannot erase an append that is between its row and index commits', async () => {
+    const base = makeIdb();
+    let armed = false;
+    let metadataReads = 0;
+    let releaseWrite = () => {};
+    let signalWriteStarted = () => {};
+    const writeStarted = new Promise<void>((resolve) => { signalWriteStarted = resolve; });
+    const writeReleased = new Promise<void>((resolve) => { releaseWrite = resolve; });
+    const idb = {
+      ...base,
+      get: async (store: string, key: string) => {
+        if (armed && store === 'sessions') metadataReads += 1;
+        return base.get(store, key);
+      },
+      put: async (store: string, value: any) => {
+        if (armed && store === 'sessions') {
+          armed = false;
+          signalWriteStarted();
+          await writeReleased;
+        }
+        await base.put(store, value);
+      },
+    };
+    const store = makeStore(idb);
+    const session = await store.create();
+    armed = true;
+
+    const append = store.appendMessage(session.sessionId, {
+      role: 'user', content: 'kept', id: 'm-race', when: 1,
+    } as any);
+    const setCost = store.setCost(session.sessionId, { input: 1, output: 2, total: 3 } as any);
+    await writeStarted;
+
+    // The cost writer must not read the stale pre-append metadata snapshot.
+    expect(metadataReads).toBe(1);
+    releaseWrite();
+    await Promise.all([append, setCost]);
+
+    const raw = base._tbl('sessions').get(session.sessionId);
+    expect(raw.msgIndex).toEqual(['m-race']);
+    expect(raw.cost).toEqual({ input: 1, output: 2, total: 3 });
+  });
+
+  test('the post-append hook runs after the session index commit and cannot fail the append', async () => {
+    const idb = makeIdb();
+    const observations: any[] = [];
+    let calls = 0;
+    const store = createSessionStore({
+      idb,
+      now: () => 1000,
+      makeId: () => 'session-hook',
+      onMessageAppended: async (sessionId, message: any) => {
+        calls += 1;
+        observations.push([...idb._tbl('sessions').get(sessionId).msgIndex]);
+        expect(idb._tbl('session_messages').get(message.id).message).toEqual(message);
+        throw new Error('post-commit acknowledgement unavailable');
+      },
+    });
+    const s = await store.create();
+    const message = { role: 'user', content: '', id: 'tool-result-1', when: 1 } as any;
+
+    await store.appendMessage(s.sessionId, message);
+    await store.appendMessage(s.sessionId, message);
+
+    expect(calls).toBe(2);
+    expect(observations).toEqual([['tool-result-1'], ['tool-result-1']]);
+    expect((await store.get(s.sessionId))!.messages.map((entry: any) => entry.id)).toEqual(['tool-result-1']);
+  });
+
   test('updateAssistantMessage patches ONLY the message record, never the session blob', async () => {
     const idb = makeIdb();
     const store = makeStore(idb);

--- a/tests/peerd-runtime/spawn.test.ts
+++ b/tests/peerd-runtime/spawn.test.ts
@@ -650,7 +650,7 @@ describe('actor context building', () => {
   });
 });
 
-describe('makeSpawnActor — isolated job inputs', () => {
+describe('makeSpawnActor: isolated job inputs', () => {
   test('the worker receives the exact task and provenance remains visible', async () => {
     const store = makeStore();
     const parent = await store.create({});

--- a/tests/peerd-runtime/spawn.test.ts
+++ b/tests/peerd-runtime/spawn.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import {
+  ActorPersistenceError,
   makeSpawnActor,
   narrowTools,
   finalActorTurnReply, finalAssistantText,
@@ -239,6 +240,50 @@ const makeMockLoop = (opts: { finalText?: string; toolUses?: number; stopReason?
 const baseDeps = (store: any, loop: any, extra: any = {}) => {
   const audits: any[] = [];
   const modelCalls: any[] = [];
+  const renderSystemPrompt = extra.renderSystemPrompt
+    ?? (async ({ taskOverride }: any) => `sys task=${taskOverride}`);
+  const runChildOffscreen = Object.hasOwn(extra, 'runChildOffscreen')
+    ? extra.runChildOffscreen
+    : async (job: any, opts: any = {}) => {
+    const newMessages: any[] = [];
+    const usage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+    let toolCalls = 0;
+    let stopReason = 'end_turn';
+    const callModel = async function* (args: any) {
+      modelCalls.push({ ...args, maxTokens: job.maxOutputTokens });
+      yield { type: 'message-stop', stopReason: 'end_turn' };
+    };
+    const sessions = {
+      appendMessage: async (_sessionId: string, message: any) => {
+        newMessages.push(message);
+        return message;
+      },
+    };
+    for await (const event of loop({
+      sessionId: job.sessionId,
+      userText: job.task,
+      callModel,
+      sessions,
+      tools: job.tools,
+      maxSteps: job.maxSteps,
+      maxOutputTokens: job.maxOutputTokens,
+      getSystemPrompt: async () => job.systemPrompt,
+      signal: opts.signal,
+    })) {
+      opts.onEvent?.(event);
+      if (event.type === 'tool-use') toolCalls++;
+      if (event.type === 'stop') stopReason = event.stopReason;
+      if (event.type === 'usage') {
+        usage.inputTokens += event.usage?.inputTokens ?? 0;
+        usage.outputTokens += event.usage?.outputTokens ?? 0;
+        usage.cacheReadTokens += event.usage?.cacheReadTokens ?? 0;
+        usage.cacheWriteTokens += event.usage?.cacheWriteTokens ?? 0;
+      }
+    }
+    const finalText = [...newMessages].reverse()
+      .find((message) => message.role === 'assistant' && message.content)?.content ?? '';
+    return { ok: true, started: true, finalText, newMessages, usage, stopReason, toolCalls };
+    };
   return {
     audits,
     modelCalls,
@@ -251,7 +296,9 @@ const baseDeps = (store: any, loop: any, extra: any = {}) => {
       appendAudit: async (e: any) => { audits.push(e); },
       buildToolContext: async ({ sessionId }: any) => ({ session: { sessionId }, audit: async () => {} }),
       dispatchToolCall: async () => ({ ok: true, content: 'tool ran' }),
-      renderSystemPrompt: async ({ taskOverride }: any) => `sys task=${taskOverride}`,
+      renderSystemPrompt,
+      renderSystemPromptForChild: (task: string) => renderSystemPrompt({ taskOverride: task }),
+      runChildOffscreen,
       getToolDescriptors: () => [
         { name: 'a', description: 'A', schema: {} },
         { name: 'b', description: 'B', schema: {} },
@@ -263,76 +310,51 @@ const baseDeps = (store: any, loop: any, extra: any = {}) => {
   };
 };
 
-// The in-SW fallback path (Firefox / a run that never started offscreen) has no
-// heap separation — that is the standing residual. What it MUST have is the
-// offscreen path's credential custody: the child loop is handed throwing stubs and
-// the real getSecret/safeFetch are added by the SW-owned callModel wrapper at the
-// call boundary. Before this, the live credentials went straight into runUserTurn,
-// so the "keyless fallback" claim held for the tool context but not for the loop.
-describe('makeSpawnActor — the in-SW fallback loop is keyless', () => {
-  test('the loop gets THROWING credential stubs, never the live ones', async () => {
-    const store = makeStore();
-    const parent = await store.create({});
-    let loopCtx: any = null;
-    async function* loop(ctx: any) {
-      loopCtx = ctx;
-      for await (const _ of ctx.callModel({ messages: [], system: 's', tools: [] })) { /* drain */ }
-      await ctx.sessions.appendMessage(ctx.sessionId, { role: 'assistant', content: 'done' });
-      yield { type: 'stop', sessionId: ctx.sessionId, stopReason: 'end_turn' };
-    }
-    const { deps } = baseDeps(store, loop);
-    await makeSpawnActor(deps)({ task: 't', parentSessionId: parent.sessionId });
-
-    expect(loopCtx).not.toBeNull();
-    // Not the injected live credentials — and not merely absent: calling them
-    // throws, so a loop (or anything reachable from its frame) that reaches for
-    // the key fails loudly instead of silently succeeding.
-    await expect(loopCtx.getSecret('anthropic')).rejects.toMatchObject({
-      name: 'ActorCredentialBoundaryError', capability: 'secret',
-    });
-    await expect(loopCtx.safeFetch('https://example.com')).rejects.toMatchObject({
-      name: 'ActorCredentialBoundaryError', capability: 'provider-network',
-    });
-  });
-
-  test('the model call still receives the REAL credentials from the wrapper', async () => {
-    const store = makeStore();
-    const parent = await store.create({});
-    // The loop must forward ctx.getSecret/ctx.safeFetch into ctx.callModel, exactly as
-    // the real agent-loop does. why that matters here: the stubs and the real
-    // credentials COLLIDE in cappedCallModel's object literal, and only the spread
-    // order ({...modelArgs, getSecret, safeFetch}) decides which wins. A mock that
-    // omits the forward never creates the collision, so the natural deps-first
-    // ordering — which hands every in-SW model call a getSecret that throws and kills
-    // the whole fallback lane — would pass. Mutation-checked: flipping the order in
-    // spawn.js fails this test.
-    let loopCtx: any = null;
-    async function* loop(ctx: any) {
-      loopCtx = ctx;
-      const stream = ctx.callModel({
-        messages: [], system: 's', tools: [],
-        getSecret: ctx.getSecret, safeFetch: ctx.safeFetch,
-      });
-      for await (const _ of stream) { /* drain */ }
-      await ctx.sessions.appendMessage(ctx.sessionId, { role: 'assistant', content: 'done' });
-      yield { type: 'stop', sessionId: ctx.sessionId, stopReason: 'end_turn' };
-    }
-    const { deps, modelCalls } = baseDeps(store, loop);
-    await makeSpawnActor(deps)({ task: 't', parentSessionId: parent.sessionId });
-
-    // Custody moved to the call boundary, so the child can still think — the
-    // point is WHERE the key is reachable, not that the lane stops working.
-    expect(modelCalls.length).toBeGreaterThan(0);
-    expect(await modelCalls[0].getSecret('anthropic')).toBe('sk-test');
-    expect(typeof modelCalls[0].safeFetch).toBe('function');
-    // And the loop's own view is still the stub, even though it forwarded it.
-    await expect(loopCtx.getSecret('anthropic')).rejects.toMatchObject({
-      name: 'ActorCredentialBoundaryError', capability: 'secret',
-    });
-  });
-});
-
 describe('makeSpawnActor', () => {
+  test('refuses when no dedicated worker host is wired', async () => {
+    const store = makeStore();
+    const parent = await store.create({});
+    let loopRuns = 0;
+    async function* loop() { loopRuns++; yield { type: 'stop', stopReason: 'end_turn' }; }
+    const { deps, audits, modelCalls } = baseDeps(store, loop, {
+      runChildOffscreen: null,
+      renderSystemPromptForChild: null,
+      buildToolContext: async () => { throw new Error('tool context must not be built'); },
+    });
+
+    const result = await makeSpawnActor(deps)({ task: 't', parentSessionId: parent.sessionId });
+
+    expect(result.refused).toBe(true);
+    expect(result.result).toContain('no dedicated worker host is wired');
+    expect(loopRuns).toBe(0);
+    expect(modelCalls).toEqual([]);
+    expect(audits).toContainEqual(expect.objectContaining({
+      type: 'actor_isolation_failure', details: expect.objectContaining({ performed: false }),
+    }));
+  });
+
+  test('a worker startup failure never falls back to the background loop', async () => {
+    const store = makeStore();
+    const parent = await store.create({});
+    let loopRuns = 0;
+    async function* loop() { loopRuns++; yield { type: 'stop', stopReason: 'end_turn' }; }
+    const { deps, audits, modelCalls } = baseDeps(store, loop, {
+      runChildOffscreen: async () => ({
+        ok: false, started: false, code: 'actor_worker_spawn_failed', error: 'worker failed to start',
+      }),
+    });
+
+    const result = await makeSpawnActor(deps)({ task: 't', parentSessionId: parent.sessionId });
+
+    expect(result.refused).toBe(true);
+    expect(result.result).toContain('worker failed to start');
+    expect(loopRuns).toBe(0);
+    expect(modelCalls).toEqual([]);
+    expect(audits).toContainEqual(expect.objectContaining({
+      type: 'actor_isolation_failure', details: expect.objectContaining({ performed: false }),
+    }));
+  });
+
   test('creates an actor session with parentage and inherits the parent model', async () => {
     const store = makeStore();
     const parent = await store.create({ model: 'parent-model' });
@@ -351,6 +373,28 @@ describe('makeSpawnActor', () => {
     expect(child.model).toBe('parent-model');   // inherited model
     expect(out.result).toBe('hello from child');
     expect(out.depth).toBe(1);
+  });
+
+  test('fails explicitly when an isolated result cannot be persisted', async () => {
+    const store = makeStore();
+    const parent = await store.create({});
+    const { loop } = makeMockLoop({ finalText: 'work may have happened' });
+    const { deps, audits } = baseDeps(store, loop);
+    store.appendMessage = async () => { throw new Error('idb unavailable'); };
+    const spawn = makeSpawnActor(deps);
+
+    try {
+      await spawn({ task: 'do a thing', parentSessionId: parent.sessionId });
+      throw new Error('expected persistence failure');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ActorPersistenceError);
+      expect((error as Error).message).toContain('outcome is unknown');
+      expect((error as Error).message).toContain('must not be retried automatically');
+    }
+    expect(audits).toContainEqual(expect.objectContaining({
+      type: 'actor_persistence_failed',
+      details: expect.objectContaining({ performed: true, outcomeKnown: false }),
+    }));
   });
 
   test('inherits the parent Plan/Act permission into the child record', async () => {
@@ -577,7 +621,7 @@ describe('actor context building', () => {
     expect(seenSystem).toBe('sys task=a thing'); // base+taskOverride path
   });
 
-  test('buildToolContext is called without a tab pin (no activeTabId)', async () => {
+  test('does not build a privileged tool context in the spawning heap', async () => {
     const store = makeStore();
     const parent = await store.create({});
     const ctxArgs: any[] = [];
@@ -587,8 +631,7 @@ describe('actor context building', () => {
     });
     const spawn = makeSpawnActor(deps);
     await spawn({ task: 'a thing', parentSessionId: parent.sessionId });
-    expect(ctxArgs.length).toBe(1);
-    expect(ctxArgs[0].activeTabId).toBeUndefined();
+    expect(ctxArgs.length).toBe(0);
   });
 
   test('accumulates child model usage and returns it (separate from the parent tally)', async () => {
@@ -607,13 +650,13 @@ describe('actor context building', () => {
   });
 });
 
-describe('makeSpawnActor — persistDeltas (ephemeral speed path)', () => {
-  test('persistDeltas:false threads to the loop; userText is exactly the task', async () => {
+describe('makeSpawnActor — isolated job inputs', () => {
+  test('the worker receives the exact task and provenance remains visible', async () => {
     const store = makeStore();
     const parent = await store.create({});
     const seen: any[] = [];
     async function* loop(ctx: any) {
-      seen.push({ userText: ctx.userText, persistDeltas: ctx.persistDeltas });
+      seen.push({ userText: ctx.userText });
       await ctx.sessions.appendMessage(ctx.sessionId, { role: 'assistant', content: 'ok' });
       yield { type: 'stop', sessionId: ctx.sessionId, stopReason: 'end_turn' };
     }
@@ -623,35 +666,17 @@ describe('makeSpawnActor — persistDeltas (ephemeral speed path)', () => {
     const events: any[] = [];
     await spawn({
       task: 'find the price',
-      persistDeltas: false,
       parentSessionId: parent.sessionId,
       parentDepth: 0,
       onEvent: (ev: any) => events.push(ev),
     });
 
     expect(seen[0].userText).toBe('find the price');
-    expect(seen[0].persistDeltas).toBe(false);
     const child = [...store.map.values()].find((s: any) => s.kind === 'spawned');
     expect(child.task).toBe('find the price');
     const spawned = audits.find((a: any) => a.type === 'actor_spawned');
     expect(spawned.details.task).toBe('find the price');
     const startEv = events.find((e: any) => e.type === 'actor-start');
     expect(startEv.task).toBe('find the price');
-  });
-
-  test('persistDeltas defaults true', async () => {
-    const store = makeStore();
-    const parent = await store.create({});
-    const seen: any[] = [];
-    async function* loop(ctx: any) {
-      seen.push({ userText: ctx.userText, persistDeltas: ctx.persistDeltas });
-      await ctx.sessions.appendMessage(ctx.sessionId, { role: 'assistant', content: 'ok' });
-      yield { type: 'stop', sessionId: ctx.sessionId, stopReason: 'end_turn' };
-    }
-    const { deps } = baseDeps(store, loop);
-    const spawn = makeSpawnActor(deps);
-    await spawn({ task: 'plain task', parentSessionId: parent.sessionId, parentDepth: 0 });
-    expect(seen[0].userText).toBe('plain task');
-    expect(seen[0].persistDeltas).toBe(true);
   });
 });

--- a/tests/peerd-runtime/tool-manifests.test.ts
+++ b/tests/peerd-runtime/tool-manifests.test.ts
@@ -23,9 +23,7 @@ import { mainAgentDescriptors } from '../../extension/peerd-runtime/tools/exposu
 import { narrowTools, makeSpawnActor } from '../../extension/peerd-runtime/actor/spawn.js';
 import { WEB_ACTOR_DOM_TOOLS } from '../../extension/peerd-runtime/tools/exposure.js';
 import { createSessionStore } from '../../extension/peerd-runtime/sessions/store.js';
-// why: real JSDoc contracts from source — LoopEvent shapes the mock loop's
-// yields, Session widens setToolManifest's inferred union return.
-import type { LoopEvent } from '../../extension/peerd-runtime/loop/agent-loop.js';
+// why: the source Session contract widens setToolManifest's inferred union return.
 import type { Session } from '../../extension/peerd-runtime/sessions/types.js';
 
 type ToolT = import('../../extension/shared/tool-types.js').Tool;
@@ -274,49 +272,36 @@ describe('makeSpawnActor — the parent manifest caps and follows the child', ()
 
   const harness = (store: any) => {
     const seenTools: any[] = [];
-    const dispatched: string[] = [];
-    async function* loop(ctx: any): AsyncGenerator<LoopEvent> {
-      seenTools.push(ctx.tools);
-      if (ctx.toolDispatch) {
-        await ctx.toolDispatch({ id: 't1', name: 'b', args: {} });
-        await ctx.toolDispatch({ id: 't2', name: 'c', args: {} });
-      }
-      await ctx.sessions.appendMessage(ctx.sessionId, { role: 'assistant', content: 'done' });
-      // why: LoopEvent's stop variant requires messageId; the orchestrator
-      // never reads it, so a fixed mock id just completes the shape.
-      yield { type: 'stop', sessionId: ctx.sessionId, messageId: 'm-mock', stopReason: 'end_turn' };
-    }
     const deps = {
       sessions: store,
-      runUserTurn: loop,
-      callModel: async function* () { yield { type: 'message-stop', stopReason: 'end_turn' }; },
-      getSecret: async () => 'sk',
-      safeFetch: async () => new Response('ok'),
       appendAudit: async () => {},
-      buildToolContext: async ({ sessionId }: any) => ({ session: { sessionId }, audit: async () => {} }),
-      dispatchToolCall: async (call: any) => { dispatched.push(call.name); return { ok: true, content: 'ran' }; },
-      renderSystemPrompt: async () => 'sys',
+      renderSystemPromptForChild: async () => 'sys',
+      runChildOffscreen: async (job: any) => {
+        seenTools.push(job.tools);
+        return {
+          ok: true, started: true, finalText: 'done',
+          newMessages: [{ role: 'assistant', content: 'done' }],
+        };
+      },
       getToolDescriptors: () => [
         { name: 'a', description: 'A', schema: {} },
         { name: 'b', description: 'B', schema: {} },
         { name: 'c', description: 'C', schema: {} },
       ],
     };
-    return { deps, seenTools, dispatched };
+    return { deps, seenTools };
   };
 
-  test('descriptors intersect the parent manifest; out-of-manifest dispatch is refused; child inherits the manifest', async () => {
+  test('descriptors intersect the parent manifest and the child inherits it', async () => {
     const store = makeMiniStore();
     const parent = await store.create({ toolManifest: { allow: ['b'] } });
-    const { deps, seenTools, dispatched } = harness(store);
+    const { deps, seenTools } = harness(store);
     const spawn = makeSpawnActor(deps);
 
     const out = await spawn({ task: 't', parentSessionId: parent.sessionId, tools: ['b', 'c'] });
 
     // descriptor layer: requested {b,c} ∩ manifest {b} = {b}
     expect(seenTools[0].map((t: any) => t.name)).toEqual(['b']);
-    // dispatch layer: 'c' never reached dispatchToolCall (allowedNames refusal)
-    expect(dispatched).toEqual(['b']);
     // inheritance: the child RECORD carries the parent's manifest verbatim
     const child = store.map.get(out.sessionId!);
     expect(child.toolManifest).toEqual({ allow: ['b'] });

--- a/tests/peerd-runtime/tools/dispatcher-meta.test.ts
+++ b/tests/peerd-runtime/tools/dispatcher-meta.test.ts
@@ -107,6 +107,37 @@ describe('dispatcher lineage spine fields', () => {
     expect(r.meta.sideEffect).toBe('read');   // enrichment still attached
   });
 
+  test('a lifecycle recovery rewrite preserves actor delivery custody', async () => {
+    registerTool(baseTool({
+      sideEffect: 'write',
+      execute: async () => ({
+        ok: false,
+        error: 'transport lost',
+        actorDeliveryId: 'delivery-one',
+        actorDeliveryIds: ['delivery-two', 'delivery-two'],
+      }),
+    }) as any);
+    const lifecycle = {
+      beginTracking: async () => ({ handle: { operationId: 'op-1' } }),
+      settleTracking: async () => ({
+        error: 'outcome_unknown: verify before retry',
+        recovery: { category: 'verify_before_retry' },
+      }),
+    };
+
+    const r: any = await dispatchToolCall(
+      { id: 't-custody', name: 'lt', args: {} } as any,
+      { ...ctx, lifecycle },
+    );
+
+    expect(r).toMatchObject({
+      ok: false,
+      error: 'outcome_unknown: verify before retry',
+      actorDeliveryId: 'delivery-one',
+      actorDeliveryIds: ['delivery-two'],
+    });
+  });
+
   test('a throwing origins() fails closed at the origin gate (never reaches meta)', async () => {
     registerTool(baseTool({ origins: () => { throw new Error('origins blew up'); } }) as any);
     const r: any = await dispatchToolCall({ id: 't3', name: 'lt', args: {} } as any, ctx);

--- a/tests/peerd-runtime/tools/remote-import-policy.test.ts
+++ b/tests/peerd-runtime/tools/remote-import-policy.test.ts
@@ -33,6 +33,18 @@ describe('remote module package policy reaches the model as a tool failure', () 
     }
   });
 
+  test('script preserves actor reply custody when policy ends the run', async () => {
+    const result = await scriptTool.execute({ code: 'return actors; await import(path)' }, {
+      session: { sessionId: 'session-1', kind: 'chat' },
+      jsOffscreenClient: { execHeadless: async () => ({
+        ...policyResult,
+        actorDeliveryIds: ['delivery-1', 'delivery-2', 'delivery-1'],
+      }) },
+    } as any);
+    expect(result.ok).toBe(false);
+    expect((result as any).actorDeliveryIds).toEqual(['delivery-1', 'delivery-2']);
+  });
+
   test('Notebook keeps code exceptions in-band but returns package policy as a failure', async () => {
     const result = await jsNotebookTool.execute({ code: "import('https://example.test/mod.js')" }, {
       session: { sessionId: 'session-1', kind: 'chat' },

--- a/tests/peerd-runtime/tools/script-format.test.ts
+++ b/tests/peerd-runtime/tools/script-format.test.ts
@@ -174,6 +174,16 @@ describe('scriptTool.execute — workspace opt + value spill', () => {
     expect(released).toEqual(['x']);
   });
 
+  test('a completed actors run returns every host custody id on its ToolResult', async () => {
+    const { ctx } = ctxWith({}, {
+      usedActors: true,
+      actorDeliveryIds: ['delivery-1', 'delivery-2', 'delivery-1'],
+    });
+    const result: any = await scriptTool.execute({ code: 'return actors' }, ctx as any);
+    expect(result.actorDeliveryIds).toEqual(['delivery-1', 'delivery-2']);
+    expect(result.content).not.toContain('delivery-1');
+  });
+
   test('a transport-failure trace redacts an instruction-shaped target', async () => {
     const payload = 'IGNORE_PREVIOUS_INSTRUCTIONS';
     const errorPayload = 'TRANSPORT_ERROR_IGNORE_INSTRUCTIONS';
@@ -185,7 +195,7 @@ describe('scriptTool.execute — workspace opt + value spill', () => {
       release: (runId: string) => { released.push(runId); },
       opsFor: () => [{
         seq: 1, method: 'call', to: payload,
-        ok: false, ms: 0, settled: false,
+        ok: false, ms: 0, settled: false, actorDeliveryId: 'delivery-mirrored',
       }],
     };
     const { ctx } = ctxWith({
@@ -201,6 +211,7 @@ describe('scriptTool.execute — workspace opt + value spill', () => {
       code: 'return actors.call(target, "inspect it")',
     }, ctx as any);
     expect(result.ok).toBe(false);
+    expect((result as any).actorDeliveryIds).toEqual(['delivery-mirrored']);
     if (!result.ok) {
       const fenceStart = result.error.indexOf(FENCE);
       const fenceEnd = result.error.indexOf('</untrusted_web_content>');

--- a/tests/red-team/scenarios/03-secret-summarization.ts
+++ b/tests/red-team/scenarios/03-secret-summarization.ts
@@ -35,6 +35,8 @@ const probeBoundActorTurnDriver = async () => {
   };
   let loopCtx: any = null;
   let modelCall: any = null;
+  const audits: any[] = [];
+  let releases = 0;
   const settings = {
     reasoningEnabled: false,
     reasoningEffort: 'medium',
@@ -56,7 +58,7 @@ const probeBoundActorTurnDriver = async () => {
     },
     sessionState: { set: () => {} },
     turnSlots: {
-      claim: () => ({ controller: new AbortController(), release: () => {} }),
+      claim: () => ({ controller: new AbortController(), release: () => { releases++; } }),
       isBusy: () => false,
     },
     buildTemporalBlock: () => '',
@@ -87,7 +89,7 @@ const probeBoundActorTurnDriver = async () => {
     makeTurnCostTracker: () => ({ onUsage: async () => {}, maybeHalt: () => {} }),
     uiConnected: () => false,
     uiPorts: { broadcast: () => {} },
-    auditLog: { append: async () => {} },
+    auditLog: { append: async (entry: any) => { audits.push(entry); } },
     postChatNote: () => {},
     resolveFailoverChain: (start: any) => [start],
     shouldFailover: () => false,
@@ -122,30 +124,11 @@ const probeBoundActorTurnDriver = async () => {
   });
 
   const result = await driver.runAgentTurn({ sessionId: session.sessionId, userText: 'inspect the page' });
-  const captureBoundary = async (call: () => Promise<unknown>) => {
-    try { await call(); return null; }
-    catch (error) { return error as any; }
-  };
-  const secretError = await captureBoundary(() => loopCtx.getSecret('anthropic'));
-  const networkError = await captureBoundary(() => loopCtx.safeFetch('https://example.com'));
+  const refused = audits.some((entry) => entry.type === 'actor_background_turn_refused'
+    && entry.details?.performed === false);
   return {
-    held: result.ok === true
-      && secretError?.name === 'ActorCredentialBoundaryError'
-      && secretError?.capability === 'secret'
-      && networkError?.name === 'ActorCredentialBoundaryError'
-      && networkError?.capability === 'provider-network'
-      && modelCall?.provider === session.provider
-      && modelCall?.model === session.model
-      && modelCall?.ollamaHost === settings.ollamaHost
-      && modelCall?.signal !== rogueSignal
-      && modelCall?.getSecret === liveGetSecret
-      && modelCall?.safeFetch === liveSafeFetch
-      && modelCall?.getSecret !== rogueGetSecret
-      && modelCall?.safeFetch !== rogueSafeFetch,
-    evidence: `secret=${secretError?.name}/${secretError?.capability} `
-      + `network=${networkError?.name}/${networkError?.capability} `
-      + `provider=${modelCall?.provider}/${modelCall?.model} brokerCredentials=${
-        modelCall?.getSecret === liveGetSecret && modelCall?.safeFetch === liveSafeFetch}`,
+    held: result === undefined && loopCtx === null && modelCall === null && refused && releases === 1,
+    evidence: `result=${String(result)} loopEntered=${loopCtx !== null} modelCalled=${modelCall !== null} refused=${refused} releases=${releases}`,
   };
 };
 
@@ -160,13 +143,13 @@ export const scenario: Scenario = {
   async run() {
     const probes: Probe[] = [];
 
-    // 1) Firefox bound fallback: production turn driver gives the loop named
-    // custody stubs and overwrites every broker-owned field at the provider edge.
+    // 1) The production turn driver refuses every actor session before the
+    // privileged background loop or provider boundary can run.
     {
       const proof = await probeBoundActorTurnDriver();
       probes.push(proof.held
-        ? blocked('bound Firefox actor tries to carry live credentials and broker fields in its loop frame', proof.evidence)
-        : leaked('bound Firefox actor tries to carry live credentials and broker fields in its loop frame', proof.evidence));
+        ? blocked('bound actor tries to enter the privileged background loop', proof.evidence)
+        : leaked('bound actor tries to enter the privileged background loop', proof.evidence));
     }
 
     // 2) Restricted tool context: no live provider capability survives any grant.
@@ -232,6 +215,6 @@ export const scenario: Scenario = {
         : leaked('forge </untrusted_web_content> to break out of the data fence', `defanged=${defanged} realCloses=${realCloses}`));
     }
 
-    return summarize(probes, ['makeTurnDriver (bound fallback custody and broker overwrite)', 'restrictCtxCapabilities (tool-context narrowing)', 'makeRelayedCallModel (isolated boundary function strip)', 'makeActorSummaryFence + wrapUntrusted (untrusted-data fence)', 'neutralizeFence (structural break-out defense)']);
+    return summarize(probes, ['makeTurnDriver (background actor refusal)', 'restrictCtxCapabilities (tool-context narrowing)', 'makeRelayedCallModel (isolated boundary function strip)', 'makeActorSummaryFence + wrapUntrusted (untrusted-data fence)', 'neutralizeFence (structural break-out defense)']);
   },
 };

--- a/tests/sidepanel/error-display.test.ts
+++ b/tests/sidepanel/error-display.test.ts
@@ -18,6 +18,7 @@ describe('mapError', () => {
     expect(mapError('spend-limit-reached')).toMatch(/Spend limit reached/i);
     expect(mapError('provider-usage-limit')).toMatch(/Usage\/credit limit/i);
     expect(mapError('provider-usage-limit:over cap')).toMatch(/\(over cap\)/);
+    expect(mapError('actor-recovery-pending')).toMatch(/Wait a moment, then send again/i);
   });
 
   test('raw provider throw text is matched, not dumped', () => {


### PR DESCRIPTION
## Summary

- Run Firefox actors in dedicated Workers hosted by the MV3 background page.
- Keep the background page alive only during active actor work with an acknowledged `storage.session` heartbeat. This follows the extension-side workaround documented in [Mozilla Bug 1851373](https://bugzilla.mozilla.org/show_bug.cgi?id=1851373).
- Require the first heartbeat acknowledgment before actor work starts.
- Treat heartbeat loss after start as an unknown outcome, abort the local provider consumer, revoke the relay grant, clear the mailbox grant, pause actor tools, and require a manual recovery probe.
- Keep the model informed with a structured `temporarily_unavailable` capability block and remove actor execution tools while paused.
- Show one persistent user status with a real Try again flow, an announced busy state, and a focused recovery receipt.
- Update security and architecture docs to match the implemented Firefox boundary.

## Packaged Firefox coverage

The installed Store XPI lane now proves:

- a 65 second actor request and its parent continuation complete with every extension UI page closed
- the same background heap owns actor start, product heartbeats, and completion
- the actor runs in a verified dedicated Worker realm
- a forced product heartbeat failure revokes an in-flight actor and provider relay after a real page side effect
- late provider bytes cannot change the terminal result or repeat the side effect
- the result is Outcome unknown, never Not run
- actor tools remain unavailable until the user selects Try again
- recovery restores the capability without replaying the ambiguous request
- no hidden actor or parent replay occurs beyond a full heartbeat interval
- failure artifacts use distinct screenshots, driver logs, and status JSON

## Verification

- Full release preflight with the four-package matrix: passed
- Bun: 4,978 passed, 0 failed
- In-browser: 784 passed, 0 failed
- Actor isolation E2E: 14/14
- Strict typecheck, ESLint, Firefox package lint, security boundaries, import closure, and packaged page boot: passed
- Security, CI, user UX, model UX, and accessibility adversarial reviews: ready
- Current Firefox only. ESR is not included.

The packaged Firefox GitHub runner remains the final authority for the MV3 lifetime behavior.