### PR TITLE
Restore keyless provider readiness after worker startup

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -4161,6 +4161,17 @@ const sessionState = makeSessionState();
  * derived from the vault, never the secret itself.
  */
 const buildStateSnapshot = async () => {
+  // A cold MV3 worker can resume the vault and accept a UI port before the
+  // asynchronous chrome.storage settings read finishes. The snapshot must not
+  // observe channel defaults in that window: if the user selected a keyless
+  // provider (Ollama / Local WebGPU), the default Anthropic projection reports
+  // hasKey:false and strands the already-open composer until some unrelated
+  // mutation happens to push state again (issue #384).
+  //
+  // A storage failure still degrades to the channel defaults, as before. Only
+  // the successful-hydration race is closed here.
+  try { await settingsReady; }
+  catch { /* loadSettings failure leaves the store's safe defaults in place */ }
   await actorIsolationReady;
   const sessionId = await sessionCache.sessionGet('currentSessionId');
   // prfEnrolled is cheap to read (one kv.get) and the side panel uses it

--- a/tests/meta/settings-hydration-invariants.test.ts
+++ b/tests/meta/settings-hydration-invariants.test.ts
@@ -1,0 +1,33 @@
+// The service worker cannot be imported under Bun because it registers browser
+// listeners at module load. Pin the cold-start ordering statically: every UI
+// snapshot must wait for persisted settings before it resolves the active
+// provider, or an Ollama/Local-WebGPU install can be projected as keyless
+// Anthropic until another state push happens (issue #384).
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { EXTENSION_DIR } from '../../packaging/lib.ts';
+
+const serviceWorker = readFileSync(join(EXTENSION_DIR, 'background/service-worker.js'), 'utf8');
+
+describe('settings hydration before UI state snapshots', () => {
+  test('waits for persisted settings before reading session or provider state', () => {
+    const start = serviceWorker.indexOf('const buildStateSnapshot = async () => {');
+    const end = serviceWorker.indexOf('const pushState = async () => {', start);
+    const snapshot = serviceWorker.slice(start, end);
+    const hydration = snapshot.indexOf('await settingsReady;');
+    const sessionRead = snapshot.indexOf("sessionCache.sessionGet('currentSessionId')");
+    const providerRead = snapshot.indexOf('const activeProv = resolveActiveProvider();');
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(hydration).toBeGreaterThan(-1);
+    expect(sessionRead).toBeGreaterThan(hydration);
+    expect(providerRead).toBeGreaterThan(hydration);
+  });
+
+  test('the readiness promise is the persisted settings load', () => {
+    expect(serviceWorker).toContain('const settingsReady = loadSettings();');
+  });
+});


### PR DESCRIPTION
## What changed

- Wait for persisted settings hydration before building side-panel, home, or options state snapshots.
- Add an invariant test that pins settings hydration ahead of provider resolution.

## Why

A cold MV3 service worker could accept a UI connection before `chrome.storage` finished restoring the selected provider. The first snapshot then used the channel-default Anthropic provider and reported `hasKey: false`, leaving an already configured Ollama or Local WebGPU user stuck on the API-key prompt until another state change happened.

The snapshot now waits for the existing one-time settings load, so keyless provider readiness is computed from the user's persisted selection.

## Validation

- 64 focused settings/provider tests
- ESLint
- TypeScript compilation and coverage check
- source and copy hygiene
- packaging invariants
- adversarial startup-order, regression, and metadata review

Related issue: #384