### PR TITLE
Salvage the safe test infrastructure from the closed identity PR (#360)

### DIFF
--- a/.github/workflows/package-and-release.yml
+++ b/.github/workflows/package-and-release.yml
@@ -293,6 +293,19 @@ jobs:
             sleep 5
           done
           exit 1
+      - name: Run the two-peer RESTORED-identity join over CDP
+        env:
+          CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
+        # Persistent identity on the live network: alice runs the full
+        # backup/adopt lifecycle in-page and must mesh as the pre-backup did.
+        # Same flake retry as the runs above.
+        run: |
+          for attempt in 1 2 3; do
+            bun run test:twopeer:restore && exit 0
+            echo "::warning::two-peer restore attempt $attempt failed (headless-WebRTC flake) - retrying"
+            sleep 5
+          done
+          exit 1
 
   # Additive job — the multi-PROCESS dweb node test (PHASE1-TESTING §A.2),
   # previously run only by hand. Spawns a relay + N real node processes that

--- a/extension/tests/dweb-twopeer.js
+++ b/extension/tests/dweb-twopeer.js
@@ -18,6 +18,11 @@
 
 import { generateIdentity, joinRoom } from '/peerd-distributed/index.js';
 import { createBaseNetwork } from '/peerd-distributed/base-network.js';
+// restore=1 mode: run the full persistent-identity lifecycle before joining.
+// Deep imports are fine here (tests/ is exempt from the no-deep-import rule,
+// same as the a2a-dispatch import below).
+import { loadIdentityMaterial, identityFromMaterial } from '/peerd-distributed/identity/keypair.js';
+import { buildIdentityRecord, adoptIdentityRecord } from '/peerd-distributed/identity/recovery-record.js';
 // The PRODUCTION a2a ask/reply correlation core — driven here over the REAL mesh
 // direct channel so the live two-peer round-trip exercises the same code the
 // dweb actor's a2a_run uses (envelope tag + request/reply, the did-bound resolve).
@@ -33,6 +38,14 @@ const roomId = params.get('room') ?? 'harness';
 const url = params.get('url') ?? 'ws://localhost:8799/rendezvous';
 const name = params.get('name') ?? 'peer';
 const a2aOn = params.get('a2a') === '1';   // add the live ask/reply beat on top of gossip
+// restore=1: this peer joins the mesh AS A RESTORED IDENTITY. It simulates the
+// whole portable-identity lifecycle in-page (install A mints and exports a
+// recovery record; a fresh install B adopts it and loads the identity exactly
+// the way the offscreen mesh host does), then joins the live mesh with the
+// result. The driver asserts the joined did equals the pre-backup did: the
+// proof that a restored identity keeps its PLACE IN THE NETWORK, not just its
+// key material.
+const restoreOn = params.get('restore') === '1';
 
 // The gossip topic the two peers exchange a hello on — proves the application
 // layer (gossip flood + dedup) works over the live mesh, not just that a data
@@ -52,6 +65,10 @@ let base = null;
 let myDid = null;
 /** @type {any} */
 let error = null;
+// restore mode: the did minted on "install A" before backup. A green run
+// requires the joined did to equal it.
+/** @type {string | null} */
+let restoredFromDid = null;
 // a2a live round-trip state (only when a2aOn): did we send an ask and get the
 // peer's reply back, over the real mesh, via the production correlation core?
 let askReplied = false;
@@ -70,9 +87,47 @@ const render = () => {
   ].filter(Boolean).join('\n');
 };
 
