### PR TITLE
Harden short security dependency seasoning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,8 @@
 # Routine dependency updates get 30 days of release seasoning. GitHub applies
 # `cooldown` only to version updates, so Dependabot security PRs remain eligible
-# immediately. The no-human merge workflow separately requires every security
-# replacement release to have completed the same 30 days of seasoning.
+# immediately. The no-human merge workflow separately requires a continuous
+# 72-hour clean observation window for patch-only Bun lockfile replacements,
+# and 30 days for Actions patch fixes.
 version: 2
 updates:
   - package-ecosystem: github-actions

--- a/.github/workflows/dependabot-malware-observation.yml
+++ b/.github/workflows/dependabot-malware-observation.yml
@@ -1,0 +1,199 @@
+# Durable, read-only observations for the shortened Bun security-patch window.
+# An exact Dependabot head must accumulate a clean result at least every four
+# hours for 72 hours. Candidate dependency code never receives a write token;
+# the separate coordinator only re-runs an already-authenticated release run.
+
+name: observe Dependabot Bun malware window
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  schedule:
+    - cron: '17 */4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    name: discover exact Bun security candidates
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      (github.event.pull_request.user.login == 'dependabot[bot]' &&
+        github.event.pull_request.base.ref == 'main' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        startsWith(github.event.pull_request.head.ref, 'dependabot/bun/bun-security-patches'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      matrix: ${{ steps.candidates.outputs.matrix }}
+    steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Resolve immutable candidate heads
+        id: candidates
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = pull_request_target ]; then
+            matrix="$(jq -cn \
+              --argjson number "$EVENT_PR_NUMBER" \
+              --arg base_sha "$EVENT_BASE_SHA" \
+              --arg head_sha "$EVENT_HEAD_SHA" \
+              --arg head_ref "$EVENT_HEAD_REF" \
+              '[{number: $number, base_sha: $base_sha, head_sha: $head_sha, head_ref: $head_ref}]')"
+          else
+            pages="$(gh api --paginate --slurp \
+              "repos/${GITHUB_REPOSITORY}/pulls?state=open&per_page=100")"
+            matrix="$(jq -c --arg repository "$GITHUB_REPOSITORY" '[
+              .[][] |
+              select(
+                .user.login == "dependabot[bot]" and
+                .base.ref == "main" and
+                .head.repo.full_name == $repository and
+                (.head.ref | startswith("dependabot/bun/bun-security-patches")) and
+                ([.labels[].name] | index("security-autorelease") | not)
+              ) |
+              {
+                number,
+                base_sha: .base.sha,
+                head_sha: .head.sha,
+                head_ref: .head.ref
+              }
+            ]' <<< "$pages")"
+          fi
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  observe:
+    name: observe Bun malware window (PR ${{ matrix.pr.number }}, ${{ matrix.pr.head_sha }})
+    needs: discover
+    if: needs.discover.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        pr: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Check out trusted base policy
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ matrix.pr.base_sha }}
+          path: trusted
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Check out exact candidate without credentials
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ matrix.pr.head_sha }}
+          path: candidate
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.9"
+
+      - name: Check the complete replacement graph and GitHub malware history
+        env:
+          BASE_SHA: ${{ matrix.pr.base_sha }}
+          HEAD_SHA: ${{ matrix.pr.head_sha }}
+          GH_API_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          bun trusted/packaging/dependabot-security.ts observe-bun \
+            --repo=candidate \
+            --base-sha="$BASE_SHA" \
+            --head-sha="$HEAD_SHA"
+
+      - name: Run the trusted-base-pinned Socket scanner without lifecycle scripts
+        working-directory: candidate
+        run: bun install --frozen-lockfile --ignore-scripts
+
+  requeue:
+    name: requeue exact candidates after a complete observation window
+    needs: [discover, observe]
+    if: >-
+      always() &&
+      needs.discover.result == 'success' &&
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Harden runner (audit egress and source writes)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Check out the trusted default-branch coordinator
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.9"
+
+      - name: Re-run eligible authenticated release workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_API_TOKEN: ${{ github.token }}
+          CANDIDATES: ${{ needs.discover.outputs.matrix }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r candidate; do
+            pr_number="$(jq -r .number <<< "$candidate")"
+            head_sha="$(jq -r .head_sha <<< "$candidate")"
+            if ! bun packaging/dependabot-security.ts verify-observations \
+              --repository="$GITHUB_REPOSITORY" \
+              --pr="$pr_number" \
+              --head-sha="$head_sha"; then
+              echo "PR #${pr_number} has not completed its clean observation window"
+              continue
+            fi
+            runs="$(gh api --method GET \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/dependabot-security-release.yml/runs" \
+              -f event=pull_request_target -f per_page=100)"
+            run_id="$(jq -r \
+              --argjson pr "$pr_number" \
+              --arg head "$head_sha" '
+                [.workflow_runs[] |
+                  select(any(.pull_requests[]?; .number == $pr and .head.sha == $head))] |
+                sort_by(.created_at) | last | .id // empty
+              ' <<< "$runs")"
+            if [ -z "$run_id" ]; then
+              echo "::warning::no authenticated release run found for PR #${pr_number} at ${head_sha}"
+              continue
+            fi
+            run_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}")"
+            status="$(jq -r .status <<< "$run_json")"
+            conclusion="$(jq -r '.conclusion // ""' <<< "$run_json")"
+            if [ "$status" = completed ] && [ "$conclusion" = failure ]; then
+              gh api --method POST \
+                "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/rerun-failed-jobs" >/dev/null
+              echo "requeued release run ${run_id} for PR #${pr_number} at ${head_sha}"
+            fi
+          done < <(jq -c '.[]' <<< "$CANDIDATES")

--- a/.github/workflows/dependabot-security-release.yml
+++ b/.github/workflows/dependabot-security-release.yml
@@ -6,7 +6,9 @@
 #   - Dependabot-authored PR with GitHub-verified Dependabot commits
 #   - explicit security-only group from dependabot.yml
 #   - semver patch dependency update (minor/major fixes stay human-reviewed)
-#   - every replacement release has independently seasoned for at least 30 days
+#   - Bun replacements: patch-only resolved graph, 3 days of periodic clean
+#     GitHub/Socket observations, and no active or withdrawn malware match
+#   - Actions replacements: 30 days (no equivalent dual malware coverage)
 #   - root Bun or GitHub Actions ecosystem, no maintainer changes
 #   - manifest/lock-only Bun diff, or SHA-pinned uses:-line-only Actions diff
 #
@@ -45,6 +47,7 @@ jobs:
       !contains(github.event.pull_request.labels.*.name, 'security-autorelease')
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
     outputs:
       release-date: ${{ steps.release.outputs.release-date }}
@@ -109,6 +112,8 @@ jobs:
           GH_API_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          minimum_age_days=30
+          if [ "$ECOSYSTEM" = bun ]; then minimum_age_days=3; fi
           bun trusted/packaging/dependabot-security.ts verify \
             --repo=candidate \
             --base-sha="$BASE_SHA" \
