### PR TITLE
Sharpen the README opening

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,14 @@
 [![Manifest V3](https://img.shields.io/badge/Manifest%20V3-Chrome%20%26%20Firefox-informational.svg)](#install)
 [![Security policy](https://img.shields.io/badge/security-policy-blue.svg)](SECURITY.md)
 
-# The first and only web-native AI agent harness
+# The first web-native AI agent harness
 
-peerd runs general-purpose agents entirely inside Chrome and Firefox. It works
-with your tabs, signed-in sessions, web apps, and local compute. You choose a
-supported cloud or local model.
+**Agent platforms are building browsers into the harness. peerd builds the
+harness into the browser.**
+
+It runs general-purpose agents entirely inside Chrome and Firefox, with your
+tabs, signed-in sessions, web apps, and local compute. You choose a supported
+cloud or local model.
 
 No Peerd account, hosted browser, or tool-server connection is required. Current
 builds send no product telemetry to Peerd.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 
 # The first web-native AI agent harness
 
-**Agent platforms are building browsers into the harness. peerd builds the
-harness into the browser.**
+**Agent platforms are trying to pull the browser into the harness. peerd pulls
+the harness into the browser.**
 
 It runs general-purpose agents entirely inside Chrome and Firefox, with your
 tabs, signed-in sessions, web apps, and local compute. You choose a supported


### PR DESCRIPTION
## Summary

- shorten the category claim to “The first web-native AI agent harness”
- open with the architectural inversion behind peerd
- keep the shipped capability list immediately below the introduction

## Copy

> Agent platforms are trying to pull the browser into the harness. peerd pulls the harness into the browser.

## Validation

- `bun run check:docpaths`
- `bun run check:hygiene`
- `bun run check:copy`
- `git diff --check`
