### PR TITLE
Stop two timer races in the test suite

### DIFF
--- a/extension/tests/unit/home/library-section.test.js
+++ b/extension/tests/unit/home/library-section.test.js
@@ -43,7 +43,25 @@ const flush = async () => {
   m.redraw.sync();
 };
 
-const nextFrame = () => new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+// why: the view moves focus from inside its OWN requestAnimationFrame
+// (focusLibraryAction), so awaiting a single frame races it - under CI load the
+// test's frame can run first and read the pre-move element. Poll to a deadline
+// instead. A genuine focus regression still fails the assertion that follows,
+// just one budget later.
+/**
+ * @param {() => boolean} landed
+ * @param {number} [budgetMs]
+ */
+const focusSettles = async (landed, budgetMs = 2000) => {
+  const deadline = performance.now() + budgetMs;
+  while (!landed() && performance.now() < deadline) {
+    await new Promise((resolve) => { setTimeout(resolve, 16); });
+  }
+};
+
+/** @param {string} action */
+const focusedAction = (action) => () =>
+  document.activeElement?.getAttribute('data-library-action') === action;
 
 /**
  * @param {FakeSend} send
@@ -128,7 +146,7 @@ describe('home.library', () => {
       expect(document.activeElement?.textContent).toBe('History & Git');
       document.activeElement?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
       await flush();
-      await nextFrame();
+      await focusSettles(() => document.activeElement === trigger);
       expect(root.querySelector('.library-menu')).toBeFalsy();
       expect(document.activeElement).toBe(trigger);
     } finally { unmount(); }
@@ -160,7 +178,7 @@ describe('home.library', () => {
       confirm.focus();
       confirm.click();                                  // confirms
       await flush();
-      await nextFrame();
+      await focusSettles(focusedAction('open'));
       expect(send.calls.some((c) => c.type === 'apps/delete')).toBe(true);
       expect(document.activeElement?.getAttribute('data-library-action')).toBe('open');
       expect(document.activeElement?.closest('.library-card')?.textContent).toContain('Calculator');
@@ -184,7 +202,7 @@ describe('home.library', () => {
       confirm.focus();
       confirm.click();
       await flush();
-      await nextFrame();
+      await focusSettles(focusedAction('more'));
       expect(root.querySelector('[role="alert"]')?.textContent).toContain('local App was kept');
       expect(document.activeElement?.getAttribute('data-library-action')).toBe('more');
       expect(document.activeElement?.closest('.library-card')?.textContent).toContain('Snake Game');
@@ -226,7 +244,7 @@ describe('home.library', () => {
       await flush();
       clickText(root, '.library-share button', 'Share');
       await flush();
-      await nextFrame();
+      await focusSettles(focusedAction('share'));
       const call = send.calls.find((c) => c.type === 'dweb/base/share-app');
       expect(call?.slug).toBe('my-cool-app');    // slugified
       expect(document.activeElement?.getAttribute('data-library-action')).toBe('share');
@@ -266,7 +284,7 @@ describe('home.library', () => {
       expect(root.textContent).toContain('new version available');
       clickText(root, 'button', 'Update');
       await flush();
-      await nextFrame();
+      await focusSettles(focusedAction('open'));
       const call = send.calls.find((c) => c.type === 'dweb/base/update-app');
       expect(call?.appId).toBe('app-7');
       expect(call?.uri).toBe('peerd://x/v2');
@@ -380,7 +398,7 @@ describe('home.library', () => {
       expect(send.calls.some((c) => c.type === 'apps/repository/restore' && c.to === 'abcdef123456')).toBe(true);
       need(root, 'button[title="Close history"]').click();
       await flush();
-      await nextFrame();
+      await focusSettles(() => document.activeElement === trigger);
       expect(document.activeElement).toBe(trigger);
     } finally { unmount(); }
   });

--- a/extension/tests/unit/sidepanel/onboarding-view.test.js
+++ b/extension/tests/unit/sidepanel/onboarding-view.test.js
@@ -29,6 +29,24 @@ const withFastTease = async (fn) => {
   try { await fn(); } finally { Object.assign(TEASE, saved); }
 };
 
+// why poll instead of one fixed wait: the tease deletes on a timer, so "sleep
+// 45ms, assert it shrank" is really "assert this runner delivered enough timer
+// ticks in 45ms". A loaded CI box does not, and the test fails for a reason that
+// has nothing to do with the contract. Waiting for the shrink itself keeps the
+// meaning; a tease that never shrinks still fails, one budget later.
+/** @param {ParentNode} root @param {number} [budgetMs] */
+const teaseShrinks = async (root, budgetMs = 2000) => {
+  const spans = () => root.querySelectorAll('.peer-name-mirror span').length;
+  const deadline = performance.now() + budgetMs;
+  let n = spans();
+  while (n >= 5 && performance.now() < deadline) {
+    await wait(5);
+    m.redraw.sync();
+    n = spans();
+  }
+  return n;
+};
+
 // A minimal stand-in for the full ChatState — needsOnboarding only reads
 // vault + profile, so cast the fixture to the production type.
 /** @param {Record<string, any>} [over] */
@@ -186,9 +204,7 @@ describe('sidepanel.onboarding', () => {
         try {
           await passProviderStep(root);
           // Past holdFull + a few del steps: the mirror must have shrunk.
-          await wait(45);
-          m.redraw.sync();
-          const shrunk = root.querySelectorAll('.peer-name-mirror span').length;
+          const shrunk = await teaseShrinks(root);
           expect(shrunk < 5).toBe(true);
           // Skipping through the whole funnel against a half-deleted
           // DISPLAY still sends the full stored name — the tease is


### PR DESCRIPTION
## Why

Two tests assert on the result of a timer after a **fixed** wait, which is really an assertion about how many timer ticks the runner delivered in that window. Loaded CI boxes do not oblige, and both have been failing PRs that touch neither surface:

- `History & Git shows status/log and restore requires a second click` - 2 red of 5 runs on one branch (in-browser, Chrome)
- `the tease type-deletes the mirror, and a MID-TEASE submit sends the FULL name` - 3 runs this week (Firefox Gecko shard 6/8)

Neither reproduces locally, and the CI log for the first is uninformative: `op: toBe`, `actual: {}`, `expected: {}`.

## What changes

Test-only. No product code.

- **Library focus** ([library-section.test.js](extension/tests/unit/home/library-section.test.js)): six assertions awaited exactly one `requestAnimationFrame` before reading `document.activeElement`, but the view moves focus from inside its *own* `requestAnimationFrame` (`focusLibraryAction`). Under load the test frame wins. They now poll for the expected focus target with a bounded budget.
- **Name tease** ([onboarding-view.test.js](extension/tests/unit/sidepanel/onboarding-view.test.js)): slept 45ms then asserted the mirror had shrunk. Now waits for the shrink itself, bounded.

A real regression in either still fails the assertion that follows - one budget later instead of immediately.

## Verification

Both proven under simulated load rather than asserted:

| | old file | this file |
|---|---|---|
| `focusLibraryAction` rescheduled to a 250ms timer | 6 failures, including the exact `actual: {} / expected: {}` signature from CI | 935 passed, 0 failed |
| fast-tease hold stretched 20ms → 200ms | the MID-TEASE case fails | 935 passed, 0 failed |

Full gate set green. In-browser 935/935 across repeated runs; Bun 6228/6228.