### PR TITLE
Harden dependency update automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,39 @@
-# Keeps the SHA-pinned GitHub Actions current: every action in the workflows
-# is pinned to a full commit SHA with the version in a trailing comment
-# (see package-and-release.yml), and Dependabot understands that format —
-# its PRs bump the SHA and the comment together, so pins never rot into
-# "immutable but ancient". Actions only, deliberately: the Bun devDependency
-# tree is governed by the committed bun.lock + `bun install --frozen-lockfile`
-# in CI, and its updates are curated by hand (signing-critical deps like crx3
-# and web-ext are exact-pinned in package.json on purpose).
+# Routine dependency updates get 30 days of release seasoning. GitHub applies
+# `cooldown` only to version updates, so Dependabot security PRs remain eligible
+# immediately. The no-human merge workflow separately requires every security
+# replacement release to have completed the same 30 days of seasoning.
 version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 30
     groups:
+      # The name is part of the fail-closed auto-merge contract in
+      # dependabot-security-release.yml. Only Dependabot security updates can
+      # enter this group; routine updates remain in the seasoned group below.
+      actions-security-patches:
+        applies-to: security-updates
+        patterns: ['*']
       actions:
+        applies-to: version-updates
+        patterns: ['*']
+
+  # Updates package.json and the committed text-based bun.lock together. This
+  # includes exact-pinned signing dependencies; they still move only through a
+  # reviewed PR and must pass the frozen-lockfile and security CI gates.
+  - package-ecosystem: bun
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 30
+    groups:
+      bun-security-patches:
+        applies-to: security-updates
+        patterns: ['*']
+      bun-dependencies:
+        applies-to: version-updates
         patterns: ['*']

--- a/.github/workflows/dependabot-security-release.yml
+++ b/.github/workflows/dependabot-security-release.yml
@@ -12,21 +12,26 @@
 #
 # The workflow prepares peerd's own patch version and changelog in the same PR,
 # regenerates the reproducible CodeMirror vendor bundle for Bun changes, then
-# asks branch protection to auto-merge only after the normal and security CI
-# checks pass. Once merged, the exact bot-prepared head is tagged and the
-# existing signed release workflow is explicitly dispatched at that tag.
+# waits for protected normal and security CI, then merges only the exact
+# authenticated head. A trusted finalizer tags that merge and explicitly
+# dispatches the existing signed release workflow at the tag.
 
 name: verified Dependabot security release
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, closed]
+    types: [opened, reopened, synchronize]
+  # GITHUB_TOKEN-triggered pull-request events do not reliably start another
+  # workflow. The publisher starts this documented exception before its final,
+  # exact-head merge so the trusted finalizer cannot be lost after the merge.
+  repository_dispatch:
+    types: [verified-security-merge-ready]
 
 permissions:
   contents: read
 
 concurrency:
-  group: dependabot-security-${{ github.event.pull_request.number }}
+  group: dependabot-security-${{ github.event.pull_request.number || github.event.client_payload.pr_number || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -157,7 +162,7 @@ jobs:
       - name: Upload generated patch from the disposable runner
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: dependabot-security-prepared-${{ github.run_id }}
+          name: dependabot-security-prepared-${{ github.event.pull_request.number }}-${{ github.run_id }}
           path: ${{ runner.temp }}/security-prepared/prepared.patch
           if-no-files-found: error
           retention-days: 1
@@ -172,6 +177,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       !contains(github.event.pull_request.labels.*.name, 'security-autorelease')
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       actions: write
       contents: write
@@ -246,7 +252,7 @@ jobs:
       - name: Download the untrusted generated patch
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: dependabot-security-prepared-${{ github.run_id }}
+          name: dependabot-security-prepared-${{ github.event.pull_request.number }}-${{ github.run_id }}
           path: prepared
 
       - name: Apply and independently validate the generated patch
@@ -317,7 +323,7 @@ jobs:
           <!-- peerd-security-autorelease: ${PREPARED_SHA} v${VERSION} -->
           This semver-patch security update was authenticated as Dependabot-only,
           every replacement release passed 30 days of seasoning, and the PR was
-          prepared as peerd v${VERSION} for protected auto-merge.
+          prepared as peerd v${VERSION} for a protected exact-head merge.
           Reproducible CodeMirror vendored bytes changed: ${VENDORED_CODEMIRROR}.
           EOF
           gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
@@ -325,36 +331,157 @@ jobs:
           gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
             --add-label security-autorelease
 
-      # GITHUB_TOKEN pushes intentionally do not recursively start workflows.
-      # Explicit dispatch attaches every required check to the prepared SHA.
-      - name: Dispatch full correctness and security CI on the prepared head
+      # A workflow dispatch normally resolves a mutable branch name. Pin this
+      # validation run to a dedicated tag so the workflow definition, checkout,
+      # and resulting checks all attach to the exact authenticated commit.
+      - name: Pin an exact read-only validation ref
+        id: validation
         env:
           GH_TOKEN: ${{ github.token }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PREPARED_SHA: ${{ steps.commit.outputs.sha }}
         run: |
           set -euo pipefail
-          gh workflow run package-and-release.yml --repo "$GITHUB_REPOSITORY" --ref "$HEAD_REF"
-          gh workflow run security.yml --repo "$GITHUB_REPOSITORY" --ref "$HEAD_REF"
+          current_head="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .head.sha)"
+          [ "$current_head" = "$PREPARED_SHA" ] \
+            || { echo '::error::PR head moved after preparation'; exit 1; }
+          validation_ref="security-validation-pr-${PR_NUMBER}-${PREPARED_SHA:0:12}"
+          existing="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${validation_ref}" \
+            --jq .object.sha 2>/dev/null || true)"
+          if [ -n "$existing" ]; then
+            [ "$existing" = "$PREPARED_SHA" ] \
+              || { echo '::error::validation ref already points at another commit'; exit 1; }
+          else
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/tags/${validation_ref}" \
+              -f sha="$PREPARED_SHA" >/dev/null
+          fi
+          echo "ref=$validation_ref" >> "$GITHUB_OUTPUT"
 
-      - name: Approve and enable protected squash auto-merge
+      # Token-pushed PR heads can acquire approval-required pull_request runs.
+      # Dispatch and track separate read-only runs on the exact prepared SHA.
+      # Write-scoped visual and CodeQL jobs are disabled in this mode because a
+      # candidate Action SHA must never execute beside a repository-write token.
+      - name: Dispatch read-only correctness and security CI on the prepared head
+        id: ci
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VALIDATION_REF: ${{ steps.validation.outputs.ref }}
+          PREPARED_SHA: ${{ steps.commit.outputs.sha }}
+        run: |
+          set -euo pipefail
+          latest_run() {
+            gh api --method GET \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/$1/runs" \
+              -f head_sha="$PREPARED_SHA" -f event=workflow_dispatch -f per_page=1 \
+              --jq '.workflow_runs[0].id // empty'
+          }
+          wait_for_new_run() {
+            local workflow="$1"
+            local previous="$2"
+            local candidate=''
+            for attempt in $(seq 1 40); do
+              candidate="$(latest_run "$workflow")"
+              if [[ "$candidate" =~ ^[1-9][0-9]*$ ]] && [ "$candidate" != "$previous" ]; then
+                printf '%s\n' "$candidate"
+                return 0
+              fi
+              sleep 3
+            done
+            echo "::error::dispatch for $workflow did not register a new run" >&2
+            return 1
+          }
+          package_previous="$(latest_run package-and-release.yml)"
+          security_previous="$(latest_run security.yml)"
+          gh workflow run package-and-release.yml --repo "$GITHUB_REPOSITORY" \
+            --ref "$VALIDATION_REF" -f security_read_only=true
+          gh workflow run security.yml --repo "$GITHUB_REPOSITORY" \
+            --ref "$VALIDATION_REF" -f security_read_only=true
+          package_run="$(wait_for_new_run package-and-release.yml "$package_previous")"
+          security_run="$(wait_for_new_run security.yml "$security_previous")"
+          for run_id in "$package_run" "$security_run"; do
+            gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
+              | jq -e \
+                --arg sha "$PREPARED_SHA" '
+                  .event == "workflow_dispatch" and
+                  .head_sha == $sha
+                ' >/dev/null
+          done
+          echo "package-run=$package_run" >> "$GITHUB_OUTPUT"
+          echo "security-run=$security_run" >> "$GITHUB_OUTPUT"
+
+      - name: Approve, await protected checks, and merge the exact head
         env:
           GH_TOKEN: ${{ github.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PREPARED_SHA: ${{ steps.commit.outputs.sha }}
+          PACKAGE_RUN_ID: ${{ steps.ci.outputs.package-run }}
+          SECURITY_RUN_ID: ${{ steps.ci.outputs.security-run }}
         run: |
           set -euo pipefail
+          current_head="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .head.sha)"
+          [ "$current_head" = "$PREPARED_SHA" ] \
+            || { echo '::error::PR head moved before approval'; exit 1; }
           gh pr review "$PR_URL" --approve \
             --body 'Automated approval: authenticated semver-patch security update; merge remains gated on protected CI.'
-          gh pr merge "$PR_URL" --auto --squash --delete-branch=false
+          for attempt in $(seq 1 160); do
+            package_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${PACKAGE_RUN_ID}")"
+            security_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${SECURITY_RUN_ID}")"
+            for run_json in "$package_json" "$security_json"; do
+              jq -e \
+                --arg sha "$PREPARED_SHA" '
+                  .event == "workflow_dispatch" and .head_sha == $sha
+                ' <<< "$run_json" >/dev/null
+              status="$(jq -r .status <<< "$run_json")"
+              conclusion="$(jq -r '.conclusion // ""' <<< "$run_json")"
+              if [ "$status" = completed ] && [ "$conclusion" != success ]; then
+                echo "::error::exact read-only validation run concluded $conclusion"
+                exit 1
+              fi
+            done
+            if [ "$(jq -r .conclusion <<< "$package_json")" = success ] \
+              && [ "$(jq -r .conclusion <<< "$security_json")" = success ]; then
+              break
+            fi
+            [ "$attempt" -lt 160 ] \
+              || { echo '::error::exact validation runs did not pass within 40 minutes'; exit 1; }
+            sleep 15
+          done
+          pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+          current_head="$(jq -r .head.sha <<< "$pr_json")"
+          [ "$current_head" = "$PREPARED_SHA" ] \
+            || { echo '::error::PR head moved while awaiting protected checks'; exit 1; }
+
+          # Start the trusted finalizer before the merge. A GITHUB_TOKEN merge
+          # does not guarantee a pull-request event, while repository_dispatch
+          # is explicitly recursive. The finalizer independently waits for and
+          # re-authenticates the exact merge before it can tag anything.
+          jq -n \
+            --arg event_type verified-security-merge-ready \
+            --argjson pr_number "$PR_NUMBER" \
+            --argjson publisher_run_id "$GITHUB_RUN_ID" \
+            --arg expected_head "$PREPARED_SHA" \
+            '{event_type: $event_type, client_payload: {
+              pr_number: $pr_number,
+              publisher_run_id: $publisher_run_id,
+              expected_head: $expected_head
+            }}' > "$RUNNER_TEMP/security-merge-ready.json"
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/dispatches" \
+            --input "$RUNNER_TEMP/security-merge-ready.json"
+
+          gh pr merge "$PR_URL" --squash --delete-branch=false \
+            --match-head-commit "$PREPARED_SHA"
 
   release:
     name: tag exact merged security patch
-    if: >-
-      github.event.action == 'closed' &&
-      github.event.pull_request.merged == true &&
-      github.event.pull_request.user.login == 'dependabot[bot]' &&
-      github.event.pull_request.base.ref == 'main' &&
-      contains(github.event.pull_request.labels.*.name, 'security-autorelease')
+    if: github.event_name == 'repository_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      RELEASE_PR_NUMBER: ${{ github.event.client_payload.pr_number }}
+      RELEASE_PUBLISHER_RUN_ID: ${{ github.event.client_payload.publisher_run_id }}
+      RELEASE_EXPECTED_HEAD: ${{ github.event.client_payload.expected_head }}
     permissions:
       actions: write
       contents: write
@@ -366,12 +493,68 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Re-authenticate and await the exact protected merge
+        id: merged
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          [[ "$RELEASE_PUBLISHER_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$RELEASE_EXPECTED_HEAD" =~ ^[0-9a-f]{40}$ ]]
+          for attempt in $(seq 1 40); do
+            publisher_json="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${RELEASE_PUBLISHER_RUN_ID}")"
+            jq -e \
+              --arg repository "$GITHUB_REPOSITORY" \
+              --arg path '.github/workflows/dependabot-security-release.yml' '
+                .event == "pull_request_target" and
+                (.path == $path or (.path | startswith($path + "@"))) and
+                .repository.full_name == $repository
+              ' <<< "$publisher_json" >/dev/null
+            if [ "$(jq -r .status <<< "$publisher_json")" = completed ]; then
+              [ "$(jq -r .conclusion <<< "$publisher_json")" = success ] \
+                || { echo '::error::authenticated publisher did not succeed'; exit 1; }
+              break
+            fi
+            [ "$attempt" -lt 40 ] \
+              || { echo '::error::authenticated publisher did not finish within 10 minutes'; exit 1; }
+            sleep 15
+          done
+          artifact="dependabot-security-prepared-${RELEASE_PR_NUMBER}-${RELEASE_PUBLISHER_RUN_ID}"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RELEASE_PUBLISHER_RUN_ID}/artifacts" \
+            | jq -e --arg artifact "$artifact" '
+                any(.artifacts[]; .name == $artifact and .expired == false)
+              ' >/dev/null
+          for attempt in $(seq 1 80); do
+            pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${RELEASE_PR_NUMBER}")"
+            jq -e \
+              --arg repository "$GITHUB_REPOSITORY" \
+              --arg head "$RELEASE_EXPECTED_HEAD" '
+                .user.login == "dependabot[bot]" and
+                .base.ref == "main" and
+                .head.repo.full_name == $repository and
+                .head.sha == $head and
+                any(.labels[]; .name == "security-autorelease")
+              ' <<< "$pr_json" >/dev/null
+            if [ "$(jq -r .merged <<< "$pr_json")" = true ]; then
+              merge_sha="$(jq -r .merge_commit_sha <<< "$pr_json")"
+              [[ "$merge_sha" =~ ^[0-9a-f]{40}$ ]] \
+                || { echo '::error::merged PR has no full merge commit SHA'; exit 1; }
+              echo "sha=$merge_sha" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo '::error::exact security head was not merged within 20 minutes'
+          exit 1
+
       - name: Read the bot-authored release marker
         id: marker
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ env.RELEASE_PR_NUMBER }}
+          EXPECTED_HEAD: ${{ env.RELEASE_EXPECTED_HEAD }}
         run: |
           set -euo pipefail
           marker="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