@@ -118,7 +123,20 @@ jobs:
             --update-type="$UPDATE_TYPE" \
             --dependencies="$DEPENDENCIES" \
             --metadata="$UPDATED_DEPENDENCIES" \
-            --minimum-age-days=30
+            --minimum-age-days="$minimum_age_days"
+
+      - name: Require a continuous clean Bun malware observation window
+        if: steps.metadata.outputs.package-ecosystem == 'bun'
+        env:
+          GH_API_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          bun trusted/packaging/dependabot-security.ts verify-observations \
+            --repository="$GITHUB_REPOSITORY" \
+            --pr="$PR_NUMBER" \
+            --head-sha="$HEAD_SHA"
 
       # Lifecycle scripts are disabled. Socket and the deterministic vendoring
       # toolchain still evaluate candidate dependency bytes, which is why this
@@ -238,6 +256,8 @@ jobs:
           GH_API_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          minimum_age_days=30
+          if [ "$ECOSYSTEM" = bun ]; then minimum_age_days=3; fi
           bun trusted/packaging/dependabot-security.ts verify \
             --repo=candidate \
             --base-sha="$BASE_SHA" \
@@ -247,7 +267,7 @@ jobs:
             --update-type="$UPDATE_TYPE" \
             --dependencies="$DEPENDENCIES" \
             --metadata="$UPDATED_DEPENDENCIES" \
-            --minimum-age-days=30
+            --minimum-age-days="$minimum_age_days"
 
       - name: Download the untrusted generated patch
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -312,6 +332,7 @@ jobs:
           PREPARED_SHA: ${{ steps.commit.outputs.sha }}
           VERSION: ${{ steps.release.outputs.version }}
           VENDORED_CODEMIRROR: ${{ steps.release.outputs.vendored-codemirror }}
+          ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
         run: |
           set -euo pipefail
           gh label create security-autorelease \
@@ -319,10 +340,14 @@ jobs:
             --color 0E8A16 \
             --description 'Verified Dependabot patch queued for automatic release' \
             --force
+          seasoning='30 days of release seasoning'
+          if [ "$ECOSYSTEM" = bun ]; then
+            seasoning='a continuous 72-hour clean GitHub and Socket observation window'
+          fi
           cat > "$RUNNER_TEMP/security-autorelease.md" <<EOF
           <!-- peerd-security-autorelease: ${PREPARED_SHA} v${VERSION} -->
           This semver-patch security update was authenticated as Dependabot-only,
-          every replacement release passed 30 days of seasoning, and the PR was
+          every replacement release passed ${seasoning}, and the PR was
           prepared as peerd v${VERSION} for a protected exact-head merge.
           Reproducible CodeMirror vendored bytes changed: ${VENDORED_CODEMIRROR}.
           EOF
