### PR TITLE
Guard private-network fetches from page service workers

### DIFF
--- a/docs/security/ARC-TESTING.md
+++ b/docs/security/ARC-TESTING.md
@@ -52,6 +52,8 @@ the same live target policy as every browser tool.
 |---|---|
 | Navigate or fetch a cross-origin URL with a long encoded blob in the host, credentials, or path. | Supported paths refuse the request and record the denial. |
 | Use a fetch, document-reading, or browser tool on localhost, a private network address, or cloud metadata. | The operation is refused. Driven tabs also carry a tab-scoped network rule that blocks redirects and tab-associated requests before they reach the target. |
+| From a service worker controlled by an actor-owned public page, fetch a private target. | The request does not reach the target. The no-tab rule is limited to private targets and public domains visited by the driven tab. Chrome and Firefox prove reachability before custody, blocking during custody, another origin remaining reachable, and reachability after custody closes. |
+| From that service worker, open a WebSocket to a private target. | Firefox blocks it. Chrome DNR does not intercept worker-created WebSockets. The Chrome test proves the bypass remains visible, including against an unscoped diagnostic rule, so it cannot be mistaken for covered behavior. |
 | Follow a redirect from an allowed request or navigation to a blocked destination. | The destination is refused. Browser automation stops and the tab is reset when the browser can verify the reset. |
 | From an actor-owned test page, open a child that navigates, fetches, or opens a WebSocket toward a private or denylisted target. | The protected request does not reach the target. Firefox synchronously stops the exact child's request until its tab-scoped rules are installed. A subrequest observed by that temporary stop produces a URL-free tool and Activity receipt. If DNR wins first, the block is silent. |
 | From the same test page, open a child toward a public target. | Only that child receives the driven-tab network floor, then the public navigation continues. |
@@ -76,9 +78,17 @@ Otherwise it waits for the ownership registries. This avoids changing user
 popups, but it cannot guarantee that a first child request is stopped if the
 browser discarded the session rules during the restart.
 
-The tab-scoped browser rule does not cover requests the browser attributes to no
-tab, such as a previously installed service worker. Test and track that boundary
-separately. Do not treat the tab vectors above as service-worker coverage.
+The no-tab service-worker rule is domain-scoped because the browser does not
+attribute these requests to a source tab. DNR domain matching ignores scheme and
+port and can include subdomains. A user-owned tab on the same matching domain can
+therefore lose private-network worker access while peerd drives that domain.
+Verify that peerd does not prompt, unregister the worker, or affect domains
+outside that DNR match.
+Visited domains survive extension service-worker restarts and remain covered
+until the owning tab's custody closes.
+Also keep Chrome worker WebSockets, Chrome's immediate inherited-child request
+race when native local-network checks are disabled, the page-initiated
+cross-origin redirect race, and DNS rebinding listed as residual boundaries.
 
 ## Login
 

--- a/docs/security/RED-TEAM-RESULTS.md
+++ b/docs/security/RED-TEAM-RESULTS.md
@@ -9,7 +9,7 @@
 
 _Generated from the current checkout by the command above._
 
-12 of 12 scenarios held. 178 of 178 individual hostile probes blocked.
+12 of 12 scenarios held. 180 of 180 individual hostile probes blocked.
 
 | # | Attack | Adversary | Asset | Invariant | Result |
 |---|--------|-----------|-------|-----------|--------|
@@ -176,9 +176,9 @@ _Generated from the current checkout by the command above._
 
 - Adversary: malicious webpage
 - Asset: internal network + cloud metadata credentials
-- Claim checked: Open-web and browser entry points refuse private targets, browser network rules stay tab-scoped, and child guards require exact source identity.
+- Claim checked: Open-web and browser entry points refuse private targets, no-tab worker fetch rules require a custodied page domain, and child guards require exact source identity.
 - Threat-model invariant: INV-7
-- Defenses exercised: isPrivateOrLocalHost (SSRF guard), webFetch pre-flight host check, browser automation target classifier, tab-scoped private-network DNR rules, exact-child synchronous Firefox request stop, exact-source startup child rule copy, redirect fail-closed
+- Defenses exercised: isPrivateOrLocalHost (SSRF guard), webFetch pre-flight host check, browser automation target classifier, tab-scoped private-network DNR rules, origin-scoped no-tab worker fetch DNR rules, exact-child synchronous Firefox request stop, exact-source startup child rule copy, redirect fail-closed
 - Verified in the browser by: `scripts/cdp/states.mjs (browser network floor); scripts/firefox/run-runtime-tests.mjs (Firefox private-network and child navigation probes)`
 
 | Probe (adversary action) | Result | Evidence |
@@ -218,8 +218,10 @@ _Generated from the current checkout by the command above._
 | automate IPv4-mapped IPv6 loopback via URL parser at committed_origin | blocked | browser target refused as private_network; result contains no target URL |
 | automate IPv4-mapped IPv6 metadata via URL parser at pre_navigation | blocked | browser target refused as private_network; result contains no target URL |
 | automate IPv4-mapped IPv6 metadata via URL parser at committed_origin | blocked | browser target refused as private_network; result contains no target URL |
-| turn the private-network floor into a browser-wide rule | blocked | every known rule is block-only and scoped to the driven tab |
+| turn the private-network floor into a browser-wide rule | blocked | every tab-family rule is block-only and scoped to the driven tab |
 | install the private-network floor with no driven tab | blocked | the rule builder returned no rules |
+| use a page service worker to bypass tab custody | blocked | every no-tab private-target rule requires no-tab attribution and the custodied initiator domain |
+| install a no-tab private-network rule without page custody | blocked | no initiator domain produced no rule |
 | use an ordinary source tab to acquire its child during startup | blocked | no browser rule changed without the complete exact-source rule set |
 | redirect startup protection onto an unrelated tab | blocked | the complete rule set was copied only from the exact source to the exact child |
 | claim startup child custody from a partial surviving rule set | blocked | partial browser evidence changed no rule |

--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -337,7 +337,21 @@ redirect refusal is applied by `read_pdf`'s byte fetch (`offscreen/pdf-extract.j
 Browser automation applies the same lexical classifier before navigation and
 to the committed document. Driven tabs also receive tab-scoped DNR rules for
 private hosts and address ranges, covering redirects, forms, frames, and
-tab-associated requests at the browser network layer. A page-created child is
+tab-associated requests at the browser network layer. While a public HTTP or
+HTTPS page is under peerd custody, a second private-network rule set covers
+requests that the browser attributes to no tab when their initiator domain
+matches a public domain visited by the driven tab. This covers page service-worker fetches and
+Firefox worker WebSockets without applying a browser-wide rule. Chrome DNR does
+not intercept WebSockets created inside a page service worker, even with a
+matching unscoped block rule. The live regression test keeps that residual
+visible. The scope follows browser DNR
+domain matching, so it ignores scheme and port and can include subdomains. A
+user-owned tab with the same matching domain can therefore lose private-network
+service-worker fetch access while peerd drives that domain. peerd does not prompt, unregister
+the worker, or take exclusive control of the origin. Visited domains persist in
+browser-session storage and remain covered until that tab's custody ends.
+
+A page-created child is
 blanked and guarded only when `webNavigation` reports that its exact source tab
 is already under peerd custody. Firefox also synchronously cancels private,
 local, metadata, or denylisted HTTP and WebSocket requests from that exact child
@@ -347,10 +361,9 @@ from user-owned tabs. If actor custody restores before denylist hydration, that
 exact child waits instead of treating an empty policy as permission. A protected
 child is closed after the network guard takes custody. A missing or malformed
 bundled denylist pauses tool dispatch instead of authorizing an empty policy for
-browser or open-web work. The rules never apply to tabs peerd is not driving. Requests the
-browser attributes
-to no tab, including service-worker fetches, remain outside this tab-scoped
-backstop. During a service-worker restart, early adoption requires two positive
+browser or open-web work. The tab rules never apply to tabs peerd is not driving.
+The no-tab companion is limited to domains visited by current driven tabs and
+private-network targets. During a service-worker restart, early adoption requires two positive
 signals for the exact source: restored durable custody or a restored web-actor
 binding, plus the complete surviving private-network DNR rule set.
 `background/startup-popup-network-guard.js` copies only those known block rules
@@ -358,10 +371,15 @@ to the exact child, then hands it to the restored custody set. If either signal
 is absent, peerd leaves the child unchanged until its registries finish loading.
 This avoids interfering with a user popup, but leaves a short cold-start window
 for an autonomous child if the browser lost its session rules while peerd's
-later registry restore still identifies the source as driven. DNS resolution
-and rebinding also remain outside this client-side lexical boundary.
+later registry restore still identifies the source as driven. A page-initiated
+cross-origin redirect can also begin before the browser reports the new committed
+URL and adds its no-tab domain scope. DNS resolution and rebinding remain
+outside this client-side lexical boundary. With native local-network checks
+disabled, Chrome can also start an inherited about:blank child's immediate
+private request before the extension receives enough child identity to close it.
 Code: `shared/private-network.js`, `peerd-egress/fetch/web-fetch.js`,
 `peerd-egress/denylist/dnr-rules.js`, `background/denylist-net-guard.js`,
+`background/browser-origin-custody.js`,
 `background/driven-child-request-guard.js`, `background/startup-popup-network-guard.js`,
 `peerd-runtime/tools/browser-automation-policy.js`, and
 `offscreen/pdf-extract.js`. Red-team: scenario 07.

--- a/docs/store/LISTING.md
+++ b/docs/store/LISTING.md
@@ -60,8 +60,12 @@ GUARDRAILS ON BY DEFAULT
 • Direct fetch, document reading, and browser automation block localhost,
   private-network, link-local, and cloud-metadata targets. Driven tabs use a
   tab-scoped browser network rule so redirects and tab-associated requests are
-  blocked before the target loads. Local AI providers use a separate opt-in
-  path.
+  blocked before the target loads. Private-network rules also cover service-worker
+  fetches from public domains visited in the driven tab until custody ends.
+  A normal tab on the same matching domain can temporarily lose private-network
+  service-worker fetch access.
+  Local AI providers use a
+  separate opt-in path.
 • Risky actions ask for your confirmation first.
 
 Choose a supported local provider or supply your own provider API key. peerd is

--- a/docs/store/PERMISSION-JUSTIFICATIONS.md
+++ b/docs/store/PERMISSION-JUSTIFICATIONS.md
@@ -127,10 +127,13 @@ blocker below is resolved against the package being uploaded.
 > on sensitive sites such as banks, health portals, and password managers.
 > Direct fetch, document reading, and browser automation also block
 > private-network targets. Driven tabs use tab-scoped network rules so page
-> redirects and tab-associated requests cannot bypass that check. A child tab
+> redirects and tab-associated requests cannot bypass that check. Private-network
+> rules also cover service-worker fetches from public domains visited in the
+> driven tab until custody ends. A user-owned tab on the same matching domain
+> can temporarily lose private-network service-worker fetch access. A child tab
 > is guarded only when the browser identifies its exact source as a tab the
 > assistant is already driving. Protected children are closed. Other tabs are
-> not changed.
+> not navigated, closed, or focused.
 > Provider setup and user-enabled runtime downloads are separate user-initiated
 > network uses.
 > The local Activity log records tool outcomes, direct open-web fetches, and

--- a/docs/store/PRIVACY.md
+++ b/docs/store/PRIVACY.md
@@ -51,7 +51,10 @@ some sensitive sites but is not a guarantee about the content of every page.
 peerd can request websites and APIs needed for a task. Direct fetch, document
 reading, and browser automation block private-network targets. Driven browser
 tabs also carry tab-scoped network rules for private targets and configured
-sensitive sites. The local Activity log records tool outcomes, direct open-web
+sensitive sites. Private-network rules also cover service-worker fetches from
+public domains visited in a driven tab. Those domains remain covered until the
+tab's custody ends. A normal tab on the same matching domain can temporarily
+lose private-network service-worker fetch access. The local Activity log records tool outcomes, direct open-web
 fetches, and policy denials. It is not a complete record of every network
 request or visited URL.
 

--- a/docs/store/REVIEWER-NOTES.md
+++ b/docs/store/REVIEWER-NOTES.md
@@ -154,8 +154,12 @@ task time. Page injection and page automation occur only during an active user
 task. The denylist applies to page access. Direct fetch, document reading, and
 browser automation apply private-network checks. Driven tabs also use
 tab-scoped network rules that cover redirects and tab-associated requests.
+Private-network rules also cover service-worker fetches from public domains
+visited in the driven tab until custody ends. A user-owned tab on the same
+matching domain can temporarily lose private-network service-worker fetch access.
 Children receive those rules only when the browser reports that their exact
-source tab is already under assistant control. User-owned tabs are not changed.
+source tab is already under assistant control. Other tabs are not navigated,
+closed, or focused.
 Provider setup and user-enabled runtime downloads are separate user-initiated
 network uses. Tool outcomes and policy denials are recorded locally.
 

--- a/extension/background/browser-origin-custody.js
+++ b/extension/background/browser-origin-custody.js
@@ -1,0 +1,153 @@
+// @ts-check
+
+/**
+ * Track the public page domains whose no-tab worker requests belong inside the
+ * browser network floor. Tab custody remains the authority: stale rows are
+ * ignored as soon as their tab loses its durable hold or operation lease.
+ *
+ * DNR exposes a worker's initiator domain, not an exact origin or calling tab.
+ * Keep that lossy projection here so the wider scope is visible and testable.
+ *
+ * @param {{ isGuarded: (tabId: number) => boolean, allowUrl?: (rawUrl: string) => boolean,
+ *   persist?: (rows: readonly (readonly [number, readonly string[]])[]) => Promise<unknown>,
+ *   deferUntilHydrated?: boolean }} deps
+ */
+export const createBrowserOriginCustody = ({
+  isGuarded,
+  allowUrl = () => true,
+  persist = async () => {},
+  deferUntilHydrated = false,
+}) => {
+  /** @type {Map<number, Set<string>>} */
+  const domainsByTab = new Map();
+  const closedDuringHydration = new Set();
+  let hydrated = false;
+  let hydrationError = /** @type {unknown} */ (null);
+  let finishHydration = /** @type {(() => void) | null} */ (null);
+  const hydrationReady = deferUntilHydrated
+    ? new Promise((resolve) => { finishHydration = () => resolve(undefined); })
+    : Promise.resolve();
+  let persistQueue = Promise.resolve();
+  let persistenceDirty = false;
+
+  /** @param {string} rawUrl */
+  const domainForUrl = (rawUrl) => {
+    try {
+      if (!allowUrl(rawUrl)) return null;
+      const parsed = new URL(rawUrl);
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+      const hostname = parsed.hostname.toLowerCase().replace(/\.$/, '');
+      return hostname || null;
+    } catch { return null; }
+  };
+
+  const snapshot = () => [...domainsByTab]
+    .map(([tabId, domains]) => /** @type {const} */ ([tabId, [...domains].sort()]))
+    .sort(([left], [right]) => left - right);
+  const persistCurrent = () => {
+    const rows = snapshot();
+    persistenceDirty = true;
+    const write = persistQueue.catch(() => {}).then(() => persist(rows)).then(
+      () => { persistenceDirty = false; },
+      (error) => { persistenceDirty = true; throw error; },
+    );
+    persistQueue = write;
+    return write;
+  };
+
+  return {
+    /**
+     * Retain a public document domain for the lifetime of a guarded tab. A
+     * service worker can outlive the document that registered it, so replacing
+     * the prior domain on navigation would release its network floor too soon.
+     * @param {number} tabId
+     * @param {string} rawUrl
+     * @param {{ keepOnPersistFailure?: boolean }} [options]
+     * @returns {Promise<{ tabId: number, domain: string, added: boolean } | null>}
+     */
+    async retain(tabId, rawUrl, options = {}) {
+      await hydrationReady;
+      if (hydrationError) throw hydrationError;
+      if (!Number.isInteger(tabId) || tabId < 0 || !isGuarded(tabId)) return null;
+      const domain = domainForUrl(rawUrl);
+      if (!domain) return null;
+      const domains = domainsByTab.get(tabId) ?? new Set();
+      const added = !domains.has(domain);
+      domains.add(domain);
+      domainsByTab.set(tabId, domains);
+      if (added || persistenceDirty) {
+        try { await persistCurrent(); }
+        catch (error) {
+          if (options.keepOnPersistFailure) throw error;
+          if (added) {
+            domains.delete(domain);
+            if (!domains.size) domainsByTab.delete(tabId);
+            try { await persistCurrent(); } catch { /* the caller still fails closed */ }
+          }
+          throw error;
+        }
+      }
+      return { tabId, domain, added };
+    },
+
+    /**
+     * Undo only a newly retained domain whose DNR update failed. A receipt for
+     * an already visited domain must never remove the older live protection.
+     * @param {{ tabId: number, domain: string, added: boolean } | null} receipt
+     */
+    async rollback(receipt) {
+      if (!receipt?.added) return false;
+      const domains = domainsByTab.get(receipt.tabId);
+      if (!domains?.delete(receipt.domain)) return false;
+      if (!domains.size) domainsByTab.delete(receipt.tabId);
+      await persistCurrent();
+      return true;
+    },
+
+    /** @param {number} tabId */
+    async close(tabId) {
+      if (!hydrated) closedDuringHydration.add(tabId);
+      if (!domainsByTab.delete(tabId)) return false;
+      await persistCurrent();
+      return true;
+    },
+
+    /** @param {readonly (readonly [number, readonly string[]])[]} rows */
+    async hydrate(rows) {
+      try {
+        for (const row of rows ?? []) {
+          if (!Array.isArray(row) || row.length !== 2) continue;
+          const [tabId, storedDomains] = row;
+          if (!Number.isInteger(tabId) || tabId < 0 || closedDuringHydration.has(tabId)
+            || !isGuarded(tabId) || !Array.isArray(storedDomains)) continue;
+          for (const storedDomain of storedDomains) {
+            if (typeof storedDomain !== 'string') continue;
+            const domain = domainForUrl(`https://${storedDomain}/`);
+            if (!domain || domain !== storedDomain) continue;
+            const domains = domainsByTab.get(tabId) ?? new Set();
+            domains.add(domain);
+            domainsByTab.set(tabId, domains);
+          }
+        }
+        if (closedDuringHydration.size) await persistCurrent();
+      } catch (error) {
+        hydrationError = error;
+        throw error;
+      } finally {
+        hydrated = true;
+        finishHydration?.();
+        finishHydration = null;
+      }
+    },
+
+    domains() {
+      for (const tabId of domainsByTab.keys()) {
+        if (!isGuarded(tabId)) domainsByTab.delete(tabId);
+      }
+      return [...new Set([...domainsByTab.values()].flatMap((domains) => [...domains]))].sort();
+    },
+
+    /** @param {number} tabId */
+    domainsForTab: (tabId) => [...(domainsByTab.get(tabId) ?? [])].sort(),
+  };
+};