@@ -390,13 +573,13 @@ jobs:
       - name: Check out the protected merge commit without credentials
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ steps.merged.outputs.sha }}
           persist-credentials: false
           fetch-depth: 0
 
       - name: Recheck patch version, changelog, and main ancestry
         env:
-          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          MERGE_SHA: ${{ steps.merged.outputs.sha }}
           VERSION: ${{ steps.marker.outputs.version }}
         run: |
           set -euo pipefail
@@ -420,8 +603,8 @@ jobs:
       - name: Create idempotent release tag and dispatch signed release
         env:
           GH_TOKEN: ${{ github.token }}
-          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MERGE_SHA: ${{ steps.merged.outputs.sha }}
+          PR_NUMBER: ${{ env.RELEASE_PR_NUMBER }}
           VERSION: ${{ steps.marker.outputs.version }}
         run: |
           set -euo pipefail
@@ -436,6 +619,13 @@ jobs:
             git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $auth" \
               push origin "refs/tags/$tag"
           fi
-          gh workflow run package-and-release.yml --repo "$GITHUB_REPOSITORY" --ref "$tag"
+          existing_run="$(gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/package-and-release.yml/runs" \
+            -f head_sha="$MERGE_SHA" -f event=workflow_dispatch -f per_page=100 \
+            --jq ".workflow_runs | map(select(.head_branch == \"$tag\"))[0].id // empty")"
+          if [ -z "$existing_run" ]; then
+            gh workflow run package-and-release.yml --repo "$GITHUB_REPOSITORY" --ref "$tag" \
+              -f security_release_sha="$MERGE_SHA"
+          fi
           gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-            --body "Merged verified security patch as $tag; the signed patch-release workflow has been dispatched."
+            --body "Merged verified security patch as $tag; signed patch-release workflow run ${existing_run:-dispatched}."