@@ -418,6 +443,14 @@ jobs:
           PREPARED_SHA: ${{ steps.commit.outputs.sha }}
           PACKAGE_RUN_ID: ${{ steps.ci.outputs.package-run }}
           SECURITY_RUN_ID: ${{ steps.ci.outputs.security-run }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CANDIDATE_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
+          GROUP: ${{ steps.metadata.outputs.dependency-group }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCIES: ${{ steps.metadata.outputs.dependency-names }}
+          UPDATED_DEPENDENCIES: ${{ steps.metadata.outputs.updated-dependencies-json }}
+          GH_API_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           current_head="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .head.sha)"
@@ -452,6 +485,28 @@ jobs:
           current_head="$(jq -r .head.sha <<< "$pr_json")"
           [ "$current_head" = "$PREPARED_SHA" ] \
             || { echo '::error::PR head moved while awaiting protected checks'; exit 1; }
+
+          # Re-query publication metadata and GitHub's active + withdrawn
+          # malware advisories after the exact-head Socket/OSV/security runs.
+          # This narrows the feed-change race immediately before merge.
+          minimum_age_days=30
+          if [ "$ECOSYSTEM" = bun ]; then minimum_age_days=3; fi
+          bun trusted/packaging/dependabot-security.ts verify \
+            --repo=candidate \
+            --base-sha="$BASE_SHA" \
+            --head-sha="$CANDIDATE_HEAD_SHA" \
+            --ecosystem="$ECOSYSTEM" \
+            --group="$GROUP" \
+            --update-type="$UPDATE_TYPE" \
+            --dependencies="$DEPENDENCIES" \
+            --metadata="$UPDATED_DEPENDENCIES" \
+            --minimum-age-days="$minimum_age_days"
+          if [ "$ECOSYSTEM" = bun ]; then
+            bun trusted/packaging/dependabot-security.ts verify-observations \
+              --repository="$GITHUB_REPOSITORY" \
+              --pr="$PR_NUMBER" \
+              --head-sha="$CANDIDATE_HEAD_SHA"
+          fi
 
           # Start the trusted finalizer before the merge. A GITHUB_TOKEN merge
           # does not guarantee a pull-request event, while repository_dispatch

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -8,14 +8,16 @@
 [install]
 # Defense in depth for local/manual resolution. Existing bun.lock entries stay
 # reproducible; newly resolved direct and transitive versions must have been
-# public for 30 days. The security auto-merge policy independently rechecks the
-# exact replacement timestamps because Dependabot writes the lockfile remotely.
+# public for 30 days. The narrower Bun security-patch auto-merge exception
+# independently requires a continuous 72-hour GitHub/Socket observation window
+# across every resolved replacement because Dependabot writes the lock remotely.
 minimumReleaseAge = 2592000
 
 [install.security]
 # Supply-chain behavior/malware signal in addition to OSV's known-CVE scan.
 # The scanner is exact-pinned in package.json and uses Socket's unauthenticated
-# public API, so CI needs no Socket account or secret.
+# public API, so CI needs no Socket account or secret. Scanner updates themselves
+# are excluded from the three-day no-human path to preserve independence.
 scanner = "@socketsecurity/bun-security-scanner"
 
 [test]

--- a/docs/security/DEPENDENCY-AUTOMATION.md
+++ b/docs/security/DEPENDENCY-AUTOMATION.md
@@ -1,10 +1,13 @@
 # Dependency update and security-release policy
 
-Every automatically merged dependency release seasons for 30 days. Dependabot
-security PRs are opened immediately, but the deliberately narrow no-human path
-also verifies the replacement artifact's publication age before it can merge.
-A fresh security fix remains visible and tested in an open PR while a person
-decides whether the known vulnerability outweighs the fresh-artifact risk.
+Routine updates and GitHub Actions security patches season for 30 days. The
+deliberately narrow Bun security-patch path may merge after a continuous 72-hour
+observation window only when every resolved replacement is patch-level, its
+exact npm integrity is authenticated, GitHub reports no active or withdrawn
+malware advisory, and every scheduled Socket scan stays clean. Dependabot
+security PRs are still opened immediately. Until the applicable window closes,
+the PR remains visible for a person to decide whether the known vulnerability
+outweighs the fresh-artifact risk.
 
 ## Covered dependency manifests
 
@@ -18,9 +21,11 @@ decides whether the known vulnerability outweighs the fresh-artifact risk.
 Routine updates are grouped per ecosystem and held until the candidate version
 is at least 30 days old. GitHub applies `cooldown` to version updates, not to
 Dependabot security updates, so the trusted workflow independently checks every
-security replacement's registry or GitHub release timestamp. `bunfig.toml`
-also applies Bun's native 30-day filter to new local/manual resolution of both
-direct and transitive packages; existing locked versions remain reproducible.
+security replacement's registry or GitHub release timestamp. Bun semver-patch
+security replacements use a 3-day publication floor plus periodic dual-malware
+observations; Actions remain at 30 days. `bunfig.toml` also applies Bun's native
+30-day filter to new local/manual resolution of both direct and transitive
+packages; existing locked versions remain reproducible.
 
 Security updates use distinct `bun-security-patches` and
 `actions-security-patches` groups. Their names are security boundaries: the
@@ -38,20 +43,32 @@ of these are true:
 3. The dependency update is semver patch-level. A security fix requiring a
    minor or major dependency change gets an immediate PR but remains
    human-reviewed.
-4. Every replacement has been public for at least 30 days. Bun versions are
-   checked against the exact npm registry publication timestamp and integrity
-   metadata. Actions must have a stable GitHub Release at least 30 days old,
-   whose tag resolves to the newly pinned full SHA and whose commit GitHub
-   marks verified.
+4. Every resolved Bun replacement in `bun.lock`, including transitives, is a
+   stable semver patch from the package already occupying that lock slot. New
+   package slots, integrity-only mutations, minor/major transitive movement, and
+   failure to bind authenticated metadata to the resolved graph remain
+   human-reviewed. The trusted policy checks every replacement's exact npm
+   publication timestamp and binds its lock integrity to the registry digest.
+   All must be public for at least 3 complete days. Every Actions replacement
+   must still have a stable GitHub Release at least 30 days old, whose tag
+   resolves to the newly pinned full SHA and whose commit GitHub marks verified.
 5. A Bun PR changes only `package.json` dependency versions and/or `bun.lock`.
    An Actions PR changes only full-SHA-pinned `uses:` lines in workflow YAML.
-6. Candidate dependency lifecycle scripts are disabled. Socket scanning and
-   deterministic generation run on a disposable runner with only a read token.
-   Its patch is treated as untrusted input; candidate code never shares a
-   runner with a repository-write token.
-7. The workflow increments peerd's patch version, adds release notes,
-   regenerates the development manifest, and, for Bun updates, rebuilds the
-   checked-in CodeMirror bundle and its complete SHA-256 vendor lock.
+6. `.github/workflows/dependabot-malware-observation.yml` starts when the exact
+   Dependabot head appears and every four hours thereafter. Each read-only job
+   rechecks all resolved replacement coordinates against GitHub's active and
+   withdrawn malware feed, verifies npm integrity metadata, and runs Socket with
+   lifecycle scripts disabled. The merge gate requires 72 continuous clean
+   hours, permits no observation gap over 6 hours, resets after a finding or
+   missed interval, and starts over when the head SHA changes. The exact-pinned
+   Socket scanner cannot itself use the three-day path. Once the window is
+   complete, a trusted coordinator re-runs the already-authenticated failed
+   release workflow; passage of time no longer requires a human click.
+7. On a disposable runner with only a read token, the workflow increments
+   peerd's patch version, adds release notes, regenerates the development
+   manifest, and, for Bun updates, rebuilds the checked-in CodeMirror bundle and
+   its complete SHA-256 vendor lock. Candidate code never shares a runner with a
+   repository-write token.
 8. A fresh privileged runner re-authenticates the original PR, rechecks the
    seasoning policy, and applies only the exact expected version, changelog,
    manifest, and CodeMirror hash changes without installing or executing the
@@ -60,8 +77,11 @@ of these are true:
    workflows in a read-only mode. Jobs whose token can write repository state
    or upload SARIF are skipped so a candidate Action SHA never shares their
    authority. The workflow records and waits for the two exact dispatched run
-   IDs, then rechecks the PR head and approves it. No auto-merge is left armed.
-   Once those runs pass, it starts a trusted finalizer through
+   IDs, then rechecks the PR head and approves it. Immediately before merge, the
+   trusted policy re-queries every resolved replacement against npm and both
+   active and withdrawn GitHub malware advisories, then revalidates the complete
+   observation window. No auto-merge is left armed. Once those runs pass, it
+   starts a trusted finalizer through
    `repository_dispatch` (the documented
    `GITHUB_TOKEN` event exception) and performs a protected squash merge with a
    matching-head constraint.
@@ -75,11 +95,16 @@ of these are true:
 Any ambiguity fails closed: the PR remains open for a person rather than being
 merged or tagged.
 
-The 30-day rule addresses a different trust boundary from Dependabot. GitHub's
+Seasoning addresses a different trust boundary from Dependabot. GitHub's
 advisory review and verified bot commits establish that the old version matches
 a reviewed advisory and that Dependabot authored the PR. They do not establish
 that a newly published upstream tarball or Action commit contains no unrelated
-malicious behavior.
+malicious behavior. The 3-day Bun exception is therefore tied to the exact
+candidate head and every resolved package/version/integrity replacement, plus
+GitHub's malware feed and Socket's independently maintained behavioral signal.
+It does not apply to new transitive package slots, minor or major movement
+anywhere in the replacement graph, routine version updates, local/manual
+installs, GitHub Actions, or the Socket scanner itself.
 
 ## Checked-in libraries
 
@@ -109,9 +134,14 @@ Socket's exact-pinned Bun scanner is configured in `bunfig.toml`. It uses the
 unauthenticated public API (no Socket secret or account), scans the resolved
 graph before installation, and fails non-interactive CI on warning or fatal
 findings. This complements OSV by looking for malware and suspicious package
-behavior rather than only known CVEs. Text `bun.lock` support is currently a
-public beta. The scanner necessarily sends the already-public dependency
-snapshot to Socket.
+behavior rather than only known CVEs. The trusted security-patch policy also
+queries GitHub's malware feed directly, including withdrawn advisories imported
+from OpenSSF's `malicious-packages` data; a feed outage or malformed response
+fails closed. The observation workflow provides durable point-in-time results
+at a four-hour cadence; neither upstream API exposes a transactional guarantee
+for the intervals between those observations. Text `bun.lock` support in Socket
+is currently a public beta. The scanner necessarily sends the already-public
+dependency snapshot to Socket.
 
 Every Actions job starts the full-SHA-pinned, seasoned StepSecurity
 Harden-Runner in audit mode. It records source writes and outbound destinations,
@@ -133,8 +163,10 @@ tests.
 The workflow is versioned, but GitHub does not store the following controls in
 the repository. Apply them only after this workflow is present on `main`:
 
-- Keep Dependabot alerts and security updates enabled (already enabled at the
-  time this policy was introduced).
+- Keep Dependabot alerts, Dependabot malware alerts, and security updates
+  enabled. The workflow's direct global-advisory query is an independent gate;
+  repository malware alerts remain the default-branch monitoring and
+  notification layer.
 - Allow GitHub Actions to create pull-request approvals.
 - Keep one required approval and stale-review dismissal on `main`, but turn off
   “require review from Code Owners.” The Actions bot cannot be the repository's

--- a/packaging/dependabot-security.ts
+++ b/packaging/dependabot-security.ts
@@ -8,11 +8,17 @@
 //     --repo=. --base-sha=<sha> --head-sha=<sha> \
 //     --ecosystem=bun --group=bun-security-patches \
 //     --update-type=version-update:semver-patch --dependencies=foo,bar \
-//     --metadata='[...]' --minimum-age-days=30
+//     --metadata='[...]' --minimum-age-days=3
 //
 //   bun packaging/dependabot-security.ts prepare \
 //     --repo=. --base-sha=<sha> --ecosystem=bun \
 //     --dependencies=foo,bar --pr=123 --date=2026-08-10
+//
+//   bun packaging/dependabot-security.ts observe-bun \
+//     --repo=. --base-sha=<sha> --head-sha=<sha>
+//
+//   bun packaging/dependabot-security.ts verify-observations \
+//     --repository=owner/repo --pr=123 --head-sha=<sha>
 //
 //   bun packaging/dependabot-security.ts validate-prepared \
 //     --repo=. --base-sha=<sha> --head-sha=<sha> --ecosystem=bun \
@@ -37,11 +43,40 @@ const SECURITY_GROUPS = {
 
 type SupportedEcosystem = keyof typeof SECURITY_GROUPS;
 
+const MINIMUM_SECURITY_AGE_DAYS: Record<SupportedEcosystem, number> = {
+  // Bun patches get the shorter window only because exact package/version
+  // malware checks from both GitHub and Socket surround the merge.
+  bun: 3,
+  // SHA-pinned Actions do not have equivalent malware-alert coverage.
+  github_actions: 30,
+};
+
+const SOCKET_SCANNER_PACKAGE = '@socketsecurity/bun-security-scanner';
+const MALWARE_OBSERVATION_WORKFLOW = 'dependabot-malware-observation.yml';
+const MALWARE_OBSERVATION_HOURS = 72;
+const MALWARE_OBSERVATION_MAX_GAP_HOURS = 6;
+
 type UpdatedDependency = {
   dependencyName: string;
   newVersion: string;
   updateType: string;
 };
+
+export type LockedNpmReplacement = {
+  lockKey: string;
+  dependencyName: string;
+  previousVersion: string;
+  newVersion: string;
+  integrity: string;
+};
+
+export type MalwareObservation = {
+  headSha: string;
+  conclusion: string;
+  completedAt: string;
+};
+
+type JsonFetcher = typeof fetch;
 
 type ActionUpdate = {
   repository: string;
@@ -271,6 +306,133 @@ export const assertAtLeastDaysOld = (
   return ageDays;
 };
 
+export const minimumSecurityAgeDays = (ecosystem: SupportedEcosystem): number =>
+  MINIMUM_SECURITY_AGE_DAYS[ecosystem];
+
+type LockedNpmPackage = {
+  lockKey: string;
+  dependencyName: string;
+  version: string;
+  integrity: string;
+  serialized: string;
+};
+
+const parseLockedNpmCoordinate = (resolution: string): { dependencyName: string, version: string } => {
+  const split = resolution.lastIndexOf('@');
+  if (split <= 0) fail(`bun.lock package resolution ${JSON.stringify(resolution)} is not an npm coordinate`);
+  const dependencyName = resolution.slice(0, split);
+  const version = resolution.slice(split + 1);
+  parseDependencyNames(dependencyName);
+  if (!/^\d+\.\d+\.\d+$/.test(version)) {
+    fail(`bun.lock package resolution ${resolution} is not a stable plain semver release`);
+  }
+  return { dependencyName, version };
+};
+
+const parseBunLockPackages = (text: string): Map<string, LockedNpmPackage> => {
+  let parsed: unknown;
+  try {
+    parsed = Bun.JSONC.parse(text) as unknown;
+  } catch {
+    fail('bun.lock is not valid JSONC');
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) fail('bun.lock root is malformed');
+  const packages = (parsed as Record<string, unknown>).packages;
+  if (!packages || typeof packages !== 'object' || Array.isArray(packages)) {
+    fail('bun.lock has no package table');
+  }
+  const result = new Map<string, LockedNpmPackage>();
+  for (const [lockKey, raw] of Object.entries(packages as Record<string, unknown>)) {
+    if (!Array.isArray(raw) || typeof raw[0] !== 'string' || typeof raw[3] !== 'string') {
+      fail(`bun.lock package ${lockKey} is not an integrity-pinned registry package`);
+    }
+    const entry = raw as unknown[];
+    const resolution = entry[0] as string;
+    const integrity = entry[3] as string;
+    const { dependencyName, version } = parseLockedNpmCoordinate(resolution);
+    if (!/^sha(?:256|384|512)-[A-Za-z0-9+/]+={0,2}$/.test(integrity)) {
+      fail(`bun.lock package ${lockKey} has an invalid integrity digest`);
+    }
+    result.set(lockKey, {
+      lockKey,
+      dependencyName,
+      version,
+      integrity,
+      serialized: JSON.stringify(raw),
+    });
+  }
+  return result;
+};
+
+const semverParts = (version: string): [number, number, number] => {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version)
+    ?? fail(`version ${JSON.stringify(version)} is not stable plain semver`);
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+};
+
+/** Return every resolved npm package replacement in a Bun lockfile update. */
+export const changedBunLockPackages = (
+  baseText: string,
+  headText: string,
+): LockedNpmReplacement[] => {
+  const base = parseBunLockPackages(baseText);
+  const head = parseBunLockPackages(headText);
+  const replacements: LockedNpmReplacement[] = [];
+  for (const [lockKey, current] of head) {
+    const existing = base.get(lockKey);
+    if (!existing) {
+      fail(`bun.lock introduced new dependency slot ${lockKey} (${current.dependencyName}@${current.version})`);
+    }
+    const previous = existing as LockedNpmPackage;
+    if (previous.serialized === current.serialized) continue;
+    if (previous.dependencyName !== current.dependencyName) {
+      fail(`bun.lock replaced ${previous.dependencyName} with ${current.dependencyName} at ${lockKey}`);
+    }
+    if (previous.version === current.version) {
+      fail(`bun.lock changed ${current.dependencyName}@${current.version} without a version replacement`);
+    }
+    const [oldMajor, oldMinor, oldPatch] = semverParts(previous.version);
+    const [newMajor, newMinor, newPatch] = semverParts(current.version);
+    if (oldMajor !== newMajor || oldMinor !== newMinor || newPatch <= oldPatch) {
+      fail(`bun.lock replacement ${current.dependencyName} ${previous.version} -> ${current.version} is not a semantic patch update`);
+    }
+    replacements.push({
+      lockKey,
+      dependencyName: current.dependencyName,
+      previousVersion: previous.version,
+      newVersion: current.version,
+      integrity: current.integrity,
+    });
+  }
+  if (replacements.length === 0) fail('bun.lock has no resolved package replacements');
+  return replacements.sort((left, right) => left.lockKey.localeCompare(right.lockKey));
+};
+
+export const assertTrustedSocketScanner = (updates: Array<{ dependencyName: string }>): void => {
+  if (updates.some(({ dependencyName }) => dependencyName === SOCKET_SCANNER_PACKAGE)) {
+    fail(`${SOCKET_SCANNER_PACKAGE} updates cannot use the three-day no-human path because the scanner cannot approve itself`);
+  }
+};
+
+export const assertNoGitHubMalwareAdvisories = (
+  advisories: unknown,
+  coordinate: string,
+  withdrawn: boolean,
+): void => {
+  if (!Array.isArray(advisories)) {
+    fail(`GitHub malware lookup for ${coordinate} returned invalid JSON`);
+  }
+  const entries = advisories as unknown[];
+  if (entries.length === 0) return;
+  const identifiers = entries.map((advisory: unknown) => {
+    if (!advisory || typeof advisory !== 'object' || Array.isArray(advisory)) return 'unknown advisory';
+    const ghsa = (advisory as Record<string, unknown>).ghsa_id;
+    return typeof ghsa === 'string' ? ghsa : 'unknown advisory';
+  });
+  const status = withdrawn ? 'withdrawn' : 'active';
+  fail(`${coordinate} matched ${status} GitHub malware advisory ${identifiers.join(', ')}`);
+};
+
 const parseMetadata = (raw: string, dependencies: string[]): UpdatedDependency[] => {
   const value = JSON.parse(raw) as unknown;
   if (!Array.isArray(value) || value.length === 0) fail('updated-dependencies-json is empty or invalid');
@@ -302,28 +464,206 @@ const parseMetadata = (raw: string, dependencies: string[]): UpdatedDependency[]
   return updates;
 };
 
-const fetchJson = async (url: string, githubToken?: string): Promise<Record<string, unknown>> => {
+const fetchJson = async (
+  url: string,
+  githubToken?: string,
+  fetcher: JsonFetcher = fetch,
+): Promise<Record<string, unknown>> => {
   const headers: Record<string, string> = {
     Accept: 'application/vnd.github+json, application/json',
     'User-Agent': 'peerd-dependabot-security-policy',
+    'X-GitHub-Api-Version': '2022-11-28',
   };
   if (githubToken) headers.Authorization = `Bearer ${githubToken}`;
-  const response = await fetch(url, { headers, redirect: 'error' });
+  const response = await fetcher(url, {
+    headers,
+    redirect: 'error',
+    signal: AbortSignal.timeout(30_000),
+  });
   if (!response.ok) fail(`metadata lookup ${url} returned HTTP ${response.status}`);
   const value = await response.json() as unknown;
   if (!value || typeof value !== 'object' || Array.isArray(value)) fail(`metadata lookup ${url} returned invalid JSON`);
   return value as Record<string, unknown>;
 };
 
-const verifyNpmSeasoning = async (
-  updates: UpdatedDependency[],
-  minimumAgeDays: number,
+const fetchJsonArray = async (
+  url: string,
+  githubToken?: string,
+  fetcher: JsonFetcher = fetch,
+): Promise<unknown[]> => {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'peerd-dependabot-security-policy',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+  if (githubToken) headers.Authorization = `Bearer ${githubToken}`;
+  const response = await fetcher(url, {
+    headers,
+    redirect: 'error',
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) fail(`metadata lookup ${url} returned HTTP ${response.status}`);
+  const value = await response.json() as unknown;
+  if (!Array.isArray(value)) fail(`metadata lookup ${url} returned invalid JSON`);
+  return value as unknown[];
+};
+
+export const verifyNoGitHubNpmMalware = async (
+  updates: Array<{ dependencyName: string, newVersion: string }>,
+  githubToken = process.env.GH_API_TOKEN,
+  fetcher: JsonFetcher = fetch,
+): Promise<void> => {
+  for (const update of updates) {
+    const version = update.newVersion.replace(/^v/, '');
+    const coordinate = `${update.dependencyName}@${version}`;
+    // Query active and withdrawn records separately. A withdrawn advisory still
+    // proves the release tripped GitHub's malware feed during seasoning, so it
+    // permanently disqualifies the three-day no-human path.
+    for (const withdrawn of [false, true]) {
+      const query = new URLSearchParams({
+        type: 'malware',
+        ecosystem: 'npm',
+        affects: coordinate,
+        is_withdrawn: String(withdrawn),
+        per_page: '1',
+      });
+      const advisories = await fetchJsonArray(
+        `https://api.github.com/advisories?${query.toString()}`,
+        githubToken,
+        fetcher,
+      );
+      assertNoGitHubMalwareAdvisories(advisories, coordinate, withdrawn);
+    }
+    console.log(`clean GitHub malware history: ${coordinate}`);
+  }
+};
+
+export const assertMalwareObservationWindow = (
+  observations: MalwareObservation[],
+  headSha: string,
+  requiredHours = MALWARE_OBSERVATION_HOURS,
+  maximumGapHours = MALWARE_OBSERVATION_MAX_GAP_HOURS,
+  now = new Date(),
+): number => {
+  assertSha(headSha, 'observation head SHA');
+  if (!Number.isSafeInteger(requiredHours) || requiredHours < 1
+    || !Number.isSafeInteger(maximumGapHours) || maximumGapHours < 1) {
+    fail('malware observation window is invalid');
+  }
+  const matching = observations
+    .filter((observation) => observation.headSha === headSha)
+    .map((observation) => {
+      const completed = new Date(observation.completedAt);
+      if (!Number.isFinite(completed.getTime())) fail('malware observation has an invalid completion time');
+      return { ...observation, completed };
+    })
+    .sort((left, right) => left.completed.getTime() - right.completed.getTime());
+  if (matching.length === 0) fail('no malware observations exist for the exact candidate head');
+
+  const maximumGapMs = maximumGapHours * 3_600_000;
+  let cleanStart: Date | undefined;
+  let previousClean: Date | undefined;
+  for (const observation of matching) {
+    if (observation.conclusion !== 'success') {
+      cleanStart = undefined;
+      previousClean = undefined;
+      continue;
+    }
+    if (!previousClean || observation.completed.getTime() - previousClean.getTime() > maximumGapMs) {
+      cleanStart = observation.completed;
+    }
+    previousClean = observation.completed;
+  }
+  if (!cleanStart || !previousClean) fail('the latest malware observation is not clean');
+  const windowStart = cleanStart as Date;
+  const latestClean = previousClean as Date;
+  const freshnessMs = now.getTime() - latestClean.getTime();
+  if (freshnessMs < 0 || freshnessMs > maximumGapMs) {
+    fail(`the latest clean malware observation is more than ${maximumGapHours} hours old`);
+  }
+  const cleanHours = Math.floor((latestClean.getTime() - windowStart.getTime()) / 3_600_000);
+  if (cleanHours < requiredHours) {
+    fail(`the exact candidate has only ${cleanHours} continuous clean observation hours; ${requiredHours} are required`);
+  }
+  return cleanHours;
+};
+
+const loadMalwareObservations = async (
+  repository: string,
+  pr: number,
+  headSha: string,
+  githubToken: string,
+  now = new Date(),
+): Promise<MalwareObservation[]> => {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) fail('GitHub repository is invalid');
+  if (!Number.isSafeInteger(pr) || pr < 1) fail('observation PR number is invalid');
+  assertSha(headSha, 'observation head SHA');
+  const since = new Date(now.getTime() - (MALWARE_OBSERVATION_HOURS + MALWARE_OBSERVATION_MAX_GAP_HOURS) * 3_600_000);
+  const query = new URLSearchParams({
+    created: `>=${since.toISOString()}`,
+    per_page: '100',
+  });
+  const response = await fetchJson(
+    `https://api.github.com/repos/${repository}/actions/workflows/${MALWARE_OBSERVATION_WORKFLOW}/runs?${query}`,
+    githubToken,
+  );
+  const runValue = response.workflow_runs;
+  if (!Array.isArray(runValue)) fail('malware observation workflow-runs response is malformed');
+  const runs = runValue as unknown[];
+  const jobName = `observe Bun malware window (PR ${pr}, ${headSha})`;
+  const observations: MalwareObservation[] = [];
+  for (const run of runs) {
+    if (!run || typeof run !== 'object' || Array.isArray(run)) fail('malware observation run is malformed');
+    const id = (run as Record<string, unknown>).id;
+    if (!Number.isSafeInteger(id)) fail('malware observation run has no numeric ID');
+    const response = await fetchJson(
+      `https://api.github.com/repos/${repository}/actions/runs/${String(id)}/jobs?filter=latest&per_page=100`,
+      githubToken,
+    );
+    if (!Array.isArray(response.jobs)) fail('malware observation jobs response is malformed');
+    for (const job of response.jobs as unknown[]) {
+      if (!job || typeof job !== 'object' || Array.isArray(job)) fail('malware observation job is malformed');
+      const record = job as Record<string, unknown>;
+      if (record.name !== jobName) continue;
+      if (typeof record.conclusion !== 'string' || typeof record.completed_at !== 'string') {
+        fail('malware observation job is incomplete');
+      }
+      const conclusion = record.conclusion as string;
+      const completedAt = record.completed_at as string;
+      observations.push({
+        headSha,
+        conclusion,
+        completedAt,
+      });
+    }
+  }
+  return observations;
+};
+
+const verifyObservationWindow = async (values: Record<string, string>): Promise<void> => {
+  const repository = required(values, 'repository');
+  const pr = Number(required(values, 'pr'));
+  const headSha = required(values, 'head-sha');
+  const githubToken = process.env.GH_API_TOKEN ?? fail('GH_API_TOKEN is required for observation verification');
+  const observations = await loadMalwareObservations(repository, pr, headSha, githubToken);
+  const cleanHours = assertMalwareObservationWindow(observations, headSha);
+  console.log(`verified ${cleanHours} continuous clean malware observation hours for PR #${pr} at ${headSha}`);
+};
+
+export const verifyNpmSeasoning = async (
+  updates: Array<{ dependencyName: string, newVersion: string, integrity?: string }>,
+  minimumAgeDays?: number,
+  fetcher: JsonFetcher = fetch,
 ): Promise<void> => {
   const packuments = new Map<string, Record<string, unknown>>();
   for (const update of updates) {
     let packument = packuments.get(update.dependencyName);
     if (!packument) {
-      packument = await fetchJson(`https://registry.npmjs.org/${encodeURIComponent(update.dependencyName)}`);
+      packument = await fetchJson(
+        `https://registry.npmjs.org/${encodeURIComponent(update.dependencyName)}`,
+        undefined,
+        fetcher,
+      );
       packuments.set(update.dependencyName, packument);
     }
     const version = update.newVersion.replace(/^v/, '');
@@ -343,11 +683,23 @@ const verifyNpmSeasoning = async (
       || typeof (dist as Record<string, unknown>).integrity !== 'string') {
       fail(`npm release ${update.dependencyName}@${version} has no registry integrity digest`);
     }
+    const registryIntegrity = (dist as Record<string, unknown>).integrity as string;
+    if (update.integrity !== undefined
+      && !registryIntegrity.split(/\s+/).includes(update.integrity)) {
+      fail(`bun.lock integrity for ${update.dependencyName}@${version} does not match the npm registry`);
+    }
     if (typeof (manifest as Record<string, unknown>).deprecated === 'string') {
       fail(`npm release ${update.dependencyName}@${version} is deprecated`);
     }
-    const age = assertAtLeastDaysOld(publishedAt as string, minimumAgeDays);
-    console.log(`seasoned npm release: ${update.dependencyName}@${version} (${age} days old)`);
+    if (minimumAgeDays === undefined) {
+      if (!Number.isFinite(new Date(publishedAt as string).getTime())) {
+        fail(`invalid publication timestamp ${JSON.stringify(publishedAt)}`);
+      }
+      console.log(`verified npm release metadata: ${update.dependencyName}@${version}`);
+    } else {
+      const age = assertAtLeastDaysOld(publishedAt as string, minimumAgeDays);
+      console.log(`seasoned npm release: ${update.dependencyName}@${version} (${age} days old)`);
+    }
   }
 };
 
@@ -454,6 +806,48 @@ const assertInitialPaths = (ecosystem: SupportedEcosystem, paths: string[]): voi
   }
 };
 
+const bunLockReplacements = (
+  repo: string,
+  baseSha: string,
+  headSha: string,
+  paths: string[],
+): LockedNpmReplacement[] => {
+  if (!paths.includes('bun.lock')) fail('Bun security PR did not replace a resolved package in bun.lock');
+  const replacements = changedBunLockPackages(
+    readAt(repo, baseSha, 'bun.lock'),
+    readAt(repo, headSha, 'bun.lock'),
+  );
+  assertTrustedSocketScanner(replacements);
+  return replacements;
+};
+
+const assertMetadataMatchesResolvedReplacements = (
+  metadata: UpdatedDependency[],
+  replacements: LockedNpmReplacement[],
+): void => {
+  const coordinates = new Set(replacements.map(({ dependencyName, newVersion }) => `${dependencyName}@${newVersion}`));
+  for (const update of metadata) {
+    const coordinate = `${update.dependencyName}@${update.newVersion.replace(/^v/, '')}`;
+    if (!coordinates.has(coordinate)) {
+      fail(`authenticated update ${coordinate} is absent from the resolved bun.lock replacements`);
+    }
+  }
+};
+
+const observeBun = async (values: Record<string, string>): Promise<void> => {
+  const repo = resolve(required(values, 'repo'));
+  const baseSha = required(values, 'base-sha');
+  const headSha = required(values, 'head-sha');
+  assertSha(baseSha, 'base SHA');
+  assertSha(headSha, 'head SHA');
+  const paths = changedPaths(repo, baseSha, headSha);
+  assertInitialPaths('bun', paths);
+  const replacements = bunLockReplacements(repo, baseSha, headSha, paths);
+  await verifyNpmSeasoning(replacements);
+  await verifyNoGitHubNpmMalware(replacements);
+  console.log(`observed clean Bun replacement graph at ${headSha}: ${replacements.map(({ dependencyName, newVersion }) => `${dependencyName}@${newVersion}`).join(', ')}`);
+};
+
 const verify = async (values: Record<string, string>): Promise<void> => {
   const repo = resolve(required(values, 'repo'));
   const baseSha = required(values, 'base-sha');
@@ -471,8 +865,9 @@ const verify = async (values: Record<string, string>): Promise<void> => {
   const dependencies = parseDependencyNames(required(values, 'dependencies'));
   const metadata = parseMetadata(required(values, 'metadata'), dependencies);
   const minimumAgeDays = Number(required(values, 'minimum-age-days'));
-  if (!Number.isSafeInteger(minimumAgeDays) || minimumAgeDays < 30) {
-    fail('no-human security updates require at least 30 days of replacement seasoning');
+  const policyMinimumAgeDays = minimumSecurityAgeDays(ecosystem);
+  if (!Number.isSafeInteger(minimumAgeDays) || minimumAgeDays < policyMinimumAgeDays) {
+    fail(`${ecosystem} no-human security updates require at least ${policyMinimumAgeDays} days of replacement seasoning`);
   }
   const paths = changedPaths(repo, baseSha, headSha);
   assertInitialPaths(ecosystem, paths);
@@ -486,7 +881,11 @@ const verify = async (values: Record<string, string>): Promise<void> => {
         Object.fromEntries(metadata.map(({ dependencyName, newVersion }) => [dependencyName, newVersion])),
       );
     }
-    await verifyNpmSeasoning(metadata, minimumAgeDays);
+    const replacements = bunLockReplacements(repo, baseSha, headSha, paths);
+    assertMetadataMatchesResolvedReplacements(metadata, replacements);
+    assertTrustedSocketScanner(metadata);
+    await verifyNpmSeasoning(replacements, minimumAgeDays);
+    await verifyNoGitHubNpmMalware(replacements);
   } else {
     const diff = git(repo, ['diff', '--no-ext-diff', '--unified=0', `${baseSha}..${headSha}`, '--', ...paths]);
     const actionUpdates = parseActionsDiff(diff);
@@ -684,9 +1083,11 @@ if (import.meta.main) {
   try {
     const { command, values } = parseArgs(process.argv.slice(2));
     if (command === 'verify') await verify(values);
+    else if (command === 'observe-bun') await observeBun(values);
+    else if (command === 'verify-observations') await verifyObservationWindow(values);
     else if (command === 'prepare') prepare(values);
     else if (command === 'validate-prepared') validatePrepared(values);
-    else fail('expected verify, prepare, or validate-prepared command');
+    else fail('expected verify, observe-bun, verify-observations, prepare, or validate-prepared command');
   } catch (error) {
     console.error(error instanceof Error ? error.message : error);
     process.exit(1);

--- a/tests/dependabot-security.test.ts
+++ b/tests/dependabot-security.test.ts
@@ -7,12 +7,19 @@ import { join } from 'node:path';
 import {
   addSecurityChangelog,
   assertAtLeastDaysOld,
+  assertMalwareObservationWindow,
+  assertNoGitHubMalwareAdvisories,
   assertRecentUtcDate,
+  assertTrustedSocketScanner,
+  changedBunLockPackages,
+  minimumSecurityAgeDays,
   nextPatchVersion,
   parseDependencyNames,
   validateActionsDiff,
   validatePackageJsonChange,
   validatePrepared,
+  verifyNoGitHubNpmMalware,
+  verifyNpmSeasoning,
 } from '../packaging/dependabot-security.ts';
 
 const sha256 = (value: string): string =>
@@ -25,6 +32,13 @@ const write = (root: string, path: string, value: string): void => {
 
 const git = (root: string, ...args: string[]): string =>
   execFileSync('git', ['-C', root, ...args], { encoding: 'utf8' }).trim();
+
+const bunLock = (packages: Record<string, unknown>): string => JSON.stringify({
+  lockfileVersion: 1,
+  configVersion: 1,
+  workspaces: { '': { devDependencies: {} } },
+  packages,
+});
 
 describe('Dependabot security automation policy', () => {
   test('accepts authenticated dependency-version-only package changes', () => {
@@ -146,9 +160,156 @@ describe('Dependabot security automation policy', () => {
 
   test('requires the replacement release itself to finish seasoning', () => {
     const now = new Date('2026-08-10T12:00:00Z');
-    expect(assertAtLeastDaysOld('2026-07-11T11:59:59Z', 30, now)).toBe(30);
-    expect(() => assertAtLeastDaysOld('2026-07-12T12:00:00Z', 30, now))
-      .toThrow('29 days ago; 30 days of seasoning are required');
+    expect(minimumSecurityAgeDays('bun')).toBe(3);
+    expect(minimumSecurityAgeDays('github_actions')).toBe(30);
+    expect(assertAtLeastDaysOld('2026-08-07T11:59:59Z', 3, now)).toBe(3);
+    expect(() => assertAtLeastDaysOld('2026-08-08T12:00:00Z', 3, now))
+      .toThrow('2 days ago; 3 days of seasoning are required');
+  });
+
+  test('permanently rejects active or withdrawn GitHub malware matches', () => {
+    expect(() => assertNoGitHubMalwareAdvisories([], 'eslint@10.4.1', false)).not.toThrow();
+    expect(() => assertNoGitHubMalwareAdvisories({}, 'eslint@10.4.1', false))
+      .toThrow('GitHub malware lookup for eslint@10.4.1 returned invalid JSON');
+    expect(() => assertNoGitHubMalwareAdvisories(
+      [{ ghsa_id: 'GHSA-1111-2222-3333', withdrawn_at: null }],
+      'eslint@10.4.1',
+      false,
+    )).toThrow('active GitHub malware advisory GHSA-1111-2222-3333');
+    expect(() => assertNoGitHubMalwareAdvisories(
+      [{ ghsa_id: 'GHSA-4444-5555-6666', withdrawn_at: '2026-08-09T00:00:00Z' }],
+      'eslint@10.4.1',
+      true,
+    )).toThrow('withdrawn GitHub malware advisory GHSA-4444-5555-6666');
+  });
+
+  test('checks the active and withdrawn advisory request path for scoped packages', async () => {
+    const urls: string[] = [];
+    const fetcher = (async (input: string | URL | Request) => {
+      urls.push(String(input));
+      return Response.json([]);
+    }) as typeof fetch;
+    await verifyNoGitHubNpmMalware([
+      { dependencyName: '@scope/widget', newVersion: '1.2.4' },
+    ], 'test-token', fetcher);
+    expect(urls).toHaveLength(2);
+    const queries = urls.map((url) => new URL(url).searchParams);
+    expect(queries.map((query) => query.get('type'))).toEqual(['malware', 'malware']);
+    expect(queries.map((query) => query.get('ecosystem'))).toEqual(['npm', 'npm']);
+    expect(queries.map((query) => query.get('affects'))).toEqual([
+      '@scope/widget@1.2.4',
+      '@scope/widget@1.2.4',
+    ]);
+    expect(queries.map((query) => query.get('is_withdrawn'))).toEqual(['false', 'true']);
+  });
+
+  test('fails closed on advisory HTTP and response-shape errors', async () => {
+    const unavailable = (async () => new Response('unavailable', { status: 503 })) as unknown as typeof fetch;
+    await expect(verifyNoGitHubNpmMalware([
+      { dependencyName: 'eslint', newVersion: '10.4.1' },
+    ], undefined, unavailable)).rejects.toThrow('returned HTTP 503');
+
+    const malformed = (async () => Response.json({ advisories: [] })) as unknown as typeof fetch;
+    await expect(verifyNoGitHubNpmMalware([
+      { dependencyName: 'eslint', newVersion: '10.4.1' },
+    ], undefined, malformed)).rejects.toThrow('returned invalid JSON');
+  });
+
+  test('applies patch-only policy to every resolved Bun lockfile replacement', () => {
+    const base = bunLock({
+      eslint: ['eslint@10.4.0', '', {}, 'sha512-AAAA'],
+      transitive: ['transitive@2.7.3', '', {}, 'sha512-BBBB'],
+    });
+    const head = bunLock({
+      eslint: ['eslint@10.4.1', '', {}, 'sha512-CCCC'],
+      transitive: ['transitive@2.7.4', '', {}, 'sha512-DDDD'],
+    });
+    expect(changedBunLockPackages(base, head)).toEqual([
+      {
+        lockKey: 'eslint',
+        dependencyName: 'eslint',
+        previousVersion: '10.4.0',
+        newVersion: '10.4.1',
+        integrity: 'sha512-CCCC',
+      },
+      {
+        lockKey: 'transitive',
+        dependencyName: 'transitive',
+        previousVersion: '2.7.3',
+        newVersion: '2.7.4',
+        integrity: 'sha512-DDDD',
+      },
+    ]);
+
+    expect(() => changedBunLockPackages(base, bunLock({
+      eslint: ['eslint@10.4.1', '', {}, 'sha512-CCCC'],
+      transitive: ['transitive@3.0.0', '', {}, 'sha512-DDDD'],
+    }))).toThrow('is not a semantic patch update');
+    expect(() => changedBunLockPackages(base, bunLock({
+      eslint: ['eslint@10.4.1', '', {}, 'sha512-CCCC'],
+      transitive: ['transitive@2.7.3', '', {}, 'sha512-EEEE'],
+    }))).toThrow('without a version replacement');
+    expect(() => changedBunLockPackages(base, bunLock({
+      eslint: ['eslint@10.4.1', '', {}, 'sha512-CCCC'],
+      transitive: ['transitive@2.7.3', '', {}, 'sha512-BBBB'],
+      surprise: ['surprise@1.0.0', '', {}, 'sha512-FFFF'],
+    }))).toThrow('introduced new dependency slot surprise');
+  });
+
+  test('binds every changed lockfile integrity to exact npm registry metadata', async () => {
+    const requested: string[] = [];
+    const fetcher = (async (input: string | URL | Request) => {
+      const url = String(input);
+      requested.push(url);
+      const dependencyName = decodeURIComponent(new URL(url).pathname.slice(1));
+      const version = dependencyName === 'eslint' ? '10.4.1' : '2.7.4';
+      const integrity = dependencyName === 'eslint' ? 'sha512-CCCC' : 'sha512-DDDD';
+      return Response.json({
+        time: { [version]: '2026-08-01T00:00:00Z' },
+        versions: { [version]: { dist: { integrity } } },
+      });
+    }) as typeof fetch;
+    const replacements = [
+      { dependencyName: 'eslint', newVersion: '10.4.1', integrity: 'sha512-CCCC' },
+      { dependencyName: 'transitive', newVersion: '2.7.4', integrity: 'sha512-DDDD' },
+    ];
+    await expect(verifyNpmSeasoning(replacements, undefined, fetcher)).resolves.toBeUndefined();
+    expect(requested).toHaveLength(2);
+    await expect(verifyNpmSeasoning([
+      { dependencyName: 'eslint', newVersion: '10.4.1', integrity: 'sha512-WRONG' },
+    ], undefined, fetcher)).rejects.toThrow('does not match the npm registry');
+  });
+
+  test('does not allow the Socket scanner to approve its own three-day update', () => {
+    expect(() => assertTrustedSocketScanner([
+      { dependencyName: '@socketsecurity/bun-security-scanner' },
+    ])).toThrow('scanner cannot approve itself');
+    expect(() => assertTrustedSocketScanner([
+      { dependencyName: 'eslint' },
+    ])).not.toThrow();
+  });
+
+  test('requires a continuous, fresh 72-hour malware observation window', () => {
+    const headSha = 'a'.repeat(40);
+    const start = new Date('2026-08-07T12:00:00Z');
+    const observation = (hour: number, conclusion = 'success') => ({
+      headSha,
+      conclusion,
+      completedAt: new Date(start.getTime() + hour * 3_600_000).toISOString(),
+    });
+    const clean = Array.from({ length: 19 }, (_, index) => observation(index * 4));
+    const now = new Date(start.getTime() + 72 * 3_600_000);
+    expect(assertMalwareObservationWindow(clean, headSha, 72, 6, now)).toBe(72);
+
+    const withFinding = clean.map((entry, index) => index === 10
+      ? { ...entry, conclusion: 'failure' }
+      : entry);
+    expect(() => assertMalwareObservationWindow(withFinding, headSha, 72, 6, now))
+      .toThrow('only 28 continuous clean observation hours');
+
+    const missed = clean.filter((_, index) => index !== 10 && index !== 11);
+    expect(() => assertMalwareObservationWindow(missed, headSha, 72, 6, now))
+      .toThrow('only 24 continuous clean observation hours');
   });
 
   test('accepts only the exact generated patch on a fresh privileged runner', () => {


### PR DESCRIPTION
## Summary

- allow exact patch-only Bun security updates to use a three-day seasoning window while retaining the 30-day rule for GitHub Actions
- observe candidate packages every four hours with Socket and GitHub malware advisory checks, requiring an uninterrupted clean 72-hour history
- validate every changed lockfile coordinate and integrity against registry metadata, including transitive replacements
- prevent the Socket scanner from approving its own expedited update
- requeue eligible release checks after the observation window without executing pull-request code in a privileged job

## Validation

- `bun run typecheck`
- `bun test tests/dependabot-security.test.ts tests/meta/settings-hydration-invariants.test.ts` (22 pass)
- Actionlint 1.7.12 on both Dependabot workflows
- YAML parse and `git diff --check`
- frozen install with scripts disabled and Socket scan clean (414 installs / 389 packages)
- full suite: 5,790 pass; 3 unrelated timing-sensitive gossip tests failed and varied on rerun
