### PR TITLE
Harden password-field attribution across DOM boundaries

### DIFF
--- a/docs/security/THREAT-MODEL.md
+++ b/docs/security/THREAT-MODEL.md
@@ -1023,13 +1023,17 @@ evaluating peerd should know. Each cites where it lives in the code.
   and passes the rest through verbatim. The scanner is already a pure function over
   strings, so the cheapest close is to run it over those values too — it is listed here
   because it is not done, not because it is hard.
-- R23. The password probe is top-frame and light-DOM only (#277). A site whose sign-in
-  lives in an iframe — an embedded IdP or payment widget, or a plain `<iframe
-  src=/login>` — or inside a shadow root is invisible to the learned signal
-  permanently, however often peerd walks it. This is the one residual that pulls
-  AGAINST another: widening the probe widens both directions at once, and #257 exists
-  because false positives on this signal have their own cost. It wants a deliberate
-  call, not a wider selector (`dom/walk-injected.js`).
+- R23. The password probe follows attributable DOM boundaries (#277). It now walks
+  open shadow roots and frames whose current origin exactly matches the top document,
+  plus declared inherited `about:blank` and `srcdoc` documents. Closed shadow roots
+  remain unobservable. Cross-origin frames are deliberately excluded: an embedded IdP
+  or payment widget belongs to its own origin, and treating its password field as
+  evidence about the relying party would recreate the false-positive cost from #257.
+  The original full light-DOM query remains intact; only discovery of additional roots
+  is bounded, and an exhausted negative stays unknown at the policy boundary. Fields
+  beyond that budget can therefore still fail open.
+  `autocomplete="new-password"` is matched as a token, including sectioned and WebAuthn
+  forms (`dom/walk-injected.js`; `tests/unit/peerd-runtime/dom-walk.test.js`).
 - R24. Chunked exfil defeats the minimum-blob threshold (#279). The tripwire is a pure
   per-call function over one call's slots, and the dispatcher hands it no history, so a
   payload split below the threshold passes as many times as an attacker cares to

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -2527,11 +2527,11 @@ const buildToolContext = async (/** @type {any} */ {
     // does NOT get the render hook (only a tab-backed web actor lazily adopts a tab).
     ...(actorType === 'web' && actorBacking !== 'api' ? { adoptWebTab: () => adoptWebTab(sessionId) } : {}),
     scripting: browser.scripting,
-    // issue 251: the snapshot tool calls this when the page it just walked had a
-    // password field. Injected rather than imported so the tool stays free of
-    // storage, and present on every context — the orchestrator's own snapshots
-    // teach the classifier exactly as well as an actor's, and there is no reason
-    // to learn less from the one the user drove themselves.
+    // issue 251: live DOM tools call this when their exact-document probe finds a
+    // password field. Injected rather than imported so the tools stay free of
+    // storage, and present on every context. The orchestrator's own probes teach
+    // the classifier exactly as well as an actor's, and there is no reason to
+    // learn less from the one the user drove themselves.
     noteLearnedOrigin,
     // DESIGN-18 P2: actor_list reads this for its integration rows — the chat's API integrations
     // (formed ∪ keyed). Referenced lazily (defined later, called at turn time, like
@@ -4057,7 +4057,7 @@ const confirmAction = async (prompt, signal) => {
   //
   // The signal's whole justification is "they affirmed it", so it fires exactly
   // where that is true. Origins the auto-approve path would have taught are still
-  // caught by the password-field signal on the first page walk.
+  // caught by the password-field signal on the first exact-document DOM-tool probe.
   //
   // Only on approval — a DECLINED write says the opposite, and recording it
   // would make refusing to act on a site the thing that marks it as yours.

--- a/extension/peerd-runtime/actor/learned-origins.js
+++ b/extension/peerd-runtime/actor/learned-origins.js
@@ -9,10 +9,10 @@
 //
 // THE TWO SIGNALS, and why these and not the obvious one:
 //
-//   password-field   A password input was on a page the actor walked. Nothing
-//                    else on the web says "this site has accounts" as plainly,
-//                    and the DOM walk already visits every element — so this
-//                    costs one boolean, not a new observation.
+//   password-field   A password input was seen by the standalone exact-document
+//                    probe at the DOM-tool chokepoint. Nothing else on the web
+//                    says "this site has accounts" as plainly; only its boolean
+//                    result reaches this store.
 //   confirmed-write  The user approved a `web:write` to this origin. They
 //                    affirmed acting there under their own name; we are only
 //                    remembering that they did.

--- a/extension/peerd-runtime/actor/origin-sensitivity.js
+++ b/extension/peerd-runtime/actor/origin-sensitivity.js
@@ -26,8 +26,8 @@
 // rather than to make the seed list exhaustive, which it never could be.
 //
 // WHAT IS NOT HERE. The store (peerd-egress), the observation points that feed
-// it (the DOM walk, the confirm path), and the enforcement (gates,
-// resolveTargetTab) all live elsewhere. This file only answers the question.
+// it (the live DOM-tool probe chokepoint, the confirm path), and the enforcement
+// (gates, resolveTargetTab) all live elsewhere. This file only answers the question.
 
 import { normalizeApiOrigin } from './web-actor.js';
 
@@ -58,9 +58,9 @@ const ORDINARY = Object.freeze({ sensitive: false });
  * same reasoning that kept `webNavigation` out — see the SW's tabs.onUpdated
  * comment). These two are observable from data we already collect.
  *
- *   password-field   A password input was seen in the DOM walk on this origin.
- *                    Nothing else on the web means "this site has accounts"
- *                    as reliably, and we already walk the DOM for the snapshot.
+ *   password-field   A password input was seen by the standalone exact-document
+ *                    probe every DOM tool passes through. Nothing else on the
+ *                    web means "this site has accounts" as reliably.
  *   confirmed-write  The user approved a web:write on this origin. They
  *                    affirmed acting there under their own name.
  *

--- a/extension/peerd-runtime/dom/walk-injected.js
+++ b/extension/peerd-runtime/dom/walk-injected.js
@@ -206,55 +206,6 @@ export function domWalkInjected() {
   var visited = 0;
   var capped = false;
 
-  // issue 251 — does this page have a password field? One boolean, read straight
-  // off the document rather than from the walk below.
-  //
-  // why not from the walk: it skips hidden elements and stops at a node cap, so
-  // a sign-in modal that has not been opened yet — the common shape on a site
-  // whose login lives behind a button — would be missed exactly where the signal
-  // is most wanted.
-  //
-  // why reporting a hidden field is safe: this says only that the SITE has
-  // accounts. It never carries what is IN the field; valueOf() below still masks
-  // password values, and nothing about this boolean reaches the model — it goes
-  // to the origin classifier, not into the snapshot text.
-  //
-  // Known miss: querySelector does not pierce shadow roots, so a login form
-  // inside a closed or open shadow tree is invisible here. Fail-open, same as
-  // the classifier it feeds.
-  //
-  // why `new-password` is EXCLUDED: that autocomplete token means "this field
-  // CREATES a password", i.e. a registration form — which is evidence the user
-  // does NOT have an account here, the exact opposite of what this signal is
-  // asking. Measured: the whole Stack Exchange network ships a hidden signup
-  // modal (action="/users/signup", autocomplete="new-password") in its page
-  // chrome, so reading ONE answer permanently marked stackoverflow.com,
-  // superuser.com, serverfault.com, askubuntu.com and math.stackexchange.com as
-  // sites the user has an identity on — after which a roaming helper could never
-  // drive a tab there again, with no UI to see or undo it.
-  //
-  // why not filter on VISIBILITY instead (the first thing that suggests itself):
-  // it would undo the deliberate choice above. A closed sign-in modal is hidden
-  // AND is a real signal; that case is the reason this reads the document rather
-  // than the walk. `new-password` separates the two without touching it.
-  //
-  // Checked against real pages: this clears 6/7 of the observed false positives
-  // and keeps 7/7 real sign-in pages firing (they use `current-password` or no
-  // autocomplete at all). The one origin still marked, instagram.com, is a
-  // genuine login form on its front page — a correct classification.
-  var hasPasswordField = false;
-  try {
-    var pwFields = document.querySelectorAll('input[type="password"]');
-    for (var pwIndex = 0; pwIndex < pwFields.length; pwIndex++) {
-      var pwAutocomplete = pwFields[pwIndex].getAttribute('autocomplete');
-      if (String(pwAutocomplete == null ? '' : pwAutocomplete).toLowerCase() === 'new-password') continue;
-      hasPasswordField = true;
-      break;
-    }
-  } catch (e) {
-    hasPasswordField = false;
-  }
-
   // DFS with an explicit stack (mirrors ax-serialize) so deep pages can't
   // blow the call stack. Each frame: element + the nodeId of its nearest
   // EMITTED ancestor — non-semantic wrappers don't create nodes, their
@@ -310,69 +261,122 @@ export function domWalkInjected() {
     pushChildren(el, parentNodeId);
   }
 
-  // probeOrigin: where this walk ACTUALLY ran. See hasPasswordFieldInjected —
-  // the caller's tab record is a snapshot taken before injection, so the
-  // password-field signal is only attributable if these agree.
-  var probeOrigin = null;
-  try { probeOrigin = location.origin; } catch (e) { probeOrigin = null; }
   return {
     ok: true, nodes: nodes, refElementCount: els.size, capped: capped,
-    hasPasswordField: hasPasswordField, probeOrigin: probeOrigin,
   };
 }
 
 /**
- * The same one boolean, on its own — for the CDP path, whose a11y tree cannot
- * tell a password input from any other textbox (both are role `textbox`).
+ * Origin-sensitivity signal: does this document contain evidence that the user
+ * can sign in here? One boolean reaches the classifier; no field value or DOM
+ * content reaches the model through this path.
  *
- * why a second injection rather than folding it into the tree fetch: CDP hands
- * back an accessibility tree, and the accessibility tree deliberately does not
- * distinguish these. The alternative was to let the signal exist only on the
- * DOM-walk channel, which would mean the origin lock learned less on the
- * platform where it has the MOST capability — precisely backwards.
+ * why standalone: every DOM tool runs this once at the exact-document target
+ * chokepoint. Snapshot capture deliberately does not repeat it; CDP cannot
+ * distinguish password inputs in its accessibility tree, and a second renderer
+ * wait could hang an otherwise complete read.
  *
  * Deliberately ES5 and self-contained: chrome.scripting serializes this source
- * and re-evaluates it in the page's classic-script world, so it can close over
- * nothing. See the header of dom-helpers.js. That is also why the
- * `new-password` rule is spelled out again here instead of shared — an injected
- * body closes over nothing, so the two copies must each stand alone. Keep them
- * in step; the walk copy carries the full rationale.
+ * and re-evaluates it in the page's classic-script world, so it closes over
+ * nothing. See the header of dom-helpers.js.
  *
- * @returns {{ has: boolean, origin: string | null, href: string | null }} the signal,
- *   and WHERE it was observed — the caller must drop it if that disagrees with the
- *   tab it resolved.
+ * @returns {{ has: boolean, capped: boolean }} the signal and whether boundary
+ *   discovery exhausted its budget.
  */
 export function hasPasswordFieldInjected() {
   'use strict';
-  // Reports WHERE it ran, not just what it saw. The caller resolves the tab
-  // first and reads `tab.url` from that frozen record, but this body runs later,
-  // in whatever document is committed by then — so a page that navigates in
-  // between could have its password field attributed to the origin the caller
-  // still thinks is loaded. Returning location.origin lets the caller drop a
-  // signal it cannot attribute. (`origin: null` on a throw, so an opaque or
-  // unreadable document is UNKNOWN rather than silently matching.)
-  //
-  // `location` is [Unforgeable] and this body runs in the ISOLATED world, so a
-  // hostile page can neither shadow it nor reach in and rewrite the answer: the
-  // document cannot lie about which document it is. That is what makes this
-  // usable as a live re-check of the caller's frozen tab record and not merely
-  // as a hint. href as well as origin, because the landing judge is asked about
-  // a URL and a path-scoped rule must not be handed a bare origin.
-  var origin = null;
-  var href = null;
-  try { origin = location.origin; } catch (e) { origin = null; }
-  try { href = location.href; } catch (e) { href = null; }
+  var MAX_VISITED = 30000;
+  // The caller targets the documentId minted by its preceding live-location
+  // probe, so a navigation destroys this injection instead of retargeting it.
+  // `location` is [Unforgeable] in the isolated world; this origin is needed
+  // only to decide whether a readable child frame belongs to the same site.
+  var topOrigin = null;
+  try { topOrigin = location.origin; } catch (e) { topOrigin = null; }
   try {
-    var fields = document.querySelectorAll('input[type="password"]');
-    for (var i = 0; i < fields.length; i++) {
-      var autocomplete = fields[i].getAttribute('autocomplete');
-      // A registration field is evidence the user has NO account here.
-      if (String(autocomplete == null ? '' : autocomplete).toLowerCase() !== 'new-password') {
-        return { has: true, origin: origin, href: href };
+    var isNewPasswordField = function (field) {
+      var autocomplete = String(field.getAttribute('autocomplete') || '').toLowerCase();
+      // Signup fields are evidence the user does not have an account here. Keep
+      // hidden sign-in modals, but exclude new-password wherever it appears in
+      // autocomplete's ASCII-whitespace-delimited token list.
+      return /(^|[\t\n\f\r ])new-password($|[\t\n\f\r ])/.test(autocomplete);
+    };
+    var rootHasPasswordField = function (root) {
+      var fields = root.querySelectorAll('input[type="password"]');
+      for (var fieldIndex = 0; fieldIndex < fields.length; fieldIndex++) {
+        if (!isNewPasswordField(fields[fieldIndex])) return true;
       }
+      return false;
+    };
+    var attributableFrameDocument = function (frameElement) {
+      try {
+        var frameDocument = frameElement.contentDocument;
+        if (!frameDocument || !frameDocument.documentElement) return null;
+        var frameOrigin = frameDocument.location.origin;
+        if (topOrigin && frameOrigin === topOrigin) return frameDocument;
+        var rawFrameSrc = frameElement.getAttribute('src');
+        var declaredBlank = frameDocument.location.protocol === 'about:'
+          && frameDocument.location.pathname === 'blank'
+          && (rawFrameSrc == null || rawFrameSrc.trim() === ''
+            || rawFrameSrc.trim().toLowerCase().indexOf('about:blank') === 0);
+        var declaredSrcdoc = frameDocument.location.protocol === 'about:'
+          && frameDocument.location.pathname === 'srcdoc'
+          && frameElement.hasAttribute('srcdoc');
+        return topOrigin && topOrigin !== 'null' && (declaredBlank || declaredSrcdoc)
+          ? frameDocument
+          : null;
+      } catch (e) { return null; }
+    };
+    var stack = [];
+    var visited = 0;
+    var capped = false;
+    var pushChildren = function (children) {
+      if (children && children.length) stack.push({ children: children, index: 0 });
+    };
+    var takeNext = function () {
+      while (stack.length) {
+        var frame = stack[stack.length - 1];
+        if (frame.index < frame.children.length) {
+          return frame.children[frame.index++];
+        }
+        stack.pop();
+      }
+      return null;
+    };
+
+    if (rootHasPasswordField(document)) return { has: true, capped: false };
+    if (document.documentElement) pushChildren([document.documentElement]);
+    var element = takeNext();
+    while (element && visited < MAX_VISITED) {
+      visited++;
+      var tag = element.tagName ? element.tagName.toLowerCase() : '';
+      var shadowChildren = null;
+      if (element.shadowRoot) {
+        if (rootHasPasswordField(element.shadowRoot)) {
+          return { has: true, capped: capped };
+        }
+        shadowChildren = element.shadowRoot.children;
+      }
+      var childDocumentRoot = null;
+      if (tag === 'iframe') {
+        var childDocument = attributableFrameDocument(element);
+        if (childDocument) {
+          if (rootHasPasswordField(childDocument)) {
+            return { has: true, capped: capped };
+          }
+          childDocumentRoot = childDocument.documentElement;
+        }
+      }
+      // Push later sources first. takeNext() reads the top frame, so ordinary
+      // light-DOM descendants retain true preorder priority over shadow and
+      // frame-document discovery without ever materializing a wide sibling list.
+      if (childDocumentRoot) pushChildren([childDocumentRoot]);
+      pushChildren(shadowChildren);
+      pushChildren(element.children);
+      element = takeNext();
     }
-    return { has: false, origin: origin, href: href };
+    if (element) capped = true;
+    return { has: false, capped: capped };
   } catch (e) {
-    return { has: false, origin: origin, href: href };
+    return { has: false, capped: true };
   }
 }

--- a/extension/peerd-runtime/tools/defs/dom-helpers.js
+++ b/extension/peerd-runtime/tools/defs/dom-helpers.js
@@ -68,6 +68,19 @@ const boundedProbe = async (operation) => {
 };
 
 /**
+ * Preserve the difference between an exhaustive negative and a boundary walk
+ * that spent its budget. A positive is definitive even if discovery capped
+ * elsewhere; an incomplete negative remains unknown.
+ * @param {any} value
+ * @returns {boolean | null}
+ */
+export const passwordFieldSignalFromProbe = (value) => {
+  if (value?.has === true) return true;
+  if (value?.capped === true) return null;
+  return value?.has === false ? false : null;
+};
+
+/**
  * Read only the current document location. The injection result also carries
  * the browser-issued documentId used to bind every later scripting operation
  * to this exact document.
@@ -124,7 +137,7 @@ const probeLiveDocument = async (tab, ctx) => {
         func: hasPasswordFieldInjected,
       }));
       const passwordValue = passwordProbe?.[0]?.result;
-      if (typeof passwordValue?.has === 'boolean') hasPasswordField = passwordValue.has;
+      hasPasswordField = passwordFieldSignalFromProbe(passwordValue);
     } catch {
       // A navigation destroys the pinned document. The later tool call carries
       // the same documentId and will fail instead of retargeting the new page.

--- a/extension/tests/fixtures/password-login-frame.html
+++ b/extension/tests/fixtures/password-login-frame.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Password probe fixture</title>
+<input type="password" autocomplete="current-password">

--- a/extension/tests/helpers/browser-scripting.js
+++ b/extension/tests/helpers/browser-scripting.js
@@ -26,10 +26,9 @@ export const browserProbeResult = (request, {
     }];
   }
   if (name === 'hasPasswordFieldInjected') {
-    const parsed = new URL(url);
     return [{
       documentId,
-      result: { has: hasPassword, origin: parsed.origin, href: parsed.href },
+      result: { has: hasPassword, capped: false },
     }];
   }
   return null;

--- a/extension/tests/unit/peerd-runtime/dom-walk.test.js
+++ b/extension/tests/unit/peerd-runtime/dom-walk.test.js
@@ -100,11 +100,7 @@ const makeCtx = () => /** @type {ToolContext & { domRefs: ReturnType<typeof crea
           } }];
         }
         if (func === hasPasswordFieldInjected) {
-          return [{ documentId: 'fixture-document', result: {
-            ...result,
-            origin: 'https://example.test',
-            href: 'https://example.test/order',
-          } }];
+          return [{ documentId: 'fixture-document', result }];
         }
         return [{ documentId: 'fixture-document', result }];
       },
@@ -477,17 +473,16 @@ describe('snapshot → click/type over walk refs — full chain', () => {
   });
 });
 
-// The password-field signal (issue 251) — the ONE bit the walk reports to the
-// origin classifier, and the only input to "does the user have an account here"
-// that the DOM can supply. Both entry points are covered because they are
-// separate ES5 copies by necessity (an injected body closes over nothing), so
-// they can drift apart silently.
+// The password-field signal (issue 251): the one bit the standalone live-document
+// probe reports to the origin classifier, and the only input to "does the user
+// have an account here" that the DOM can supply. Snapshot capture does not repeat
+// the probe.
 //
 // The load-bearing case is `new-password`. Measured on the live web, the Stack
 // Exchange network ships a hidden SIGNUP modal on every page; treating that as
 // "you have an account here" locked a roaming helper out of stackoverflow.com
 // after a single ordinary read, permanently and invisibly.
-describe('dom walk — the password-field signal', () => {
+describe('live document: the password-field signal', () => {
   /**
    * A fixture with NO password field of its own, so each test controls exactly
    * what is in the document. why its own helper: the shared FIXTURE_HTML above
@@ -504,23 +499,20 @@ describe('dom walk — the password-field signal', () => {
     finally { host.remove(); }
   };
 
-  it('no password field anywhere: both entry points say false', async () => {
+  it('no password field anywhere reports false', async () => {
     await withInputs('<input type="text" name="q">', () => {
-      expect(domWalkInjected().hasPasswordField).toBe(false);
       expect(hasPasswordFieldInjected().has).toBe(false);
     });
   });
 
   it('a bare password field marks the origin', async () => {
     await withInputs('<input type="password" name="pass">', () => {
-      expect(domWalkInjected().hasPasswordField).toBe(true);
       expect(hasPasswordFieldInjected().has).toBe(true);
     });
   });
 
   it('autocomplete="current-password" marks the origin — that IS a sign-in box', async () => {
     await withInputs('<input type="password" autocomplete="current-password">', () => {
-      expect(domWalkInjected().hasPasswordField).toBe(true);
       expect(hasPasswordFieldInjected().has).toBe(true);
     });
   });
@@ -531,7 +523,6 @@ describe('dom walk — the password-field signal', () => {
     // behind a button is hidden AND is a real signal. It is the reason the signal
     // reads the document rather than the walk.
     await withInputs('<div style="display:none"><input type="password" autocomplete="current-password"></div>', () => {
-      expect(domWalkInjected().hasPasswordField).toBe(true);
       expect(hasPasswordFieldInjected().has).toBe(true);
     });
   });
@@ -545,7 +536,6 @@ describe('dom walk — the password-field signal', () => {
       + '<input type="password" name="password" autocomplete="new-password">'
       + '</form>',
       () => {
-        expect(domWalkInjected().hasPasswordField).toBe(false);
         expect(hasPasswordFieldInjected().has).toBe(false);
       },
     );
@@ -558,7 +548,7 @@ describe('dom walk — the password-field signal', () => {
     await withInputs(
       '<form><input type="text" name="email"><input type="password" autocomplete="new-password"></form>',
       () => {
-        expect(domWalkInjected().hasPasswordField).toBe(false);
+        expect(hasPasswordFieldInjected().has).toBe(false);
       },
     );
   });
@@ -568,7 +558,6 @@ describe('dom walk — the password-field signal', () => {
       '<input type="password" autocomplete="new-password">'
       + '<input type="password" autocomplete="current-password">',
       () => {
-        expect(domWalkInjected().hasPasswordField).toBe(true);
         expect(hasPasswordFieldInjected().has).toBe(true);
       },
     );
@@ -576,31 +565,147 @@ describe('dom walk — the password-field signal', () => {
 
   it('the token is matched case-insensitively', async () => {
     await withInputs('<input type="password" autocomplete="NEW-PASSWORD">', () => {
-      expect(domWalkInjected().hasPasswordField).toBe(false);
       expect(hasPasswordFieldInjected().has).toBe(false);
     });
   });
-});
 
-// ── attribution (issue 278) ─────────────────────────────────────────────────
-// The caller resolves the tab BEFORE injecting, so `tab.url` is a snapshot; the
-// probe runs later, in whatever document is committed by then. Without the probe
-// saying where it ran, a page that navigates inside that window gets its password
-// field credited to the origin the caller started on — which lets a hostile page
-// mark arbitrary third parties as "the user has an account here", and, repeated,
-// fill the 500-entry cap so nothing further is ever learned.
-describe('peerd-runtime.dom-walk · the probe reports where it ran', () => {
-  it('hasPasswordFieldInjected returns the observing origin alongside the boolean', () => {
-    const r = hasPasswordFieldInjected();
-    expect(typeof r).toBe('object');
-    expect(typeof r.has).toBe('boolean');
-    // In the test page this is the extension origin; what matters is that it is
-    // the DOCUMENT's own origin, not anything the caller passed in.
-    expect(r.origin).toBe(location.origin);
+  it('an open shadow-root sign-in field marks the owning origin', async () => {
+    await withInputs('<div id="shadow-login"></div>', (host) => {
+      const shadow = /** @type {HTMLElement} */ (host.querySelector('#shadow-login'))
+        .attachShadow({ mode: 'open' });
+      shadow.innerHTML = '<input type="password" autocomplete="current-password">';
+      expect(hasPasswordFieldInjected().has).toBe(true);
+    });
   });
 
-  it('the full walk reports it too — the dom-walk path races identically', () => {
-    const walk = domWalkInjected();
-    expect(walk.probeOrigin).toBe(location.origin);
+  it('an open shadow-root signup field keeps a compound new-password token excluded', async () => {
+    await withInputs('<div id="shadow-signup"></div>', (host) => {
+      const shadow = /** @type {HTMLElement} */ (host.querySelector('#shadow-signup'))
+        .attachShadow({ mode: 'open' });
+      shadow.innerHTML = '<input type="password" autocomplete="section-register new-password webauthn">';
+      expect(hasPasswordFieldInjected().has).toBe(false);
+    });
+  });
+
+  it('a closed shadow root remains unobservable', async () => {
+    await withInputs('<div id="closed-shadow-login"></div>', (host) => {
+      const shadow = /** @type {HTMLElement} */ (host.querySelector('#closed-shadow-login'))
+        .attachShadow({ mode: 'closed' });
+      shadow.innerHTML = '<input type="password" autocomplete="current-password">';
+      expect(hasPasswordFieldInjected().has).toBe(false);
+    });
+  });
+
+  it('preserves full light-DOM coverage beyond the boundary-discovery budget', async () => {
+    await withInputs('', (host) => {
+      const fragment = document.createDocumentFragment();
+      for (let index = 0; index < 30001; index++) fragment.appendChild(document.createElement('i'));
+      const password = document.createElement('input');
+      password.type = 'password';
+      password.autocomplete = 'current-password';
+      fragment.appendChild(password);
+      host.appendChild(fragment);
+      expect(hasPasswordFieldInjected().has).toBe(true);
+    });
+  });
+
+  it('reports boundary-discovery exhaustion instead of claiming an exhaustive negative', async () => {
+    await withInputs('', (host) => {
+      const fragment = document.createDocumentFragment();
+      for (let index = 0; index < 30001; index++) fragment.appendChild(document.createElement('i'));
+      host.appendChild(fragment);
+      expect(hasPasswordFieldInjected().capped).toBe(true);
+    });
+  });
+
+  it('keeps DOM-prefix priority when a wide sibling list exhausts the budget', async () => {
+    await withInputs('', (host) => {
+      const fragment = document.createDocumentFragment();
+      const earlyWrapper = document.createElement('div');
+      const earlyLogin = document.createElement('div');
+      earlyLogin.attachShadow({ mode: 'open' }).innerHTML =
+        '<input type="password" autocomplete="current-password">';
+      earlyWrapper.appendChild(earlyLogin);
+      fragment.appendChild(earlyWrapper);
+      for (let index = 0; index < 30001; index++) fragment.appendChild(document.createElement('i'));
+      host.appendChild(fragment);
+      const result = hasPasswordFieldInjected();
+      expect(result.has).toBe(true);
+    });
+  });
+
+  it('a same-origin frame sign-in field marks the owning origin', async () => {
+    await withInputs('<iframe id="same-origin-login"></iframe>', (host) => {
+      const frame = /** @type {HTMLIFrameElement} */ (host.querySelector('#same-origin-login'));
+      if (!frame.contentDocument?.body) throw new Error('same-origin fixture frame did not mount');
+      frame.contentDocument.body.innerHTML =
+        '<input type="password" autocomplete="current-password">';
+      expect(hasPasswordFieldInjected().has).toBe(true);
+    });
+  });
+
+  it('an exact-origin URL frame marks the owning origin', async () => {
+    await withInputs('<iframe id="url-login"></iframe>', async (host) => {
+      const frame = /** @type {HTMLIFrameElement} */ (host.querySelector('#url-login'));
+      await new Promise((resolve) => {
+        frame.addEventListener('load', resolve, { once: true });
+        frame.src = '/tests/fixtures/password-login-frame.html';
+      });
+      expect(frame.contentDocument?.location.origin).toBe(location.origin);
+      expect(hasPasswordFieldInjected().has).toBe(true);
+    });
+  });
+
+  it('a readable document reporting a different origin is not attributed', async () => {
+    await withInputs('<iframe id="relaxed-origin-login"></iframe>', (host) => {
+      const frame = /** @type {HTMLIFrameElement} */ (host.querySelector('#relaxed-origin-login'));
+      const foreignRoot = document.createElement('html');
+      foreignRoot.innerHTML = '<input type="password" autocomplete="current-password">';
+      const readableForeignDocument = {
+        documentElement: foreignRoot,
+        location: { origin: 'https://accounts.example.test', protocol: 'https:', pathname: '/' },
+        querySelectorAll: (/** @type {string} */ selector) => foreignRoot.querySelectorAll(selector),
+      };
+      Object.defineProperty(frame, 'contentDocument', { value: readableForeignDocument });
+      expect(hasPasswordFieldInjected().has).toBe(false);
+    });
+  });
+
+  it('an unexpected attributable-root failure remains an incomplete negative', async () => {
+    await withInputs('<iframe id="broken-root"></iframe>', (host) => {
+      const frame = /** @type {HTMLIFrameElement} */ (host.querySelector('#broken-root'));
+      const brokenDocument = {
+        documentElement: document.createElement('html'),
+        location: { origin: location.origin, protocol: location.protocol, pathname: '/broken' },
+        querySelectorAll: () => { throw new Error('fixture traversal failure'); },
+      };
+      Object.defineProperty(frame, 'contentDocument', { value: brokenDocument });
+      expect(hasPasswordFieldInjected()).toEqual({ has: false, capped: true });
+    });
+  });
+
+  it('an inherited about:blank URL with query and fragment remains attributable', async () => {
+    await withInputs('<iframe id="queried-blank-login"></iframe>', async (host) => {
+      const frame = /** @type {HTMLIFrameElement} */ (host.querySelector('#queried-blank-login'));
+      await new Promise((resolve) => {
+        frame.addEventListener('load', resolve, { once: true });
+        frame.src = 'about:blank?login#form';
+      });
+      if (!frame.contentDocument?.body) throw new Error('inherited fixture frame did not mount');
+      frame.contentDocument.body.innerHTML =
+        '<input type="password" autocomplete="current-password">';
+      expect(hasPasswordFieldInjected().has).toBe(true);
+    });
+  });
+
+  it('an opaque-origin frame is not attributed to the owning origin', async () => {
+    await withInputs('<iframe id="opaque-login" sandbox></iframe>', async (host) => {
+      const frame = /** @type {HTMLIFrameElement} */ (host.querySelector('#opaque-login'));
+      await new Promise((resolve) => {
+        frame.addEventListener('load', resolve, { once: true });
+        frame.srcdoc = '<input type="password" autocomplete="current-password">';
+      });
+      expect(hasPasswordFieldInjected().has).toBe(false);
+    });
   });
 });

--- a/extension/tests/unit/peerd-runtime/idp-sign-in-flow.test.js
+++ b/extension/tests/unit/peerd-runtime/idp-sign-in-flow.test.js
@@ -36,7 +36,9 @@ describe('identity-provider transit sign-in flow', () => {
           result: { origin: 'https://app.test', href: liveUrl, timeOrigin: 1 },
         }];
       }
-      if (options.func?.name === 'hasPasswordFieldInjected') return [{ result: { has: false } }];
+      if (options.func?.name === 'hasPasswordFieldInjected') {
+        return [{ result: { has: false, capped: false } }];
+      }
       if (options.func?.name === 'loginTargetReader') {
         return [{ result: { ok: true, descriptor: {
           tag: 'button', name: 'Sign in with Google',

--- a/tests/helpers/browser-scripting.ts
+++ b/tests/helpers/browser-scripting.ts
@@ -25,10 +25,9 @@ export const browserProbeResult = (
     }];
   }
   if (request?.func === hasPasswordFieldInjected || name === 'hasPasswordFieldInjected') {
-    const parsed = new URL(url);
     return [{
       documentId,
-      result: { has: hasPassword, origin: parsed.origin, href: parsed.href },
+      result: { has: hasPassword, capped: false },
     }];
   }
   return null;

--- a/tests/peerd-runtime/tools/live-document-probe.test.ts
+++ b/tests/peerd-runtime/tools/live-document-probe.test.ts
@@ -11,7 +11,10 @@
 // an exact document fails closed.
 
 import { describe, test, expect } from 'bun:test';
-import { resolveTargetTab } from '../../../extension/peerd-runtime/tools/defs/dom-helpers.js';
+import {
+  passwordFieldSignalFromProbe,
+  resolveTargetTab,
+} from '../../../extension/peerd-runtime/tools/defs/dom-helpers.js';
 
 const tabsApi = (byId: Record<number, any>) => ({
   get: async (id: number) => { if (!byId[id]) throw new Error('no tab'); return byId[id]; },
@@ -33,7 +36,10 @@ const scriptingSaying = (result: unknown, opts: { calls?: number[] } = {}) => ({
         },
       }];
     }
-    return [{ documentId: 'doc-1', result: { has: value?.has ?? false } }];
+    return [{
+      documentId: 'doc-1',
+      result: { has: value?.has ?? false, capped: value?.capped === true },
+    }];
   },
 });
 
@@ -44,6 +50,13 @@ const baseCtx = (over: Record<string, unknown> = {}) => ({
 });
 
 describe('issue 267 — every DOM tool teaches the classifier, not just snapshot', () => {
+  test('an exhausted negative remains unknown at the policy consumer', () => {
+    expect(passwordFieldSignalFromProbe({ has: false, capped: true })).toBeNull();
+    expect(passwordFieldSignalFromProbe({ has: false, capped: false })).toBe(false);
+    expect(passwordFieldSignalFromProbe({ has: true, capped: true })).toBe(true);
+    expect(passwordFieldSignalFromProbe(null)).toBeNull();
+  });
+
   test('a password field seen at the chokepoint is learned', async () => {
     const learned: Array<[string, string]> = [];
     const ctx: any = baseCtx({


### PR DESCRIPTION
Fixes #277

## What changed

- Search open shadow roots, exact-origin frames, and declared inherited about:blank/srcdoc frames from the exact-document password probe.
- Keep cross-origin frames and closed shadow roots excluded so a child origin cannot make the top origin look sensitive.
- Preserve the complete native top-document scan while bounding only added-boundary discovery with streaming preorder traversal.
- Treat incomplete negative probes as unknown, recognize new-password as an autocomplete token, and remove the obsolete duplicate snapshot probe.
- Refresh the security contract, browser fixtures, and coverage for boundary, ordering, cap, and failure cases.

## Why

The learned sensitive-origin signal only inspected top-frame light DOM. Same-origin embedded sign-in fields and open-shadow login components were therefore invisible, while blindly including foreign frames would misattribute a third-party identity or payment surface to its embedder. This PR widens only the boundaries whose password field can safely be attributed to the current origin.

## Impact

There is no user-visible or model-visible surface change. The internal classifier learns more attributable password origins without widening authority or turning an incomplete scan into a false safe result.

## Validation

- bun run preflight: 5,729 passed, 0 failed
- Chrome in-browser suite: 880 passed, 0 failed
- Packaged Firefox Gecko suite: 874 passed, including the Notebook Run/Stop regression case
- Transient unrelated dweb room timing test: 70/70 across ten targeted reruns
- Final adversarial swarm: security CLEAN; user/model UX CLEAN; architecture/elegance CLEAN