--- a/.github/workflows/dependabot-security-release.yml
+++ b/.github/workflows/dependabot-security-release.yml
@@ -1,0 +1,441 @@
+# No-human happy path for the narrow, mechanically verifiable subset of
+# Dependabot security updates. This workflow NEVER checks out PR code into the
+# trusted policy checkout and never exposes a secret while candidate code runs.
+#
+# Eligibility (all fail closed):
+#   - Dependabot-authored PR with GitHub-verified Dependabot commits
+#   - explicit security-only group from dependabot.yml
+#   - semver patch dependency update (minor/major fixes stay human-reviewed)
+#   - every replacement release has independently seasoned for at least 30 days
+#   - root Bun or GitHub Actions ecosystem, no maintainer changes
+#   - manifest/lock-only Bun diff, or SHA-pinned uses:-line-only Actions diff
+#
+# The workflow prepares peerd's own patch version and changelog in the same PR,
+# regenerates the reproducible CodeMirror vendor bundle for Bun changes, then
+# asks branch protection to auto-merge only after the normal and security CI
+# checks pass. Once merged, the exact bot-prepared head is tagged and the
+# existing signed release workflow is explicitly dispatched at that tag.
+
+name: verified Dependabot security release
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependabot-security-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: verify and generate on a read-only runner
+    if: >-
+      github.event.action != 'closed' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(github.event.pull_request.labels.*.name, 'security-autorelease')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      release-date: ${{ steps.release.outputs.release-date }}
+    steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      # This action verifies the PR author AND every pre-existing PR commit's
+      # GitHub verification. Keep skip-verification at its safe default false.
+      - name: Authenticate Dependabot metadata and commits
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Check immutable event and metadata boundaries
+        env:
+          DIRECTORY: ${{ steps.metadata.outputs.directory }}
+          TARGET_BRANCH: ${{ steps.metadata.outputs.target-branch }}
+          MAINTAINER_CHANGES: ${{ steps.metadata.outputs.maintainer-changes }}
+        run: |
+          set -euo pipefail
+          [ "$DIRECTORY" = / ] || { echo "::error::only the root dependency manifests are eligible"; exit 1; }
+          [ "$TARGET_BRANCH" = main ] || { echo "::error::security PR does not target main"; exit 1; }
+          [ "$MAINTAINER_CHANGES" = false ] || { echo "::error::maintainer-edited Dependabot PR requires human review"; exit 1; }
+
+      # Two disjoint trees are intentional. The candidate can update deps, but
+      # it cannot replace the policy script that judges its diff.
+      - name: Check out trusted base policy
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: trusted
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Check out candidate without credentials
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: candidate
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.9"
+
+      - name: Enforce the dependency-only patch policy
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
+          GROUP: ${{ steps.metadata.outputs.dependency-group }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCIES: ${{ steps.metadata.outputs.dependency-names }}
+          UPDATED_DEPENDENCIES: ${{ steps.metadata.outputs.updated-dependencies-json }}
+          # Used only by the trusted base policy for read-only upstream Action
+          # release/tag/commit verification. Candidate processes never see it.
+          GH_API_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          bun trusted/packaging/dependabot-security.ts verify \
+            --repo=candidate \
+            --base-sha="$BASE_SHA" \
+            --head-sha="$HEAD_SHA" \
+            --ecosystem="$ECOSYSTEM" \
+            --group="$GROUP" \
+            --update-type="$UPDATE_TYPE" \
+            --dependencies="$DEPENDENCIES" \
+            --metadata="$UPDATED_DEPENDENCIES" \
+            --minimum-age-days=30
+
+      # Lifecycle scripts are disabled. Socket and the deterministic vendoring
+      # toolchain still evaluate candidate dependency bytes, which is why this
+      # entire generation job has only a read token and its runner is discarded.
+      - name: Install candidate tree without lifecycle scripts
+        working-directory: candidate
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Prepare patch release and reproducible vendored bytes
+        id: release
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
+          DEPENDENCIES: ${{ steps.metadata.outputs.dependency-names }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          release_date="$(date -u +%F)"
+          bun trusted/packaging/dependabot-security.ts prepare \
+            --repo=candidate \
+            --base-sha="$BASE_SHA" \
+            --ecosystem="$ECOSYSTEM" \
+            --dependencies="$DEPENDENCIES" \
+            --pr="$PR_NUMBER" \
+            --date="$release_date"
+
+      # Candidate dependencies and generated bytes never share a runner with
+      # a repository-write token. The next job treats this patch as untrusted
+      # input and revalidates it from a fresh checkout before it can push.
+      - name: Export the untrusted generated patch
+        working-directory: candidate
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/security-prepared"
+          git diff --binary --full-index "$HEAD_SHA" -- \
+            > "$RUNNER_TEMP/security-prepared/prepared.patch"
+          test -s "$RUNNER_TEMP/security-prepared/prepared.patch"
+
+      - name: Upload generated patch from the disposable runner
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dependabot-security-prepared-${{ github.run_id }}
+          path: ${{ runner.temp }}/security-prepared/prepared.patch
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: revalidate and publish exact prepared patch
+    needs: verify
+    if: >-
+      github.event.action != 'closed' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(github.event.pull_request.labels.*.name, 'security-autorelease')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Re-authenticate Dependabot metadata and commits
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Recheck immutable event and metadata boundaries
+        env:
+          DIRECTORY: ${{ steps.metadata.outputs.directory }}
+          TARGET_BRANCH: ${{ steps.metadata.outputs.target-branch }}
+          MAINTAINER_CHANGES: ${{ steps.metadata.outputs.maintainer-changes }}
+        run: |
+          set -euo pipefail
+          [ "$DIRECTORY" = / ] || { echo "::error::only the root dependency manifests are eligible"; exit 1; }
+          [ "$TARGET_BRANCH" = main ] || { echo "::error::security PR does not target main"; exit 1; }
+          [ "$MAINTAINER_CHANGES" = false ] || { echo "::error::maintainer-edited Dependabot PR requires human review"; exit 1; }
+
+      - name: Check out trusted base policy
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: trusted
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Check out exact authenticated candidate without credentials
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: candidate
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.9"
+
+      - name: Re-enforce the authenticated dependency-only policy
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
+          GROUP: ${{ steps.metadata.outputs.dependency-group }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCIES: ${{ steps.metadata.outputs.dependency-names }}
+          UPDATED_DEPENDENCIES: ${{ steps.metadata.outputs.updated-dependencies-json }}
+          GH_API_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          bun trusted/packaging/dependabot-security.ts verify \
+            --repo=candidate \
+            --base-sha="$BASE_SHA" \
+            --head-sha="$HEAD_SHA" \
+            --ecosystem="$ECOSYSTEM" \
+            --group="$GROUP" \
+            --update-type="$UPDATE_TYPE" \
+            --dependencies="$DEPENDENCIES" \
+            --metadata="$UPDATED_DEPENDENCIES" \
+            --minimum-age-days=30
+
+      - name: Download the untrusted generated patch
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dependabot-security-prepared-${{ github.run_id }}
+          path: prepared
+
+      - name: Apply and independently validate the generated patch
+        id: release
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
+          DEPENDENCIES: ${{ steps.metadata.outputs.dependency-names }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RELEASE_DATE: ${{ needs.verify.outputs.release-date }}
+        run: |
+          set -euo pipefail
+          [ -f prepared/prepared.patch ] && [ ! -L prepared/prepared.patch ]
+          [ "$(find prepared -mindepth 1 -maxdepth 1 | wc -l)" -eq 1 ]
+          [ "$(wc -c < prepared/prepared.patch)" -le 2097152 ] \
+            || { echo '::error::generated patch exceeds the 2 MiB safety cap'; exit 1; }
+          git -C candidate apply --check --index ../prepared/prepared.patch
+          git -C candidate apply --index ../prepared/prepared.patch
+          bun trusted/packaging/dependabot-security.ts validate-prepared \
+            --repo=candidate \
+            --base-sha="$BASE_SHA" \
+            --head-sha="$HEAD_SHA" \
+            --ecosystem="$ECOSYSTEM" \
+            --dependencies="$DEPENDENCIES" \
+            --pr="$PR_NUMBER" \
+            --date="$RELEASE_DATE"
+
+      - name: Commit the independently validated preparation
+        id: commit
+        working-directory: candidate
+        run: |
+          set -euo pipefail
+          git add --all
+          git -c user.name='github-actions[bot]' \
+            -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+            commit -m "chore(release): prepare verified security patch v${{ steps.release.outputs.version }}"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      # No candidate dependency code runs in this job. The repository-write
+      # token is introduced only after fresh authentication and pure validation.
+      - name: Push prepared commit to the Dependabot branch
+        working-directory: candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          auth="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)"
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $auth" \
+            push https://github.com/${GITHUB_REPOSITORY}.git "HEAD:${HEAD_REF}"
+
+      - name: Mark the exact releasable PR head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PREPARED_SHA: ${{ steps.commit.outputs.sha }}
+          VERSION: ${{ steps.release.outputs.version }}
+          VENDORED_CODEMIRROR: ${{ steps.release.outputs.vendored-codemirror }}
+        run: |
+          set -euo pipefail
+          gh label create security-autorelease \
+            --repo "$GITHUB_REPOSITORY" \
+            --color 0E8A16 \
+            --description 'Verified Dependabot patch queued for automatic release' \
+            --force
+          cat > "$RUNNER_TEMP/security-autorelease.md" <<EOF
+          <!-- peerd-security-autorelease: ${PREPARED_SHA} v${VERSION} -->
+          This semver-patch security update was authenticated as Dependabot-only,
+          every replacement release passed 30 days of seasoning, and the PR was
+          prepared as peerd v${VERSION} for protected auto-merge.
+          Reproducible CodeMirror vendored bytes changed: ${VENDORED_CODEMIRROR}.
+          EOF
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --body-file "$RUNNER_TEMP/security-autorelease.md"
+          gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --add-label security-autorelease
+
+      # GITHUB_TOKEN pushes intentionally do not recursively start workflows.
+      # Explicit dispatch attaches every required check to the prepared SHA.
+      - name: Dispatch full correctness and security CI on the prepared head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          gh workflow run package-and-release.yml --repo "$GITHUB_REPOSITORY" --ref "$HEAD_REF"
+          gh workflow run security.yml --repo "$GITHUB_REPOSITORY" --ref "$HEAD_REF"
+
+      - name: Approve and enable protected squash auto-merge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+          gh pr review "$PR_URL" --approve \
+            --body 'Automated approval: authenticated semver-patch security update; merge remains gated on protected CI.'
+          gh pr merge "$PR_URL" --auto --squash --delete-branch=false
+
+  release:
+    name: tag exact merged security patch
+    if: >-
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.base.ref == 'main' &&
+      contains(github.event.pull_request.labels.*.name, 'security-autorelease')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Read the bot-authored release marker
+        id: marker
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          marker="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq '.[] | select(.user.login == "github-actions[bot]") | .body' \
+            | sed -n 's/.*peerd-security-autorelease: \([0-9a-f]\{40\}\) v\([0-9][0-9.]*\).*/\1 \2/p' \
+            | tail -1)"
+          read -r prepared_sha version <<< "$marker"
+          [ -n "${prepared_sha:-}" ] && [ -n "${version:-}" ] \
+            || { echo '::error::missing bot-authored security release marker'; exit 1; }
+          [ "$prepared_sha" = "$EXPECTED_HEAD" ] \
+            || { echo '::error::PR head changed after automated preparation; refusing to tag'; exit 1; }
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+            || { echo '::error::invalid marked version'; exit 1; }
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Check out the protected merge commit without credentials
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Recheck patch version, changelog, and main ancestry
+        env:
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          VERSION: ${{ steps.marker.outputs.version }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$MERGE_SHA" origin/main \
+            || { echo '::error::merged commit is not on origin/main'; exit 1; }
+          package_version="$(jq -r .version package.json)"
+          [ "$package_version" = "$VERSION" ] \
+            || { echo '::error::merged package version differs from prepared version'; exit 1; }
+          parent_line="$(git rev-list --parents -n 1 "$MERGE_SHA")"
+          [ "$(wc -w <<< "$parent_line")" -eq 2 ] \
+            || { echo '::error::security squash merge does not have exactly one protected-main parent'; exit 1; }
+          base_commit="$(awk '{print $2}' <<< "$parent_line")"
+          base_version="$(git show "$base_commit:package.json" | jq -r .version)"
+          IFS=. read -r major minor patch <<< "$base_version"
+          [ "$VERSION" = "$major.$minor.$((patch + 1))" ] \
+            || { echo '::error::security release is not exactly one peerd patch version'; exit 1; }
+          grep -Eq "^## \\[$VERSION\\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$" CHANGELOG.md \
+            || { echo '::error::prepared changelog section is missing'; exit 1; }
+
+      - name: Create idempotent release tag and dispatch signed release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          VERSION: ${{ steps.marker.outputs.version }}
+        run: |
+          set -euo pipefail
+          tag="v${VERSION}"
+          remote_sha="$(git ls-remote --tags origin "refs/tags/$tag" | awk '{print $1}')"
+          if [ -n "$remote_sha" ]; then
+            [ "$remote_sha" = "$MERGE_SHA" ] \
+              || { echo "::error::$tag already points at another commit"; exit 1; }
+          else
+            git tag "$tag" "$MERGE_SHA"
+            auth="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)"
+            git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $auth" \
+              push origin "refs/tags/$tag"
+          fi
+          gh workflow run package-and-release.yml --repo "$GITHUB_REPOSITORY" --ref "$tag"
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --body "Merged verified security patch as $tag; the signed patch-release workflow has been dispatched."

--- a/.github/workflows/package-and-release.yml
+++ b/.github/workflows/package-and-release.yml
@@ -35,6 +35,14 @@ on:
         description: 'Recapture the side-panel visual baselines on the CI authority and upload them as an artifact to commit'
         type: boolean
         default: false
+      security_read_only:
+        description: 'Run candidate security validation without any write-capable jobs'
+        type: boolean
+        default: false
+      security_release_sha:
+        description: 'Bind an automated security release dispatch to this exact merge commit'
+        type: string
+        default: ''
 
 # Default the workflow token to read-only; jobs that write (visual's diff
 # branch + PR comment, release's assets) elevate per-job. why: the default
@@ -329,6 +337,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.9"
+      - run: bun install --frozen-lockfile --ignore-scripts
       # why setup-chrome: it installs the system libraries headless Chrome
       # needs. We then run against Chrome for Testing (branded Chrome ignores
       # --load-extension), which reuses those libs.
@@ -376,6 +385,14 @@ jobs:
     # instead of comparing). A distinct name means a reseed can never satisfy
     # the gating check. Otherwise this display name stays stable.
     name: "visual (render)${{ github.event_name == 'workflow_dispatch' && inputs.update_visual_baselines && ' (reseed baselines)' || '' }}"
+    # A prepared Dependabot head can contain a candidate Action SHA. Never let
+    # that candidate share this job's repository-write token.
+    if: >-
+      !(github.event_name == 'pull_request' &&
+        github.event.pull_request.user.login == 'dependabot[bot]') &&
+      !(github.event_name == 'workflow_dispatch' &&
+        (inputs.security_read_only ||
+          startsWith(github.ref, 'refs/tags/security-validation-pr-')))
     # PINNED, not ubuntu-latest: `latest` migrates between images, and a
     # freetype/fontconfig bump would re-rasterize every glyph in every baseline.
     runs-on: ubuntu-24.04
@@ -699,7 +716,10 @@ jobs:
 
   release:
     name: GitHub Release (preview channel)
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: >-
+      startsWith(github.ref, 'refs/tags/v') &&
+      (github.event_name != 'workflow_dispatch' ||
+        (inputs.security_release_sha != '' && inputs.security_release_sha == github.sha))
     runs-on: ubuntu-latest
     # Bound the same image-validation exposure on the trusted signing path.
     timeout-minutes: 30

--- a/.github/workflows/package-and-release.yml
+++ b/.github/workflows/package-and-release.yml
@@ -64,6 +64,10 @@ jobs:
     name: bun test
     runs-on: ubuntu-latest
     steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -78,6 +82,10 @@ jobs:
     # loop. This bounds a crafted PR asset until upstream publishes a fix.
     timeout-minutes: 15
     steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
@@ -151,6 +159,10 @@ jobs:
     name: in-browser tests (headless Chrome)
     runs-on: ubuntu-latest
     steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -174,6 +186,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -219,6 +235,10 @@ jobs:
     name: dweb two-peer (headless WebRTC)
     runs-on: ubuntu-latest
     steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -275,6 +295,10 @@ jobs:
     name: dweb netproc (multi-process nodes)
     runs-on: ubuntu-latest
     steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -297,6 +321,10 @@ jobs:
     name: e2e (side panel)
     runs-on: ubuntu-latest
     steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -360,6 +388,10 @@ jobs:
       VISUAL_PLATFORM: linux-x64
       TZ: UTC
     steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -581,6 +613,10 @@ jobs:
     name: packaged page boot
     runs-on: ubuntu-latest
     steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -609,6 +645,10 @@ jobs:
         channel: [store, preview]
         browser: [chrome, firefox]
     steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -677,6 +717,10 @@ jobs:
       id-token: write
       attestations: write
     steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -691,6 +735,19 @@ jobs:
             echo "::error::tag v$TAG_VERSION does not match package.json version $PKG_VERSION"
             exit 1
           fi
+
+      # Required once the release environment's manual reviewer is removed for
+      # verified security auto-releases: a v* tag is not sufficient authority
+      # on its own. The exact tagged commit must already be reachable from the
+      # protected main branch before this job is allowed to read signing keys.
+      - name: Require the tagged commit to belong to protected main
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main || {
+            echo '::error::release tag does not point to a commit on origin/main'
+            exit 1
+          }
 
       - name: Require signing credentials
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,6 +35,10 @@ jobs:
       contents: read
       security-events: write   # upload the SARIF result to the Security tab
     steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
@@ -58,6 +62,10 @@ jobs:
       # the same over-grant the top-level `contents: read` default exists to avoid.
       contents: read
     steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Scans bun.lock — the devDependency tree that builds and SIGNS the
       # artifacts. Nothing here ships inside the extension (vendor/ is pinned
@@ -80,6 +88,10 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # GATING. This ran continue-on-error while the repo's Dependency graph
       # setting was off, because without it the action errors "not supported" —
@@ -101,6 +113,10 @@ jobs:
     name: peerd security invariants
     runs-on: ubuntu-latest
     steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,6 +23,11 @@ on:
     # surfaces — the PR-time gates only ever see what a diff touches.
     - cron: '23 6 * * 1'
   workflow_dispatch:
+    inputs:
+      security_read_only:
+        description: 'Run candidate security validation without write-scoped analyzers'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -30,6 +35,15 @@ permissions:
 jobs:
   codeql:
     name: CodeQL (javascript-typescript)
+    # Candidate Action updates are intentionally not executed with the SARIF
+    # upload token. Authenticated dependency-only heads are checked by the
+    # read-only policy, vulnerability, and repository-invariant lanes instead.
+    if: >-
+      !(github.event_name == 'pull_request' &&
+        github.event.pull_request.user.login == 'dependabot[bot]') &&
+      !(github.event_name == 'workflow_dispatch' &&
+        (inputs.security_read_only ||
+          startsWith(github.ref, 'refs/tags/security-validation-pr-')))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -56,7 +70,7 @@ jobs:
     name: OSV scan (resolved dependency tree)
     runs-on: ubuntu-latest
     permissions:
-      # read only: this job runs a third-party CONTAINER over the repo tree and
+      # read only: this job runs a third-party scanner over the repo tree and
       # never uploads SARIF (no --format=sarif, no upload-sarif step), so granting
       # security-events: write would hand it an API scope it has no use for —
       # the same over-grant the top-level `contents: read` default exists to avoid.
@@ -74,10 +88,23 @@ jobs:
       # osv-scanner.toml holds the triaged, EXPIRING ignore list for advisories
       # that cannot move from here (web-ext pins several of them exactly). New
       # findings are not on that list and fail this job.
-      - uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
-        with:
-          scan-args: |-
-            --config=./osv-scanner.toml
+      # The upstream wrapper is SHA-pinned, but its action.yml references a
+      # mutable container tag that GitHub pulls before the first job step. Use
+      # the official release binary only after Harden Runner starts, and verify
+      # the exact asset digest published by the v2.3.8 GitHub Release.
+      - name: Run checksum-pinned OSV-Scanner v2.3.8
+        env:
+          OSV_SCANNER_SHA256: bc98e15319ed0d515e3f9235287ba53cdc5535d576d24fd573978ecfe9ab92dc
+          OSV_SCANNER_URL: https://github.com/google/osv-scanner/releases/download/v2.3.8/osv-scanner_linux_amd64
+        run: |
+          set -euo pipefail
+          curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
+            "$OSV_SCANNER_URL" --output "$RUNNER_TEMP/osv-scanner"
+          printf '%s  %s\n' "$OSV_SCANNER_SHA256" "$RUNNER_TEMP/osv-scanner" \
+            | sha256sum --check --strict -
+          chmod 0755 "$RUNNER_TEMP/osv-scanner"
+          "$RUNNER_TEMP/osv-scanner" scan \
+            --config=./osv-scanner.toml \
             --lockfile=./bun.lock
 
   dependency-review:
@@ -86,7 +113,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Harden runner (audit egress and source writes)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -107,7 +133,6 @@ jobs:
           # Mirrors the PR checklist's "no GPL / AGPL / copyleft" line — the
           # extension is Apache-2.0 and vendors only permissive code.
           deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0, LGPL-2.1, LGPL-3.0
-          comment-summary-in-pr: on-failure
 
   invariants:
     name: peerd security invariants

--- a/.github/workflows/update-feed-monitor.yml
+++ b/.github/workflows/update-feed-monitor.yml
@@ -20,6 +20,10 @@ jobs:
   probe:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - name: Compare live feeds against the latest release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,6 +44,17 @@ The [`lifecycle and recovery contract`](docs/security/LIFECYCLE-CONTRACT.md)
 states what happens to operations, tabs, sandboxes, and stored data when a
 worker or browser session stops unexpectedly.
 
+## Supply-chain security
+
+Dependency updates are treated as untrusted code, including updates labeled as
+security fixes. The canonical policy, automation boundary, coverage, and
+explicit exclusions live in
+[`docs/security/DEPENDENCY-AUTOMATION.md`](docs/security/DEPENDENCY-AUTOMATION.md).
+Its enforcement is kept close to the mechanism: `.github/dependabot.yml` and
+`bunfig.toml` season new releases; `.github/workflows/security.yml` and
+`.github/workflows/dependabot-security-release.yml` gate changes; and
+`extension/vendor/vendor.lock.json` pins every checked-in third-party byte.
+
 ## Trust model (what peerd already defends)
 
 Understanding the boundaries helps you scope a report:

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@codemirror/state": "^6.6.0",
         "@codemirror/theme-one-dark": "^6.1.3",
         "@codemirror/view": "^6.43.0",
+        "@socketsecurity/bun-security-scanner": "1.1.2",
         "@types/bun": "^1.3.14",
         "@types/chrome": "^0.2.0",
         "@types/webextension-polyfill": "^0.12.5",
@@ -125,6 +126,8 @@
     "@pnpm/npm-conf": ["@pnpm/npm-conf@3.0.3", "", { "dependencies": { "@pnpm/config.env-replace": "^1.1.0", "@pnpm/network.ca-file": "^1.0.1", "config-chain": "^1.1.11" } }, "sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA=="],
 
     "@puppeteer/browsers": ["@puppeteer/browsers@3.1.0", "", { "dependencies": { "modern-tar": "^0.7.6", "yargs": "^18.0.0" }, "peerDependencies": { "proxy-agent": ">=8.0.1", "yauzl": "^2.10.0 || ^3.4.0" }, "optionalPeers": ["proxy-agent", "yauzl"], "bin": { "browsers": "lib/main-cli.js" } }, "sha512-RDLpio3fH/qrj5k4DVY6eyiN8tCS0Zovd/6jW//n605oeqkWcUjn+3k+9ZtZBnbwMpsu0F7xDIiKXvVmG5c5Bw=="],
+
+    "@socketsecurity/bun-security-scanner": ["@socketsecurity/bun-security-scanner@1.1.2", "", {}, "sha512-TdsAg6SMolubyZ6HfIjLWlANfHvhV6i7pdWof4OQ33zPEwXJm2ilA755levHMR618MKq22+06Ag8efiVKowxqA=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -5,5 +5,18 @@
 # integration and runs headless via scripts/cdp/run-inbrowser-tests.mjs).
 # Bun walks recursively for *.test.{ts,js}.
 
+[install]
+# Defense in depth for local/manual resolution. Existing bun.lock entries stay
+# reproducible; newly resolved direct and transitive versions must have been
+# public for 30 days. The security auto-merge policy independently rechecks the
+# exact replacement timestamps because Dependabot writes the lockfile remotely.
+minimumReleaseAge = 2592000
+
+[install.security]
+# Supply-chain behavior/malware signal in addition to OSV's known-CVE scan.
+# The scanner is exact-pinned in package.json and uses Socket's unauthenticated
+# public API, so CI needs no Socket account or secret.
+scanner = "@socketsecurity/bun-security-scanner"
+
 [test]
 preload = ["./tests/setup.ts"]

--- a/docs/security/DEPENDENCY-AUTOMATION.md
+++ b/docs/security/DEPENDENCY-AUTOMATION.md
@@ -1,0 +1,147 @@
+# Dependency update and security-release policy
+
+Every automatically merged dependency release seasons for 30 days. Dependabot
+security PRs are opened immediately, but the deliberately narrow no-human path
+also verifies the replacement artifact's publication age before it can merge.
+A fresh security fix remains visible and tested in an open PR while a person
+decides whether the known vulnerability outweighs the fresh-artifact risk.
+
+## Covered dependency manifests
+
+`.github/dependabot.yml` covers both dependency manifests in this repository:
+
+- `package.json` plus the committed `bun.lock` (`package-ecosystem: bun`),
+  including development dependencies and exact-pinned release tooling.
+- Every SHA-pinned `uses:` reference under `.github/workflows/`
+  (`package-ecosystem: github-actions`).
+
+Routine updates are grouped per ecosystem and held until the candidate version
+is at least 30 days old. GitHub applies `cooldown` to version updates, not to
+Dependabot security updates, so the trusted workflow independently checks every
+security replacement's registry or GitHub release timestamp. `bunfig.toml`
+also applies Bun's native 30-day filter to new local/manual resolution of both
+direct and transitive packages; existing locked versions remain reproducible.
+
+Security updates use distinct `bun-security-patches` and
+`actions-security-patches` groups. Their names are security boundaries: the
+trusted automation accepts no other group.
+
+## No-human security path
+
+`.github/workflows/dependabot-security-release.yml` accepts a PR only when all
+of these are true:
+
+1. `dependabot/fetch-metadata` authenticates the Dependabot author and every
+   existing Dependabot commit (commit verification is not skipped).
+2. The PR came from one of the explicit security-only groups, targets `/` on
+   `main`, is same-repository, and has no maintainer edits.
+3. The dependency update is semver patch-level. A security fix requiring a
+   minor or major dependency change gets an immediate PR but remains
+   human-reviewed.
+4. Every replacement has been public for at least 30 days. Bun versions are
+   checked against the exact npm registry publication timestamp and integrity
+   metadata. Actions must have a stable GitHub Release at least 30 days old,
+   whose tag resolves to the newly pinned full SHA and whose commit GitHub
+   marks verified.
+5. A Bun PR changes only `package.json` dependency versions and/or `bun.lock`.
+   An Actions PR changes only full-SHA-pinned `uses:` lines in workflow YAML.
+6. Candidate dependency lifecycle scripts are disabled. Socket scanning and
+   deterministic generation run on a disposable runner with only a read token.
+   Its patch is treated as untrusted input; candidate code never shares a
+   runner with a repository-write token.
+7. The workflow increments peerd's patch version, adds release notes,
+   regenerates the development manifest, and, for Bun updates, rebuilds the
+   checked-in CodeMirror bundle and its complete SHA-256 vendor lock.
+8. A fresh privileged runner re-authenticates the original PR, rechecks the
+   seasoning policy, and applies only the exact expected version, changelog,
+   manifest, and CodeMirror hash changes without installing or executing the
+   candidate graph. It then commits the output, explicitly dispatches the full
+   correctness/package and security workflows on the new head, approves the
+   PR, and enables squash auto-merge. Branch protection remains the merge gate.
+9. After merge, the workflow requires the PR head to exactly match the
+   bot-authored release marker, verifies a one-patch version increment and main
+   ancestry, creates the tag idempotently, and dispatches the existing signed
+   release workflow at that tag.
+
+Any ambiguity fails closed: the PR remains open for a person rather than being
+merged or tagged.
+
+The 30-day rule addresses a different trust boundary from Dependabot. GitHub's
+advisory review and verified bot commits establish that the old version matches
+a reviewed advisory and that Dependabot authored the PR. They do not establish
+that a newly published upstream tarball or Action commit contains no unrelated
+malicious behavior.
+
+## Checked-in libraries
+
+Every byte under `extension/vendor/` is always integrity-checked against
+`extension/vendor/vendor.lock.json` in CI. CodeMirror is additionally updated
+by the no-human path because its complete source dependency graph is in
+`package.json`/`bun.lock`, the bundle has a deterministic Bun generator, and
+the result is covered by the vendor lock.
+
+Every other entry in `extension/vendor/vendor.lock.json` remains
+integrity-pinned but is not automatically upgraded. The adjacent `SOURCE.txt`,
+`VERSION`, and checksum files are the live inventory and provenance record;
+duplicating that changing list here would drift. Those update recipes include
+one or more of local patches, CDN or tarball hash changes, multi-package version
+coupling, WASM/model assets, license/provenance review, or browser/microphone
+smoke tests. Treating them as an ordinary lockfile regeneration would weaken,
+not strengthen, the security posture. A library should move to the automatic
+set only after receiving a deterministic generator and a dedicated behavioral
+gate.
+
+OS/package-manager inputs, browser/runtime pins, models, and remote assets that
+are not expressed in `dependabot.yml` are also outside Dependabot coverage.
+
+## Independent supply-chain signals
+
+Socket's exact-pinned Bun scanner is configured in `bunfig.toml`. It uses the
+unauthenticated public API (no Socket secret or account), scans the resolved
+graph before installation, and fails non-interactive CI on warning or fatal
+findings. This complements OSV by looking for malware and suspicious package
+behavior rather than only known CVEs. Text `bun.lock` support is currently a
+public beta. The scanner necessarily sends the already-public dependency
+snapshot to Socket.
+
+Every Actions job starts the full-SHA-pinned, seasoned StepSecurity
+Harden-Runner in audit mode. It records source writes and outbound destinations,
+builds a per-job baseline, and surfaces anomalous behavior. Audit mode observes
+but does not block egress; move individual jobs to block mode only after their
+legitimate endpoint baselines are established. On a public repository, workflow
+logs and StepSecurity network insights should be treated as public operational
+evidence.
+
+The Socket GitHub App is not installed. It would add visible PR checks and
+experimental GitHub Actions scanning, but also requests repository contents
+write access so it can create patch PRs. That broader external grant is not
+needed for the Bun scanner and remains a separate owner decision. Neither
+Socket nor StepSecurity replaces seasoning, immutable pins, or the existing
+tests.
+
+## One-time repository settings
+
+The workflow is versioned, but GitHub does not store the following controls in
+the repository. Apply them only after this workflow is present on `main`:
+
+- Keep Dependabot alerts and security updates enabled (already enabled at the
+  time this policy was introduced).
+- Keep auto-merge enabled (already enabled).
+- Allow GitHub Actions to create pull-request approvals.
+- Keep one required approval and stale-review dismissal on `main`, but turn off
+  “require review from Code Owners.” The Actions bot cannot be the repository's
+  Code Owner; ordinary PRs still require one approval.
+- Add `CodeQL (javascript-typescript)`, `OSV scan (resolved dependency tree)`,
+  and `peerd security invariants` to the required checks alongside the existing
+  full correctness/package matrix.
+- On the `release` environment, restrict deployments to tags matching `v*` and
+  remove the required reviewers. The release job itself rejects tags whose
+  commit is not reachable from protected `main`, checks the tag/package
+  version match, rebuilds and verifies all artifacts, signs them, attests
+  provenance, and creates the GitHub release.
+
+Removing the environment reviewer makes every valid `v*` release from
+protected `main` automatic, not only security releases. A separate automatic
+environment would be narrower, but it would require copying the three signing
+secrets into that environment; GitHub does not permit workflows to read and
+copy existing secret values.

--- a/docs/security/DEPENDENCY-AUTOMATION.md
+++ b/docs/security/DEPENDENCY-AUTOMATION.md
@@ -55,13 +55,22 @@ of these are true:
 8. A fresh privileged runner re-authenticates the original PR, rechecks the
    seasoning policy, and applies only the exact expected version, changelog,
    manifest, and CodeMirror hash changes without installing or executing the
-   candidate graph. It then commits the output, explicitly dispatches the full
-   correctness/package and security workflows on the new head, approves the
-   PR, and enables squash auto-merge. Branch protection remains the merge gate.
-9. After merge, the workflow requires the PR head to exactly match the
-   bot-authored release marker, verifies a one-patch version increment and main
+   candidate graph. It then commits the output, pins that exact commit with a
+   dedicated validation tag, and dispatches correctness/package and security
+   workflows in a read-only mode. Jobs whose token can write repository state
+   or upload SARIF are skipped so a candidate Action SHA never shares their
+   authority. The workflow records and waits for the two exact dispatched run
+   IDs, then rechecks the PR head and approves it. No auto-merge is left armed.
+   Once those runs pass, it starts a trusted finalizer through
+   `repository_dispatch` (the documented
+   `GITHUB_TOKEN` event exception) and performs a protected squash merge with a
+   matching-head constraint.
+9. The already-running finalizer waits for and re-authenticates that exact
+   merged PR and marker, verifies a one-patch version increment and main
    ancestry, creates the tag idempotently, and dispatches the existing signed
-   release workflow at that tag.
+   release workflow at that tag with an exact merge-SHA constraint. Starting it
+   before the merge removes any reliance on a token-triggered pull-request
+   event after the merge.
 
 Any ambiguity fails closed: the PR remains open for a person rather than being
 merged or tagged.
@@ -126,7 +135,6 @@ the repository. Apply them only after this workflow is present on `main`:
 
 - Keep Dependabot alerts and security updates enabled (already enabled at the
   time this policy was introduced).
-- Keep auto-merge enabled (already enabled).
 - Allow GitHub Actions to create pull-request approvals.
 - Keep one required approval and stale-review dismissal on `main`, but turn off
   “require review from Code Owners.” The Actions bot cannot be the repository's

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@codemirror/state": "^6.6.0",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.43.0",
+    "@socketsecurity/bun-security-scanner": "1.1.2",
     "@types/bun": "^1.3.14",
     "@types/chrome": "^0.2.0",
     "@types/webextension-polyfill": "^0.12.5",

--- a/packaging/dependabot-security.ts
+++ b/packaging/dependabot-security.ts
@@ -1,0 +1,650 @@
+// Fail-closed policy and release preparation for Dependabot security PRs.
+//
+// This file is deliberately executed from the trusted BASE checkout by
+// .github/workflows/dependabot-security-release.yml. A dependency PR is allowed
+// to touch the candidate checkout, but it cannot replace the policy judging it.
+//
+//   bun packaging/dependabot-security.ts verify \
+//     --repo=. --base-sha=<sha> --head-sha=<sha> \
+//     --ecosystem=bun --group=bun-security-patches \
+//     --update-type=version-update:semver-patch --dependencies=foo,bar \
+//     --metadata='[...]' --minimum-age-days=30
+//
+//   bun packaging/dependabot-security.ts prepare \
+//     --repo=. --base-sha=<sha> --ecosystem=bun \
+//     --dependencies=foo,bar --pr=123 --date=2026-08-10
+//
+//   bun packaging/dependabot-security.ts validate-prepared \
+//     --repo=. --base-sha=<sha> --head-sha=<sha> --ecosystem=bun \
+//     --dependencies=foo,bar --pr=123 --date=2026-08-10
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  appendFileSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { isDeepStrictEqual } from 'node:util';
+import { resolve } from 'node:path';
+
+const SECURITY_GROUPS = {
+  bun: 'bun-security-patches',
+  // fetch-metadata derives this from Dependabot's branch prefix, whose
+  // internal spelling is github_actions (the YAML ecosystem uses a hyphen).
+  github_actions: 'actions-security-patches',
+} as const;
+
+type SupportedEcosystem = keyof typeof SECURITY_GROUPS;
+
+type UpdatedDependency = {
+  dependencyName: string;
+  newVersion: string;
+  updateType: string;
+};
+
+type ActionUpdate = {
+  repository: string;
+  sha: string;
+  version: string;
+};
+
+const DEPENDENCY_SECTIONS = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies',
+] as const;
+
+const BASE_BUN_PATHS = new Set(['package.json', 'bun.lock']);
+const GENERATED_RELEASE_PATHS = new Set([
+  'CHANGELOG.md',
+  'package.json',
+  'extension/manifest.json',
+]);
+const CODEMIRROR_VENDOR_PATHS = new Set([
+  'extension/vendor/codemirror/cm.js',
+  'extension/vendor/codemirror/SOURCE.txt',
+  'extension/vendor/vendor.lock.json',
+]);
+const VENDOR_LOCK_PATH = 'extension/vendor/vendor.lock.json';
+
+const fail = (message: string): never => {
+  throw new Error(`Dependabot security policy rejected the PR: ${message}`);
+};
+
+const parseArgs = (argv: string[]): { command: string; values: Record<string, string> } => {
+  const [command = '', ...rest] = argv;
+  const values: Record<string, string> = {};
+  for (const arg of rest) {
+    if (!arg.startsWith('--') || !arg.includes('=')) fail(`invalid argument ${JSON.stringify(arg)}`);
+    const split = arg.indexOf('=');
+    values[arg.slice(2, split)] = arg.slice(split + 1);
+  }
+  return { command, values };
+};
+
+const required = (values: Record<string, string>, name: string): string => {
+  const value = values[name];
+  if (!value) fail(`missing --${name}`);
+  return value;
+};
+
+const assertSha = (sha: string, name: string): void => {
+  if (!/^[0-9a-f]{40}$/.test(sha)) fail(`${name} is not a full commit SHA`);
+};
+
+const normalizePath = (path: string): string => path.replaceAll('\\', '/');
+
+const git = (repo: string, args: string[]): string =>
+  execFileSync('git', ['-C', repo, ...args], { encoding: 'utf8' });
+
+const run = (repo: string, executable: string, args: string[]): void => {
+  execFileSync(executable, args, { cwd: repo, stdio: 'inherit' });
+};
+
+const changedPaths = (repo: string, baseSha: string, headSha?: string): string[] => {
+  const range = headSha ? `${baseSha}..${headSha}` : baseSha;
+  return git(repo, ['diff', '--name-only', '-z', range, '--'])
+    .split('\0')
+    .filter(Boolean)
+    .map(normalizePath)
+    .sort();
+};
+
+const readAt = (repo: string, sha: string, path: string): string =>
+  git(repo, ['show', `${sha}:${path}`]);
+
+export const parseDependencyNames = (raw: string): string[] => {
+  const names = [...new Set(raw.split(',').map((name) => name.trim()).filter(Boolean))].sort();
+  if (names.length === 0) fail('Dependabot did not report an updated dependency');
+  for (const name of names) {
+    if (!/^[A-Za-z0-9@][A-Za-z0-9@/_.-]*$/.test(name)) {
+      fail(`unexpected dependency name ${JSON.stringify(name)}`);
+    }
+  }
+  return names;
+};
+
+const withoutDependencySections = (value: Record<string, unknown>): Record<string, unknown> => {
+  const copy = structuredClone(value);
+  for (const section of DEPENDENCY_SECTIONS) delete copy[section];
+  return copy;
+};
+
+const dependencyMap = (value: Record<string, unknown>, section: string): Record<string, string> => {
+  const candidate = value[section];
+  if (candidate === undefined) return {};
+  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+    fail(`package.json ${section} is not an object`);
+  }
+  const map = candidate as Record<string, unknown>;
+  for (const [name, version] of Object.entries(map)) {
+    if (typeof version !== 'string') fail(`package.json ${section}.${name} is not a string`);
+  }
+  return map as Record<string, string>;
+};
+
+/** Verify that package.json changed only versions Dependabot authenticated. */
+export const validatePackageJsonChange = (
+  baseText: string,
+  headText: string,
+  dependencies: string[],
+): string[] => {
+  const base = JSON.parse(baseText) as Record<string, unknown>;
+  const head = JSON.parse(headText) as Record<string, unknown>;
+
+  if (!isDeepStrictEqual(withoutDependencySections(base), withoutDependencySections(head))) {
+    fail('package.json changed outside dependency version maps');
+  }
+
+  const authenticated = new Set(dependencies);
+  const changed = new Set<string>();
+  for (const section of DEPENDENCY_SECTIONS) {
+    const before = dependencyMap(base, section);
+    const after = dependencyMap(head, section);
+    for (const name of new Set([...Object.keys(before), ...Object.keys(after)])) {
+      if (before[name] === after[name]) continue;
+      if (!authenticated.has(name)) {
+        fail(`package.json changed unauthenticated dependency ${name}`);
+      }
+      if (!(name in before) || !(name in after)) {
+        fail(`package.json added or removed dependency ${name}`);
+      }
+      changed.add(name);
+    }
+  }
+  return [...changed].sort();
+};
+
+const ACTION_USE = /^\s*(?:-\s*)?uses:\s+(?<repository>[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)(?:\/[A-Za-z0-9_./-]+)?@(?<sha>[0-9a-f]{40})\s+#\s+(?<version>v?\d+\.\d+\.\d+)\s*$/;
+
+const parseActionsDiff = (diff: string): ActionUpdate[] => {
+  const additions: ActionUpdate[] = [];
+  let deletionCount = 0;
+  for (const line of diff.split('\n')) {
+    if (!line || line.startsWith('diff --git ') || line.startsWith('index ')
+      || line.startsWith('--- ') || line.startsWith('+++ ') || line.startsWith('@@ ')) continue;
+    if (line.startsWith('\\ No newline at end of file')) continue;
+    if (line.startsWith('+') || line.startsWith('-')) {
+      const match = ACTION_USE.exec(line.slice(1));
+      const groups = match?.groups
+        ?? fail('GitHub Actions update changed more than a SHA-pinned uses: line');
+      if (line.startsWith('+')) {
+        additions.push({
+          repository: groups.repository,
+          sha: groups.sha,
+          version: groups.version,
+        });
+      } else {
+        deletionCount += 1;
+      }
+    }
+  }
+  if (additions.length === 0 || additions.length !== deletionCount) {
+    fail('GitHub Actions update is not a one-for-one immutable SHA replacement');
+  }
+  return additions;
+};
+
+/** Verify an Actions diff consists only of one-for-one immutable SHA bumps. */
+export const validateActionsDiff = (diff: string): number => {
+  return parseActionsDiff(diff).length;
+};
+
+export const assertAtLeastDaysOld = (
+  publishedAt: string,
+  minimumAgeDays: number,
+  now = new Date(),
+): number => {
+  if (!Number.isSafeInteger(minimumAgeDays) || minimumAgeDays < 1) fail('minimum age is invalid');
+  const published = new Date(publishedAt);
+  if (!Number.isFinite(published.getTime())) fail(`invalid publication timestamp ${JSON.stringify(publishedAt)}`);
+  const ageMs = now.getTime() - published.getTime();
+  const ageDays = Math.floor(ageMs / 86_400_000);
+  if (ageDays < minimumAgeDays) {
+    fail(`replacement was published ${ageDays} days ago; ${minimumAgeDays} days of seasoning are required`);
+  }
+  return ageDays;
+};
+
+const parseMetadata = (raw: string, dependencies: string[]): UpdatedDependency[] => {
+  const value = JSON.parse(raw) as unknown;
+  if (!Array.isArray(value) || value.length === 0) fail('updated-dependencies-json is empty or invalid');
+  const entries = value as unknown[];
+  const updates: UpdatedDependency[] = entries.map((entry: unknown) => {
+    if (!entry || typeof entry !== 'object') fail('updated dependency metadata is not an object');
+    const record = entry as Record<string, unknown>;
+    if (typeof record.dependencyName !== 'string' || typeof record.newVersion !== 'string'
+      || typeof record.updateType !== 'string') fail('updated dependency metadata is incomplete');
+    if (record.updateType !== 'version-update:semver-patch') {
+      fail(`metadata for ${record.dependencyName} is not a semantic patch update`);
+    }
+    const dependencyName = record.dependencyName as string;
+    const newVersion = record.newVersion as string;
+    const updateType = record.updateType as string;
+    if (!/^v?\d+\.\d+\.\d+$/.test(newVersion)) {
+      fail(`replacement version for ${dependencyName} is not a stable plain semver release`);
+    }
+    return {
+      dependencyName,
+      newVersion,
+      updateType,
+    };
+  });
+  const metadataNames = [...new Set(updates.map((entry) => entry.dependencyName))].sort();
+  if (!isDeepStrictEqual(metadataNames, [...dependencies].sort())) {
+    fail('dependency names do not match authenticated updated-dependencies-json');
+  }
+  return updates;
+};
+
+const fetchJson = async (url: string, githubToken?: string): Promise<Record<string, unknown>> => {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json, application/json',
+    'User-Agent': 'peerd-dependabot-security-policy',
+  };
+  if (githubToken) headers.Authorization = `Bearer ${githubToken}`;
+  const response = await fetch(url, { headers, redirect: 'error' });
+  if (!response.ok) fail(`metadata lookup ${url} returned HTTP ${response.status}`);
+  const value = await response.json() as unknown;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(`metadata lookup ${url} returned invalid JSON`);
+  return value as Record<string, unknown>;
+};
+
+const verifyNpmSeasoning = async (
+  updates: UpdatedDependency[],
+  minimumAgeDays: number,
+): Promise<void> => {
+  const packuments = new Map<string, Record<string, unknown>>();
+  for (const update of updates) {
+    let packument = packuments.get(update.dependencyName);
+    if (!packument) {
+      packument = await fetchJson(`https://registry.npmjs.org/${encodeURIComponent(update.dependencyName)}`);
+      packuments.set(update.dependencyName, packument);
+    }
+    const version = update.newVersion.replace(/^v/, '');
+    const times = packument.time;
+    const versions = packument.versions;
+    if (!times || typeof times !== 'object' || Array.isArray(times)
+      || !versions || typeof versions !== 'object' || Array.isArray(versions)) {
+      fail(`npm registry metadata for ${update.dependencyName} lacks versions or publication times`);
+    }
+    const publishedAt = (times as Record<string, unknown>)[version];
+    const manifest = (versions as Record<string, unknown>)[version];
+    if (typeof publishedAt !== 'string' || !manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+      fail(`npm registry has no exact ${update.dependencyName}@${version} release metadata`);
+    }
+    const dist = (manifest as Record<string, unknown>).dist;
+    if (!dist || typeof dist !== 'object' || Array.isArray(dist)
+      || typeof (dist as Record<string, unknown>).integrity !== 'string') {
+      fail(`npm release ${update.dependencyName}@${version} has no registry integrity digest`);
+    }
+    if (typeof (manifest as Record<string, unknown>).deprecated === 'string') {
+      fail(`npm release ${update.dependencyName}@${version} is deprecated`);
+    }
+    const age = assertAtLeastDaysOld(publishedAt as string, minimumAgeDays);
+    console.log(`seasoned npm release: ${update.dependencyName}@${version} (${age} days old)`);
+  }
+};
+
+const githubApi = async (path: string): Promise<Record<string, unknown>> =>
+  fetchJson(`https://api.github.com${path}`, process.env.GH_API_TOKEN);
+
+const resolveTagCommit = async (repository: string, tag: string): Promise<string> => {
+  const ref = await githubApi(`/repos/${repository}/git/ref/tags/${encodeURIComponent(tag)}`);
+  const object = ref.object;
+  if (!object || typeof object !== 'object' || Array.isArray(object)) fail(`GitHub tag ${repository}@${tag} has no object`);
+  let type = (object as Record<string, unknown>).type;
+  let sha = (object as Record<string, unknown>).sha;
+  if (typeof type !== 'string' || typeof sha !== 'string') fail(`GitHub tag ${repository}@${tag} is malformed`);
+  if (type === 'tag') {
+    const annotated = await githubApi(`/repos/${repository}/git/tags/${sha}`);
+    const target = annotated.object;
+    if (!target || typeof target !== 'object' || Array.isArray(target)) fail(`annotated tag ${repository}@${tag} has no target`);
+    type = (target as Record<string, unknown>).type;
+    sha = (target as Record<string, unknown>).sha;
+  }
+  if (type !== 'commit' || typeof sha !== 'string' || !/^[0-9a-f]{40}$/.test(sha)) {
+    fail(`GitHub tag ${repository}@${tag} does not resolve directly to a commit`);
+  }
+  return sha as string;
+};
+
+const verifyActionsSeasoning = async (
+  updates: UpdatedDependency[],
+  actionUpdates: ActionUpdate[],
+  minimumAgeDays: number,
+): Promise<void> => {
+  const metadata = new Map(updates.map((entry) => [entry.dependencyName.toLowerCase(), entry]));
+  const unique = new Map(actionUpdates.map((entry) => [`${entry.repository}@${entry.sha}`, entry]));
+  for (const action of unique.values()) {
+    const update = metadata.get(action.repository.toLowerCase())
+      ?? fail(`Actions diff contains ${action.repository}, absent from authenticated metadata`);
+    if (action.version.replace(/^v/, '') !== update.newVersion.replace(/^v/, '')) {
+      fail(`Actions version comment for ${action.repository} does not match authenticated metadata`);
+    }
+    const release = await githubApi(`/repos/${action.repository}/releases/tags/${encodeURIComponent(action.version)}`);
+    if (release.draft !== false || release.prerelease !== false || typeof release.published_at !== 'string') {
+      fail(`GitHub Action ${action.repository}@${action.version} is not a stable published release`);
+    }
+    const taggedSha = await resolveTagCommit(action.repository, action.version);
+    if (taggedSha !== action.sha) fail(`GitHub Action ${action.repository}@${action.version} tag does not match pinned SHA`);
+    const commit = await githubApi(`/repos/${action.repository}/commits/${action.sha}`);
+    const inner = commit.commit;
+    if (!inner || typeof inner !== 'object' || Array.isArray(inner)) fail(`GitHub Action ${action.repository} commit is malformed`);
+    const verification = (inner as Record<string, unknown>).verification;
+    if (!verification || typeof verification !== 'object' || Array.isArray(verification)
+      || (verification as Record<string, unknown>).verified !== true) {
+      fail(`GitHub Action ${action.repository}@${action.version} commit is not GitHub-verified`);
+    }
+    const age = assertAtLeastDaysOld(release.published_at as string, minimumAgeDays);
+    console.log(`seasoned GitHub Action release: ${action.repository}@${action.version} (${age} days old)`);
+  }
+  for (const update of updates) {
+    if (![...unique.values()].some((action) => action.repository.toLowerCase() === update.dependencyName.toLowerCase())) {
+      fail(`authenticated Actions metadata contains ${update.dependencyName}, absent from the diff`);
+    }
+  }
+};
+
+export const nextPatchVersion = (version: string): string => {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version)
+    ?? fail(`package version ${JSON.stringify(version)} is not plain semver`);
+  return `${match[1]}.${match[2]}.${Number(match[3]) + 1}`;
+};
+
+export const addSecurityChangelog = (
+  changelog: string,
+  version: string,
+  date: string,
+  dependencies: string[],
+  pr: number,
+): string => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) fail('release date is not YYYY-MM-DD');
+  if (!Number.isSafeInteger(pr) || pr <= 0) fail('PR number is invalid');
+  if (changelog.includes(`## [${version}]`)) fail(`CHANGELOG.md already has a ${version} section`);
+  const marker = '## [Unreleased]\n';
+  if (!changelog.includes(marker)) fail('CHANGELOG.md has no Unreleased section');
+  const named = dependencies.map((name) => `\`${name}\``).join(', ');
+  const section = `\n## [${version}] - ${date}\n\n### Security\n- Updated ${named} through verified Dependabot security PR #${pr}. The update\n  remains dependency-only and must pass the full protected CI and supply-chain\n  gates before this patch release is tagged.\n`;
+  return changelog.replace(marker, `${marker}${section}`);
+};
+
+export const assertRecentUtcDate = (date: string, now = new Date()): void => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) fail('release date is not YYYY-MM-DD');
+  const today = now.toISOString().slice(0, 10);
+  const yesterday = new Date(now.getTime() - 86_400_000).toISOString().slice(0, 10);
+  if (date !== today && date !== yesterday) {
+    fail('release date is not the current UTC date (or the previous date across a midnight handoff)');
+  }
+};
+
+const assertInitialPaths = (ecosystem: SupportedEcosystem, paths: string[]): void => {
+  if (paths.length === 0) fail('the PR has no file changes');
+  for (const path of paths) {
+    if (ecosystem === 'bun') {
+      if (!BASE_BUN_PATHS.has(path)) fail(`Bun security PR changed disallowed path ${path}`);
+    } else if (!path.startsWith('.github/workflows/') || !/\.ya?ml$/.test(path)) {
+      fail(`GitHub Actions security PR changed disallowed path ${path}`);
+    }
+  }
+};
+
+const verify = async (values: Record<string, string>): Promise<void> => {
+  const repo = resolve(required(values, 'repo'));
+  const baseSha = required(values, 'base-sha');
+  const headSha = required(values, 'head-sha');
+  assertSha(baseSha, 'base SHA');
+  assertSha(headSha, 'head SHA');
+  const ecosystem = required(values, 'ecosystem') as SupportedEcosystem;
+  if (!(ecosystem in SECURITY_GROUPS)) fail(`unsupported ecosystem ${ecosystem}`);
+  if (required(values, 'group') !== SECURITY_GROUPS[ecosystem]) {
+    fail('PR is not in the configured Dependabot security-only group');
+  }
+  if (required(values, 'update-type') !== 'version-update:semver-patch') {
+    fail('only semantic patch dependency updates are eligible for no-human merge');
+  }
+  const dependencies = parseDependencyNames(required(values, 'dependencies'));
+  const metadata = parseMetadata(required(values, 'metadata'), dependencies);
+  const minimumAgeDays = Number(required(values, 'minimum-age-days'));
+  if (!Number.isSafeInteger(minimumAgeDays) || minimumAgeDays < 30) {
+    fail('no-human security updates require at least 30 days of replacement seasoning');
+  }
+  const paths = changedPaths(repo, baseSha, headSha);
+  assertInitialPaths(ecosystem, paths);
+
+  if (ecosystem === 'bun') {
+    if (paths.includes('package.json')) {
+      validatePackageJsonChange(
+        readAt(repo, baseSha, 'package.json'),
+        readAt(repo, headSha, 'package.json'),
+        dependencies,
+      );
+    }
+    await verifyNpmSeasoning(metadata, minimumAgeDays);
+  } else {
+    const diff = git(repo, ['diff', '--no-ext-diff', '--unified=0', `${baseSha}..${headSha}`, '--', ...paths]);
+    const actionUpdates = parseActionsDiff(diff);
+    await verifyActionsSeasoning(metadata, actionUpdates, minimumAgeDays);
+  }
+
+  console.log(`verified seasoned ${ecosystem} security patch for ${dependencies.join(', ')} (${paths.join(', ')})`);
+};
+
+const writeOutput = (name: string, value: string): void => {
+  const output = process.env.GITHUB_OUTPUT;
+  if (output) appendFileSync(output, `${name}=${value}\n`);
+};
+
+const prepare = (values: Record<string, string>): void => {
+  const repo = resolve(required(values, 'repo'));
+  const baseSha = required(values, 'base-sha');
+  assertSha(baseSha, 'base SHA');
+  const ecosystem = required(values, 'ecosystem') as SupportedEcosystem;
+  if (!(ecosystem in SECURITY_GROUPS)) fail(`unsupported ecosystem ${ecosystem}`);
+  const dependencies = parseDependencyNames(required(values, 'dependencies'));
+  const pr = Number(required(values, 'pr'));
+  const date = required(values, 'date');
+  assertRecentUtcDate(date);
+
+  const packagePath = resolve(repo, 'package.json');
+  const packageJson = JSON.parse(readFileSync(packagePath, 'utf8')) as Record<string, unknown>;
+  const currentVersion = packageJson.version;
+  if (typeof currentVersion !== 'string') fail('package.json has no string version');
+  const version = nextPatchVersion(currentVersion as string);
+  packageJson.version = version;
+  writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+
+  const changelogPath = resolve(repo, 'CHANGELOG.md');
+  writeFileSync(changelogPath, addSecurityChangelog(
+    readFileSync(changelogPath, 'utf8'),
+    version,
+    date,
+    dependencies,
+    pr,
+  ));
+
+  // CodeMirror is the checked-in library we can safely rebuild without human
+  // judgment: its source dependencies are in bun.lock, its bundle is generated
+  // deterministically, and every emitted byte is covered by vendor.lock.json.
+  // Rebuild on every Bun security PR; unrelated graph changes yield no diff.
+  if (ecosystem === 'bun') {
+    run(repo, 'bun', ['run', 'vendor:codemirror']);
+    run(repo, 'bun', ['packaging/check-vendor.ts', '--write']);
+  }
+  run(repo, 'bun', ['packaging/gen-manifest.ts', '--channel=dev', '--browser=chrome']);
+  run(repo, 'bun', ['run', 'check:vendor']);
+  run(repo, 'bun', ['install', '--frozen-lockfile']);
+
+  const initial = new Set(changedPaths(repo, baseSha));
+  const allowed = new Set([...initial, ...GENERATED_RELEASE_PATHS]);
+  if (ecosystem === 'bun') {
+    for (const path of CODEMIRROR_VENDOR_PATHS) allowed.add(path);
+  }
+  for (const path of initial) {
+    if (ecosystem === 'bun') {
+      if (!BASE_BUN_PATHS.has(path) && !GENERATED_RELEASE_PATHS.has(path)
+        && !CODEMIRROR_VENDOR_PATHS.has(path)) fail(`unexpected prepared path ${path}`);
+    } else if (!path.startsWith('.github/workflows/') && !GENERATED_RELEASE_PATHS.has(path)) {
+      fail(`unexpected prepared path ${path}`);
+    }
+  }
+  const finalPaths = changedPaths(repo, baseSha);
+  for (const path of finalPaths) {
+    if (!allowed.has(path)) fail(`release preparation generated disallowed path ${path}`);
+  }
+  for (const requiredPath of GENERATED_RELEASE_PATHS) {
+    if (!finalPaths.includes(requiredPath)) fail(`release preparation did not update ${requiredPath}`);
+  }
+  execFileSync('git', ['-C', repo, 'diff', '--check', baseSha, '--'], { stdio: 'inherit' });
+
+  writeOutput('version', version);
+  writeOutput('tag', `v${version}`);
+  writeOutput('release-date', date);
+  writeOutput('vendored-codemirror', String(
+    finalPaths.some((path) => CODEMIRROR_VENDOR_PATHS.has(path)),
+  ));
+  console.log(JSON.stringify({ version, dependencies, finalPaths }, null, 2));
+};
+
+const sha256 = (value: Buffer | Uint8Array): string =>
+  createHash('sha256').update(value).digest('hex');
+
+/**
+ * Revalidate the untrusted generation artifact in a fresh privileged runner.
+ * This command uses only the trusted base policy and Node/Bun built-ins. It
+ * never installs or executes code from the candidate dependency graph.
+ */
+export const validatePrepared = (values: Record<string, string>): void => {
+  const repo = resolve(required(values, 'repo'));
+  const baseSha = required(values, 'base-sha');
+  const headSha = required(values, 'head-sha');
+  assertSha(baseSha, 'base SHA');
+  assertSha(headSha, 'head SHA');
+  const ecosystem = required(values, 'ecosystem') as SupportedEcosystem;
+  if (!(ecosystem in SECURITY_GROUPS)) fail(`unsupported ecosystem ${ecosystem}`);
+  const dependencies = parseDependencyNames(required(values, 'dependencies'));
+  const pr = Number(required(values, 'pr'));
+  const date = required(values, 'date');
+  assertRecentUtcDate(date);
+
+  const initialPaths = changedPaths(repo, baseSha, headSha);
+  assertInitialPaths(ecosystem, initialPaths);
+  if (ecosystem === 'bun' && initialPaths.includes('package.json')) {
+    validatePackageJsonChange(
+      readAt(repo, baseSha, 'package.json'),
+      readAt(repo, headSha, 'package.json'),
+      dependencies,
+    );
+  }
+
+  // The checkout began at the authenticated Dependabot head. The downloaded
+  // patch may add only deterministic release files, plus the narrowly scoped
+  // CodeMirror output for Bun updates.
+  const preparedPaths = changedPaths(repo, headSha);
+  const allowedPrepared = new Set(GENERATED_RELEASE_PATHS);
+  if (ecosystem === 'bun') {
+    for (const path of CODEMIRROR_VENDOR_PATHS) allowedPrepared.add(path);
+  }
+  for (const path of preparedPaths) {
+    if (!allowedPrepared.has(path)) fail(`untrusted generation changed disallowed path ${path}`);
+  }
+  for (const requiredPath of GENERATED_RELEASE_PATHS) {
+    if (!preparedPaths.includes(requiredPath)) fail(`untrusted generation did not update ${requiredPath}`);
+  }
+
+  const deleted = git(repo, ['diff', '--diff-filter=D', '--name-only', headSha, '--']).trim();
+  if (deleted) fail(`untrusted generation deleted a file: ${deleted.split('\n')[0]}`);
+  for (const path of preparedPaths) {
+    const stage = git(repo, ['ls-files', '--stage', '--', path]).trim();
+    if (!stage.startsWith('100644 ')) fail(`prepared path is not a regular non-executable file: ${path}`);
+  }
+
+  const headPackage = JSON.parse(readAt(repo, headSha, 'package.json')) as Record<string, unknown>;
+  const preparedPackage = JSON.parse(readFileSync(resolve(repo, 'package.json'), 'utf8')) as Record<string, unknown>;
+  const currentVersion = headPackage.version;
+  if (typeof currentVersion !== 'string') fail('authenticated head package.json has no string version');
+  const version = nextPatchVersion(currentVersion as string);
+  const expectedPackage = structuredClone(headPackage);
+  expectedPackage.version = version;
+  if (!isDeepStrictEqual(preparedPackage, expectedPackage)) {
+    fail('prepared package.json differs from the authenticated head beyond the patch version');
+  }
+
+  const expectedChangelog = addSecurityChangelog(
+    readAt(repo, headSha, 'CHANGELOG.md'),
+    version,
+    date,
+    dependencies,
+    pr,
+  );
+  if (readFileSync(resolve(repo, 'CHANGELOG.md'), 'utf8') !== expectedChangelog) {
+    fail('prepared CHANGELOG.md is not the exact trusted security release entry');
+  }
+
+  const headManifest = JSON.parse(readAt(repo, headSha, 'extension/manifest.json')) as Record<string, unknown>;
+  headManifest.version = version;
+  const expectedManifest = `${JSON.stringify(headManifest, null, 2)}\n`;
+  if (readFileSync(resolve(repo, 'extension/manifest.json'), 'utf8') !== expectedManifest) {
+    fail('prepared extension manifest differs from the authenticated head beyond the patch version');
+  }
+
+  // The untrusted generator may alter only the two CodeMirror outputs and the
+  // corresponding lock entries. It cannot use the lock rewrite to bless any
+  // unrelated vendored byte.
+  const headLock = JSON.parse(readAt(repo, headSha, VENDOR_LOCK_PATH)) as {
+    files?: Record<string, string>;
+  };
+  if (!headLock.files || typeof headLock.files !== 'object') fail('authenticated vendor lock is malformed');
+  const expectedLock = structuredClone(headLock);
+  for (const relative of ['codemirror/cm.js', 'codemirror/SOURCE.txt']) {
+    const path = `extension/vendor/${relative}`;
+    expectedLock.files![relative] = sha256(readFileSync(resolve(repo, path)));
+  }
+  const expectedLockText = `${JSON.stringify(expectedLock, null, 2)}\n`;
+  if (readFileSync(resolve(repo, VENDOR_LOCK_PATH), 'utf8') !== expectedLockText) {
+    fail('prepared vendor lock changed beyond the exact CodeMirror output hashes');
+  }
+
+  execFileSync('git', ['-C', repo, 'diff', '--check', headSha, '--'], { stdio: 'inherit' });
+  writeOutput('version', version);
+  writeOutput('tag', `v${version}`);
+  writeOutput('vendored-codemirror', String(
+    preparedPaths.some((path) => CODEMIRROR_VENDOR_PATHS.has(path)),
+  ));
+  console.log(JSON.stringify({ version, dependencies, preparedPaths }, null, 2));
+};
+
+if (import.meta.main) {
+  try {
+    const { command, values } = parseArgs(process.argv.slice(2));
+    if (command === 'verify') await verify(values);
+    else if (command === 'prepare') prepare(values);
+    else if (command === 'validate-prepared') validatePrepared(values);
+    else fail('expected verify, prepare, or validate-prepared command');
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}

--- a/packaging/dependabot-security.ts
+++ b/packaging/dependabot-security.ts
@@ -150,6 +150,7 @@ export const validatePackageJsonChange = (
   baseText: string,
   headText: string,
   dependencies: string[],
+  expectedVersions: Record<string, string> = {},
 ): string[] => {
   const base = JSON.parse(baseText) as Record<string, unknown>;
   const head = JSON.parse(headText) as Record<string, unknown>;
@@ -171,40 +172,82 @@ export const validatePackageJsonChange = (
       if (!(name in before) || !(name in after)) {
         fail(`package.json added or removed dependency ${name}`);
       }
+      const expected = expectedVersions[name]?.replace(/^v/, '');
+      if (expected !== undefined
+        && after[name] !== expected
+        && after[name] !== `^${expected}`
+        && after[name] !== `~${expected}`) {
+        fail(`package.json ${section}.${name} does not match authenticated version ${expected}`);
+      }
       changed.add(name);
     }
   }
   return [...changed].sort();
 };
 