+// The vault-secret shape both the transfer helper and the mesh host program
+// against, reduced to a Map for the in-page lifecycle simulation.
+const fakeSecretStore = () => {
+  /** @type {Map<string, string>} */
+  const secrets = new Map();
+  return {
+    getSecret: async (/** @type {string} */ secretName) => secrets.get(secretName) ?? null,
+    setSecret: async (/** @type {string} */ secretName, /** @type {string} */ value) => { secrets.set(secretName, value); },
+  };
+};
+const IDENTITY_SECRET = 'distributed/identity/v1';
+const RESTORE_PASSPHRASE = 'twopeer-harness-restore-passphrase';
+
+// The persistent-identity lifecycle, end to end, yielding the identity the
+// mesh will join with: install A mints via the production first-run path and
+// exports a recovery record; install B (a fresh empty store) adopts it,
+// persists the material under the identity secret, and loads it back through
+// loadIdentityMaterial + identityFromMaterial, byte-for-byte the composition
+// offscreen/dweb-base.js runs at mesh start.
+const restoreIdentity = async () => {
+  const installA = fakeSecretStore();
+  const original = await loadIdentityMaterial(installA);
+  restoredFromDid = original.did;
+  const record = await buildIdentityRecord({
+    material: { seed: original.seed, pub: original.pub },
+    wrappers: [{ kind: 'passphrase', passphrase: RESTORE_PASSPHRASE }],
+  });
+  const outcome = await adoptIdentityRecord({
+    record, passphrase: RESTORE_PASSPHRASE, existingMaterial: null,
+  });
+  if (!outcome.adopted || typeof outcome.material !== 'string') {
+    throw new Error(`restore failed before join: ${outcome.reason}`);
+  }
+  const installB = fakeSecretStore();
+  await installB.setSecret(IDENTITY_SECRET, outcome.material);
+  return identityFromMaterial(await loadIdentityMaterial(installB));
+};
+
 const boot = async () => {
   try {
-    const identity = await generateIdentity();
+    const identity = restoreOn ? await restoreIdentity() : await generateIdentity();
     myDid = identity.did;
     render();
 
@@ -175,6 +230,10 @@ const boot = async () => {
           heard: heardFrom.size,
           askReplied,
           askReply,
+          // restore mode: true only when the mesh identity IS the pre-backup
+          // did. The driver requires it for the restore-mode pass gate.
+          restored: restoreOn ? (restoredFromDid !== null && myDid === restoredFromDid) : null,
+          restoredFrom: restoredFromDid,
           peers: snap.peers.map((/** @type {any} */ p) => ({ did: p.did, name: p.name, linked: p.linked, path: p.path })),
           error,
         };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:twopeer": "bun scripts/cdp/run-dweb-twopeer.mjs",
     "test:twopeer:a2a": "A2A=1 bun scripts/cdp/run-dweb-twopeer.mjs",
     "test:twopeer:conv": "CONV=1 bun scripts/cdp/run-dweb-twopeer.mjs",
+    "test:twopeer:restore": "RESTORE=1 bun scripts/cdp/run-dweb-twopeer.mjs",
     "e2e:verify": "bun scripts/cdp/run-e2e-verify.mjs",
     "test:e2e": "bun scripts/cdp/run-e2e-verify.mjs --functional",
     "test:e2e:all": "bun scripts/cdp/run-e2e-verify.mjs --functional",

--- a/scripts/cdp/run-dweb-twopeer.mjs
+++ b/scripts/cdp/run-dweb-twopeer.mjs
@@ -159,10 +159,15 @@ const main = async () => {
   // CONV=1 (implies A2A) proves a STANDING conversation: converse opens a thread,
   // say continues it, the convId survives real WebRTC end to end.
   const conv = process.env.CONV === '1';
+  // RESTORE=1: alice joins as a RESTORED identity: the page runs the full
+  // backup/adopt lifecycle first and the pass gate requires the did she meshes
+  // with to equal the pre-backup did. Persistent identity, proven on the live
+  // network, not just at the values level.
+  const restore = process.env.RESTORE === '1';
   const room = `harness-${Math.random().toString(36).slice(2, 8)}`;
-  const pageUrl = (who) => `http://localhost:${httpPort}/tests/dweb-twopeer.html`
-    + `?room=${room}&name=${who}&url=${encodeURIComponent(rendezvous)}${(a2a || conv) ? '&a2a=1' : ''}${conv ? '&conv=1' : ''}`;
-  const alice = await openPeer(cdpPort, pageUrl('alice'));
+  const pageUrl = (who, extra = '') => `http://localhost:${httpPort}/tests/dweb-twopeer.html`
+    + `?room=${room}&name=${who}&url=${encodeURIComponent(rendezvous)}${(a2a || conv) ? '&a2a=1' : ''}${conv ? '&conv=1' : ''}${extra}`;
+  const alice = await openPeer(cdpPort, pageUrl('alice', restore ? '&restore=1' : ''));
   const bob = await openPeer(cdpPort, pageUrl('bob'));
   console.log(`[twopeer] two contexts joining room "${room}"`);
 
@@ -170,16 +175,20 @@ const main = async () => {
   const reportExpr = 'window.__DWEB__?.ready ? JSON.stringify(window.__DWEB__.report()) : ""';
   let a = null; let b = null;
   const deadline = Date.now() + RESULT_BUDGET_MS;
-  // A2A mode additionally requires the live ask/reply round-trip on both peers.
-  const done = (r) => r && r.linked >= 1 && r.heard >= 1 && ((!a2a && !conv) || r.askReplied === true);
+  // A2A mode additionally requires the live ask/reply round-trip on both peers;
+  // RESTORE mode additionally requires alice's mesh did to be the restored one.
+  const done = (r, restoredRequired = false) => r && r.linked >= 1 && r.heard >= 1
+    && ((!a2a && !conv) || r.askReplied === true)
+    && (!restoredRequired || r.restored === true);
   while (Date.now() < deadline) {
     const [ja, jb] = await Promise.all([alice.evaluate(reportExpr), bob.evaluate(reportExpr)]);
     a = ja ? JSON.parse(ja) : a;
     b = jb ? JSON.parse(jb) : b;
     if (a?.error || b?.error) break;
-    if (done(a) && done(b)) {
+    if (done(a, restore) && done(b)) {
       const a2aNote = (a2a || conv) ? ` · ${conv ? 'standing conversation' : 'a2a ask/reply'} ✓ (alice⇐"${a.askReply}", bob⇐"${b.askReply}")` : '';
-      console.log(`[twopeer] ✅ PASS — alice⇄bob meshed (alice linked ${a.linked}/heard ${a.heard}, bob linked ${b.linked}/heard ${b.heard})${a2aNote}`);
+      const restoreNote = restore ? ` · restored identity ✓ (alice meshed as pre-backup did …${String(a.did).slice(-8)})` : '';
+      console.log(`[twopeer] ✅ PASS - alice⇄bob meshed (alice linked ${a.linked}/heard ${a.heard}, bob linked ${b.linked}/heard ${b.heard})${a2aNote}${restoreNote}`);
       cleanup();
       process.exit(0);
     }

--- a/scripts/firefox/run-runtime-tests.mjs
+++ b/scripts/firefox/run-runtime-tests.mjs
@@ -4820,7 +4820,6 @@ const main = async () => {
     await runLocalModuleGraphSmoke(driver);
     await runBoundActorSmoke(driver, providerServer);
     await runNumericTabAuthoritySmoke(driver, providerServer);
-    await runBackgroundCapabilityProbe();
     await runActorLifetimeSmoke({ providerServer });
     await runActorKeepaliveLossSmoke({ providerServer });
     await runActorRecoverySmoke({ providerServer });
@@ -4992,6 +4991,12 @@ const main = async () => {
     'installed Firefox Preview omits the dweb surface until it has a mesh host',
     JSON.stringify(previewPosture));
     await runPreviewRemoteModuleSmoke(driver, providerServer);
+
+    // why LAST: this lane is a measurement, not a gate, and it stands up a
+    // second browser. Several lanes above assert on tight deadlines (the
+    // remote-module import deadline is 400ms), so anything optional belongs
+    // downstream of them where it cannot perturb their scheduling.
+    await runBackgroundCapabilityProbe();
 
     await driver.setWindowRect({ width: 400, height: 900, x: 0, y: 0 });
 

--- a/scripts/firefox/run-runtime-tests.mjs
+++ b/scripts/firefox/run-runtime-tests.mjs
@@ -83,6 +83,7 @@ const KEEPALIVE_LOSS_RESPONSE_DELAY_MS = 20_000;
 const KEEPALIVE_LOSS_SCREENSHOT = 'keepalive-loss.png';
 const KEEPALIVE_LOSS_LOG = 'keepalive-loss-geckodriver.log';
 const KEEPALIVE_LOSS_DIAGNOSTIC = 'keepalive-loss.json';
+const CAPABILITY_PROBE_DIAGNOSTIC = 'background-capability-probe.json';
 const RECOVERY_SEED_KEY = 'peerdFirefoxActorRecoverySeed';
 const RECOVERY_BOOT_KEY = 'peerdFirefoxActorRecoveryBoot';
 const LIFECYCLE_OPERATIONS_KEY = 'peerd.lifecycle.operations';
@@ -1688,6 +1689,253 @@ browser.runtime.onMessage.addListener((message) => {
     env: { ...process.env, TZ: 'UTC' },
   });
   return { artifact, directory };
+};
+
+// The Firefox background-page capability probe (issue #376).
+//
+// why it exists: the dweb mesh runs in Chrome's offscreen document, and
+// Firefox has no offscreen API, so no host starts the base network there.
+// Which replacement hosts are even POSSIBLE is decided by platform facts
+// nobody has measured: whether a Firefox MV3 background page exposes
+// RTCPeerConnection at all, whether a Worker does (which would let the mesh
+// keep a keyless heap on both browsers and dissolve the host question),
+// whether crypto.subtle speaks Ed25519 there, whether the shipped CSP admits
+// wss:, and whether a page's own runtime.sendMessage reaches its own
+// listener (which sizes the dweb-base.js port).
+//
+// why it does not gate: this lane is an EXPERIMENT, not an assertion of
+// desired behavior. A missing capability is the finding, not a regression,
+// so the lane fails only when the probe itself cannot run. The measured
+// report is written to the diagnostics artifact and printed.
+const createCapabilityProbeArtifact = () => {
+  const directory = mkdtempSync(join(tmpdir(), 'peerd-firefox-capability-'));
+  const staging = join(directory, 'staging');
+  const artifact = join(directory, `peerd-${VERSION}-preview-firefox-capability.xpi`);
+  // why preview, not store: preview is the channel the dweb would ship in, so
+  // its manifest CSP is the one whose verdict on wss: actually matters.
+  cpSync(join(ROOT, 'artifacts', 'staging', 'preview-firefox'), staging, { recursive: true });
+
+  const worker = join(staging, 'background', 'firefox-capability-probe-worker.js');
+  writeFileSync(worker, `self.postMessage({
+  ok: true,
+  rtcPeerConnection: typeof RTCPeerConnection,
+  webSocket: typeof WebSocket,
+  subtle: typeof crypto === 'object' && crypto !== null ? typeof crypto.subtle : 'no-crypto',
+});
+`, { flag: 'wx', mode: 0o600 });
+
+  const probe = join(staging, 'background', 'firefox-capability-probe.js');
+  writeFileSync(probe, `const WEBRTC_BUDGET_MS = 10_000;
+const WORKER_BUDGET_MS = 8_000;
+const SIGNALING_URL = 'wss://bootstrap.peerd.ai/rendezvous';
+
+const settle = (promise, budgetMs, fallback) => Promise.race([
+  promise,
+  new Promise((resolve) => { setTimeout(() => resolve(fallback), budgetMs); }),
+]);
+
+// A full loopback offer/answer with an open data channel. peer.js throws
+// without RTCPeerConnection, so a negative answer here rules out every
+// non-document host.
+const probeWebrtc = async () => {
+  if (typeof RTCPeerConnection !== 'function') return { available: false };
+  let local = null;
+  let remote = null;
+  try {
+    local = new RTCPeerConnection({ iceServers: [] });
+    remote = new RTCPeerConnection({ iceServers: [] });
+    const channel = local.createDataChannel('peerd-capability-probe');
+    const opened = new Promise((resolve) => { channel.onopen = () => resolve(true); });
+    local.onicecandidate = (event) => {
+      if (event.candidate) remote.addIceCandidate(event.candidate).catch(() => {});
+    };
+    remote.onicecandidate = (event) => {
+      if (event.candidate) local.addIceCandidate(event.candidate).catch(() => {});
+    };
+    const offer = await local.createOffer();
+    await local.setLocalDescription(offer);
+    await remote.setRemoteDescription(offer);
+    const answer = await remote.createAnswer();
+    await remote.setLocalDescription(answer);
+    await local.setRemoteDescription(answer);
+    const dataChannelOpen = await settle(opened, WEBRTC_BUDGET_MS, false);
+    return {
+      available: true,
+      dataChannelOpen,
+      connectionState: local.connectionState ?? null,
+      iceConnectionState: local.iceConnectionState ?? null,
+    };
+  } catch (error) {
+    return { available: true, dataChannelOpen: false, error: String(error?.message ?? error) };
+  } finally {
+    try { local?.close(); } catch { /* already gone */ }
+    try { remote?.close(); } catch { /* already gone */ }
+  }
+};
+
+// If a Worker exposes RTCPeerConnection, the mesh can hold a keyless heap on
+// BOTH browsers and the host question stops being browser-specific.
+const probeWorkerScope = async () => {
+  let worker = null;
+  try {
+    worker = new Worker(
+      browser.runtime.getURL('background/firefox-capability-probe-worker.js'),
+      { type: 'module' },
+    );
+    const reported = new Promise((resolve) => {
+      worker.onmessage = (event) => resolve(event.data);
+      worker.onerror = (event) => resolve({ ok: false, reason: String(event?.message ?? 'worker error') });
+    });
+    return await settle(reported, WORKER_BUDGET_MS, { ok: false, reason: 'timeout' });
+  } catch (error) {
+    return { ok: false, reason: String(error?.message ?? error) };
+  } finally {
+    try { worker?.terminate(); } catch { /* already gone */ }
+  }
+};
+
+// keypair.js depends on Ed25519 unconditionally and slices the seed out of a
+// 48-byte PKCS#8, so the export length is part of the answer.
+const probeEd25519 = async () => {
+  try {
+    const pair = await crypto.subtle.generateKey({ name: 'Ed25519' }, true, ['sign', 'verify']);
+    const bytes = new TextEncoder().encode('peerd firefox capability probe');
+    const signature = await crypto.subtle.sign({ name: 'Ed25519' }, pair.privateKey, bytes);
+    const verified = await crypto.subtle.verify({ name: 'Ed25519' }, pair.publicKey, signature, bytes);
+    const pkcs8 = new Uint8Array(await crypto.subtle.exportKey('pkcs8', pair.privateKey));
+    return { available: true, verified, pkcs8Length: pkcs8.length };
+  } catch (error) {
+    return { available: false, error: String(error?.message ?? error) };
+  }
+};
+
+// CSP is evaluated when the socket is CONSTRUCTED, before any network
+// activity, so a synchronous SecurityError means the policy refused the
+// scheme. The socket is closed immediately; nothing is sent and the probe
+// never waits for a connection.
+const probeWebSocketCsp = () => {
+  let socket = null;
+  try {
+    socket = new WebSocket(SIGNALING_URL);
+    return { constructed: true };
+  } catch (error) {
+    return { constructed: false, name: error?.name ?? null, error: String(error?.message ?? error) };
+  } finally {
+    try { socket?.close(); } catch { /* never opened */ }
+  }
+};
+
+// dweb-base.js talks to the service worker over runtime messaging in both
+// directions. On Firefox the host and the SW would be the SAME realm, so
+// whether a page's own sendMessage reaches its own listener decides whether
+// that transport survives the port or has to become in-process calls.
+// listenerFired true is unambiguous; false only means THIS listener did not
+// see it (another extension context may have answered).
+const probeSelfMessage = async () => {
+  let listenerFired = false;
+  const listener = (message) => {
+    if (message?.type !== 'firefox-capability/self-ping') return undefined;
+    listenerFired = true;
+    return Promise.resolve({ pong: true });
+  };
+  browser.runtime.onMessage.addListener(listener);
+  let response = null;
+  let error = null;
+  try {
+    response = await settle(
+      browser.runtime.sendMessage({ type: 'firefox-capability/self-ping' }),
+      WORKER_BUDGET_MS,
+      { timedOut: true },
+    );
+  } catch (sendError) {
+    error = String(sendError?.message ?? sendError);
+  } finally {
+    browser.runtime.onMessage.removeListener(listener);
+  }
+  return { listenerFired, response, error };
+};
+
+const runCapabilityProbe = async () => {
+  const manifest = browser.runtime.getManifest();
+  const [webrtc, workerScope, ed25519, selfMessage] = await Promise.all([
+    probeWebrtc(), probeWorkerScope(), probeEd25519(), probeSelfMessage(),
+  ]);
+  return {
+    ok: true,
+    realm: {
+      hasDocument: typeof document !== 'undefined',
+      hasWindow: typeof window !== 'undefined',
+      userAgent: navigator?.userAgent ?? null,
+    },
+    manifestVersion: manifest?.manifest_version ?? null,
+    contentSecurityPolicy: manifest?.content_security_policy ?? null,
+    webrtc,
+    workerScope,
+    ed25519,
+    webSocketCsp: probeWebSocketCsp(),
+    selfMessage,
+  };
+};
+
+browser.runtime.onMessage.addListener((message) => (message?.type === 'firefox-capability/probe'
+  ? runCapabilityProbe().catch((error) => ({ ok: false, error: String(error?.message ?? error) }))
+  : undefined));
+`, { flag: 'wx', mode: 0o600 });
+
+  const serviceWorker = join(staging, 'background', 'service-worker.js');
+  const source = readFileSync(serviceWorker, 'utf8');
+  overwriteRegularFile(serviceWorker, `import './firefox-capability-probe.js';\n${source}`);
+  execFileSync('zip', ['-q', '-X', '-r', artifact, '.'], {
+    cwd: staging,
+    env: { ...process.env, TZ: 'UTC' },
+  });
+  return { artifact, directory };
+};
+
+const runBackgroundCapabilityProbe = async () => {
+  console.log('Firefox background capability probe: WebRTC, worker scope, Ed25519, CSP, self-messaging (#376)');
+  const { artifact, directory } = createCapabilityProbeArtifact();
+  let driver = null;
+  try {
+    driver = await startGeckodriver({
+      binary: geckodriverBinary,
+      firefoxBinary,
+      prefs: {
+        'extensions.webextensions.uuids': JSON.stringify({ [PREVIEW_ADDON_ID]: PREVIEW_TEST_UUID }),
+      },
+    });
+    const installedId = await driver.installAddon(resolve(artifact));
+    assert(installedId === PREVIEW_ADDON_ID,
+      'the capability probe XPI keeps the Preview add-on id', String(installedId));
+    await driver.navigate(`${PREVIEW_EXTENSION_ORIGIN}/sidepanel/sidepanel.html`);
+    const report = await driver.executeAsync(`
+      const done = arguments[arguments.length - 1];
+      browser.runtime.sendMessage({ type: 'firefox-capability/probe' })
+        .then(done, (error) => done({ ok: false, error: error?.message || String(error) }));
+    `);
+    assert(report?.ok === true,
+      'the Firefox background capability probe returns a report', JSON.stringify(report));
+    writeFileSync(join(OUTPUT, CAPABILITY_PROBE_DIAGNOSTIC), `${JSON.stringify(report, null, 2)}\n`);
+
+    // why print rather than assert: every line here is a MEASUREMENT. The
+    // decision it feeds (which Firefox host the mesh can use) belongs to a
+    // human reading #376, not to a threshold invented here.
+    const webrtc = report.webrtc ?? {};
+    const workerScope = report.workerScope ?? {};
+    const ed25519 = report.ed25519 ?? {};
+    console.log(`  background realm: document=${report.realm?.hasDocument} window=${report.realm?.hasWindow}`);
+    console.log(`  RTCPeerConnection in background page: available=${webrtc.available} dataChannelOpen=${webrtc.dataChannelOpen}`
+      + `${webrtc.error ? ` error=${webrtc.error}` : ''}`);
+    console.log(`  RTCPeerConnection in module Worker: ${workerScope.ok === true ? workerScope.rtcPeerConnection : `unavailable (${workerScope.reason})`}`);
+    console.log(`  Ed25519 in background page: available=${ed25519.available} verified=${ed25519.verified ?? false} pkcs8=${ed25519.pkcs8Length ?? 'n/a'}`);
+    console.log(`  wss:// under the preview CSP: constructed=${report.webSocketCsp?.constructed}`
+      + `${report.webSocketCsp?.name ? ` (${report.webSocketCsp.name})` : ''}`);
+    console.log(`  self-addressed runtime.sendMessage reaches own listener: ${report.selfMessage?.listenerFired}`);
+    console.log(`  full report: artifacts/firefox-runtime/${CAPABILITY_PROBE_DIAGNOSTIC}`);
+  } finally {
+    await driver?.close();
+    rmSync(directory, { recursive: true, force: true });
+  }
 };
 
 const runActorLifetimeSmoke = async ({ providerServer }) => {
@@ -4361,6 +4609,7 @@ const main = async () => {
     BROKEN_WORKER_SCREENSHOT, KEEPALIVE_LOSS_SCREENSHOT,
     KEEPALIVE_LOSS_LOG, KEEPALIVE_LOSS_DIAGNOSTIC,
     LIFETIME_FAILURE_SCREENSHOT, LIFETIME_FAILURE_LOG, LIFETIME_FAILURE_DIAGNOSTIC,
+    CAPABILITY_PROBE_DIAGNOSTIC,
   ]) {
     rmSync(join(OUTPUT, diagnostic), { force: true });
   }
@@ -4571,6 +4820,7 @@ const main = async () => {
     await runLocalModuleGraphSmoke(driver);
     await runBoundActorSmoke(driver, providerServer);
     await runNumericTabAuthoritySmoke(driver, providerServer);
+    await runBackgroundCapabilityProbe();
     await runActorLifetimeSmoke({ providerServer });
     await runActorKeepaliveLossSmoke({ providerServer });
     await runActorRecoverySmoke({ providerServer });

--- a/tests/engine-tabs/notebook-tab/notebook-wasi.test.ts
+++ b/tests/engine-tabs/notebook-tab/notebook-wasi.test.ts
@@ -57,17 +57,17 @@ describe('runWasi', () => {
   });
 
   test('refuses a module without _start (reactor / empty)', async () => {
-    expect(runWasi(buildEmptyModule())).rejects.toThrow(WasiRunError);
-    expect(runWasi(buildEmptyModule())).rejects.toThrow(/command module/);
+    await expect(runWasi(buildEmptyModule())).rejects.toThrow(WasiRunError);
+    await expect(runWasi(buildEmptyModule())).rejects.toThrow(/command module/);
   });
 
   test('refuses a module that wants non-WASI imports, with an actionable message', async () => {
-    expect(runWasi(buildNonWasiModule())).rejects.toThrow(WasiRunError);
-    expect(runWasi(buildNonWasiModule())).rejects.toThrow(/WASI preview1/);
+    await expect(runWasi(buildNonWasiModule())).rejects.toThrow(WasiRunError);
+    await expect(runWasi(buildNonWasiModule())).rejects.toThrow(/WASI preview1/);
   });
 
   test('rejects junk bytes at compile', async () => {
-    expect(runWasi(new Uint8Array([1, 2, 3, 4]))).rejects.toThrow();
+    await expect(runWasi(new Uint8Array([1, 2, 3, 4]))).rejects.toThrow();
   });
 
   test('the shim debug logger stays OFF (no per-syscall console spam)', async () => {

--- a/tests/peerd-distributed/identity-capsule.test.ts
+++ b/tests/peerd-distributed/identity-capsule.test.ts
@@ -25,9 +25,9 @@ describe('capsule', () => {
     const material = await mintKeypairMaterial();
     const capK = await generateCapsuleKey();
     const capsule = await sealCapsule(material, capK);
-    expect(openCapsule(capsule, await generateCapsuleKey())).rejects.toThrow();
+    await expect(openCapsule(capsule, await generateCapsuleKey())).rejects.toThrow();
     const tampered = `${capsule.slice(0, -4)}AAAA`;
-    expect(openCapsule(tampered, capK)).rejects.toThrow();
+    await expect(openCapsule(tampered, capK)).rejects.toThrow();
   });
 });
 
@@ -47,13 +47,13 @@ describe('credential wrappers', () => {
     const capK = await generateCapsuleKey();
     const wrapper = await makePassphraseWrapper(capK, 'right');
     // AES-KW integrity check rejects a wrong KEK deterministically.
-    expect(openPassphraseWrapper(wrapper, 'wrong')).rejects.toThrow();
+    await expect(openPassphraseWrapper(wrapper, 'wrong')).rejects.toThrow();
   });
 
   test('untrusted KDF work factors are refused before crypto', async () => {
     const capK = await generateCapsuleKey();
     const wrapper = await makePassphraseWrapper(capK, 'right');
-    expect(openPassphraseWrapper({
+    await expect(openPassphraseWrapper({
       ...wrapper,
       kdf: { ...wrapper.kdf!, iters: 999_999_999 },
     }, 'right')).rejects.toThrow(/unsupported-kdf/);

--- a/tests/peerd-distributed/identity-mesh-join.test.ts
+++ b/tests/peerd-distributed/identity-mesh-join.test.ts
@@ -1,0 +1,116 @@
+// The load-bearing integration for portable identity: the DID that
+// backup/restore round-trips MUST be the one the p2p mesh joins with.
+//
+// Restore and mesh-join meet at exactly one place - the vault secret
+// distributed/identity/v1. Restore writes it (adoptIdentityRecord ->
+// vault.setSecret), and the offscreen mesh host reads it to join
+// (client.identityMaterial = loadIdentityMaterial -> identityFromMaterial
+// -> joinBaseNetwork, in offscreen/dweb-base.js). This test drives that
+// exact seam over a fake secret store: adopt a recovery record, then load
+// it back the way the mesh does, and prove the identity signs a
+// HELLO-style payload verifiably under the SAME did. If this breaks, a
+// restored identity would fail to authenticate on the mesh - the peer
+// would recover its key but not its place in the network.
+
+import { describe, test, expect } from 'bun:test';
+import {
+  buildIdentityRecord, adoptIdentityRecord,
+} from '../../extension/peerd-distributed/identity/recovery-record.js';
+import {
+  mintKeypairMaterial, loadIdentityMaterial, identityFromMaterial, verifySignature,
+} from '../../extension/peerd-distributed/identity/keypair.js';
+
+// A fake vault-secret surface - the same get/setSecret shape the SW's
+// identity custody exposes to both the transfer helper and the mesh host.
+const fakeSecrets = (seed: Record<string, string> = {}) => {
+  const m = new Map<string, string>(Object.entries(seed));
+  return {
+    getSecret: async (name: string) => m.get(name) ?? null,
+    setSecret: async (name: string, value: string) => { m.set(name, value); },
+    map: m,
+  };
+};
+
+const IDENTITY_SECRET = 'distributed/identity/v1';
+
+// Exactly what offscreen/dweb-base.js does to obtain the mesh identity:
+// client.identityMaterial(io) === loadIdentityMaterial(io), then
+// client.identityFromMaterial(material). Reproduced here so the test
+// breaks if that consumption path and the stored shape ever diverge.
+const meshIdentityFrom = async (io: ReturnType<typeof fakeSecrets>) => {
+  const material = await loadIdentityMaterial(io);
+  return identityFromMaterial(material);
+};
+
+describe('restored identity joins the mesh as the same did', () => {
+  test('adopt on a fresh install → the mesh loads and authenticates as that did', async () => {
+    // A peer's identity, backed up to a passphrase recovery record.
+    const original = await mintKeypairMaterial();
+    const record = await buildIdentityRecord({
+      material: { seed: original.seed, pub: original.pub },
+      wrappers: [{ kind: 'passphrase', passphrase: 'export-passphrase-xyz' }],
+    });
+
+    // Fresh install: empty secret store. Restore writes the recovered
+    // material to the identity secret, exactly as dwebTransfer.adoptRecord
+    // does (vault.setSecret(identitySecretName, outcome.material)).
+    const vault = fakeSecrets();
+    const outcome = await adoptIdentityRecord({
+      record, passphrase: 'export-passphrase-xyz', existingMaterial: null,
+    });
+    expect(outcome.adopted).toBe(true);
+    expect(outcome.did).toBe(original.did);
+    await vault.setSecret(IDENTITY_SECRET, outcome.material as string);
+
+    // Now the mesh host starts and reads that secret to join. It must
+    // come up as the ORIGINAL did - same place in the network.
+    const identity = await meshIdentityFrom(vault);
+    expect(identity.did).toBe(original.did);
+
+    // And it must actually authenticate: the mesh HELLO handshake signs
+    // with identity.sign and peers verify via verifySignature(did, …).
+    const hello = new TextEncoder().encode(`peerd-hello:${identity.did}:room:lobby`);
+    const sig = await identity.sign(hello);
+    expect(await verifySignature(original.did, sig, hello)).toBe(true);
+  });
+
+  test('loading did not fork the identity: the secret is unchanged after a mesh join', async () => {
+    const original = await mintKeypairMaterial();
+    const vault = fakeSecrets({
+      [IDENTITY_SECRET]: JSON.stringify({ v: 1, seed: original.seed, pub: original.pub }),
+    });
+    const before = vault.map.get(IDENTITY_SECRET);
+    const identity = await meshIdentityFrom(vault);
+    expect(identity.did).toBe(original.did);
+    // A pre-existing identity must be reused verbatim - loadIdentityMaterial
+    // must not re-mint and orphan the peer from its network identity.
+    expect(vault.map.get(IDENTITY_SECRET)).toBe(before);
+    expect(vault.map.size).toBe(1);
+  });
+
+  test('replace on a peer that already has a DIFFERENT did → mesh rejoins as the incoming did', async () => {
+    // The device is already on the mesh as `local`; the user restores a
+    // different identity `incoming` with explicit replace approval.
+    const local = await mintKeypairMaterial();
+    const incoming = await mintKeypairMaterial();
+    const record = await buildIdentityRecord({
+      material: { seed: incoming.seed, pub: incoming.pub },
+      wrappers: [{ kind: 'passphrase', passphrase: 'pw-replace-123' }],
+    });
+    const existing = JSON.stringify({ v: 1, seed: local.seed, pub: local.pub });
+    const vault = fakeSecrets({ [IDENTITY_SECRET]: existing });
+
+    const outcome = await adoptIdentityRecord({
+      record, passphrase: 'pw-replace-123', existingMaterial: existing, replaceExisting: true,
+    });
+    expect(outcome.adopted).toBe(true);
+    expect(outcome.did).toBe(incoming.did);
+    await vault.setSecret(IDENTITY_SECRET, outcome.material as string);
+
+    // The runtime restart (stopIdentityRuntime → write → startIdentityRuntime,
+    // driven by dwebTransfer) means the NEXT mesh load sees the incoming did.
+    const identity = await meshIdentityFrom(vault);
+    expect(identity.did).toBe(incoming.did);
+    expect(identity.did).not.toBe(local.did);
+  });
+});

--- a/tests/peerd-distributed/recovery-record.test.ts
+++ b/tests/peerd-distributed/recovery-record.test.ts
@@ -48,7 +48,7 @@ describe('buildIdentityRecord / openIdentityRecord', () => {
       material, wrappers: [{ kind: 'passphrase', passphrase: 'pw' }],
     });
     const forged = { ...record, did: other.did };
-    expect(openIdentityRecord(forged, { passphrase: 'pw' })).rejects.toThrow(/does not match/);
+    await expect(openIdentityRecord(forged, { passphrase: 'pw' })).rejects.toThrow(/does not match/);
   });
 
   test('a seed paired with another public key is refused before adoption', async () => {
@@ -63,7 +63,7 @@ describe('buildIdentityRecord / openIdentityRecord', () => {
       wrappers: [await makePassphraseWrapper(capsuleKey, 'pw')],
       updatedAt: 1,
     };
-    expect(openIdentityRecord(record, { passphrase: 'pw' })).rejects.toThrow(/valid keypair/);
+    await expect(openIdentityRecord(record, { passphrase: 'pw' })).rejects.toThrow(/valid keypair/);
   });
 
   test('unknown wrapper kinds are skipped, not fatal (forward compat)', async () => {

--- a/tests/peerd-engine/notebook-registry.test.ts
+++ b/tests/peerd-engine/notebook-registry.test.ts
@@ -34,7 +34,7 @@ describe('createNotebookRegistry', () => {
 
   test('setDefaultForSession throws for unknown id', async () => {
     const reg = createNotebookRegistry({ storage: createStorageStub() });
-    expect(reg.setDefaultForSession('chat-1', 'notebook-missing'))
+    await expect(reg.setDefaultForSession('chat-1', 'notebook-missing'))
       .rejects.toThrow('notebook not found');
   });
 });

--- a/tests/peerd-runtime/skills/install.test.ts
+++ b/tests/peerd-runtime/skills/install.test.ts
@@ -67,7 +67,7 @@ describe('install sources go through the injected webFetch (egress)', () => {
   test('a denied webFetch surfaces as a clean install failure', async () => {
     const registry = reg.createSkillRegistry({ store: store.createSkillStore() });
     const webFetch = async () => { throw new Error('egress denied: raw.githubusercontent.com'); };
-    expect(install.installFromGit({ registry, webFetch }, { url: 'https://github.com/u/r/SKILL.md' }))
+    await expect(install.installFromGit({ registry, webFetch }, { url: 'https://github.com/u/r/SKILL.md' }))
       .rejects.toThrow(install.SkillInstallError);
   });
 

--- a/tests/peerd-runtime/skills/registry.test.ts
+++ b/tests/peerd-runtime/skills/registry.test.ts
@@ -80,9 +80,9 @@ describe('skill registry — progressive disclosure', () => {
   test('loadBody throws SkillNotFoundError for unknown / disabled skills', async () => {
     const r = make();
     await r.install(SKILL_A, { source: 'local' });
-    expect(r.loadBody('nope')).rejects.toThrow(reg.SkillNotFoundError);
+    await expect(r.loadBody('nope')).rejects.toThrow(reg.SkillNotFoundError);
     await r.setEnabled('alpha', false);
-    expect(r.loadBody('alpha')).rejects.toThrow(reg.SkillNotFoundError);
+    await expect(r.loadBody('alpha')).rejects.toThrow(reg.SkillNotFoundError);
     // Disabled skills also drop out of the prompt block.
     expect(await r.describeForPrompt()).toBe('');
   });
@@ -90,7 +90,7 @@ describe('skill registry — progressive disclosure', () => {
   test('duplicate install throws unless replace is set', async () => {
     const r = make();
     await r.install(SKILL_A, { source: 'local' });
-    expect(r.install(SKILL_A, { source: 'local' })).rejects.toThrow(reg.SkillExistsError);
+    await expect(r.install(SKILL_A, { source: 'local' })).rejects.toThrow(reg.SkillExistsError);
     await r.install(SKILL_A.replace('Use for A tasks.', 'UPDATED.'), { source: 'local', replace: true });
     const list = await r.list();
     expect(list).toHaveLength(1);

--- a/tests/peerd-runtime/transfer/transfer.test.ts
+++ b/tests/peerd-runtime/transfer/transfer.test.ts
@@ -63,7 +63,7 @@ describe('passphrase crypto', () => {
 
   test('wrong passphrase throws ExportPassphraseError', async () => {
     const box = await encryptWithPassphrase('right', { k: 'v' });
-    expect(decryptWithPassphrase('wrong', box)).rejects.toBeInstanceOf(ExportPassphraseError);
+    await expect(decryptWithPassphrase('wrong', box)).rejects.toBeInstanceOf(ExportPassphraseError);
   });
 
   test('rejects attacker-controlled KDF parameters before doing crypto', async () => {
@@ -106,7 +106,7 @@ describe('buildExport', () => {
   });
 
   test('refuses secrets without a passphrase', async () => {
-    expect(buildExport({
+    await expect(buildExport({
       channel: 'store', storedSettings: {}, providerEndpoints: null,
       secrets: { anthropic: 'sk-1' }, passphrase: '', memory: null, hooks: [], skills: [],
     })).rejects.toBeInstanceOf(ExportPassphraseError);


### PR DESCRIPTION
## What & why

#360 was closed because the URL-fragment passkey handoff is not a safe foundation for a production credential. This branch has been **restarted from `main`** and carries only the parts of that work that are independent of the rejected design: test infrastructure and a Firefox capability probe. The rejected surface (`web-identity/`, `identity/handoff.js`, the `passkey-prf` wrapper, the frozen PRF vectors, and doc 04) is **not** here and the identity module is byte-identical to `main`.

Nothing in this PR touches the credential/handoff design. It is test-only plus one CI harness lane.

Related: #376 (Firefox mesh host).

### 1. Await floating async assertions (test hygiene, unrelated to identity)

18 assertions across 7 test files were written as `expect(promise).rejects.toThrow(...)` with no `await`. They asserted nothing (the statement returns an uninspected promise) and could leak a late rejection onto whichever test ran next. All 18 pass once awaited, so no behavior was broken, but the coverage they claimed was not real. Found by walking back from each `.rejects.`/`.resolves.` to its statement start so multi-line awaited forms are not miscounted.

Files: `notebook-wasi`, `identity-capsule`, `recovery-record`, `notebook-registry`, `skills/install`, `skills/registry`, `transfer`.

### 2. Firefox background-page capability probe (`scripts/firefox/run-runtime-tests.mjs`)

A non-gating lane, run last, that measures from the real MV3 background page of a packaged `preview-firefox` XPI the platform facts a Firefox mesh host would depend on: whether `RTCPeerConnection` works there (full loopback offer/answer to an open data channel), whether a module `Worker` exposes it, whether `crypto.subtle` speaks Ed25519, whether the shipped CSP admits `wss:`, and whether a self-addressed `runtime.sendMessage` reaches its own listener. It prints the report and writes `background-capability-probe.json` into the diagnostics artifact. A missing capability is the finding, not a regression, so the lane fails only if the probe cannot run.

The measured results are on #376. Headline: background-page WebRTC works; a module Worker does not expose `RTCPeerConnection`; Ed25519 works with a 48-byte PKCS#8; the preview CSP blocks `wss:`; runtime messaging does not self-deliver.

### 3. Restored-identity mesh-join proof

A values-level test (`identity-mesh-join.test.ts`) and a live-WebRTC harness mode (`dweb-twopeer.js` `RESTORE=1`, wired into CI) proving that a DID restored from a passphrase-protected recovery record is the DID the mesh actually joins with. This exercises the capsule/recovery-record path already shipped on `main` via the **passphrase** wrapper only. It does not touch the rejected passkey/ceremony path.

## Checklist

- [x] `bun run preflight` equivalents pass locally: `bun test ./tests` (5829 pass, 0 fail), `bun run typecheck`, `bun run check:tscheck`, `bun run check:copy`, `bun run check:boundary`, `eslint extension web`
- [x] Only original code
- [x] Tests added or updated
- [x] No hand-edited generated files
- [ ] Danger zone: the mesh-join proof reads the `peerd-distributed` identity surface but adds no production code there; the Firefox lane is CI harness only

## Notes for reviewers

This is deliberately the uncontroversial subset. The identity **design** flaws you raised on #360 (open PRF oracle, unauthenticated responder, RP ID breadth, fixed PRF input, replay, origin checks, secret cleanup, the `localhost`/`127.0.0.1` pairing, and the missing real-browser ceremony tests) are being addressed separately as a corrected design, not re-shipped here. The three items above stand on their own and were green across the closed PR's final CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKuaX4WrkR7wBDakYqahND)_