### PR TITLE
Finish provider readiness polish

### DIFF
--- a/badges/functional-tests.json
+++ b/badges/functional-tests.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Functional Tests",
-  "message": "6238/6238 passing",
+  "message": "6239/6239 passing",
   "color": "brightgreen"
 }

--- a/extension/options/options.css
+++ b/extension/options/options.css
@@ -272,7 +272,7 @@
 .library-refresh.is-spinning { animation: library-spin 0.85s linear infinite; }
 @keyframes library-spin { to { transform: rotate(360deg); } }
 /* "update available" for an installed dwapp — a quiet brand-cyan line. */
-.library-update-badge { font-size: 11px; margin: 2px 0 0; color: var(--fg); display: flex; flex-direction: column; align-items: flex-start; gap: 3px; }
+.library-update-badge { font-size: 11px; margin: 2px 0 0; color: var(--accent); display: flex; flex-direction: column; align-items: flex-start; gap: 3px; }
 .library-changelog { color: var(--fg-muted); line-height: 1.35; white-space: pre-wrap; }
 .library-notice { padding: 8px 10px; border: 1px solid var(--border); border-radius: var(--radius); font-size: 12px; }
 

--- a/extension/options/sections/providers.js
+++ b/extension/options/sections/providers.js
@@ -285,13 +285,23 @@ export const ProvidersSection = {
       : 'your API key';
     const settingsProviderName = state.settings?.providerName ?? '';
     const localWebGpuAvailable = state.capabilities?.localWebGpuHost?.status === 'available';
-    // why: A provider is usable when it has its required key, Local WebGPU has a
-    // runtime host, or a keyless daemon is reachable. Keep an explicitly chosen
+    // why NOT localWebGpuAvailable here: that flag is a HOST fact, not readiness.
+    // It reports only that an offscreen document can be created, so it is true on
+    // every Chrome regardless of GPU or whether the on-device model was ever
+    // downloaded. models/options is the readiness signal: model-catalog drops
+    // local-webgpu until it is resident, so membership there means a first turn
+    // would actually run. Matches ensureActiveProvider, which binds a new chat on
+    // localModelState.available(); Settings must not name a default the SW would
+    // refuse to bind.
+    const localWebGpuReady = (ui.modelOptions ?? [])
+      .some((/** @type {any} */ o) => o.provider === 'local-webgpu');
+    // why: A provider is usable when it has its required key, the on-device model
+    // is resident, or a keyless daemon is reachable. Keep an explicitly chosen
     // Ollama usable through a transient outage so its warning does not replace
     // the configured default controls. A confirmed no-models result still blocks.
     /** @param {ProviderRow} p */
     const isUsable = (p) => (!p.keyless && !!p.hasKey)
-      || (p.name === 'local-webgpu' && localWebGpuAvailable)
+      || (p.name === 'local-webgpu' && localWebGpuReady)
       || (!!p.keyless && ui.connStatus[p.name] === 'connected')
       || (p.name === 'ollama'
         && settingsProviderName === p.name

--- a/extension/options/sections/providers.js
+++ b/extension/options/sections/providers.js
@@ -258,9 +258,9 @@ export const ProvidersSection = {
             text: reply?.error === 'invalid-key' ? 'Provider rejected the key (401). Double-check it.'
               : reply?.error === 'no-key' ? 'No key saved for this provider yet.'
               : reply?.error === 'locked' ? 'Vault is locked — unlock in the peerd panel first.'
-              : reply?.error === 'no-models' ? 'Ollama is running, but it has no models installed. Run “ollama pull qwen3:8b”, then test again.'
+              : reply?.error === 'no-models' ? 'Ollama is running, but it has no models installed. Then test again after running: ollama pull qwen3:8b'
               : name === 'ollama' && reply?.error === 'unreachable'
-                ? 'Couldn’t reach Ollama. Start it with “ollama serve”, then test again.'
+                ? 'Couldn’t reach Ollama. Start it, then test again. Command: ollama serve'
               : `Couldn’t reach the provider: ${reply?.error ?? 'unknown error'}.`,
           };
       if (name === 'ollama' && (reply?.ok || reply?.reachable)) ui.modelOptionsKey = '';
@@ -283,13 +283,19 @@ export const ProvidersSection = {
       // why: providers without a stable sk- prefix (Z.ai GLM keys are shaped
       // `id.secret`) get a neutral hint rather than a misleading `sk-...`.
       : 'your API key';
-    // A provider is USABLE when it's keyed-with-key, or a keyless daemon we've
-    // confirmed reachable (Ollama probed 'connected'). anyUsable gates the whole
-    // "Default model for new chats" block: on a fresh install (nothing
-    // configured) it stays hidden rather than showing a keyless-Anthropic guess.
+    const settingsProviderName = state.settings?.providerName ?? '';
+    const localWebGpuAvailable = state.capabilities?.localWebGpuHost?.status === 'available';
+    // why: A provider is usable when it has its required key, Local WebGPU has a
+    // runtime host, or a keyless daemon is reachable. Keep an explicitly chosen
+    // Ollama usable through a transient outage so its warning does not replace
+    // the configured default controls. A confirmed no-models result still blocks.
     /** @param {ProviderRow} p */
     const isUsable = (p) => (!p.keyless && !!p.hasKey)
-      || (!!p.keyless && ui.connStatus[p.name] === 'connected');
+      || (p.name === 'local-webgpu' && localWebGpuAvailable)
+      || (!!p.keyless && ui.connStatus[p.name] === 'connected')
+      || (p.name === 'ollama'
+        && settingsProviderName === p.name
+        && ui.connStatus[p.name] !== 'no-models');
     const firstUsable = providerRows.find(isUsable);
     const anyUsable = !!firstUsable || ((ui.modelOptions ?? []).length > 0);
     // The provider the block edits. HONOR an explicit choice as-is — even one
@@ -301,17 +307,16 @@ export const ProvidersSection = {
     // fallback resolveActiveProvider returns for an empty providerName. The
     // modelOptions[0] fallback covers the brief window where a daemon probe is
     // still in flight (so it never momentarily reads as Anthropic).
-    const settingsProviderName = state.settings?.providerName ?? '';
     const selectableProviderRows = providerRows.filter((p) =>
       p.name !== 'local-webgpu'
-        || state.capabilities?.localWebGpuHost?.status === 'available');
+        || localWebGpuAvailable);
     const effectiveProvider =
       (settingsProviderName && selectableProviderRows.some((p) => p.name === settingsProviderName))
         ? settingsProviderName
         : (firstUsable?.name ?? (ui.modelOptions ?? [])[0]?.provider ?? provider.current);
     const defaultProvRow = providerRows.find((p) => p.name === effectiveProvider);
     const providerRunnerDefault = defaultProvRow?.defaultRunnerModel ?? provider.defaultRunnerModel ?? 'claude-haiku-4-5';
-    const localRunnerCapable = state.capabilities?.localWebGpuHost?.status === 'available';
+    const localRunnerCapable = localWebGpuAvailable;
     // Keep the Model selector populated from the chat-picker source; re-fetch
     // when the active provider, the curated OpenRouter set, or key-state changes.
     const providerStatusKey = providerRows

--- a/extension/options/sections/providers.js
+++ b/extension/options/sections/providers.js
@@ -258,9 +258,9 @@ export const ProvidersSection = {
             text: reply?.error === 'invalid-key' ? 'Provider rejected the key (401). Double-check it.'
               : reply?.error === 'no-key' ? 'No key saved for this provider yet.'
               : reply?.error === 'locked' ? 'Vault is locked — unlock in the peerd panel first.'
-              : reply?.error === 'no-models' ? 'Ollama is running, but it has no models installed. Then test again after running: ollama pull qwen3:8b'
+              : reply?.error === 'no-models' ? 'Ollama is running, but it has no models installed. Get one with: ollama pull qwen3:8b'
               : name === 'ollama' && reply?.error === 'unreachable'
-                ? 'Couldn’t reach Ollama. Start it, then test again. Command: ollama serve'
+                ? 'Couldn’t reach Ollama. Start it with: ollama serve'
               : `Couldn’t reach the provider: ${reply?.error ?? 'unknown error'}.`,
           };
       if (name === 'ollama' && (reply?.ok || reply?.reachable)) ui.modelOptionsKey = '';

--- a/extension/sidepanel/provider-readiness.js
+++ b/extension/sidepanel/provider-readiness.js
@@ -31,6 +31,11 @@ export const composerUnavailableCopy = (composer, { compact = false } = {}) => {
       ? 'Provider settings are temporarily unavailable.'
       : 'Provider settings could not be loaded. Reopen peerd to retry.';
   }
+  if (composer?.reason === 'vault-locked') {
+    return compact
+      ? 'Vault is locked. Unlock it to send.'
+      : 'Vault is locked. Unlock it to start chatting.';
+  }
   if (composer?.reason === 'local-model-not-installed') {
     return compact
       ? 'Install the Local WebGPU model in Settings to send.'

--- a/extension/tests/unit/options/provider-races.test.js
+++ b/extension/tests/unit/options/provider-races.test.js
@@ -15,6 +15,84 @@ const settle = async () => {
 };
 
 describe('provider settings request ordering', () => {
+  it('auto-selects Local WebGPU when its runtime host is available', async () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    const state = {
+      providers: { current: 'anthropic', hasKey: false, model: 'claude-sonnet' },
+      settings: { providerName: '', providerModel: '' },
+      capabilities: { localWebGpuHost: { status: 'available' } },
+    };
+    const send = async (/** @type {{ type: string }} */ msg) => {
+      if (msg.type === 'provider/status') return {
+        ok: true,
+        providers: [
+          { name: 'anthropic', label: 'Anthropic', defaultModel: 'claude-sonnet', hasKey: false, keyless: false },
+          { name: 'local-webgpu', label: 'Local WebGPU', defaultModel: 'gemma-4-e2b', hasKey: true, keyless: true },
+        ],
+      };
+      if (msg.type === 'local-model/status') return { ok: true, downloaded: false };
+      if (msg.type === 'models/options') return { ok: true, options: [] };
+      return { ok: false };
+    };
+    m.mount(root, { view: () => m(ProvidersSection, { state, send }) });
+    try {
+      await settle();
+      await settle();
+      const providerSelect = root.querySelector('#provider');
+      if (!(providerSelect instanceof HTMLSelectElement)) throw new Error('provider select missing');
+      expect(providerSelect.value).toBe('local-webgpu');
+      expect(root.textContent).toContain('Default model for new chats');
+      expect(root.textContent?.includes('Nothing is assumed')).toBe(false);
+    } finally {
+      m.mount(root, null);
+      root.remove();
+    }
+  });
+
+  it('keeps a configured Ollama default editable when its daemon is unreachable', async () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    const state = {
+      providers: { current: 'ollama', hasKey: true, model: 'qwen3:8b' },
+      settings: { providerName: 'ollama', providerModel: '', ollamaHost: 'http://localhost:11434' },
+      capabilities: { localWebGpuHost: { status: 'unsupported' } },
+    };
+    const probe = deferred();
+    const send = async (/** @type {{ type: string }} */ msg) => {
+      if (msg.type === 'provider/status') return {
+        ok: true,
+        providers: [{
+          name: 'ollama', label: 'Ollama', defaultModel: 'qwen3:8b',
+          hasKey: true, keyless: true, liveModels: true,
+        }],
+      };
+      if (msg.type === 'provider/test') return probe.promise;
+      if (msg.type === 'models/options') return { ok: true, options: [] };
+      return { ok: false };
+    };
+    m.mount(root, { view: () => m(ProvidersSection, { state, send }) });
+    try {
+      await settle();
+      let providerSelect = root.querySelector('#provider');
+      if (!(providerSelect instanceof HTMLSelectElement)) throw new Error('provider select missing');
+      expect(providerSelect.value).toBe('ollama');
+      expect(root.textContent).toContain('Checking…');
+      expect(root.textContent?.includes('Nothing is assumed')).toBe(false);
+
+      probe.resolve({ ok: false, error: 'unreachable' });
+      await settle();
+      providerSelect = root.querySelector('#provider');
+      if (!(providerSelect instanceof HTMLSelectElement)) throw new Error('provider select missing after probe');
+      expect(providerSelect.value).toBe('ollama');
+      expect(root.textContent).toContain('Not reachable');
+      expect(root.textContent?.includes('Nothing is assumed')).toBe(false);
+    } finally {
+      m.mount(root, null);
+      root.remove();
+    }
+  });
+
   it('describes the blank web-actor model as local-first Automatic policy', async () => {
     const root = document.createElement('div');
     document.body.appendChild(root);

--- a/extension/tests/unit/options/provider-races.test.js
+++ b/extension/tests/unit/options/provider-races.test.js
@@ -15,7 +15,13 @@ const settle = async () => {
 };
 
 describe('provider settings request ordering', () => {
-  it('auto-selects Local WebGPU when its runtime host is available', async () => {
+  // why both directions: `localWebGpuHost` is available on EVERY Chrome (it only
+  // reports that an offscreen document can be created), so gating selection on it
+  // would name a default that ensureActiveProvider then refuses to bind. Settings
+  // would read "Local WebGPU" while the composer still demanded an Anthropic key.
+  // Residency, reported through models/options, is the signal that matters.
+  /** @param {any[]} options models/options reply for a host-available Chrome */
+  const mountLocalWebGpu = (options) => {
     const root = document.createElement('div');
     document.body.appendChild(root);
     const state = {
@@ -31,11 +37,33 @@ describe('provider settings request ordering', () => {
           { name: 'local-webgpu', label: 'Local WebGPU', defaultModel: 'gemma-4-e2b', hasKey: true, keyless: true },
         ],
       };
-      if (msg.type === 'local-model/status') return { ok: true, downloaded: false };
-      if (msg.type === 'models/options') return { ok: true, options: [] };
+      if (msg.type === 'local-model/status') return { ok: true, downloaded: options.length > 0 };
+      if (msg.type === 'models/options') return { ok: true, options };
       return { ok: false };
     };
     m.mount(root, { view: () => m(ProvidersSection, { state, send }) });
+    return root;
+  };
+
+  it('does not select Local WebGPU while the on-device model is not resident', async () => {
+    const root = mountLocalWebGpu([]);
+    try {
+      await settle();
+      await settle();
+      // The host exists but the model was never downloaded, so nothing is usable:
+      // the honest empty state, not a default the first turn could not serve.
+      expect(root.querySelector('#provider')).toBe(null);
+      expect(root.textContent).toContain('Nothing is assumed');
+    } finally {
+      m.mount(root, null);
+      root.remove();
+    }
+  });
+
+  it('auto-selects Local WebGPU once the on-device model is resident', async () => {
+    const root = mountLocalWebGpu([
+      { provider: 'local-webgpu', model: 'gemma-4-e2b', label: 'gemma-4-e2b' },
+    ]);
     try {
       await settle();
       await settle();

--- a/tests/background/provider-readiness.test.ts
+++ b/tests/background/provider-readiness.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { resolveComposerReadiness } from '../../extension/background/provider-readiness.js';
+import { composerUnavailableCopy } from '../../extension/sidepanel/provider-readiness.js';
 
 const providers = [
   { name: 'anthropic', vaultSecretName: 'provider/anthropic' },
@@ -84,5 +85,13 @@ describe('composer provider readiness', () => {
       canSend: false,
       reason: 'settings-unavailable',
     });
+  });
+
+  test('a locked vault asks for unlock instead of an API key', () => {
+    const composer = { provider: 'ollama', reason: 'vault-locked' };
+    expect(composerUnavailableCopy(composer, { compact: true }))
+      .toBe('Vault is locked. Unlock it to send.');
+    expect(composerUnavailableCopy(composer))
+      .toBe('Vault is locked. Unlock it to start chatting.');
   });
 });


### PR DESCRIPTION
## Why

The composer readiness fix left a few Settings edge cases behind. Local WebGPU could not become the default, a temporary Ollama outage hid configured controls, and a locked vault had misleading fallback copy.

## What changes

- Lets an available Local WebGPU host participate in provider selection
- Keeps a configured Ollama provider editable during a transient outage while still blocking a confirmed empty model list
- Gives the locked-vault state direct unlock copy
- Makes Ollama recovery commands safe to copy and paste
- Restores the update-available accent cue

## How it works

Settings now uses the same runtime capability signal already used to show Local WebGPU and preserves an explicit Ollama choice unless the daemon confirms that no models are installed. Focused browser and Bun tests cover the pending, unreachable, local-host, and locked-vault paths.

## Verification

- Full local gate set passed
- Bun: 6229 passed, 0 failed
- In-browser: 937 passed, 0 failed
- E2E: 74 states, 346/346 checks