-const ACTION_USE = /^\s*(?:-\s*)?uses:\s+(?<repository>[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)(?:\/[A-Za-z0-9_./-]+)?@(?<sha>[0-9a-f]{40})\s+#\s+(?<version>v?\d+\.\d+\.\d+)\s*$/;
+const ACTION_USE = /^(?<prefix>\s*(?:-\s*)?uses:\s+)(?<repository>[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)(?<subpath>\/[A-Za-z0-9_./-]+)?@(?<sha>[0-9a-f]{40})\s+#\s+(?<version>v?\d+\.\d+\.\d+)\s*$/;
+const DIFF_FILE = /^diff --git a\/(?<before>\S+) b\/(?<after>\S+)$/;
+const DIFF_HUNK = /^@@ -(?<oldStart>\d+)(?:,(?<oldCount>\d+))? \+(?<newStart>\d+)(?:,(?<newCount>\d+))? @@/;
 
 const parseActionsDiff = (diff: string): ActionUpdate[] => {
-  const additions: ActionUpdate[] = [];
-  let deletionCount = 0;
+  const additions: Array<{ slot: string, update: ActionUpdate }> = [];
+  const deletions: string[] = [];
+  let file = '';
+  let hunk = '';
+  let additionOrdinal = 0;
+  let deletionOrdinal = 0;
   for (const line of diff.split('\n')) {
-    if (!line || line.startsWith('diff --git ') || line.startsWith('index ')
-      || line.startsWith('--- ') || line.startsWith('+++ ') || line.startsWith('@@ ')) continue;
+    if (!line || line.startsWith('index ') || line.startsWith('--- ') || line.startsWith('+++ ')) continue;
+    if (line.startsWith('diff --git ')) {
+      const groups = DIFF_FILE.exec(line)?.groups
+        ?? fail('GitHub Actions update has an unrecognized file diff');
+      if (groups.before !== groups.after) fail('GitHub Actions update moved a workflow file');
+      file = groups.before;
+      hunk = '';
+      additionOrdinal = 0;
+      deletionOrdinal = 0;
+      continue;
+    }
+    if (line.startsWith('@@ ')) {
+      const groups = DIFF_HUNK.exec(line)?.groups
+        ?? fail('GitHub Actions update has an unrecognized diff hunk');
+      const oldCount = Number(groups.oldCount ?? '1');
+      const newCount = Number(groups.newCount ?? '1');
+      if (groups.oldStart !== groups.newStart || oldCount !== newCount) {
+        fail('GitHub Actions update relocated a uses: line');
+      }
+      hunk = `${groups.oldStart}:${oldCount}`;
+      additionOrdinal = 0;
+      deletionOrdinal = 0;
+      continue;
+    }
     if (line.startsWith('\\ No newline at end of file')) continue;
     if (line.startsWith('+') || line.startsWith('-')) {
+      if (!file || !hunk) fail('GitHub Actions update has a change outside a file hunk');
       const match = ACTION_USE.exec(line.slice(1));
       const groups = match?.groups
         ?? fail('GitHub Actions update changed more than a SHA-pinned uses: line');
+      const ordinal = line.startsWith('+') ? additionOrdinal++ : deletionOrdinal++;
+      const slot = `${file}:${hunk}:${ordinal}:${groups.prefix}${groups.repository}${groups.subpath ?? ''}`;
       if (line.startsWith('+')) {
         additions.push({
-          repository: groups.repository,
-          sha: groups.sha,
-          version: groups.version,
+          slot,
+          update: {
+            repository: groups.repository,
+            sha: groups.sha,
+            version: groups.version,
+          },
         });
       } else {
-        deletionCount += 1;
+        deletions.push(slot);
       }
     }
   }
-  if (additions.length === 0 || additions.length !== deletionCount) {
+  if (additions.length === 0
+    || !isDeepStrictEqual(additions.map(({ slot }) => slot).sort(), deletions.sort())) {
     fail('GitHub Actions update is not a one-for-one immutable SHA replacement');
   }
-  return additions;
+  return additions.map(({ update }) => update);
 };
 
 /** Verify an Actions diff consists only of one-for-one immutable SHA bumps. */
@@ -440,6 +483,7 @@ const verify = async (values: Record<string, string>): Promise<void> => {
         readAt(repo, baseSha, 'package.json'),
         readAt(repo, headSha, 'package.json'),
         dependencies,
+        Object.fromEntries(metadata.map(({ dependencyName, newVersion }) => [dependencyName, newVersion])),
       );
     }
     await verifyNpmSeasoning(metadata, minimumAgeDays);

--- a/tests/dependabot-security.test.ts
+++ b/tests/dependabot-security.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  addSecurityChangelog,
+  assertAtLeastDaysOld,
+  assertRecentUtcDate,
+  nextPatchVersion,
+  parseDependencyNames,
+  validateActionsDiff,
+  validatePackageJsonChange,
+  validatePrepared,
+} from '../packaging/dependabot-security.ts';
+
+const sha256 = (value: string): string =>
+  createHash('sha256').update(value).digest('hex');
+
+const write = (root: string, path: string, value: string): void => {
+  mkdirSync(join(root, path, '..'), { recursive: true });
+  writeFileSync(join(root, path), value);
+};
+
+const git = (root: string, ...args: string[]): string =>
+  execFileSync('git', ['-C', root, ...args], { encoding: 'utf8' }).trim();
+
+describe('Dependabot security automation policy', () => {
+  test('accepts authenticated dependency-version-only package changes', () => {
+    const base = JSON.stringify({
+      name: 'peerd',
+      version: '0.5.0',
+      devDependencies: { eslint: '10.4.0', typescript: '^6.0.3' },
+    });
+    const head = JSON.stringify({
+      name: 'peerd',
+      version: '0.5.0',
+      devDependencies: { eslint: '10.4.1', typescript: '^6.0.3' },
+    });
+    expect(validatePackageJsonChange(base, head, ['eslint'])).toEqual(['eslint']);
+  });
+
+  test('rejects package scripts hidden in a dependency update', () => {
+    const base = JSON.stringify({ name: 'peerd', scripts: { test: 'bun test' }, devDependencies: { eslint: '10.4.0' } });
+    const head = JSON.stringify({ name: 'peerd', scripts: { test: 'curl bad.test' }, devDependencies: { eslint: '10.4.1' } });
+    expect(() => validatePackageJsonChange(base, head, ['eslint'])).toThrow('outside dependency version maps');
+  });
+
+  test('rejects a second unauthenticated dependency change', () => {
+    const base = JSON.stringify({ devDependencies: { eslint: '10.4.0', typescript: '6.0.2' } });
+    const head = JSON.stringify({ devDependencies: { eslint: '10.4.1', typescript: '6.0.3' } });
+    expect(() => validatePackageJsonChange(base, head, ['eslint'])).toThrow('unauthenticated dependency typescript');
+  });
+
+  test('accepts only one-for-one SHA-pinned Actions replacements', () => {
+    const diff = [
+      'diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml',
+      '--- a/.github/workflows/ci.yml',
+      '+++ b/.github/workflows/ci.yml',
+      '@@ -4 +4 @@ jobs:',
+      '-      - uses: actions/checkout@1111111111111111111111111111111111111111 # v7.0.0',
+      '+      - uses: actions/checkout@2222222222222222222222222222222222222222 # v7.0.1',
+    ].join('\n');
+    expect(validateActionsDiff(diff)).toBe(1);
+  });
+
+  test('rejects mutable action tags and unrelated workflow edits', () => {
+    const mutable = [
+      '--- a/.github/workflows/ci.yml',
+      '+++ b/.github/workflows/ci.yml',
+      '@@ -4 +4 @@',
+      '-      - uses: actions/checkout@1111111111111111111111111111111111111111 # v7.0.0',
+      '+      - uses: actions/checkout@v7',
+    ].join('\n');
+    expect(() => validateActionsDiff(mutable)).toThrow('SHA-pinned uses: line');
+  });
+
+  test('normalizes names and creates a patch release changelog section', () => {
+    const dependencies = parseDependencyNames('typescript, eslint,typescript');
+    expect(dependencies).toEqual(['eslint', 'typescript']);
+    expect(nextPatchVersion('0.5.9')).toBe('0.5.10');
+    const next = addSecurityChangelog(
+      '# Changelog\n\n## [Unreleased]\n\n## [0.5.0] - 2026-08-06\n',
+      '0.5.1',
+      '2026-08-10',
+      dependencies,
+      42,
+    );
+    expect(next).toContain('## [0.5.1] - 2026-08-10');
+    expect(next).toContain('`eslint`, `typescript`');
+    expect(next).toContain('security PR #42');
+  });
+
+  test('requires the replacement release itself to finish seasoning', () => {
+    const now = new Date('2026-08-10T12:00:00Z');
+    expect(assertAtLeastDaysOld('2026-07-11T11:59:59Z', 30, now)).toBe(30);
+    expect(() => assertAtLeastDaysOld('2026-07-12T12:00:00Z', 30, now))
+      .toThrow('29 days ago; 30 days of seasoning are required');
+  });
+
+  test('accepts only the exact generated patch on a fresh privileged runner', () => {
+    const root = mkdtempSync(join(tmpdir(), 'peerd-dependabot-policy-'));
+    const today = new Date().toISOString().slice(0, 10);
+    const source = 'CodeMirror source\n';
+    const bundle = 'export const cm = true;\n';
+    const lock = {
+      '//': 'test fixture',
+      files: {
+        'codemirror/SOURCE.txt': sha256(source),
+        'codemirror/cm.js': sha256(bundle),
+      },
+    };
+    try {
+      write(root, 'package.json', `${JSON.stringify({
+        name: 'peerd',
+        version: '0.5.0',
+        devDependencies: { eslint: '1.0.0' },
+      }, null, 2)}\n`);
+      write(root, 'bun.lock', 'lock-v1\n');
+      write(root, 'CHANGELOG.md', '# Changelog\n\n## [Unreleased]\n');
+      write(root, 'extension/manifest.json', `${JSON.stringify({
+        manifest_version: 3,
+        version: '0.5.0',
+        name: 'peerd',
+      }, null, 2)}\n`);
+      write(root, 'extension/vendor/codemirror/SOURCE.txt', source);
+      write(root, 'extension/vendor/codemirror/cm.js', bundle);
+      write(root, 'extension/vendor/vendor.lock.json', `${JSON.stringify(lock, null, 2)}\n`);
+      git(root, 'init', '-q');
+      git(root, 'config', 'user.name', 'test');
+      git(root, 'config', 'user.email', 'test@example.invalid');
+      git(root, 'add', '--all');
+      git(root, 'commit', '-qm', 'base');
+      const baseSha = git(root, 'rev-parse', 'HEAD');
+
+      write(root, 'package.json', `${JSON.stringify({
+        name: 'peerd',
+        version: '0.5.0',
+        devDependencies: { eslint: '1.0.1' },
+      }, null, 2)}\n`);
+      write(root, 'bun.lock', 'lock-v2\n');
+      git(root, 'add', '--all');
+      git(root, 'commit', '-qm', 'dependabot patch');
+      const headSha = git(root, 'rev-parse', 'HEAD');
+
+      write(root, 'package.json', `${JSON.stringify({
+        name: 'peerd',
+        version: '0.5.1',
+        devDependencies: { eslint: '1.0.1' },
+      }, null, 2)}\n`);
+      write(root, 'CHANGELOG.md', addSecurityChangelog(
+        '# Changelog\n\n## [Unreleased]\n',
+        '0.5.1',
+        today,
+        ['eslint'],
+        42,
+      ));
+      write(root, 'extension/manifest.json', `${JSON.stringify({
+        manifest_version: 3,
+        version: '0.5.1',
+        name: 'peerd',
+      }, null, 2)}\n`);
+
+      const values = {
+        repo: root,
+        'base-sha': baseSha,
+        'head-sha': headSha,
+        ecosystem: 'bun',
+        dependencies: 'eslint',
+        pr: '42',
+        date: today,
+      };
+      expect(() => validatePrepared(values)).not.toThrow();
+
+      lock.files['codemirror/cm.js'] = '0'.repeat(64);
+      write(root, 'extension/vendor/vendor.lock.json', `${JSON.stringify(lock, null, 2)}\n`);
+      expect(() => validatePrepared(values)).toThrow('vendor lock changed beyond');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  test('prepared release dates tolerate only the UTC midnight handoff', () => {
+    const now = new Date('2026-08-10T00:00:01Z');
+    expect(() => assertRecentUtcDate('2026-08-10', now)).not.toThrow();
+    expect(() => assertRecentUtcDate('2026-08-09', now)).not.toThrow();
+    expect(() => assertRecentUtcDate('2026-08-08', now)).toThrow('current UTC date');
+  });
+});

--- a/tests/dependabot-security.test.ts
+++ b/tests/dependabot-security.test.ts
@@ -53,6 +53,15 @@ describe('Dependabot security automation policy', () => {
     expect(() => validatePackageJsonChange(base, head, ['eslint'])).toThrow('unauthenticated dependency typescript');
   });
 
+  test('binds a manifest change to the authenticated replacement version', () => {
+    const base = JSON.stringify({ devDependencies: { eslint: '^10.4.0' } });
+    const head = JSON.stringify({ devDependencies: { eslint: '^10.4.1' } });
+    expect(validatePackageJsonChange(base, head, ['eslint'], { eslint: '10.4.1' }))
+      .toEqual(['eslint']);
+    expect(() => validatePackageJsonChange(base, head, ['eslint'], { eslint: '10.4.2' }))
+      .toThrow('does not match authenticated version 10.4.2');
+  });
+
   test('accepts only one-for-one SHA-pinned Actions replacements', () => {
     const diff = [
       'diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml',
@@ -67,6 +76,7 @@ describe('Dependabot security automation policy', () => {
 
   test('rejects mutable action tags and unrelated workflow edits', () => {
     const mutable = [
+      'diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml',
       '--- a/.github/workflows/ci.yml',
       '+++ b/.github/workflows/ci.yml',
       '@@ -4 +4 @@',
@@ -74,6 +84,48 @@ describe('Dependabot security automation policy', () => {
       '+      - uses: actions/checkout@v7',
     ].join('\n');
     expect(() => validateActionsDiff(mutable)).toThrow('SHA-pinned uses: line');
+  });
+
+  test('rejects swapping the authenticated Action target or subpath', () => {
+    const swapped = [
+      'diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml',
+      '--- a/.github/workflows/ci.yml',
+      '+++ b/.github/workflows/ci.yml',
+      '@@ -4 +4 @@',
+      '-      - uses: actions/checkout/subpath@1111111111111111111111111111111111111111 # v7.0.0',
+      '+      - uses: actions/checkout/other@2222222222222222222222222222222222222222 # v7.0.1',
+    ].join('\n');
+    expect(() => validateActionsDiff(swapped)).toThrow('one-for-one immutable SHA replacement');
+  });
+
+  test('rejects relocating an authenticated Action into another workflow', () => {
+    const relocated = [
+      'diff --git a/.github/workflows/read.yml b/.github/workflows/read.yml',
+      '--- a/.github/workflows/read.yml',
+      '+++ b/.github/workflows/read.yml',
+      '@@ -4 +3,0 @@',
+      '-      - uses: actions/checkout@1111111111111111111111111111111111111111 # v7.0.0',
+      'diff --git a/.github/workflows/write.yml b/.github/workflows/write.yml',
+      '--- a/.github/workflows/write.yml',
+      '+++ b/.github/workflows/write.yml',
+      '@@ -9,0 +10 @@',
+      '+      - uses: actions/checkout@2222222222222222222222222222222222222222 # v7.0.1',
+    ].join('\n');
+    expect(() => validateActionsDiff(relocated)).toThrow('relocated a uses: line');
+  });
+
+  test('rejects reordering authenticated Actions inside one diff hunk', () => {
+    const reordered = [
+      'diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml',
+      '--- a/.github/workflows/ci.yml',
+      '+++ b/.github/workflows/ci.yml',
+      '@@ -4,2 +4,2 @@',
+      '-      - uses: actions/checkout@1111111111111111111111111111111111111111 # v7.0.0',
+      '-      - uses: oven-sh/setup-bun@2222222222222222222222222222222222222222 # v2.1.9',
+      '+      - uses: oven-sh/setup-bun@3333333333333333333333333333333333333333 # v2.2.0',
+      '+      - uses: actions/checkout@4444444444444444444444444444444444444444 # v7.0.1',
+    ].join('\n');
+    expect(() => validateActionsDiff(reordered)).toThrow('one-for-one immutable SHA replacement');
   });
 
   test('normalizes names and creates a patch release changelog section', () => {


### PR DESCRIPTION
## Summary

- season routine Bun and GitHub Actions dependency updates for 30 days
- open security updates immediately but auto-merge only authenticated, semver-patch replacements that have independently seasoned for 30 days
- isolate candidate dependency execution on a disposable read-only runner, then re-authenticate and validate the generated patch on a fresh write-capable runner
- automatically prepare, merge, tag, and dispatch a signed peerd patch release for the narrow verified path
- add Socket's Bun scanner and full-SHA-pinned StepSecurity Harden Runner audit coverage
- integrity-check all checked-in vendor bytes and automatically regenerate only the deterministic CodeMirror bundle
- add a small supply-chain pointer to SECURITY.md and keep the detailed policy in one canonical document

## Threat model

Dependabot's security classification authenticates the advisory and bot-authored change; it is not proof that a newly published replacement artifact is benign. Security PRs therefore remain immediate, while unattended merge and release still require 30 days of artifact seasoning. Fresh, non-patch, prerelease, malformed, or unsupported updates fail closed for human review.

## Validation

- `bun install --frozen-lockfile` (Socket scanned 388 packages with no findings)
- `bun test --timeout=20000 --max-concurrency=1 ./tests` (5,775 passing)
- lint and TypeScript
- vendor integrity, security invariants, source hygiene, doc-path, and copy-hygiene gates
- Actionlint v1.7.12 with verified release checksum
- every workflow action remains pinned to a full commit SHA

## Post-merge repository settings

The versioned workflow deliberately lands before live settings change. After merge, enable Actions PR approvals, adjust the Code Owner review requirement while retaining one approval and stale-review dismissal, require the documented security checks, and remove release-environment reviewers only after restricting that environment to `v*` tags. See `docs/security/DEPENDENCY-AUTOMATION.md` for the exact rollout and tradeoffs.