--- a/extension/background/denylist-net-guard.js
+++ b/extension/background/denylist-net-guard.js
@@ -33,7 +33,8 @@
  * @param {any} deps.dnr  the chrome.declarativeNetRequest namespace (or a fake)
  * @param {() => readonly string[]} deps.getPatterns  live denylist patterns
  * @param {() => readonly number[]} deps.getTabIds    tabs peerd is driving right now
- * @param {(input: { patterns: readonly string[], tabIds: readonly number[] }) =>
+ * @param {() => readonly string[]} [deps.getInitiatorDomains]
+ * @param {(input: { patterns: readonly string[], tabIds: readonly number[], initiatorDomains: readonly string[] }) =>
  *   { removeRuleIds: number[], addRules: any[] }} deps.buildUpdate
  *   peerd-egress's denylistSessionRuleUpdate (pure).
  * @param {(entry: { type: string, details?: Record<string, any> }) => any} [deps.audit]
@@ -41,7 +42,8 @@
  * @param {boolean} [deps.deferUntilStarted]
  */
 export const makeDenylistNetGuard = ({
-  dnr, getPatterns, getTabIds, buildUpdate, audit, console: log = console,
+  dnr, getPatterns, getTabIds, getInitiatorDomains = () => [], buildUpdate,
+  audit, console: log = console,
   deferUntilStarted = false,
 }) => {
   const supported = typeof dnr?.updateSessionRules === 'function';
@@ -52,6 +54,7 @@ export const makeDenylistNetGuard = ({
   /** Distinct failure messages already logged (so a stuck API isn't a log flood). */
   const loggedFailures = new Set();
   let lastError = /** @type {string | null} */ (null);
+  let custodyError = /** @type {string | null} */ (null);
   let ruleDomains = 0;
   let ruleTabs = /** @type {number[]} */ ([]);
   let startupError = /** @type {string | null} */ (null);
@@ -80,6 +83,7 @@ export const makeDenylistNetGuard = ({
       const update = buildUpdate({
         patterns: getPatterns() ?? [],
         tabIds: getTabIds() ?? [],
+        initiatorDomains: getInitiatorDomains() ?? [],
       });
       const denylistRule = /** @type {any} */ (update.addRules.find((candidate) =>
         candidate.priority === 1 && Array.isArray(candidate.condition?.requestDomains)));
@@ -123,13 +127,30 @@ export const makeDenylistNetGuard = ({
       return queue;
     },
 
+    /**
+     * Mark a custody-side failure that prevented a safe rule projection. Page
+     * actions remain closed until a later successful sync proves the complete
+     * state was installed.
+     * @param {unknown} error
+     */
+    fail(error) {
+      custodyError = error instanceof Error ? error.message : String(error);
+      recordFailure(error);
+    },
+
+    /** Clear a custody-side failure only after its durable snapshot recovers. */
+    recover() {
+      custodyError = null;
+      applied = null;
+    },
+
     /** Is a usable DNR session-rule API present? (false → this guard is a no-op.) */
     supported: () => supported,
 
     /** Diagnostics for the audit/inspect surfaces. No authority. */
     state: () => ({
       supported, domains: ruleDomains, tabs: [...ruleTabs],
-      lastError: startupError || lastError,
+      lastError: startupError || custodyError || lastError,
       startupError,
     }),
   };

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -404,6 +404,7 @@ import { makeSettingsStore } from './settings-store.js';
 import { makeDenylistStore, requireDenylistPolicy } from './denylist-store.js';
 import { makeDenylistNetGuard } from './denylist-net-guard.js';
 import { createBrowserNetworkCustody } from './browser-network-custody.js';
+import { createBrowserOriginCustody } from './browser-origin-custody.js';
 import { makeDrivenPopupGuard, popupSourceState } from './driven-popup-guard.js';
 import {
   classifyDrivenChildRequestTarget,
@@ -1139,10 +1140,17 @@ const denylistReady = loadDenylist()
 // access. Current Firefox supports the portable rule shape; Chrome receives
 // its additional request-type enums below.
 const GUARDED_BROWSER_TABS_KEY = 'guardedBrowserTabIds';
+const GUARDED_BROWSER_ORIGINS_KEY = 'guardedBrowserOriginDomains';
 const browserDnr = /** @type {any} */ ((globalThis).chrome?.declarativeNetRequest);
 const startupPopupNetworkGuard = makeStartupPopupNetworkGuard(browserDnr, PRIVATE_NETWORK_RULE_IDS);
 const browserNetworkCustody = createBrowserNetworkCustody({
   persist: (tabIds) => sessionCache.sessionSet(GUARDED_BROWSER_TABS_KEY, tabIds),
+});
+const browserOriginCustody = createBrowserOriginCustody({
+  isGuarded: (tabId) => drivenTabIds().includes(tabId),
+  allowUrl: (rawUrl) => classifyBrowserAutomationTarget(rawUrl).allowed,
+  persist: (rows) => sessionCache.sessionSet(GUARDED_BROWSER_ORIGINS_KEY, rows),
+  deferUntilHydrated: true,
 });
 const guardedBrowserTabsReady = Promise.resolve(sessionCache.sessionGet(GUARDED_BROWSER_TABS_KEY))
   .then(async (ids) => {
@@ -1155,6 +1163,19 @@ const guardedBrowserTabsReady = Promise.resolve(sessionCache.sessionGet(GUARDED_
       error: `guarded_tabs_hydration_failed: ${error instanceof Error ? error.message : String(error)}`,
     };
   });
+const guardedBrowserOriginsReady = guardedBrowserTabsReady.then(async (tabsResult) => {
+  if (tabsResult.ok === false) return tabsResult;
+  try {
+    const rows = await sessionCache.sessionGet(GUARDED_BROWSER_ORIGINS_KEY);
+    await browserOriginCustody.hydrate(Array.isArray(rows) ? rows : []);
+    return { ok: true };
+  } catch (error) {
+    return {
+      ok: false,
+      error: `guarded_origins_hydration_failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+});
 
 const drivenTabIds = () => {
   /** @type {Set<number>} */
@@ -1205,6 +1226,7 @@ const denylistNetGuard = makeDenylistNetGuard({
   }),
   getPatterns: () => denylistStore.patterns(),
   getTabIds: drivenTabIds,
+  getInitiatorDomains: () => browserOriginCustody.domains(),
   audit: (/** @type {any} */ entry) => { auditLog.append(entry).catch(() => {}); },
   // Existing session rules survive an MV3 worker restart. Do not replace them
   // from a half-hydrated tab set. The boot barrier starts reconciliation after
@@ -1217,6 +1239,7 @@ const denylistNetGuard = makeDenylistNetGuard({
 // update either lands before execution or the tool fails closed.
 const holdBrowserNetworkGuard = async (
   /** @type {number} */ tabId,
+  /** @type {string | undefined} */ targetUrl,
   /** @type {{ tabId: number, token: string } | undefined} */ requiredLease,
 ) => {
   await browserNetworkGuardReady;
@@ -1234,6 +1257,13 @@ const holdBrowserNetworkGuard = async (
     await denylistNetGuard.sync();
     return browserNetworkGuardUnavailableResult('network_guard_install_failed');
   }
+  let originReceipt = null;
+  try {
+    originReceipt = targetUrl ? await browserOriginCustody.retain(tabId, targetUrl) : null;
+  } catch {
+    if (claim.added) await browserNetworkCustody.removeDurable(tabId).catch(() => {});
+    return browserNetworkGuardUnavailableResult('network_guard_install_failed');
+  }
   await denylistNetGuard.sync();
   const state = denylistNetGuard.state();
   if (state.supported && !state.lastError
@@ -1246,8 +1276,10 @@ const holdBrowserNetworkGuard = async (
   }
   if (claim.added) {
     await browserNetworkCustody.removeDurable(tabId).catch(() => {});
-    await denylistNetGuard.sync();
   }
+  await browserOriginCustody.rollback(originReceipt).catch(() => {});
+  if (claim.added) await browserOriginCustody.close(tabId).catch(() => {});
+  await denylistNetGuard.sync();
   return browserNetworkGuardUnavailableResult(
     state.supported ? 'network_guard_install_failed' : 'network_guard_unsupported',
   );
@@ -1277,7 +1309,26 @@ const releaseBrowserNetworkGuardLease = async (
   if (!lease || typeof lease.tabId !== 'number' || typeof lease.token !== 'string') return;
   await browserNetworkGuardReady;
   if (!browserNetworkCustody.release(lease)) return;
+  browserOriginCustody.domains();
   await denylistNetGuard.sync();
+};
+
+const updateBrowserNetworkGuardOrigin = async (
+  /** @type {number} */ tabId,
+  /** @type {string | undefined} */ rawUrl,
+) => {
+  if (!rawUrl || !drivenTabIds().includes(tabId)) {
+    return browserNetworkGuardUnavailableResult('network_guard_install_failed');
+  }
+  const originReceipt = await browserOriginCustody.retain(tabId, rawUrl).catch(() => null);
+  if (!originReceipt) return browserNetworkGuardUnavailableResult('network_guard_install_failed');
+  await denylistNetGuard.sync();
+  const state = denylistNetGuard.state();
+  if (state.supported && !state.lastError) return { ok: true };
+  await browserOriginCustody.rollback(originReceipt).catch(() => {});
+  return browserNetworkGuardUnavailableResult(
+    state.supported ? 'network_guard_install_failed' : 'network_guard_unsupported',
+  );
 };
 
 // A page-created child receives authority only from the exact peerd-owned
@@ -1349,7 +1400,8 @@ const adoptPopupBrowserNetworkGuard = async (
     const state = denylistNetGuard.state();
     return { ok: !state.supported || !state.lastError, adopted: false };
   }
-  const result = await holdBrowserNetworkGuard(childTabId, startupLease);
+  const child = await browser.tabs.get(childTabId).catch(() => null);
+  const result = await holdBrowserNetworkGuard(childTabId, child?.url, startupLease);
   releaseStartupLease();
   if (result.ok) startupPopupNetworkGuard.handoff(childTabId);
   else {
@@ -2268,6 +2320,7 @@ const buildToolContext = async (/** @type {any} */ { sessionId: overrideSessionI
     domRefs,
     tabs: browser.tabs,
     ensureBrowserNetworkGuard: holdBrowserNetworkGuard,
+    updateBrowserNetworkGuardOrigin,
     acquireBrowserNetworkGuardLease,
     releaseBrowserNetworkGuardLease,
     consumeBrowserChildPolicyNotice,
@@ -4025,6 +4078,7 @@ browser.tabs.onRemoved.addListener((tabId) => {
   // its next op (the clients ensureTab internally); the binding persists.
   // Drop any DOM-nav refs for the closed tab.
   domRefs.clear(tabId);
+  browserOriginCustody.close(tabId).catch(() => {});
   browserNetworkCustody.close(tabId).catch(() => {});
   // ...and drop it out of the network backstop's tab scope. Tab ids remain
   // unique within one browser session, but closed tabs no longer need rules.
@@ -4037,6 +4091,20 @@ browser.tabs.onRemoved.addListener((tabId) => {
 // cannot find the node and the model has to take a new snapshot.
 browser.tabs.onUpdated.addListener((tabId, changeInfo) => {
   if (changeInfo.status === 'loading') domRefs.clear(tabId);
+  if (typeof changeInfo.url === 'string' && drivenTabIds().includes(tabId)) {
+    browserOriginCustody.retain(tabId, changeInfo.url, { keepOnPersistFailure: true })
+      .then((originReceipt) => {
+        if (originReceipt) denylistNetGuard.recover();
+        return denylistNetGuard.sync();
+      })
+      .catch(async (error) => {
+        // Keep the volatile domain in the rule projection so the live page and
+        // its worker remain contained. Future tools stay closed until a later
+        // retain successfully persists the complete snapshot.
+        denylistNetGuard.fail(error);
+        await denylistNetGuard.sync();
+      });
+  }
 });
 
 browser.runtime.onConnect.addListener((port) => {
@@ -7135,13 +7203,30 @@ const engineTrackersReady = (async () => {
 const browserNetworkGuardReady = Promise.all([
   denylistReady,
   guardedBrowserTabsReady,
+  guardedBrowserOriginsReady,
   webActorBindingsReady,
   engineTrackersReady,
 ]).then(async (results) => {
-  const failed = results.find((result) => result?.ok === false);
+  let failed = results.find((result) => result?.ok === false);
   startupPopupCandidatesOpen = false;
   await startupPopupCandidateQueue;
   await startupPopupNetworkGuard.seal();
+  if (!failed) {
+    for (const tabId of drivenTabIds()) {
+      const tab = await browser.tabs.get(tabId).catch(() => null);
+      if (!tab) {
+        failed = { ok: false, error: 'browser_origin_custody_hydration_failed' };
+        break;
+      }
+      if (tab.url) {
+        try { await browserOriginCustody.retain(tabId, tab.url); }
+        catch {
+          failed = { ok: false, error: 'browser_origin_custody_hydration_failed' };
+          break;
+        }
+      }
+    }
+  }
   await denylistNetGuard.start(failed ?? { ok: true });
   if (!failed) {
     await denylistNetGuard.sync();

--- a/extension/peerd-egress/denylist/dnr-rules.js
+++ b/extension/peerd-egress/denylist/dnr-rules.js
@@ -15,10 +15,12 @@
 // webFetch.
 //
 // declarativeNetRequest closes it at the layer the page cannot argue with. The
-// rules are SESSION-scoped and TAB-scoped: they apply only to tabs peerd is
-// currently driving, never to the user's own browsing. Blocking the user's bank
-// tab would be a bug, not a feature — the denylist says "the agent may not go
-// here", not "this browser may not go here".
+// rules are SESSION-scoped and custody-scoped. Ordinary page requests are tied
+// to tabs peerd is driving. Page service-worker requests are tied to both the
+// browser's no-tab identity and a currently custodied initiator domain. Neither
+// form becomes a browser-wide rule. Blocking the user's bank tab would be a
+// bug, not a feature. The denylist says "the agent may not go here", not "this
+// browser may not go here".
 //
 // This is a BACKSTOP, not the primary control. The JS gates stay exactly as
 // they are: they produce the refusal the model can read and the audit entry the
@@ -169,6 +171,17 @@ export const PRIVATE_NETWORK_RULE_IDS = Object.freeze([
   PRIVATE_NETWORK_HOST_RULE_ID,
   ...PRIVATE_NETWORK_REGEX_RULES.map(({ id }) => id),
 ]);
+
+// Page service-worker requests have no tab identity. Give their companion
+// rules a disjoint id range so tab custody and origin custody can be replaced
+// atomically without either set mistaking the other's rules for stale state.
+export const PRIVATE_NETWORK_INITIATOR_RULE_ID_OFFSET = 100;
+export const PRIVATE_NETWORK_INITIATOR_RULE_IDS = Object.freeze(
+  PRIVATE_NETWORK_RULE_IDS.map((id) => id + PRIVATE_NETWORK_INITIATOR_RULE_ID_OFFSET),
+);
+// browser.tabs.TAB_ID_NONE is -1 in both supported browsers. Keep the value in
+// the pure core so rule construction does not import a privileged browser API.
+export const PRIVATE_NETWORK_NO_TAB_ID = -1;
 
 /**
  * Resource types the block rule covers. Enumerated EXPLICITLY rather than left
@@ -363,6 +376,85 @@ export const buildPrivateNetworkBlockRules = ({
 };
 
 /**
+ * Retain only browser-canonical initiator hostnames. The imperative custody
+ * shell supplies URL.hostname values; validating again here prevents a scheme,
+ * path, wildcard, port, mixed-case alias, or empty entry from widening a
+ * no-tab rule. IPv4 and bracketed IPv6 literals ride the same URL
+ * canonicalization as DNS names.
+ *
+ * @param {readonly string[]} domains
+ * @returns {string[]}
+ */
+const canonicalInitiatorDomains = (domains) => [...new Set((domains ?? [])
+  .filter((domain) => {
+    if (typeof domain !== 'string' || !domain || domain !== domain.toLowerCase()
+        || !/^[\x21-\x7e]+$/.test(domain)) return false;
+    try {
+      const parsed = new URL(`https://${domain}/`);
+      const canonicalHostname = parsed.hostname === domain;
+      const ipv6Literal = /^\[[0-9a-f:.]+\]$/.test(domain);
+      const dnsName = domain.length <= 253 && domain.split('.').every((label) =>
+        label.length > 0 && label.length <= 63
+          && /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label));
+      return canonicalHostname
+        && (ipv6Literal || dnsName)
+        && parsed.username === ''
+        && parsed.password === ''
+        && parsed.port === '';
+    } catch { return false; }
+  }))].sort();
+
+/**
+ * Private-network floor for requests the browser attributes to no tab, such
+ * as a page service worker. Both scopes are mandatory: TAB_ID_NONE alone
+ * would intercept unrelated extension, provider, and browser traffic, while
+ * an initiator alone would also affect ordinary page requests in user tabs.
+ *
+ * The browser's initiator condition is domain-scoped rather than origin-
+ * scoped. The imperative shell therefore passes only hostnames currently
+ * under peerd custody and retains visited domains until custody ends because a
+ * service worker can survive page navigation.
+ *
+ * @param {Object} input
+ * @param {readonly string[]} input.initiatorDomains
+ * @param {number} [input.noTabId]
+ * @param {readonly string[]} [input.resourceTypes]
+ * @returns {object[]}
+ */
+export const buildPrivateNetworkInitiatorBlockRules = ({
+  initiatorDomains,
+  noTabId = PRIVATE_NETWORK_NO_TAB_ID,
+  resourceTypes = DENYLIST_RESOURCE_TYPES,
+}) => {
+  const initiators = canonicalInitiatorDomains(initiatorDomains);
+  if (!initiators.length || noTabId !== PRIVATE_NETWORK_NO_TAB_ID) return [];
+  const base = {
+    priority: 4,
+    action: { type: 'block' },
+  };
+  /** @param {Record<string, unknown>} condition */
+  const scoped = (condition) => ({
+    ...base,
+    condition: {
+      ...condition,
+      initiatorDomains: initiators,
+      tabIds: [PRIVATE_NETWORK_NO_TAB_ID],
+      resourceTypes: [...resourceTypes],
+    },
+  });
+  return [
+    {
+      id: PRIVATE_NETWORK_HOST_RULE_ID + PRIVATE_NETWORK_INITIATOR_RULE_ID_OFFSET,
+      ...scoped({ requestDomains: [...PRIVATE_NETWORK_HOSTS] }),
+    },
+    ...PRIVATE_NETWORK_REGEX_RULES.map(({ id, regex }) => ({
+      id: id + PRIVATE_NETWORK_INITIATOR_RULE_ID_OFFSET,
+      ...scoped({ regexFilter: regex, isUrlFilterCaseSensitive: false }),
+    })),
+  ];
+};
+
+/**
  * The full `updateSessionRules` argument for the current state. Always removes
  * all owned rule ids first so the call is idempotent and self-healing: whatever the
  * previous state was (stale tab list, stale domains, nothing at all), applying
@@ -372,6 +464,7 @@ export const buildPrivateNetworkBlockRules = ({
  * @param {readonly string[]} input.patterns  the live denylist
  * @param {readonly number[]} input.tabIds
  * @param {readonly number[]} [input.appTabIds]
+ * @param {readonly string[]} [input.initiatorDomains]
  * @param {readonly string[]} [input.exemptDomains]  IdP domains that stay
  *   reachable inside a driven tab — injected, see DENYLIST_ALLOW_RULE_ID.
  * @param {number} [input.ruleId]
@@ -382,6 +475,7 @@ export const buildPrivateNetworkBlockRules = ({
  */
 export const denylistSessionRuleUpdate = ({
   patterns, tabIds, appTabIds = [],
+  initiatorDomains = [],
   exemptDomains = [], ruleId = DENYLIST_RULE_ID,
   allowRuleId = DENYLIST_ALLOW_RULE_ID, appRuleId = APP_EGRESS_RULE_ID,
   resourceTypes = DENYLIST_RESOURCE_TYPES,
@@ -397,14 +491,19 @@ export const denylistSessionRuleUpdate = ({
     tabIds: appTabIds, ruleId: appRuleId, resourceTypes,
   });
   const privateNetworkBlocks = buildPrivateNetworkBlockRules({ tabIds, resourceTypes });
+  const privateNetworkInitiatorBlocks = buildPrivateNetworkInitiatorBlockRules({
+    initiatorDomains, resourceTypes,
+  });
   return {
     removeRuleIds: [
       ruleId, allowRuleId, appRuleId,
       ...PRIVATE_NETWORK_RULE_IDS,
+      ...PRIVATE_NETWORK_INITIATOR_RULE_IDS,
     ],
     addRules: [
       block, allow, appBlock,
       ...privateNetworkBlocks,
+      ...privateNetworkInitiatorBlocks,
     ].filter((rule) => rule !== null),
   };
 };

--- a/extension/peerd-egress/index.js
+++ b/extension/peerd-egress/index.js
@@ -101,6 +101,7 @@ export {
   buildDenylistBlockRule,
   buildAppEgressBlockRule,
   buildPrivateNetworkBlockRules,
+  buildPrivateNetworkInitiatorBlockRules,
   denylistSessionRuleUpdate,
   DENYLIST_RULE_ID,
   APP_EGRESS_RULE_ID,
@@ -111,6 +112,9 @@ export {
   PRIVATE_NETWORK_DOTTED_HOST_REGEX_RULES,
   PRIVATE_NETWORK_REGEX_RULES,
   PRIVATE_NETWORK_RULE_IDS,
+  PRIVATE_NETWORK_INITIATOR_RULE_ID_OFFSET,
+  PRIVATE_NETWORK_INITIATOR_RULE_IDS,
+  PRIVATE_NETWORK_NO_TAB_ID,
   DENYLIST_RESOURCE_TYPES,
   CHROME_DNR_RESOURCE_TYPES,
 } from './denylist/dnr-rules.js';

--- a/extension/peerd-runtime/index.js
+++ b/extension/peerd-runtime/index.js
@@ -446,6 +446,7 @@ export {
 // used by the background-owned activity overlay before it injects UI.
 export {
   browserNetworkGuardUnavailableResult,
+  browserNetworkGuardPostNavigationResult,
   classifyBrowserAutomationTarget,
   isAddressableBrowserTab,
 } from './tools/browser-automation-policy.js';

--- a/extension/peerd-runtime/tools/browser-automation-policy.js
+++ b/extension/peerd-runtime/tools/browser-automation-policy.js
@@ -228,6 +228,22 @@ export const browserNetworkGuardUnavailableResult = (reason = 'network_guard_una
   });
 
 /**
+ * A navigation can commit before the worker-origin companion rule finishes
+ * installing. Report the browser effect truthfully while withholding further
+ * page authority.
+ * @param {'network_guard_unavailable' | 'network_guard_unsupported' | 'network_guard_install_failed'} [reason]
+ */
+export const browserNetworkGuardPostNavigationResult = (reason = 'network_guard_unavailable') => {
+  const base = browserNetworkGuardUnavailableVerdict(reason);
+  return browserTargetRefusalResult({
+    ...base,
+    stage: BROWSER_TARGET_STAGES.COMMITTED_ORIGIN,
+    outcome: 'page_loaded_not_automated',
+    message: 'Navigation loaded a public page, but peerd stopped further browser automation because private-network request blocking could not be installed.',
+  }, { effectCompleted: true });
+};
+
+/**
  * A public navigation can redirect onto a site protected by the user's
  * denylist. Keep that landing on the same URL-free recovery contract as a
  * private-network redirect, while naming the distinct user-controlled policy.

--- a/extension/peerd-runtime/tools/defs/dom-helpers.js
+++ b/extension/peerd-runtime/tools/defs/dom-helpers.js
@@ -215,7 +215,7 @@ const enforceCommittedBrowserTarget = (target) => {
  * yields null, which every caller already surfaces as a refusal.
  *
  * @param {{ tabId?: number }} args
- * @param {{ tabs: any, denylist?: readonly string[], activeTab?: { id: number, url: string, origin: string }, actorType?: string, noteTab?: (tabId: number, url?: string, opts?: { opened?: boolean }) => void, judgeLanding?: (url: string) => Promise<{ action: string } | null>, scripting?: any, noteLearnedOrigin?: (origin: string, reason: string) => void, ensureBrowserNetworkGuard?: (tabId: number) => Promise<{ ok?: boolean, structured?: { reason?: string } }> }} ctx
+ * @param {{ tabs: any, denylist?: readonly string[], activeTab?: { id: number, url: string, origin: string }, actorType?: string, noteTab?: (tabId: number, url?: string, opts?: { opened?: boolean }) => void, judgeLanding?: (url: string) => Promise<{ action: string } | null>, scripting?: any, noteLearnedOrigin?: (origin: string, reason: string) => void, ensureBrowserNetworkGuard?: (tabId: number, targetUrl?: string) => Promise<{ ok?: boolean, structured?: { reason?: string } }> }} ctx
  * @param {{ allowRestrictedSource?: boolean }} [options]
  *
  * `judgeLanding` (issue 251) is the origin lock, injected by the SW so this
@@ -244,7 +244,7 @@ export const resolveTargetTab = async (args, ctx, options = {}) => {
   }
   if (!tab) return null;
   if (typeof tab.id === 'number' && typeof ctx.ensureBrowserNetworkGuard === 'function') {
-    const guarded = await ctx.ensureBrowserNetworkGuard(tab.id);
+    const guarded = await ctx.ensureBrowserNetworkGuard(tab.id, tab.url);
     if (!guarded?.ok) {
       const reason = guarded?.structured?.reason;
       throw new BrowserNetworkGuardUnavailableError(

--- a/extension/peerd-runtime/tools/defs/navigate.js
+++ b/extension/peerd-runtime/tools/defs/navigate.js
@@ -13,6 +13,7 @@
 import { isDenylistedTab, resolveTargetTab, originOfUrl } from './dom-helpers.js';
 import {
   BROWSER_TARGET_STAGES,
+  browserNetworkGuardPostNavigationResult,
   browserTargetRefusalResult,
   classifyBrowserAutomationTarget,
   sensitiveSiteBrowserTargetVerdict,
@@ -136,7 +137,7 @@ export const navigateTool = {
     const tabId = tab.id;
 
     if (typeof c.ensureBrowserNetworkGuard === 'function') {
-      const guarded = await c.ensureBrowserNetworkGuard(tabId);
+      const guarded = await c.ensureBrowserNetworkGuard(tabId, requestedUrl);
       if (!guarded.ok) return guarded;
     }
 
@@ -172,7 +173,6 @@ export const navigateTool = {
         outcomeKind: 'host-lost',
       };
     }
-
     // Keep the turn's activeTab pin fresh: if it points at the tab we just drove,
     // re-stamp its url/origin to where the page LANDED so the next tool's origin gate
     // sees the live origin, not the turn-start one (matters most for a freshly-adopted
@@ -213,11 +213,7 @@ export const navigateTool = {
     const committedVerdict = classifyBrowserAutomationTarget(finalTab?.url, {
       stage: BROWSER_TARGET_STAGES.COMMITTED_ORIGIN,
     });
-    const privateLanding = !committedVerdict.allowed
-      && (committedVerdict.reason === 'private_network'
-        || committedVerdict.reason === 'cloud_metadata');
-    if (!committedVerdict.allowed
-      && (privateLanding || navigation.status === 'complete')) {
+    if (!committedVerdict.allowed) {
       try { await c.siteCapture?.cancel?.({ tabId }); } catch { /* policy cleanup continues */ }
       // Give the actor binding its existing stop signal, then independently
       // remove the page authority. Either step may fail, so neither gates the
@@ -263,6 +259,28 @@ export const navigateTool = {
           ? 'The tab was reset to a verified blank page.'
           : 'The tab could not be reset, so browser automation remains stopped for it.'}`,
       };
+    }
+
+    if (typeof c.updateBrowserNetworkGuardOrigin === 'function') {
+      const guarded = await c.updateBrowserNetworkGuardOrigin(tabId, finalTab?.url);
+      if (!guarded.ok) {
+        const neutralized = await neutralizeBlockedLanding(
+          tabsApi,
+          tabId,
+          pin,
+          navigationTimeoutMs,
+        );
+        const refusal = browserNetworkGuardPostNavigationResult(
+          guarded.structured?.reason,
+        );
+        return {
+          ...refusal,
+          structured: { ...refusal.structured, neutralized },
+          content: `${refusal.content} ${neutralized
+            ? 'The tab was reset to a verified blank page.'
+            : 'The tab could not be reset, so browser automation remains stopped for it.'}`,
+        };
+      }
     }
 
     // why: even a timeout or rejected update can leave the browser on a new

--- a/extension/peerd-runtime/tools/defs/open-tab.js
+++ b/extension/peerd-runtime/tools/defs/open-tab.js
@@ -10,6 +10,7 @@
 import { isDenylistedTab, originOfUrl } from './dom-helpers.js';
 import {
   BROWSER_TARGET_STAGES,
+  browserNetworkGuardPostNavigationResult,
   browserTargetRefusalResult,
   classifyBrowserAutomationTarget,
   sensitiveSiteBrowserTargetVerdict,
@@ -100,7 +101,7 @@ export const openTabTool = {
     const tabsApi = /** @type {import('./committed-navigation.js').NavigationTabsApi & { create: (opts: CreateOpts) => Promise<BrowserTab>, remove?: (tabId: number) => Promise<unknown> }} */ (ctx.tabs);
     // why: noteTab / hintPullIn are optional SW-injected context extras not on
     // the ToolContext contract slot.
-    const ctxExtras = /** @type {{ noteTab?: (id: number | undefined, label?: string) => Promise<unknown>, hintPullIn?: (id: number | undefined, url: string) => unknown, judgeLanding?: (url: string) => Promise<unknown>, navigationTimeoutMs?: number, ensureBrowserNetworkGuard?: (tabId: number) => Promise<import('/shared/tool-types.js').ToolResult> }} */ (ctx);
+    const ctxExtras = /** @type {{ noteTab?: (id: number | undefined, label?: string) => Promise<unknown>, hintPullIn?: (id: number | undefined, url: string) => unknown, judgeLanding?: (url: string) => Promise<unknown>, navigationTimeoutMs?: number, ensureBrowserNetworkGuard?: (tabId: number, targetUrl?: string) => Promise<import('/shared/tool-types.js').ToolResult>, updateBrowserNetworkGuardOrigin?: (tabId: number, rawUrl?: string) => Promise<import('/shared/tool-types.js').ToolResult> }} */ (ctx);
     /** @type {BrowserTab} */
     let tab;
     try { tab = await tabsApi.create(opts); }
@@ -109,7 +110,7 @@ export const openTabTool = {
     }
     if (!tab.id) return { ok: false, error: 'tabs_create_failed: browser returned no tab id' };
     if (typeof ctxExtras.ensureBrowserNetworkGuard === 'function') {
-      const guarded = await ctxExtras.ensureBrowserNetworkGuard(tab.id);
+      const guarded = await ctxExtras.ensureBrowserNetworkGuard(tab.id, requestedUrl ?? tab.url);
       if (!guarded.ok) {
         await tabsApi.remove?.(tab.id).catch(() => {});
         return guarded;
@@ -146,11 +147,7 @@ export const openTabTool = {
         const committedVerdict = classifyBrowserAutomationTarget(finalTab?.url, {
           stage: BROWSER_TARGET_STAGES.COMMITTED_ORIGIN,
         });
-        const privateLanding = !committedVerdict.allowed
-          && (committedVerdict.reason === 'private_network'
-            || committedVerdict.reason === 'cloud_metadata');
-        if (!committedVerdict.allowed
-          && (privateLanding || navigation.status === 'complete')) {
+        if (!committedVerdict.allowed) {
           if (ctxExtras.judgeLanding && finalTab?.url) {
             try { await ctxExtras.judgeLanding(finalTab.url); } catch { /* best-effort */ }
           }
@@ -184,6 +181,29 @@ export const openTabTool = {
           };
         }
 
+        if (typeof ctxExtras.updateBrowserNetworkGuardOrigin === 'function') {
+          const guarded = await ctxExtras.updateBrowserNetworkGuardOrigin(tab.id, finalTab?.url);
+          if (!guarded.ok) {
+            let closed = false;
+            if (typeof tabsApi.remove === 'function') {
+              try {
+                await tabsApi.remove(tab.id);
+                closed = true;
+              } catch { /* the policy result below reports the failed cleanup */ }
+            }
+            const refusal = browserNetworkGuardPostNavigationResult(
+              guarded.structured?.reason,
+            );
+            return {
+              ...refusal,
+              structured: { ...refusal.structured, neutralized: closed },
+              content: `${refusal.content} ${closed
+                ? 'The new tab was closed.'
+                : 'The new tab could not be closed, so browser automation remains stopped for it.'}`,
+            };
+          }
+        }
+
         if (navigation.status !== 'complete') {
           return {
             ok: false,
@@ -214,9 +234,11 @@ export const openTabTool = {
         tabId: tab.id,
         url: tab.url || tab.pendingUrl || requestedUrl || '',
         networkGuard: {
-          scope: 'tab',
+          scope: 'tab_and_visited_origin_workers',
           lifetime: 'until_tab_closed',
           blocks: ['private_network', 'sensitive_site_denylist'],
+          workerScope: 'private_network_fetch',
+          chromeWorkerWebSocket: 'not_covered_by_dnr',
         },
       }, null, 2),
     };

--- a/packaging/check-tscheck.ts
+++ b/packaging/check-tscheck.ts
@@ -158,7 +158,7 @@ import { computeCoverage } from './tscheck-coverage.ts';
 // route, Options surface, and rendered side-panel coverage.
 // 673 → 676: the Actor Fabric adds its pure topology model, SW live projection,
 // and rendered browser contract while replacing the checked async-task bar.
-const COVERED_FLOOR = 687;
+const COVERED_FLOOR = 688;
 
 // The scan (walk + // @ts-check detection + the ES5-injected exemption set)
 // lives in tscheck-coverage.ts so the badge generator reports the same number.

--- a/scripts/cdp/e2e-harness.mjs
+++ b/scripts/cdp/e2e-harness.mjs
@@ -36,6 +36,7 @@ const ROOT = resolve(__dirname, '..', '..');
 const EXT = resolve(ROOT, 'extension');
 
 export const PASSPHRASE = 'correct-horse-battery-staple';
+export const NETWORK_GUARD_CONTROLLER_PORT = 18_763;
 export const READY_BUDGET_MS = 30_000; // extension load + SW boot + page mount
 export const POLL_MS = 250;
 
@@ -312,7 +313,7 @@ export async function openWidePage(ctx, path, { metrics = WIDE_METRICS, ready } 
 }
 
 // ---- raw CDP attach over Chrome's WebSocket (no npm client) -----------------
-async function attach(wsUrl, onEvent) {
+export async function attach(wsUrl, onEvent) {
   const ws = new WebSocket(wsUrl);
   await new Promise((res, rej) => { ws.onopen = res; ws.onerror = rej; });
   let id = 0;
@@ -438,6 +439,12 @@ export async function launchPeerd({ modelResponder, tagsModel = 'qwen3:8b', exte
     // servers stay deterministic and offline. Reserved .test names preserve the
     // documented DNS-resolution residual without weakening localhost coverage.
     '--host-resolver-rules=MAP orders.peerd.test 127.0.0.1, MAP acme.peerd.test 127.0.0.1, MAP acct.peerd.test 127.0.0.1, MAP guard.peerd.test 127.0.0.1',
+    // Product-boundary security tests must not pass because Chrome's separate
+    // Local Network Access feature stopped the request first.
+    '--disable-features=LocalNetworkAccessChecks,LocalNetworkAccessChecksWebSockets,LocalNetworkAccessForWorkers',
+    '--disable-web-security',
+    '--ip-address-space-overrides=127.0.0.0/8=public',
+    `--unsafely-treat-insecure-origin-as-secure=http://orders.peerd.test:${NETWORK_GUARD_CONTROLLER_PORT},http://acct.peerd.test:${NETWORK_GUARD_CONTROLLER_PORT}`,
     '--disable-gpu', '--no-sandbox',
     ...DETERMINISM_FLAGS,
     `--user-data-dir=${profile}`,
@@ -465,9 +472,10 @@ export async function launchPeerd({ modelResponder, tagsModel = 'qwen3:8b', exte
   // Redirect downloads browser-wide to the temp dir (headless honors this CDP
   // call where profile Preferences often don't). Best-effort: attach to the
   // browser target and leave the conn open so the setting persists for the run.
+  let browserConn = null;
   try {
     const ver = await fetch(`http://127.0.0.1:${port}/json/version`).then((r) => r.json());
-    const browserConn = await attach(ver.webSocketDebuggerUrl);
+    browserConn = await attach(ver.webSocketDebuggerUrl);
     await browserConn.send('Browser.setDownloadBehavior', { behavior: 'allow', downloadPath: downloadDir });
   } catch { /* download redirect is best-effort; never block the run on it */ }
 

--- a/scripts/cdp/states.mjs
+++ b/scripts/cdp/states.mjs
@@ -20,8 +20,9 @@
 import { createServer } from 'node:http';
 import { createSocket } from 'node:dgram';
 import {
-  rpc, evalIn, waitFor, sseText, sseToolCall, sseToolCalls, openExtPage, openWidePage,
+  rpc, evalIn, waitFor, sseText, sseToolCall, sseToolCalls, openExtPage, openWidePage, attach,
   sleep, setEmulatedTheme, PASSPHRASE, PANEL_METRICS, NARROW_PANEL_METRICS,
+  NETWORK_GUARD_CONTROLLER_PORT,
 } from './e2e-harness.mjs';
 
 // A compact transcript probe shared by the functional states.
@@ -354,6 +355,10 @@ export const STATES = [
         res.end();
       });
       probeServer.on('connection', () => { probeConnections += 1; });
+      probeServer.on('upgrade', (req, socket) => {
+        probeRequests.push(req.url ?? '/');
+        socket.destroy();
+      });
       const controllerServer = createServer((req, res) => {
         controllerRequests += 1;
         const requestUrl = new URL(req.url ?? '/', 'http://orders.peerd.test');
@@ -361,6 +366,25 @@ export const STATES = [
           controllerAttempts.add(requestUrl.searchParams.get('vector') ?? '');
           res.writeHead(204);
           res.end();
+          return;
+        }
+        if (requestUrl.pathname === '/worker.js') {
+          res.writeHead(200, {
+            'content-type': 'application/javascript',
+            'service-worker-allowed': '/',
+            'cache-control': 'no-store',
+          });
+          res.end(`self.addEventListener('install', () => self.skipWaiting());
+            self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));
+            self.addEventListener('message', (event) => {
+              const { fetchUrl, socketUrl, token } = event.data || {};
+              event.waitUntil((async () => {
+                await fetch('/attempt?vector=worker-' + encodeURIComponent(token)
+                  + '-websocket-' + typeof WebSocket, { cache: 'no-store' });
+                void fetch(fetchUrl, { mode: 'no-cors', cache: 'no-store' }).catch(() => {});
+                try { void new WebSocket(socketUrl); } catch { /* reported by raw probe */ }
+              })());
+            });`);
           return;
         }
         res.setHeader('content-type', 'text/html');
@@ -415,6 +439,7 @@ export const STATES = [
           <h1>network-guard-controller</h1>
           <button id="trusted-blank-burst">Open child</button>
           <script>
+            navigator.serviceWorker.register('/worker.js');
             document.querySelector('#trusted-blank-burst').addEventListener('click', () => {
               const child = window.open(${JSON.stringify(trustedTarget)}, 'trusted-private-child');
               if (!child) return;
@@ -425,13 +450,13 @@ export const STATES = [
       });
       await Promise.all([
         new Promise((resolve) => probeServer.listen(0, '127.0.0.1', resolve)),
-        new Promise((resolve) => controllerServer.listen(0, '127.0.0.1', resolve)),
+        new Promise((resolve, reject) => controllerServer
+          .once('error', reject)
+          .listen(NETWORK_GUARD_CONTROLLER_PORT, '127.0.0.1', resolve)),
       ]);
       const probePort = /** @type {{ port: number }} */ (probeServer.address()).port;
-      const controllerPort = /** @type {{ port: number }} */ (controllerServer.address()).port;
-      networkGuardFixtureUrl = `http://orders.peerd.test:${controllerPort}/`;
+      networkGuardFixtureUrl = `http://orders.peerd.test:${NETWORK_GUARD_CONTROLLER_PORT}/`;
       const resetProbe = async () => {
-        probeServer.closeAllConnections?.();
         await sleep(100);
         probeConnections = 0;
         probeRequests = [];
@@ -545,8 +570,8 @@ export const STATES = [
         };
         rec.check('the trusted click reaches its about:blank child action',
           burstObserved.completed && burstObserved.attempted, JSON.stringify(burstObserved));
-        rec.check('the trusted about:blank child causes no private TCP or HTTP side effect',
-          burstObserved.connections === 0 && burstObserved.requests.length === 0,
+        rec.check('Chrome immediate-child race remains visible with native local-network checks disabled',
+          burstObserved.requests.some((request) => request.includes('trusted-click-blank')),
           JSON.stringify(burstObserved));
         rec.check('the protected child is closed instead of left as a blank tab',
           !burstTabs.some((tab) => !burstTabIdsBefore.has(tab.id) && tab.openerTabId === drivenTab.id),
@@ -639,6 +664,230 @@ export const STATES = [
             observed.connections === 0 && observed.requests.length === 0,
             JSON.stringify(observed));
         }
+
+        // A blocked top-level navigation can leave Chrome displaying its
+        // network error document. Return to the controlled fixture before the
+        // worker lane so the test exercises the page worker, not an error page.
+        await evalIn(ctx.page,
+          `chrome.tabs.update(${drivenTab.id}, { url: ${JSON.stringify(networkGuardFixtureUrl)} })`, true);
+        await waitFor(() => evalIn(ctx.page, `chrome.tabs.get(${drivenTab.id}).then((tab) =>
+          tab.status === 'complete' && tab.url === ${JSON.stringify(networkGuardFixtureUrl)})`, true), {
+          budgetMs: 5_000, pollMs: 25,
+        });
+
+        const workerRuleShape = await evalIn(ctx.page, `(async () => {
+          const policy = await import(chrome.runtime.getURL('peerd-egress/index.js'));
+          const rules = await chrome.declarativeNetRequest.getSessionRules();
+          return rules.filter((rule) => policy.PRIVATE_NETWORK_INITIATOR_RULE_IDS.includes(rule.id));
+        })()`, true);
+        rec.check('the worker fetch floor is no-tab and limited to a visited page domain',
+          workerRuleShape.length > 0 && workerRuleShape.every((rule) =>
+            JSON.stringify(rule.condition?.tabIds) === JSON.stringify([-1])
+              && JSON.stringify(rule.condition?.initiatorDomains) === JSON.stringify(['orders.peerd.test'])),
+          JSON.stringify(workerRuleShape));
+        const initiatorOutcomes = await evalIn(ctx.page, `Promise.all([
+          chrome.declarativeNetRequest.testMatchOutcome({
+            url: ${JSON.stringify(`http://127.0.0.1:${probePort}/probe?vector=dnr-match`)},
+            type: 'xmlhttprequest', tabId: -1,
+            initiator: ${JSON.stringify(new URL(networkGuardFixtureUrl).origin)},
+          }),
+          chrome.declarativeNetRequest.testMatchOutcome({
+            url: ${JSON.stringify(`http://127.0.0.1:${probePort}/probe?vector=dnr-miss`)},
+            type: 'xmlhttprequest', tabId: -1,
+            initiator: ${JSON.stringify(new URL(networkGuardFixtureUrl.replace('orders.peerd.test', 'acct.peerd.test')).origin)},
+          }),
+          chrome.declarativeNetRequest.testMatchOutcome({
+            url: ${JSON.stringify(`ws://127.0.0.1:${probePort}/probe?vector=dnr-socket-match`)},
+            type: 'websocket', tabId: -1,
+            initiator: ${JSON.stringify(new URL(networkGuardFixtureUrl).origin)},
+          }),
+        ])`, true).catch((error) => ({ error: String(error) }));
+        rec.check('Chrome matches the no-tab rule only for the custodied initiator',
+          Array.isArray(initiatorOutcomes)
+            && initiatorOutcomes[0]?.matchedRules?.length > 0
+            && initiatorOutcomes[1]?.matchedRules?.length === 0
+            && initiatorOutcomes[2]?.matchedRules?.some(({ ruleId }) => ruleId >= 100),
+          JSON.stringify(initiatorOutcomes));
+
+        const attachWorkerMonitor = async (origin) => {
+          const target = await waitFor(async () => {
+            const targets = await fetch(`http://127.0.0.1:${ctx.port}/json/list`).then((response) => response.json());
+            return targets.find((candidate) => candidate.type === 'service_worker'
+              && candidate.url === `${origin}/worker.js`);
+          }, { budgetMs: 5_000, pollMs: 25 });
+          if (!target) return null;
+          const events = [];
+          const requests = new Map();
+          const connection = await attach(target.webSocketDebuggerUrl, (method, params) => {
+            if (method === 'Network.requestWillBeSent') {
+              requests.set(params.requestId, params.request?.url ?? '');
+            }
+            if (method === 'Network.loadingFailed') {
+              events.push({
+                url: requests.get(params.requestId) ?? '',
+                blockedReason: params.blockedReason ?? '',
+                errorText: params.errorText ?? '',
+              });
+            }
+            if (method === 'Network.webSocketCreated') {
+              events.push({
+                url: params.url ?? '',
+                webSocketCreated: true,
+                initiator: params.initiator ?? null,
+              });
+            }
+          });
+          await connection.send('Network.enable');
+          return { connection, events };
+        };
+        const networkFailureFor = (monitor, token) => monitor?.events
+          .find((event) => event.url.includes(token));
+        const ordersWorkerMonitor = await attachWorkerMonitor(new URL(networkGuardFixtureUrl).origin);
+        rec.check('Chrome exposes the fixture service worker to the network test',
+          ordersWorkerMonitor !== null, JSON.stringify({ monitored: ordersWorkerMonitor !== null }));
+
+        const triggerWorker = async (tabId, token) => evalIn(ctx.page, `(async () => {
+          const [injection] = await chrome.scripting.executeScript({
+            target: { tabId: ${tabId} },
+            world: 'MAIN',
+            func: async (fetchUrl, socketUrl, workerToken) => {
+              const registration = await navigator.serviceWorker.ready;
+              registration.active.postMessage({ fetchUrl, socketUrl, token: workerToken });
+              return { secure: isSecureContext, active: !!registration.active };
+            },
+            args: [
+              ${JSON.stringify(`http://127.0.0.1:${probePort}/probe?vector=worker-fetch-${token}`)},
+              ${JSON.stringify(`ws://127.0.0.1:${probePort}/probe?vector=worker-websocket-${token}`)},
+              ${JSON.stringify(token)},
+            ],
+          });
+          return injection?.result;
+        })()`, true);
+
+        await resetProbe();
+        const guardedWorker = await triggerWorker(drivenTab.id, 'guarded');
+        await waitFor(() => [...controllerAttempts]
+          .some((value) => value === 'worker-guarded-websocket-function'), {
+          budgetMs: 5_000, pollMs: 25,
+        });
+        await sleep(500);
+        const guardedNetworkFailure = networkFailureFor(ordersWorkerMonitor, 'worker-fetch-guarded');
+        rec.check('the public fixture has an active service worker with WebSocket support',
+          guardedWorker?.secure === true && guardedWorker?.active === true
+            && controllerAttempts.has('worker-guarded-websocket-function'),
+          JSON.stringify({ guardedWorker, attempts: [...controllerAttempts] }));
+        rec.check('the custodied page worker fetch causes no private-network side effect',
+          !probeRequests.some((request) => request.includes('worker-fetch-guarded')),
+          JSON.stringify({ probeConnections, probeRequests, events: ordersWorkerMonitor?.events }));
+        rec.check('Chrome reports the custodied worker request as browser-policy blocked',
+          guardedNetworkFailure?.errorText === 'net::ERR_BLOCKED_BY_CLIENT',
+          JSON.stringify(guardedNetworkFailure));
+
+        rec.check('Chrome worker WebSocket bypass remains visible to the regression test',
+          probeRequests.some((request) => request.includes('worker-websocket-guarded')),
+          JSON.stringify({ probeConnections, probeRequests, events: ordersWorkerMonitor?.events }));
+
+        // Characterize the browser boundary directly. If even an unscoped
+        // WebSocket rule does not see this request, adding wider peerd custody
+        // cannot close the gap and would only disrupt unrelated browsing.
+        await evalIn(ctx.page, `chrome.declarativeNetRequest.updateSessionRules({
+          removeRuleIds: [4999],
+          addRules: [{
+            id: 4999,
+            priority: 10,
+            action: { type: 'block' },
+            condition: {
+              regexFilter: ${JSON.stringify('^wss?://(?:[^/]+@)?127\\.')},
+              resourceTypes: ['websocket'],
+            },
+          }],
+        })`, true);
+        await resetProbe();
+        await triggerWorker(drivenTab.id, 'unscoped-diagnostic');
+        await sleep(500);
+        rec.check('Chrome does not expose worker WebSockets to an unscoped DNR block',
+          probeRequests.some((request) => request.includes('worker-websocket-unscoped-diagnostic')),
+          JSON.stringify({ probeConnections, probeRequests, events: ordersWorkerMonitor?.events }));
+        await evalIn(ctx.page, `chrome.declarativeNetRequest.updateSessionRules({
+          removeRuleIds: [4999],
+        })`, true);
+
+        rec.check('the page-domain worker rule does not intercept the extension local provider',
+          ctx.modelCallCount() > 0,
+          JSON.stringify({ modelCalls: ctx.modelCallCount() }));
+
+        const unrelatedUrl = networkGuardFixtureUrl.replace('orders.peerd.test', 'acct.peerd.test');
+        const unrelatedTab = await evalIn(ctx.page,
+          `chrome.tabs.create({ url: ${JSON.stringify(unrelatedUrl)}, active: false })`, true);
+        await waitFor(async () => {
+          if (!Number.isInteger(unrelatedTab?.id)) return false;
+          const tab = await evalIn(ctx.page, `chrome.tabs.get(${unrelatedTab.id})`, true).catch(() => null);
+          return tab?.status === 'complete';
+        }, { budgetMs: 5_000, pollMs: 25 });
+        await resetProbe();
+        const unrelatedWorkerMonitor = await attachWorkerMonitor(new URL(unrelatedUrl).origin);
+        const unrelatedWorker = await triggerWorker(unrelatedTab.id, 'unrelated');
+        await waitFor(() => probeRequests.some((request) => request.includes('worker-fetch-unrelated'))
+          && probeRequests.some((request) => request.includes('worker-websocket-unrelated')),
+        { budgetMs: 5_000, pollMs: 25 });
+        const unrelatedNetworkFailure = networkFailureFor(unrelatedWorkerMonitor, 'worker-fetch-unrelated');
+        rec.check('a different-origin user service worker remains outside peerd DNR custody',
+          unrelatedWorker?.secure === true
+            && probeRequests.some((request) => request.includes('worker-fetch-unrelated'))
+            && probeRequests.some((request) => request.includes('worker-websocket-unrelated')),
+          JSON.stringify({ unrelatedWorker, unrelatedNetworkFailure, probeConnections, probeRequests }));
+        unrelatedWorkerMonitor?.connection.close();
+        await evalIn(ctx.page, `chrome.tabs.remove(${unrelatedTab.id})`, true).catch(() => {});
+
+        await evalIn(ctx.page,
+          `chrome.tabs.update(${drivenTab.id}, { url: ${JSON.stringify(unrelatedUrl)} })`, true);
+        const retainedScope = await waitFor(() => evalIn(ctx.page, `(async () => {
+          const policy = await import(chrome.runtime.getURL('peerd-egress/index.js'));
+          const rules = await chrome.declarativeNetRequest.getSessionRules();
+          const workerRules = rules.filter((rule) => policy.PRIVATE_NETWORK_INITIATOR_RULE_IDS.includes(rule.id));
+          return workerRules.length > 0
+            && workerRules.every((rule) =>
+              JSON.stringify(rule.condition?.initiatorDomains) === JSON.stringify(['acct.peerd.test', 'orders.peerd.test']));
+        })()`, true), { budgetMs: 5_000, pollMs: 25 });
+        rec.check('navigation retains prior worker domains and adds the committed domain',
+          retainedScope === true, JSON.stringify({ retainedScope }));
+
+        const oldOriginTab = await evalIn(ctx.page,
+          `chrome.tabs.create({ url: ${JSON.stringify(networkGuardFixtureUrl)}, active: false })`, true);
+        await sleep(500);
+        await resetProbe();
+        const retainedWorker = await triggerWorker(oldOriginTab.id, 'retained');
+        await sleep(500);
+        const retainedNetworkFailure = networkFailureFor(ordersWorkerMonitor, 'worker-fetch-retained');
+        rec.check('a previously visited worker domain remains guarded after navigation',
+          retainedWorker?.secure === true
+            && retainedNetworkFailure?.errorText === 'net::ERR_BLOCKED_BY_CLIENT'
+            && !probeRequests.some((request) => request.includes('worker-fetch-retained'))
+            && probeRequests.some((request) => request.includes('worker-websocket-retained')),
+          JSON.stringify({ retainedWorker, retainedNetworkFailure, probeConnections, probeRequests }));
+
+        await evalIn(ctx.page, `chrome.tabs.remove(${drivenTab.id})`, true).catch(() => {});
+        const releasedScope = await waitFor(() => evalIn(ctx.page, `(async () => {
+          const policy = await import(chrome.runtime.getURL('peerd-egress/index.js'));
+          const rules = await chrome.declarativeNetRequest.getSessionRules();
+          return rules.every((rule) =>
+            !policy.PRIVATE_NETWORK_INITIATOR_RULE_IDS.includes(rule.id));
+        })()`, true), { budgetMs: 5_000, pollMs: 25 });
+        rec.check('closing custody removes every visited worker-domain rule',
+          releasedScope === true, JSON.stringify({ releasedScope }));
+
+        await resetProbe();
+        const releasedWorker = await triggerWorker(oldOriginTab.id, 'released');
+        await waitFor(() => probeRequests.some((request) => request.includes('worker-fetch-released'))
+          && probeRequests.some((request) => request.includes('worker-websocket-released')),
+        { budgetMs: 5_000, pollMs: 25 });
+        rec.check('after custody closes, worker fetch and WebSocket both reach the private probe',
+          releasedWorker?.secure === true
+            && probeRequests.some((request) => request.includes('worker-fetch-released'))
+            && probeRequests.some((request) => request.includes('worker-websocket-released')),
+          JSON.stringify({ releasedWorker, probeConnections, probeRequests }));
+        await evalIn(ctx.page, `chrome.tabs.remove(${oldOriginTab.id})`, true).catch(() => {});
+        ordersWorkerMonitor?.connection.close();
       } finally {
         probeServer.closeAllConnections?.();
         controllerServer.closeAllConnections?.();

--- a/scripts/firefox/run-runtime-tests.mjs
+++ b/scripts/firefox/run-runtime-tests.mjs
@@ -47,6 +47,9 @@ const DNR_SCRIPT_PATH = '/__firefox-dnr-script';
 const DNR_ACTION_PATH = '/__firefox-dnr-action';
 const DNR_ATTEMPT_PATH = '/__firefox-dnr-attempt';
 const DNR_CHILD_PATH = '/__firefox-dnr-child';
+const DNR_SERVICE_WORKER_FIXTURE_PATH = '/__firefox-dnr-service-worker';
+const DNR_SERVICE_WORKER_SCRIPT_PATH = '/__firefox-dnr-service-worker.js';
+const DNR_SERVICE_WORKER_ATTEMPT_PATH = '/__firefox-dnr-service-worker-attempt';
 const RESULT_BUDGET_MS = 180_000;
 const PROVIDER_PATH = '/v1/messages';
 const PASSPHRASE_CANARY = 'firefox-runtime-passphrase-canary-7d12f198';
@@ -107,6 +110,55 @@ const FIREFOX_RUNTIME_FIXTURE = `<!doctype html>
     });
   </script>
 </body></html>`;
+
+const FIREFOX_DNR_SERVICE_WORKER_FIXTURE = `<!doctype html>
+<html lang="en"><meta charset="utf-8"><title>Firefox DNR Service Worker fixture</title>
+<body>Service Worker fixture<script type="module">
+  const params = new URLSearchParams(location.search);
+  const action = params.get('action');
+  const target = params.get('target');
+  const token = params.get('token');
+  if (action && target && token) {
+    const registration = await navigator.serviceWorker.register(${JSON.stringify(DNR_SERVICE_WORKER_SCRIPT_PATH)}, {
+      scope: '/',
+    });
+    const ready = await navigator.serviceWorker.ready;
+    const worker = ready.active || registration.active || registration.waiting;
+    if (!worker) throw new Error('Service Worker did not activate');
+    worker.postMessage({ action, target, token });
+    document.body.dataset.dnrServiceWorkerReady = 'yes';
+  }
+</script></body></html>`;
+
+const FIREFOX_DNR_SERVICE_WORKER_SCRIPT = `
+self.addEventListener('install', (event) => event.waitUntil(self.skipWaiting()));
+self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));
+self.addEventListener('message', (event) => {
+  const { action, target, token } = event.data || {};
+  const report = (phase) => fetch(${JSON.stringify(DNR_SERVICE_WORKER_ATTEMPT_PATH)}
+    + '?action=' + encodeURIComponent(action)
+    + '&token=' + encodeURIComponent(token)
+    + '&phase=' + encodeURIComponent(phase), {
+    method: 'POST', cache: 'no-store',
+  });
+  const fetchTarget = () => fetch(target, { mode: 'no-cors', cache: 'no-store' }).catch(() => {});
+  const openSocket = () => new Promise((resolve) => {
+    let socket;
+    try { socket = new WebSocket(target); } catch { resolve(); return; }
+    const finish = () => {
+      try { socket.close(); } catch { /* socket did not open */ }
+      resolve();
+    };
+    socket.addEventListener('open', finish, { once: true });
+    socket.addEventListener('error', finish, { once: true });
+    setTimeout(finish, 1_500);
+  });
+  event.waitUntil((async () => {
+    await report('started');
+    await (action === 'fetch' ? fetchTarget() : openSocket());
+    await report('settled');
+  })());
+});`;
 
 const onPath = (name) => (process.env.PATH ?? '').split(delimiter)
   .map((directory) => join(directory, name))
@@ -287,8 +339,9 @@ const KEEPALIVE_LOSS_CLICK_RESPONSE = toolUseResponse({
 // and safeFetch correctly rejects HTTP redirects. The proxy leaves the URL as
 // https://api.anthropic.com/v1/messages, so the real adapter and egress policy
 // run unchanged while the local server can inspect the final request header.
-// The proxy refuses every other CONNECT target. Its certificate key exists only
-// in the OS temp directory for this run and is deleted during cleanup.
+// The proxy also admits the named TLS browser fixtures and refuses every other
+// CONNECT target. Its certificate key exists only in the OS temp directory for
+// this run and is deleted during cleanup.
 const startProviderServer = async () => {
   const records = [];
   const connections = [];
@@ -302,6 +355,7 @@ const startProviderServer = async () => {
   const httpRequests = [];
   const webSocketUpgrades = [];
   const dnrRedirectAttempts = [];
+  const dnrServiceWorkerAttempts = [];
   const dnrVectors = new Map();
   let nextDnrVectorId = 0;
   let dnrFlow = null;
@@ -313,7 +367,7 @@ const startProviderServer = async () => {
     execFileSync('openssl', [
       'req', '-x509', '-newkey', 'rsa:2048', '-nodes', '-days', '1',
       '-subj', '/CN=api.anthropic.com',
-      '-addext', 'subjectAltName=DNS:api.anthropic.com',
+      '-addext', `subjectAltName=DNS:api.anthropic.com,DNS:${DNR_PUBLIC_HOST},DNS:${DNR_FRAME_HOST}`,
       '-keyout', keyPath, '-out', certificatePath,
     ], { stdio: ['ignore', 'ignore', 'pipe'] });
   } catch (error) {
@@ -323,6 +377,41 @@ const startProviderServer = async () => {
   }
 
   const providerRequestHandler = (request, response) => {
+    const host = String(request.headers.host ?? '').split(':')[0].toLowerCase();
+    const requestUrl = new URL(request.url ?? '/', `https://${host || 'localhost'}`);
+    if ([DNR_PUBLIC_HOST, DNR_FRAME_HOST].includes(host) && request.method === 'GET'
+        && requestUrl.pathname === DNR_SERVICE_WORKER_FIXTURE_PATH) {
+      response.writeHead(200, {
+        'content-type': 'text/html; charset=utf-8',
+        'cache-control': 'no-store',
+        'service-worker-allowed': '/',
+      });
+      response.end(FIREFOX_DNR_SERVICE_WORKER_FIXTURE);
+      return;
+    }
+    if ([DNR_PUBLIC_HOST, DNR_FRAME_HOST].includes(host) && request.method === 'GET'
+        && requestUrl.pathname === DNR_SERVICE_WORKER_SCRIPT_PATH) {
+      response.writeHead(200, {
+        'content-type': 'text/javascript; charset=utf-8',
+        'cache-control': 'no-store',
+        'service-worker-allowed': '/',
+      });
+      response.end(FIREFOX_DNR_SERVICE_WORKER_SCRIPT);
+      return;
+    }
+    if ([DNR_PUBLIC_HOST, DNR_FRAME_HOST].includes(host) && request.method === 'POST'
+        && requestUrl.pathname === DNR_SERVICE_WORKER_ATTEMPT_PATH) {
+      dnrServiceWorkerAttempts.push({
+        host,
+        action: requestUrl.searchParams.get('action'),
+        token: requestUrl.searchParams.get('token'),
+        phase: requestUrl.searchParams.get('phase'),
+      });
+      request.resume();
+      response.writeHead(204, { 'cache-control': 'no-store' });
+      response.end();
+      return;
+    }
     if (request.method === 'POST' && request.url === WORKER_PROBE_PATH) {
       workerStartupProbes += 1;
       response.writeHead(204, {
@@ -699,11 +788,17 @@ const startProviderServer = async () => {
     socket.once('close', () => sockets.delete(socket));
   });
   proxyServer.on('connect', (request, socket, head) => {
-    if (request.url?.toLowerCase() !== 'api.anthropic.com:443') {
+    const authority = request.url?.toLowerCase();
+    const providerAuthority = 'api.anthropic.com:443';
+    const serviceWorkerAuthorities = new Set([
+      `${DNR_PUBLIC_HOST}:${tlsPort}`,
+      `${DNR_FRAME_HOST}:${tlsPort}`,
+    ]);
+    if (authority !== providerAuthority && !serviceWorkerAuthorities.has(authority)) {
       socket.end('HTTP/1.1 403 Forbidden\r\n\r\n');
       return;
     }
-    connections.push(request.url);
+    if (authority === providerAuthority) connections.push(request.url);
     const upstream = connectSocket({ host: '127.0.0.1', port: tlsPort }, () => {
       socket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
       if (head.length > 0) upstream.write(head);
@@ -750,7 +845,8 @@ const startProviderServer = async () => {
     throw new Error('Firefox provider proxy did not receive a port');
   }
   return {
-    port, records, connections, tlsErrors, httpRequests, webSocketUpgrades, dnrRedirectAttempts,
+    port, tlsPort, records, connections, tlsErrors, httpRequests, webSocketUpgrades,
+    dnrRedirectAttempts, dnrServiceWorkerAttempts,
     registerDnrVector: ({ action, token, target }) => {
       const routeId = `dnr-${nextDnrVectorId += 1}`;
       dnrVectors.set(routeId, Object.freeze({ routeId, action, token, target }));
@@ -2522,6 +2618,50 @@ return 'REACHED';`;
   }
 };
 
+const serviceWorkerProbeUrl = (providerServer, {
+  action, target, token, host = DNR_PUBLIC_HOST,
+}) => {
+  const url = new URL(DNR_SERVICE_WORKER_FIXTURE_PATH,
+    `https://${host}:${providerServer.tlsPort}`);
+  url.searchParams.set('action', action);
+  url.searchParams.set('target', target);
+  url.searchParams.set('token', token);
+  return url.href;
+};
+
+const driveServiceWorkerProbe = async ({
+  driver, providerServer, tabId = null, action, target, token, host = DNR_PUBLIC_HOST,
+}) => {
+  const url = serviceWorkerProbeUrl(providerServer, { action, target, token, host });
+  const opened = await driver.executeAsync(`
+    const [tabId, url] = arguments;
+    const done = arguments[arguments.length - 1];
+    (Number.isInteger(tabId)
+      ? browser.tabs.update(tabId, { url, active: false })
+      : browser.tabs.create({ url, active: false }))
+      .then((tab) => done({ ok: true, tabId: tab.id, url: tab.url }),
+        (error) => done({ ok: false, error: error?.message || String(error) }));
+  `, [tabId, url]);
+  assert(opened?.ok === true && Number.isInteger(opened.tabId),
+    `Firefox opens the ${action} Service Worker probe page`, JSON.stringify(opened));
+  const started = await waitFor(() => providerServer.dnrServiceWorkerAttempts.some((attempt) =>
+    attempt.host === host && attempt.action === action && attempt.token === token
+      && attempt.phase === 'started') ? true : null,
+  { budgetMs: 10_000, pollMs: 50 });
+  assert(started === true, `Firefox ${action} Service Worker probe started`, JSON.stringify({ host, token }));
+  return opened.tabId;
+};
+
+const waitForServiceWorkerProbe = async (providerServer, {
+  action, token, host = DNR_PUBLIC_HOST,
+}) => {
+  const settled = await waitFor(() => providerServer.dnrServiceWorkerAttempts.some((attempt) =>
+    attempt.host === host && attempt.action === action && attempt.token === token
+      && attempt.phase === 'settled') ? true : null,
+  { budgetMs: 5_000, pollMs: 50 });
+  assert(settled === true, `Firefox ${action} Service Worker probe settled`, JSON.stringify({ host, token }));
+};
+
 const runPrivateNetworkDnrSmoke = async (driver, providerServer) => {
   console.log('Firefox private-network DNR smoke: enforce the packaged portable rules before network IO');
   const publicBase = `http://${DNR_PUBLIC_HOST}`;
@@ -2529,6 +2669,55 @@ const runPrivateNetworkDnrSmoke = async (driver, providerServer) => {
   let parentTabId = null;
   let extensionTabId = null;
   try {
+    const preflightFetchProbe = await startNetworkProbe();
+    const preflightSocketProbe = await startNetworkProbe();
+    let preflightTabId = null;
+    try {
+      preflightTabId = await driveServiceWorkerProbe({
+        driver,
+        providerServer,
+        action: 'fetch',
+        target: `http://127.0.0.1:${preflightFetchProbe.port}/service-worker-preflight-fetch`,
+        token: `preflight-fetch-${preflightFetchProbe.port}`,
+      });
+      await waitFor(() => preflightFetchProbe.connections > 0 && preflightFetchProbe.requests.length > 0
+        ? true : null, { budgetMs: 5_000, pollMs: 50 });
+      await waitForServiceWorkerProbe(providerServer, {
+        action: 'fetch', token: `preflight-fetch-${preflightFetchProbe.port}`,
+      });
+      assert(preflightFetchProbe.connections > 0 && preflightFetchProbe.requests.length > 0,
+        'Firefox Service Worker fetch reaches the private probe before origin custody',
+        JSON.stringify({
+          connections: preflightFetchProbe.connections,
+          requests: preflightFetchProbe.requests,
+        }));
+      preflightTabId = await driveServiceWorkerProbe({
+        driver,
+        providerServer,
+        tabId: preflightTabId,
+        action: 'websocket',
+        target: `ws://127.0.0.1:${preflightSocketProbe.port}/service-worker-preflight-websocket`,
+        token: `preflight-websocket-${preflightSocketProbe.port}`,
+      });
+      await waitFor(() => preflightSocketProbe.connections > 0 ? true : null,
+        { budgetMs: 5_000, pollMs: 50 });
+      await waitForServiceWorkerProbe(providerServer, {
+        action: 'websocket', token: `preflight-websocket-${preflightSocketProbe.port}`,
+      });
+      assert(preflightSocketProbe.connections > 0,
+        'Firefox Service Worker WebSocket reaches the private probe before origin custody',
+        JSON.stringify({ connections: preflightSocketProbe.connections }));
+    } finally {
+      if (Number.isInteger(preflightTabId)) {
+        await driver.executeAsync(`
+          const [tabId] = arguments;
+          const done = arguments[arguments.length - 1];
+          browser.tabs.remove(tabId).then(() => done(true), () => done(false));
+        `, [preflightTabId]).catch(() => {});
+      }
+      await Promise.all([preflightFetchProbe.close(), preflightSocketProbe.close()]);
+    }
+
     providerServer.beginDnrFlow(fixtureUrl);
     const started = await driver.executeAsync(`
       const done = arguments[arguments.length - 1];
@@ -2564,6 +2753,7 @@ const runPrivateNetworkDnrSmoke = async (driver, providerServer) => {
         const tab = await browser.tabs.get(lock.ownedTabId).catch(() => null);
         if (tab?.url !== fixtureUrl) return null;
         const ids = [...policy.PRIVATE_NETWORK_RULE_IDS];
+        const initiatorIds = [...policy.PRIVATE_NETWORK_INITIATOR_RULE_IDS];
         const liveRules = await browser.declarativeNetRequest.getSessionRules();
         const [extensionTab] = await browser.tabs.query({ active: true, currentWindow: true });
         return {
@@ -2571,9 +2761,12 @@ const runPrivateNetworkDnrSmoke = async (driver, providerServer) => {
           tabId: lock.ownedTabId,
           extensionTabId: extensionTab?.id,
           expectedIds: ids,
+          expectedInitiatorIds: initiatorIds,
+          noTabId: policy.PRIVATE_NETWORK_NO_TAB_ID,
           expectedResourceTypes: [...policy.DENYLIST_RESOURCE_TYPES],
           hostRuleId: policy.PRIVATE_NETWORK_HOST_RULE_ID,
           rules: liveRules.filter((rule) => ids.includes(rule.id)),
+          initiatorRules: liveRules.filter((rule) => initiatorIds.includes(rule.id)),
         };
       })().then(done, (error) => done({ failed: error?.message || String(error) }));
     `, [DNR_ACTOR_REPLY_CANARY, DNR_FINAL_REPLY_CANARY, fixtureUrl]), { budgetMs: 60_000, pollMs: 200 });
@@ -2597,6 +2790,21 @@ const runPrivateNetworkDnrSmoke = async (driver, providerServer) => {
       && JSON.stringify([...(rule.condition?.resourceTypes ?? [])].sort()) === JSON.stringify(expectedTypes));
     assert(ruleShapeOk, 'installed Firefox DNR rules are block-only, tab-scoped, and use portable resource types',
       JSON.stringify(installed.rules));
+    const installedInitiatorIds = installed.initiatorRules.map((rule) => rule.id).sort((a, b) => a - b);
+    const expectedInitiatorIds = [...installed.expectedInitiatorIds].sort((a, b) => a - b);
+    assert(JSON.stringify(installedInitiatorIds) === JSON.stringify(expectedInitiatorIds),
+      'Firefox retains every no-tab private-network companion rule id',
+      JSON.stringify({ installedInitiatorIds, expectedInitiatorIds }));
+    const initiatorRuleShapeOk = installed.initiatorRules.every((rule) =>
+      rule.action?.type === 'block'
+      && rule.priority === 4
+      && JSON.stringify(rule.condition?.tabIds ?? []) === JSON.stringify([installed.noTabId])
+      && JSON.stringify([...(rule.condition?.initiatorDomains ?? [])].sort())
+        === JSON.stringify([DNR_PUBLIC_HOST])
+      && JSON.stringify([...(rule.condition?.resourceTypes ?? [])].sort()) === JSON.stringify(expectedTypes));
+    assert(initiatorRuleShapeOk,
+      'installed Firefox companion rules cover no-tab requests only from the custodied domain',
+      JSON.stringify(installed.initiatorRules));
     const hostRule = installed.rules.find((rule) => rule.id === installed.hostRuleId);
     assert(hostRule?.condition?.requestDomains?.includes('localhost')
       && expectedTypes.includes('main_frame')
@@ -2638,6 +2846,127 @@ const runPrivateNetworkDnrSmoke = async (driver, providerServer) => {
       }
     } finally {
       await unrelatedProbe.close();
+    }
+
+    const workerFetchProbe = await startNetworkProbe();
+    const workerSocketProbe = await startNetworkProbe();
+    let workerTabId = null;
+    try {
+      workerTabId = await driveServiceWorkerProbe({
+        driver,
+        providerServer,
+        action: 'fetch',
+        target: `http://127.0.0.1:${workerFetchProbe.port}/service-worker-guarded-fetch`,
+        token: `guarded-fetch-${workerFetchProbe.port}`,
+      });
+      const workerTabScope = await driver.executeAsync(`
+        const [tabId] = arguments;
+        const done = arguments[arguments.length - 1];
+        (async () => {
+          const policy = await import(browser.runtime.getURL('peerd-egress/index.js'));
+          const rules = await browser.declarativeNetRequest.getSessionRules();
+          return {
+            tabId,
+            baseRuleIds: rules.filter((rule) =>
+              policy.PRIVATE_NETWORK_RULE_IDS.includes(rule.id)
+                && rule.condition?.tabIds?.includes(tabId)).map((rule) => rule.id),
+          };
+        })().then(done, (error) => done({ failed: error?.message || String(error) }));
+      `, [workerTabId]);
+      assert(workerTabScope?.baseRuleIds?.length === 0,
+        'the Service Worker probe tab is outside every tab-scoped private-network rule',
+        JSON.stringify(workerTabScope));
+      await waitForServiceWorkerProbe(providerServer, {
+        action: 'fetch', token: `guarded-fetch-${workerFetchProbe.port}`,
+      });
+      assert(workerFetchProbe.connections === 0 && workerFetchProbe.requests.length === 0,
+        'custodied Firefox Service Worker fetch causes zero private-network side effects',
+        JSON.stringify({
+          connections: workerFetchProbe.connections,
+          requests: workerFetchProbe.requests,
+        }));
+      workerTabId = await driveServiceWorkerProbe({
+        driver,
+        providerServer,
+        tabId: workerTabId,
+        action: 'websocket',
+        target: `ws://127.0.0.1:${workerSocketProbe.port}/service-worker-guarded-websocket`,
+        token: `guarded-websocket-${workerSocketProbe.port}`,
+      });
+      await waitForServiceWorkerProbe(providerServer, {
+        action: 'websocket', token: `guarded-websocket-${workerSocketProbe.port}`,
+      });
+      assert(workerSocketProbe.connections === 0 && workerSocketProbe.requests.length === 0,
+        'custodied Firefox Service Worker WebSocket causes zero private-network side effects',
+        JSON.stringify({
+          connections: workerSocketProbe.connections,
+          requests: workerSocketProbe.requests,
+        }));
+    } finally {
+      if (Number.isInteger(workerTabId)) {
+        await driver.executeAsync(`
+          const [tabId] = arguments;
+          const done = arguments[arguments.length - 1];
+          browser.tabs.remove(tabId).then(() => done(true), () => done(false));
+        `, [workerTabId]).catch(() => {});
+      }
+      await Promise.all([workerFetchProbe.close(), workerSocketProbe.close()]);
+    }
+
+    const otherOriginFetchProbe = await startNetworkProbe();
+    const otherOriginSocketProbe = await startNetworkProbe();
+    let otherOriginTabId = null;
+    try {
+      otherOriginTabId = await driveServiceWorkerProbe({
+        driver,
+        providerServer,
+        host: DNR_FRAME_HOST,
+        action: 'fetch',
+        target: `http://127.0.0.1:${otherOriginFetchProbe.port}/service-worker-other-origin-fetch`,
+        token: `other-origin-fetch-${otherOriginFetchProbe.port}`,
+      });
+      await waitFor(() => otherOriginFetchProbe.connections > 0
+        && otherOriginFetchProbe.requests.length > 0 ? true : null,
+      { budgetMs: 5_000, pollMs: 50 });
+      await waitForServiceWorkerProbe(providerServer, {
+        host: DNR_FRAME_HOST,
+        action: 'fetch',
+        token: `other-origin-fetch-${otherOriginFetchProbe.port}`,
+      });
+      assert(otherOriginFetchProbe.connections > 0 && otherOriginFetchProbe.requests.length > 0,
+        'another Firefox Service Worker origin still reaches private fetch while custody is active',
+        JSON.stringify({
+          connections: otherOriginFetchProbe.connections,
+          requests: otherOriginFetchProbe.requests,
+        }));
+      otherOriginTabId = await driveServiceWorkerProbe({
+        driver,
+        providerServer,
+        tabId: otherOriginTabId,
+        host: DNR_FRAME_HOST,
+        action: 'websocket',
+        target: `ws://127.0.0.1:${otherOriginSocketProbe.port}/service-worker-other-origin-websocket`,
+        token: `other-origin-websocket-${otherOriginSocketProbe.port}`,
+      });
+      await waitFor(() => otherOriginSocketProbe.connections > 0 ? true : null,
+        { budgetMs: 5_000, pollMs: 50 });
+      await waitForServiceWorkerProbe(providerServer, {
+        host: DNR_FRAME_HOST,
+        action: 'websocket',
+        token: `other-origin-websocket-${otherOriginSocketProbe.port}`,
+      });
+      assert(otherOriginSocketProbe.connections > 0,
+        'another Firefox Service Worker origin still reaches private WebSocket while custody is active',
+        JSON.stringify({ connections: otherOriginSocketProbe.connections }));
+    } finally {
+      if (Number.isInteger(otherOriginTabId)) {
+        await driver.executeAsync(`
+          const [tabId] = arguments;
+          const done = arguments[arguments.length - 1];
+          browser.tabs.remove(tabId).then(() => done(true), () => done(false));
+        `, [otherOriginTabId]).catch(() => {});
+      }
+      await Promise.all([otherOriginFetchProbe.close(), otherOriginSocketProbe.close()]);
     }
 
     const vectors = [
@@ -2904,14 +3233,65 @@ const runPrivateNetworkDnrSmoke = async (driver, providerServer) => {
           const stillScoped = rules.some((rule) =>
             policy.PRIVATE_NETWORK_RULE_IDS.includes(rule.id)
               && rule.condition?.tabIds?.includes(tabId));
-          if (!stillScoped) return { ok: true };
+          const initiatorStillScoped = rules.some((rule) =>
+            policy.PRIVATE_NETWORK_INITIATOR_RULE_IDS.includes(rule.id));
+          if (!stillScoped && !initiatorStillScoped) return { ok: true };
           await new Promise((resolveWait) => setTimeout(resolveWait, 50));
         }
-        return { ok: false, error: 'closed actor tab remained in private-network rules' };
+        return { ok: false, error: 'closed actor tab or origin remained in private-network rules' };
       })().then(done, (error) => done({ ok: false, error: error?.message || String(error) }));
     `, [parentTabId, extensionTabId]);
     assert(released?.ok === true, 'closing the driven actor tab removes its production DNR scope', JSON.stringify(released));
     parentTabId = null;
+
+    const releasedFetchProbe = await startNetworkProbe();
+    const releasedSocketProbe = await startNetworkProbe();
+    let releasedTabId = null;
+    try {
+      releasedTabId = await driveServiceWorkerProbe({
+        driver,
+        providerServer,
+        action: 'fetch',
+        target: `http://127.0.0.1:${releasedFetchProbe.port}/service-worker-released-fetch`,
+        token: `released-fetch-${releasedFetchProbe.port}`,
+      });
+      await waitFor(() => releasedFetchProbe.connections > 0 && releasedFetchProbe.requests.length > 0
+        ? true : null, { budgetMs: 5_000, pollMs: 50 });
+      await waitForServiceWorkerProbe(providerServer, {
+        action: 'fetch', token: `released-fetch-${releasedFetchProbe.port}`,
+      });
+      assert(releasedFetchProbe.connections > 0 && releasedFetchProbe.requests.length > 0,
+        'Firefox Service Worker fetch reaches the private probe after custody release',
+        JSON.stringify({
+          connections: releasedFetchProbe.connections,
+          requests: releasedFetchProbe.requests,
+        }));
+      releasedTabId = await driveServiceWorkerProbe({
+        driver,
+        providerServer,
+        tabId: releasedTabId,
+        action: 'websocket',
+        target: `ws://127.0.0.1:${releasedSocketProbe.port}/service-worker-released-websocket`,
+        token: `released-websocket-${releasedSocketProbe.port}`,
+      });
+      await waitFor(() => releasedSocketProbe.connections > 0 ? true : null,
+        { budgetMs: 5_000, pollMs: 50 });
+      await waitForServiceWorkerProbe(providerServer, {
+        action: 'websocket', token: `released-websocket-${releasedSocketProbe.port}`,
+      });
+      assert(releasedSocketProbe.connections > 0,
+        'Firefox Service Worker WebSocket reaches the private probe after custody release',
+        JSON.stringify({ connections: releasedSocketProbe.connections }));
+    } finally {
+      if (Number.isInteger(releasedTabId)) {
+        await driver.executeAsync(`
+          const [tabId] = arguments;
+          const done = arguments[arguments.length - 1];
+          browser.tabs.remove(tabId).then(() => done(true), () => done(false));
+        `, [releasedTabId]).catch(() => {});
+      }
+      await Promise.all([releasedFetchProbe.close(), releasedSocketProbe.close()]);
+    }
   } finally {
     if (parentTabId != null) {
       await driver.executeAsync(`
@@ -2961,6 +3341,7 @@ const main = async () => {
         // own DNR behavior, so the probe counters isolate the product boundary.
         'network.lna.enabled': false,
         'network.lna.blocking': false,
+        'network.lna.websocket.enabled': false,
         'network.dns.disableIPv6': true,
         'dom.disable_open_during_load': false,
       },

--- a/tests/background/browser-origin-custody.test.ts
+++ b/tests/background/browser-origin-custody.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from 'bun:test';
+import { createBrowserOriginCustody } from '../../extension/background/browser-origin-custody.js';
+
+describe('browser origin custody', () => {
+  test('projects guarded HTTP origins to stable canonical domains', async () => {
+    const guarded = new Set([7, 8]);
+    const custody = createBrowserOriginCustody({ isGuarded: (tabId) => guarded.has(tabId) });
+
+    expect(await custody.retain(7, 'HTTPS://Shop.Example./orders')).toEqual({
+      tabId: 7, domain: 'shop.example', added: true,
+    });
+    expect(await custody.retain(8, 'https://shop.example:8443/other')).toEqual({
+      tabId: 8, domain: 'shop.example', added: true,
+    });
+    expect(custody.domains()).toEqual(['shop.example']);
+  });
+
+  test('ignores unguarded tabs and non-web navigation without releasing visited origins', async () => {
+    const guarded = new Set([3]);
+    const custody = createBrowserOriginCustody({ isGuarded: (tabId) => guarded.has(tabId) });
+
+    expect(await custody.retain(4, 'https://other.example/')).toBeNull();
+    await custody.retain(3, 'https://owned.example/');
+    expect(await custody.retain(3, 'about:blank')).toBeNull();
+    expect(custody.domains()).toEqual(['owned.example']);
+  });
+
+  test('ignores URLs rejected by the browser automation target policy', async () => {
+    const custody = createBrowserOriginCustody({
+      isGuarded: () => true,
+      allowUrl: (rawUrl) => !rawUrl.includes('127.0.0.1'),
+    });
+    await custody.retain(3, 'https://public.example/');
+    expect(await custody.retain(3, 'http://127.0.0.1/')).toBeNull();
+    expect(custody.domains()).toEqual(['public.example']);
+  });
+
+  test('navigation retains visited domains until the owning tab closes', async () => {
+    const guarded = new Set([1, 2]);
+    const custody = createBrowserOriginCustody({ isGuarded: (tabId) => guarded.has(tabId) });
+    await custody.retain(1, 'https://a.example/');
+    await custody.retain(2, 'https://a.example/');
+    await custody.retain(1, 'https://b.example/');
+    expect(custody.domains()).toEqual(['a.example', 'b.example']);
+    await custody.close(2);
+    expect(custody.domains()).toEqual(['a.example', 'b.example']);
+    await custody.close(1);
+    expect(custody.domains()).toEqual([]);
+  });
+
+  test('rollback removes only a domain newly staged by a failed rule update', async () => {
+    const custody = createBrowserOriginCustody({ isGuarded: () => true });
+    const first = await custody.retain(1, 'https://stable.example/');
+    const repeated = await custody.retain(1, 'https://stable.example/');
+    const staged = await custody.retain(1, 'https://new.example/');
+
+    expect(await custody.rollback(repeated)).toBe(false);
+    expect(await custody.rollback(staged)).toBe(true);
+    expect(custody.domains()).toEqual(['stable.example']);
+    expect(await custody.rollback(first)).toBe(true);
+    expect(custody.domains()).toEqual([]);
+  });
+
+  test('tab authority loss prunes stale rows without a lifecycle callback', async () => {
+    const guarded = new Set([9]);
+    const custody = createBrowserOriginCustody({ isGuarded: (tabId) => guarded.has(tabId) });
+    await custody.retain(9, 'https://stale.example/');
+    guarded.delete(9);
+    expect(custody.domains()).toEqual([]);
+    guarded.add(9);
+    expect(custody.domainsForTab(9)).toEqual([]);
+  });
+
+  test('persists and restores every visited domain for a live guarded tab', async () => {
+    let stored: readonly (readonly [number, readonly string[]])[] = [];
+    const first = createBrowserOriginCustody({
+      isGuarded: (tabId) => tabId === 5,
+      persist: async (rows) => { stored = structuredClone(rows); },
+    });
+    await first.hydrate([]);
+    await first.retain(5, 'https://a.example/');
+    await first.retain(5, 'https://b.example/');
+
+    const restored = createBrowserOriginCustody({
+      isGuarded: (tabId) => tabId === 5,
+      persist: async (rows) => { stored = structuredClone(rows); },
+    });
+    await restored.hydrate(stored);
+    expect(restored.domains()).toEqual(['a.example', 'b.example']);
+  });
+
+  test('a failed persistence write rolls back the new domain and rejects', async () => {
+    let writes = 0;
+    const custody = createBrowserOriginCustody({
+      isGuarded: () => true,
+      persist: async () => {
+        writes += 1;
+        if (writes === 1) throw new Error('session storage unavailable');
+      },
+    });
+    await expect(custody.retain(5, 'https://new.example/'))
+      .rejects.toThrow('session storage unavailable');
+    expect(custody.domains()).toEqual([]);
+    expect(writes).toBe(2);
+  });
+
+  test('retaining an existing domain does not require another persistence write', async () => {
+    let writes = 0;
+    const custody = createBrowserOriginCustody({
+      isGuarded: () => true,
+      persist: async () => { writes += 1; },
+    });
+    await custody.retain(5, 'https://stable.example/');
+    await custody.retain(5, 'https://stable.example/path');
+    expect(writes).toBe(1);
+  });
+
+  test('a live-navigation write failure keeps volatile custody until persistence recovers', async () => {
+    let failing = true;
+    let stored: readonly (readonly [number, readonly string[]])[] = [];
+    const custody = createBrowserOriginCustody({
+      isGuarded: () => true,
+      persist: async (rows) => {
+        if (failing) throw new Error('session storage unavailable');
+        stored = structuredClone(rows);
+      },
+    });
+    await expect(custody.retain(5, 'https://live.example/', {
+      keepOnPersistFailure: true,
+    })).rejects.toThrow('session storage unavailable');
+    expect(custody.domains()).toEqual(['live.example']);
+    await expect(custody.retain(5, 'https://live.example/'))
+      .rejects.toThrow('session storage unavailable');
+    expect(custody.domains()).toEqual(['live.example']);
+    failing = false;
+    expect(await custody.retain(5, 'https://live.example/')).toEqual({
+      tabId: 5, domain: 'live.example', added: false,
+    });
+    expect(stored).toEqual([[5, ['live.example']]]);
+  });
+
+  test('a close before hydration cannot resurrect stale visited domains', async () => {
+    let stored: readonly (readonly [number, readonly string[]])[] = [[6, ['old.example']]];
+    const custody = createBrowserOriginCustody({
+      isGuarded: () => true,
+      persist: async (rows) => { stored = structuredClone(rows); },
+    });
+    await custody.close(6);
+    await custody.hydrate(stored);
+    expect(custody.domains()).toEqual([]);
+    expect(stored).toEqual([]);
+  });
+
+  test('a retain racing delayed hydration cannot overwrite older visited domains', async () => {
+    let stored: readonly (readonly [number, readonly string[]])[] = [
+      [5, ['old-a.example', 'old-b.example']],
+    ];
+    const custody = createBrowserOriginCustody({
+      isGuarded: (tabId) => tabId === 5,
+      deferUntilHydrated: true,
+      persist: async (rows) => { stored = structuredClone(rows); },
+    });
+    const pendingRetain = custody.retain(5, 'https://current.example/');
+    await Promise.resolve();
+    expect(stored).toEqual([[5, ['old-a.example', 'old-b.example']]]);
+    await custody.hydrate(stored);
+    await pendingRetain;
+    expect(custody.domains()).toEqual([
+      'current.example', 'old-a.example', 'old-b.example',
+    ]);
+    expect(stored).toEqual([[
+      5, ['current.example', 'old-a.example', 'old-b.example'],
+    ]]);
+  });
+});

--- a/tests/background/denylist-net-guard.test.ts
+++ b/tests/background/denylist-net-guard.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from 'bun:test';
 import { makeDenylistNetGuard } from '../../extension/background/denylist-net-guard.js';
 import {
   denylistSessionRuleUpdate,
+  PRIVATE_NETWORK_INITIATOR_RULE_IDS,
   PRIVATE_NETWORK_RULE_IDS,
 } from '../../extension/peerd-egress/denylist/dnr-rules.js';
 
@@ -54,8 +55,30 @@ describe('denylist-net-guard — rule sync', () => {
     const { guard } = guardOver(dnr, ['chase.com'], []);
     await guard.sync();
     expect(dnr.calls[0].addRules).toEqual([]);
-    // The three policy-owned base ids plus every private-network range rule.
-    expect(dnr.calls[0].removeRuleIds).toHaveLength(3 + PRIVATE_NETWORK_RULE_IDS.length);
+    // The three policy-owned base ids plus both private-network rule families.
+    expect(dnr.calls[0].removeRuleIds).toHaveLength(3
+      + PRIVATE_NETWORK_RULE_IDS.length
+      + PRIVATE_NETWORK_INITIATOR_RULE_IDS.length);
+  });
+
+  test('origin changes atomically replace the no-tab worker scope', async () => {
+    const dnr = makeDnr();
+    let domains = ['a.example'];
+    const guard = makeDenylistNetGuard({
+      dnr,
+      buildUpdate: denylistSessionRuleUpdate,
+      getPatterns: () => [],
+      getTabIds: () => [12],
+      getInitiatorDomains: () => domains,
+    });
+    await guard.sync();
+    domains = ['b.example'];
+    await guard.sync();
+    const workerRules = dnr.calls[1].addRules.filter((rule: any) =>
+      rule.condition.tabIds?.includes(-1));
+    expect(workerRules).toHaveLength(PRIVATE_NETWORK_INITIATOR_RULE_IDS.length);
+    expect(workerRules.every((rule: any) =>
+      JSON.stringify(rule.condition.initiatorDomains) === JSON.stringify(['b.example']))).toBe(true);
   });
 
   test('a repeat sync with unchanged state does not re-call the API', async () => {
@@ -206,5 +229,18 @@ describe('denylist-net-guard — degrades, never breaks', () => {
     const { guard } = guardOver(dnr, ['chase.com'], [12], () => { throw new Error('audit down'); });
     await guard.sync();               // must not reject
     expect(guard.state().lastError).toBe('nope');
+  });
+
+  test('a custody projection failure closes page actions until a successful sync', async () => {
+    const dnr = makeDnr();
+    const { guard } = guardOver(dnr, [], [12]);
+    guard.fail(new Error('origin persistence failed'));
+    expect(guard.state().lastError).toBe('origin persistence failed');
+    await guard.sync();
+    expect(guard.state().lastError).toBe('origin persistence failed');
+    guard.recover();
+    await guard.sync();
+    expect(guard.state().lastError).toBeNull();
+    expect(dnr.calls).toHaveLength(2);
   });
 });

--- a/tests/peerd-egress/denylist-dnr.test.ts
+++ b/tests/peerd-egress/denylist-dnr.test.ts
@@ -10,11 +10,15 @@ import {
   DENYLIST_ALLOW_RULE_ID,
   DENYLIST_RESOURCE_TYPES,
   buildPrivateNetworkBlockRules,
+  buildPrivateNetworkInitiatorBlockRules,
   PRIVATE_NETWORK_HOSTS,
   PRIVATE_NETWORK_IPV4_REGEX_RULES,
   PRIVATE_NETWORK_IPV6_REGEX_RULES,
   PRIVATE_NETWORK_DOTTED_HOST_REGEX_RULES,
   PRIVATE_NETWORK_RULE_IDS,
+  PRIVATE_NETWORK_INITIATOR_RULE_ID_OFFSET,
+  PRIVATE_NETWORK_INITIATOR_RULE_IDS,
+  PRIVATE_NETWORK_NO_TAB_ID,
   CHROME_DNR_RESOURCE_TYPES,
 } from '../../extension/peerd-egress/denylist/dnr-rules.js';
 
@@ -23,11 +27,13 @@ const ALL_RULE_IDS = [
   DENYLIST_ALLOW_RULE_ID,
   APP_EGRESS_RULE_ID,
   ...PRIVATE_NETWORK_RULE_IDS,
+  ...PRIVATE_NETWORK_INITIATOR_RULE_IDS,
 ];
 
 // The denylist's network-level backstop, pure half. The property that matters
-// most is negative: this must never produce a rule that isn't scoped to peerd's
-// own driven tabs, because that rule would block the USER's browsing.
+// most is negative: every rule must be scoped either to peerd's driven tabs or
+// to a custodied initiator with no-tab narrowing. An unscoped rule would block
+// the user's browsing.
 
 describe('denylistBlockDomains — patterns → requestDomains', () => {
   test('apex and its wildcard collapse to one domain', () => {
@@ -260,6 +266,70 @@ describe('buildPrivateNetworkBlockRules, tab-associated network floor', () => {
       'http://[64:ff9b::808:808]',
       'http://[::ffff:808:808]',
     ]) expect(matches(raw)).toBe(false);
+  });
+});
+
+describe('buildPrivateNetworkInitiatorBlockRules, no-tab worker floor', () => {
+  test('no custodied initiator domains means no no-tab rule', () => {
+    expect(buildPrivateNetworkInitiatorBlockRules({ initiatorDomains: [] })).toEqual([]);
+  });
+
+  test('every rule requires both no-tab and canonical initiator scope', () => {
+    const rules: any[] = buildPrivateNetworkInitiatorBlockRules({
+      initiatorDomains: ['worker.example', 'worker.example', 'api.worker.example'],
+    });
+    expect(rules.map((rule) => rule.id)).toEqual([...PRIVATE_NETWORK_INITIATOR_RULE_IDS]);
+    expect(rules).toHaveLength(PRIVATE_NETWORK_RULE_IDS.length);
+    for (const rule of rules) {
+      expect(rule.action).toEqual({ type: 'block' });
+      expect(rule.priority).toBe(4);
+      expect(rule.condition.tabIds).toEqual([PRIVATE_NETWORK_NO_TAB_ID]);
+      expect(rule.condition.initiatorDomains).toEqual(['api.worker.example', 'worker.example']);
+      expect(rule.condition.resourceTypes).toEqual([...DENYLIST_RESOURCE_TYPES]);
+    }
+  });
+
+  test('the companion ids are disjoint from every tab-scoped rule id', () => {
+    expect(PRIVATE_NETWORK_INITIATOR_RULE_IDS.every((id) =>
+      id >= PRIVATE_NETWORK_INITIATOR_RULE_ID_OFFSET
+        && !PRIVATE_NETWORK_RULE_IDS.includes(id))).toBe(true);
+  });
+
+  test('invalid or non-canonical initiators cannot widen the no-tab scope', () => {
+    const rules: any[] = buildPrivateNetworkInitiatorBlockRules({
+      initiatorDomains: [
+        '', 'Worker.Example', 'https://worker.example', 'worker.example:8443',
+        '*.worker.example', 'worker.example/path', 'work\u00e9r.example',
+      ],
+    });
+    expect(rules).toEqual([]);
+  });
+
+  test('a caller cannot substitute an ordinary or browser-wide tab scope', () => {
+    expect(buildPrivateNetworkInitiatorBlockRules({
+      initiatorDomains: ['worker.example'], noTabId: 7,
+    })).toEqual([]);
+  });
+
+  test('the full reconcile adds companions only for live initiators', () => {
+    const withoutInitiator = denylistSessionRuleUpdate({ patterns: [], tabIds: [7] });
+    expect(withoutInitiator.addRules).toHaveLength(PRIVATE_NETWORK_RULE_IDS.length);
+
+    const withInitiator: any = denylistSessionRuleUpdate({
+      patterns: [], tabIds: [7], initiatorDomains: ['worker.example'],
+    });
+    expect(withInitiator.removeRuleIds).toEqual(ALL_RULE_IDS);
+    expect(withInitiator.addRules).toHaveLength(
+      PRIVATE_NETWORK_RULE_IDS.length
+        + PRIVATE_NETWORK_INITIATOR_RULE_IDS.length,
+    );
+    const companions = withInitiator.addRules.filter((rule: any) =>
+      PRIVATE_NETWORK_INITIATOR_RULE_IDS.includes(rule.id));
+    expect(companions).toHaveLength(PRIVATE_NETWORK_INITIATOR_RULE_IDS.length);
+    expect(companions.every((rule: any) =>
+      JSON.stringify(rule.condition.tabIds) === JSON.stringify([PRIVATE_NETWORK_NO_TAB_ID])
+        && JSON.stringify(rule.condition.initiatorDomains) === JSON.stringify(['worker.example'])))
+      .toBe(true);
   });
 });
 

--- a/tests/peerd-runtime/tools/navigate-private-network.test.ts
+++ b/tests/peerd-runtime/tools/navigate-private-network.test.ts
@@ -171,6 +171,32 @@ describe('navigate private-network policy', () => {
     expect(pin).toEqual({ id: 7, url: privateUrl, origin: 'http://127.0.0.1' });
   });
 
+  test('reports a committed effect and resets the tab when origin protection fails', async () => {
+    const landingUrl = 'https://public.example/landed';
+    const { ctx, pin, publicUrl, updates } = redirectContext({ landingUrl });
+    ctx.updateBrowserNetworkGuardOrigin = async () => ({
+      ok: false,
+      error: 'browser_network_guard_unavailable',
+      outcomeKind: 'pre-effect-failure',
+      structured: { reason: 'network_guard_install_failed' },
+    });
+    const result = await navigateTool.execute({ url: publicUrl }, ctx);
+    expect(result).toMatchObject({
+      ok: false,
+      error: 'browser_network_guard_unavailable',
+      outcomeKind: 'effect-completed',
+      structured: {
+        reason: 'network_guard_install_failed',
+        stage: 'committed_origin',
+        outcome: 'page_loaded_not_automated',
+        neutralized: true,
+      },
+    });
+    expect(result.content).toContain('verified blank page');
+    expect(updates).toEqual([publicUrl, 'about:blank']);
+    expect(pin).toEqual({ id: 7, url: 'about:blank', origin: '' });
+  });
+
   test('a timed-out navigation still classifies and resets a private landing', async () => {
     const publicUrl = 'https://example.com/start';
     const privateUrl = 'http://127.0.0.1/private';
@@ -268,8 +294,8 @@ describe('navigate private-network policy', () => {
   test('refuses before tabs.update when the tab-scoped network floor is unavailable', async () => {
     const { ctx, publicUrl, updates } = redirectContext();
     const guarded: Array<[number, string | undefined]> = [];
-    ctx.ensureBrowserNetworkGuard = async (tabId: number) => {
-      guarded.push([tabId, undefined]);
+    ctx.ensureBrowserNetworkGuard = async (tabId: number, targetUrl?: string) => {
+      guarded.push([tabId, targetUrl]);
       if (guarded.length === 1) return { ok: true };
       return {
         ok: false,
@@ -282,7 +308,10 @@ describe('navigate private-network policy', () => {
       error: 'browser_network_guard_unavailable',
       outcomeKind: 'pre-effect-failure',
     });
-    expect(guarded).toEqual([[7, undefined], [7, undefined]]);
+    expect(guarded).toEqual([
+      [7, publicUrl],
+      [7, publicUrl],
+    ]);
     expect(updates).toEqual([]);
   });
 });

--- a/tests/peerd-runtime/tools/open-tab-private-network.test.ts
+++ b/tests/peerd-runtime/tools/open-tab-private-network.test.ts
@@ -6,6 +6,7 @@ type HarnessOptions = {
   complete?: boolean;
   finalUrl?: string;
   guardFails?: boolean;
+  originGuardFails?: boolean;
   withGuard?: boolean;
   denylist?: string[];
 };
@@ -15,6 +16,7 @@ const openHarness = ({
   complete = true,
   finalUrl = 'http://127.0.0.1/private',
   guardFails = false,
+  originGuardFails = false,
   withGuard = false,
   denylist = [],
 }: HarnessOptions = {}) => {
@@ -28,6 +30,7 @@ const openHarness = ({
   const removed: number[] = [];
   const released: number[] = [];
   const guarded: Array<[number, string | undefined]> = [];
+  const reconciled: Array<[number, string | undefined]> = [];
   const tabs: any = {
     onUpdated: {
       addListener: (next: any) => { listener = next; },
@@ -66,11 +69,23 @@ const openHarness = ({
     noteTab: async (id: number | undefined, label: string | undefined) => { noted.push([id, label]); },
     hintPullIn: (id: number | undefined, url: string) => { hints.push([id, url]); },
     ...(withGuard ? {
-      ensureBrowserNetworkGuard: async (tabId: number) => {
+      ensureBrowserNetworkGuard: async (tabId: number, targetUrl?: string) => {
         order.push('guard');
-        guarded.push([tabId, undefined]);
+        guarded.push([tabId, targetUrl]);
         return guardFails
           ? { ok: false, error: 'browser_network_guard_unavailable', outcomeKind: 'pre-effect-failure' }
+          : { ok: true };
+      },
+      updateBrowserNetworkGuardOrigin: async (tabId: number, targetUrl?: string) => {
+        order.push('origin');
+        reconciled.push([tabId, targetUrl]);
+        return originGuardFails
+          ? {
+            ok: false,
+            error: 'browser_network_guard_unavailable',
+            outcomeKind: 'pre-effect-failure',
+            structured: { reason: 'network_guard_install_failed' },
+          }
           : { ok: true };
       },
       releaseBrowserNetworkGuard: async (tabId: number) => {
@@ -79,7 +94,7 @@ const openHarness = ({
       },
     } : {}),
   };
-  return { creates, ctx, guarded, hints, noted, order, released, removed, updates };
+  return { creates, ctx, guarded, hints, noted, order, reconciled, released, removed, updates };
 };
 
 describe('open_tab committed target policy', () => {
@@ -140,6 +155,27 @@ describe('open_tab committed target policy', () => {
     expect(updates).toEqual(['https://public.example/start', 'about:blank']);
   });
 
+  test('refuses an unverified committed URL before origin reconciliation', async () => {
+    const { ctx, reconciled, updates } = openHarness({
+      finalUrl: 'https://public.example/landed',
+      withGuard: true,
+    });
+    const originalGet = ctx.tabs.get;
+    let reads = 0;
+    ctx.tabs.get = async () => {
+      reads += 1;
+      return reads === 1 ? { id: 9 } : originalGet();
+    };
+    const result = await openTabTool.execute({ url: 'https://public.example/start' }, ctx);
+    expect(result).toMatchObject({
+      ok: false,
+      outcomeKind: 'effect-completed',
+      structured: { stage: 'committed_origin', neutralized: true },
+    });
+    expect(reconciled).toEqual([]);
+    expect(updates).toEqual(['https://public.example/start', 'about:blank']);
+  });
+
   test('announces the verified public landing rather than the requested URL', async () => {
     const finalUrl = 'https://public.example/landed';
     const { ctx, hints, noted, updates } = openHarness({ finalUrl });
@@ -153,22 +189,25 @@ describe('open_tab committed target policy', () => {
       tabId: 9,
       url: finalUrl,
       networkGuard: {
-        scope: 'tab',
+        scope: 'tab_and_visited_origin_workers',
         lifetime: 'until_tab_closed',
         blocks: ['private_network', 'sensitive_site_denylist'],
+        workerScope: 'private_network_fetch',
+        chromeWorkerWebSocket: 'not_covered_by_dnr',
       },
     });
   });
 
   test('installs the tab-scoped network floor before starting navigation', async () => {
-    const { ctx, guarded, order } = openHarness({
+    const { ctx, guarded, order, reconciled } = openHarness({
       finalUrl: 'https://public.example/landed',
       withGuard: true,
     });
     const result = await openTabTool.execute({ url: 'https://public.example/start' }, ctx);
     expect(result.ok).toBe(true);
-    expect(order).toEqual(['guard', 'update']);
-    expect(guarded).toEqual([[9, undefined]]);
+    expect(order).toEqual(['guard', 'update', 'origin']);
+    expect(guarded).toEqual([[9, 'https://public.example/start']]);
+    expect(reconciled).toEqual([[9, 'https://public.example/landed']]);
   });
 
   test('keeps an unbound blank tab guarded until browser close cleanup', async () => {
@@ -178,6 +217,48 @@ describe('open_tab committed target policy', () => {
     expect(order).toEqual(['guard']);
     expect(released).toEqual([]);
     expect(updates).toEqual([]);
+  });
+
+  test('reports a committed effect and closes the tab when origin protection fails', async () => {
+    const { ctx, noted, hints, removed, updates } = openHarness({
+      finalUrl: 'https://public.example/landed',
+      originGuardFails: true,
+      withGuard: true,
+    });
+    const result = await openTabTool.execute({ url: 'https://public.example/start' }, ctx);
+    expect(result).toMatchObject({
+      ok: false,
+      error: 'browser_network_guard_unavailable',
+      outcomeKind: 'effect-completed',
+      structured: {
+        reason: 'network_guard_install_failed',
+        stage: 'committed_origin',
+        outcome: 'page_loaded_not_automated',
+        neutralized: true,
+      },
+    });
+    expect(result.content).toContain('The new tab was closed.');
+    expect(updates).toEqual(['https://public.example/start']);
+    expect(removed).toEqual([9]);
+    expect(noted).toEqual([]);
+    expect(hints).toEqual([]);
+  });
+
+  test('does not claim cleanup when the committed tab cannot be closed', async () => {
+    const { ctx, removed } = openHarness({
+      finalUrl: 'https://public.example/landed',
+      originGuardFails: true,
+      withGuard: true,
+    });
+    ctx.tabs.remove = async () => { throw new Error('tab close refused'); };
+    const result = await openTabTool.execute({ url: 'https://public.example/start' }, ctx);
+    expect(result).toMatchObject({
+      ok: false,
+      outcomeKind: 'effect-completed',
+      structured: { neutralized: false },
+    });
+    expect(result.content).toContain('could not be closed');
+    expect(removed).toEqual([]);
   });
 
   test('closes the blank tab when the network floor cannot be installed', async () => {

--- a/tests/red-team/scenarios/07-ssrf-private-network.ts
+++ b/tests/red-team/scenarios/07-ssrf-private-network.ts
@@ -19,7 +19,8 @@ import { makeWebFetch } from '../../../extension/peerd-egress/fetch/web-fetch.js
 import { isPrivateOrLocalHost } from '../../../extension/peerd-egress/fetch/private-network.js';
 import { EgressDeniedError } from '../../../extension/peerd-egress/fetch/errors.js';
 import {
-  buildPrivateNetworkBlockRules, PRIVATE_NETWORK_RULE_IDS,
+  buildPrivateNetworkBlockRules, buildPrivateNetworkInitiatorBlockRules,
+  PRIVATE_NETWORK_INITIATOR_RULE_IDS, PRIVATE_NETWORK_RULE_IDS,
 } from '../../../extension/peerd-egress/denylist/dnr-rules.js';
 import {
   BROWSER_TARGET_STAGES, browserTargetRefusalResult, classifyBrowserAutomationTarget,
@@ -69,7 +70,7 @@ export const scenario: Scenario = {
   title: 'Private-network / metadata SSRF',
   adversary: 'malicious webpage',
   asset: 'internal network + cloud metadata credentials',
-  claim: 'Open-web and browser entry points refuse private targets, browser network rules stay tab-scoped, and child guards require exact source identity.',
+  claim: 'Open-web and browser entry points refuse private targets, no-tab worker fetch rules require a custodied page domain, and child guards require exact source identity.',
   threatModelRef: 'INV-7',
   tier: 'unit',
   async run() {
@@ -149,14 +150,36 @@ export const scenario: Scenario = {
       const exactScope = rules.every((rule) => rule.action?.type === 'block'
         && JSON.stringify(rule.condition?.tabIds) === JSON.stringify([drivenTabId]));
       probes.push(exactRuleSet && exactScope
-        ? blocked('turn the private-network floor into a browser-wide rule', 'every known rule is block-only and scoped to the driven tab')
+        ? blocked('turn the private-network floor into a browser-wide rule', 'every tab-family rule is block-only and scoped to the driven tab')
         : leaked('turn the private-network floor into a browser-wide rule', 'a rule was missing, non-blocking, or not exact-tab scoped'));
       probes.push(buildPrivateNetworkBlockRules({ tabIds: [] }).length === 0
         ? blocked('install the private-network floor with no driven tab', 'the rule builder returned no rules')
         : leaked('install the private-network floor with no driven tab', 'an unscoped rule was produced'));
     }
 
-    // 6) Cold-start child copying is limited to a complete surviving rule set
+    // 6) A page worker loses tab identity, so its companion must require BOTH
+    // TAB_ID_NONE and the currently custodied public initiator domain. Either
+    // condition missing would turn a narrow worker backstop into browser-wide
+    // interception.
+    {
+      const rules = buildPrivateNetworkInitiatorBlockRules({
+        initiatorDomains: ['shop.example'],
+      }) as any[];
+      const exactRuleSet = rules.length === PRIVATE_NETWORK_INITIATOR_RULE_IDS.length
+        && PRIVATE_NETWORK_INITIATOR_RULE_IDS.every((id) =>
+          rules.some((rule) => rule.id === id));
+      const exactScope = rules.every((rule) => rule.action?.type === 'block'
+        && JSON.stringify(rule.condition?.tabIds) === JSON.stringify([-1])
+        && JSON.stringify(rule.condition?.initiatorDomains) === JSON.stringify(['shop.example']));
+      probes.push(exactRuleSet && exactScope
+        ? blocked('use a page service worker to bypass tab custody', 'every no-tab private-target rule requires no-tab attribution and the custodied initiator domain')
+        : leaked('use a page service worker to bypass tab custody', 'the worker rule family was missing or overbroad'));
+      probes.push(buildPrivateNetworkInitiatorBlockRules({ initiatorDomains: [] }).length === 0
+        ? blocked('install a no-tab private-network rule without page custody', 'no initiator domain produced no rule')
+        : leaked('install a no-tab private-network rule without page custody', 'a browser-wide no-tab rule was produced'));
+    }
+
+    // 7) Cold-start child copying is limited to a complete surviving rule set
     // on the exact source. The service worker separately requires restored
     // custody or an actor binding before it calls this pure browser-rule core.
     {
@@ -201,7 +224,7 @@ export const scenario: Scenario = {
         : leaked('claim startup child custody from a partial surviving rule set', 'partial browser evidence was accepted'));
     }
 
-    // 7) Firefox's synchronous first-request stop is exact-child scoped. It
+    // 8) Firefox's synchronous first-request stop is exact-child scoped. It
     // does not infer ownership from an ordinary opener and it does not block a
     // public request from the adopted child.
     {
@@ -259,6 +282,7 @@ export const scenario: Scenario = {
         'webFetch pre-flight host check',
         'browser automation target classifier',
         'tab-scoped private-network DNR rules',
+        'origin-scoped no-tab worker fetch DNR rules',
         'exact-child synchronous Firefox request stop',
         'exact-source startup child rule copy',
         'redirect fail-closed',


### PR DESCRIPTION
Closes #350.

## What changed

- adds origin-scoped, no-tab private-network DNR rules for page service-worker fetches
- retains visited worker domains through navigation and MV3 restarts until tab custody closes
- keeps volatile protection installed and browser tools closed through session-storage failures
- adds real Chrome and current Firefox worker fetch and WebSocket probes with positive controls
- makes post-navigation guard failures and successful tool receipts truthful
- updates security, red-team, privacy, listing, and reviewer documentation

## Browser boundary

Firefox blocks the tested worker fetch and WebSocket requests. Chrome blocks worker fetches, but does not expose service-worker-created WebSockets to DNR, even with an unscoped diagnostic rule. The live regression test and security docs keep that residual explicit. Chrome also retains its documented immediate-child request race when native local-network checks are disabled.

## Verification

- preflight: 5,512 tests passed
- red-team: 12/12 scenarios held
- Chrome live browser-network lane: 37/37 checks passed
- full Chrome functional E2E: 34 states, 263/263 checks passed
- typecheck, lint, copy hygiene, and diff checks passed
- fresh browser, security, UX, and model-UX adversarial reviews completed

Firefox browser execution is delegated to the required CI lane because Firefox and geckodriver are not installed on the development machine.