### PR TITLE
test: make two classes of silently-passing assertion actually run

### DIFF
--- a/extension/tests/unit/home/library-section.test.js
+++ b/extension/tests/unit/home/library-section.test.js
@@ -384,6 +384,13 @@ describe('home.library', () => {
       expect(need(root, '.library-card').classList.contains('is-expanded')).toBe(true);
       const panel = need(root, '.library-repository', HTMLElement);
       expect(panel.getAttribute('role')).toBe('region');
+      // why: the panel claims focus from its own oncreate, which only runs once
+      // the repository send has resolved and Mithril has committed that redraw.
+      // A fixed flush() is a bet on how many turns that takes. #405 polled the
+      // kebab-focus assertions in this file but not this one, and this is the one
+      // that kept turning Gecko shard 5/8 red with the uninformative
+      // `actual: {} / expected: {}` signature.
+      await focusSettles(() => document.activeElement === panel);
       expect(document.activeElement).toBe(panel);
       expect(root.textContent).toContain('1 uncommitted change');
       expect(root.textContent).toContain('checkpoint');

--- a/tests/peerd-distributed/identity-capsule.test.ts
+++ b/tests/peerd-distributed/identity-capsule.test.ts
@@ -25,9 +25,9 @@ describe('capsule', () => {
     const material = await mintKeypairMaterial();
     const capK = await generateCapsuleKey();
     const capsule = await sealCapsule(material, capK);
-    expect(openCapsule(capsule, await generateCapsuleKey())).rejects.toThrow();
+    await expect(openCapsule(capsule, await generateCapsuleKey())).rejects.toThrow();
     const tampered = `${capsule.slice(0, -4)}AAAA`;
-    expect(openCapsule(tampered, capK)).rejects.toThrow();
+    await expect(openCapsule(tampered, capK)).rejects.toThrow();
   });
 });
 
@@ -47,13 +47,13 @@ describe('credential wrappers', () => {
     const capK = await generateCapsuleKey();
     const wrapper = await makePassphraseWrapper(capK, 'right');
     // AES-KW integrity check rejects a wrong KEK deterministically.
-    expect(openPassphraseWrapper(wrapper, 'wrong')).rejects.toThrow();
+    await expect(openPassphraseWrapper(wrapper, 'wrong')).rejects.toThrow();
   });
 
   test('untrusted KDF work factors are refused before crypto', async () => {
     const capK = await generateCapsuleKey();
     const wrapper = await makePassphraseWrapper(capK, 'right');
-    expect(openPassphraseWrapper({
+    await expect(openPassphraseWrapper({
       ...wrapper,
       kdf: { ...wrapper.kdf!, iters: 999_999_999 },
     }, 'right')).rejects.toThrow(/unsupported-kdf/);

--- a/tests/peerd-distributed/recovery-record.test.ts
+++ b/tests/peerd-distributed/recovery-record.test.ts
@@ -48,7 +48,7 @@ describe('buildIdentityRecord / openIdentityRecord', () => {
       material, wrappers: [{ kind: 'passphrase', passphrase: 'pw' }],
     });
     const forged = { ...record, did: other.did };
-    expect(openIdentityRecord(forged, { passphrase: 'pw' })).rejects.toThrow(/does not match/);
+    await expect(openIdentityRecord(forged, { passphrase: 'pw' })).rejects.toThrow(/does not match/);
   });
 
   test('a seed paired with another public key is refused before adoption', async () => {
@@ -63,7 +63,7 @@ describe('buildIdentityRecord / openIdentityRecord', () => {
       wrappers: [await makePassphraseWrapper(capsuleKey, 'pw')],
       updatedAt: 1,
     };
-    expect(openIdentityRecord(record, { passphrase: 'pw' })).rejects.toThrow(/valid keypair/);
+    await expect(openIdentityRecord(record, { passphrase: 'pw' })).rejects.toThrow(/valid keypair/);
   });
 
   test('unknown wrapper kinds are skipped, not fatal (forward compat)', async () => {

--- a/tests/peerd-engine/notebook-registry.test.ts
+++ b/tests/peerd-engine/notebook-registry.test.ts
@@ -34,7 +34,7 @@ describe('createNotebookRegistry', () => {
 
   test('setDefaultForSession throws for unknown id', async () => {
     const reg = createNotebookRegistry({ storage: createStorageStub() });
-    expect(reg.setDefaultForSession('chat-1', 'notebook-missing'))
+    await expect(reg.setDefaultForSession('chat-1', 'notebook-missing'))
       .rejects.toThrow('notebook not found');
   });
 });

--- a/tests/peerd-runtime/skills/install.test.ts
+++ b/tests/peerd-runtime/skills/install.test.ts
@@ -67,7 +67,7 @@ describe('install sources go through the injected webFetch (egress)', () => {
   test('a denied webFetch surfaces as a clean install failure', async () => {
     const registry = reg.createSkillRegistry({ store: store.createSkillStore() });
     const webFetch = async () => { throw new Error('egress denied: raw.githubusercontent.com'); };
-    expect(install.installFromGit({ registry, webFetch }, { url: 'https://github.com/u/r/SKILL.md' }))
+    await expect(install.installFromGit({ registry, webFetch }, { url: 'https://github.com/u/r/SKILL.md' }))
       .rejects.toThrow(install.SkillInstallError);
   });
 

--- a/tests/peerd-runtime/skills/registry.test.ts
+++ b/tests/peerd-runtime/skills/registry.test.ts
@@ -80,9 +80,9 @@ describe('skill registry — progressive disclosure', () => {
   test('loadBody throws SkillNotFoundError for unknown / disabled skills', async () => {
     const r = make();
     await r.install(SKILL_A, { source: 'local' });
-    expect(r.loadBody('nope')).rejects.toThrow(reg.SkillNotFoundError);
+    await expect(r.loadBody('nope')).rejects.toThrow(reg.SkillNotFoundError);
     await r.setEnabled('alpha', false);
-    expect(r.loadBody('alpha')).rejects.toThrow(reg.SkillNotFoundError);
+    await expect(r.loadBody('alpha')).rejects.toThrow(reg.SkillNotFoundError);
     // Disabled skills also drop out of the prompt block.
     expect(await r.describeForPrompt()).toBe('');
   });
@@ -90,7 +90,7 @@ describe('skill registry — progressive disclosure', () => {
   test('duplicate install throws unless replace is set', async () => {
     const r = make();
     await r.install(SKILL_A, { source: 'local' });
-    expect(r.install(SKILL_A, { source: 'local' })).rejects.toThrow(reg.SkillExistsError);
+    await expect(r.install(SKILL_A, { source: 'local' })).rejects.toThrow(reg.SkillExistsError);
     await r.install(SKILL_A.replace('Use for A tasks.', 'UPDATED.'), { source: 'local', replace: true });
     const list = await r.list();
     expect(list).toHaveLength(1);

--- a/tests/peerd-runtime/transfer/transfer.test.ts
+++ b/tests/peerd-runtime/transfer/transfer.test.ts
@@ -63,7 +63,7 @@ describe('passphrase crypto', () => {
 
   test('wrong passphrase throws ExportPassphraseError', async () => {
     const box = await encryptWithPassphrase('right', { k: 'v' });
-    expect(decryptWithPassphrase('wrong', box)).rejects.toBeInstanceOf(ExportPassphraseError);
+    await expect(decryptWithPassphrase('wrong', box)).rejects.toBeInstanceOf(ExportPassphraseError);
   });
 
   test('rejects attacker-controlled KDF parameters before doing crypto', async () => {
@@ -106,7 +106,7 @@ describe('buildExport', () => {
   });
 
   test('refuses secrets without a passphrase', async () => {
-    expect(buildExport({
+    await expect(buildExport({
       channel: 'store', storedSettings: {}, providerEndpoints: null,
       secrets: { anthropic: 'sk-1' }, passphrase: '', memory: null, hooks: [], skills: [],
     })).rejects.toBeInstanceOf(ExportPassphraseError);


### PR DESCRIPTION
## What & why

Two unrelated ways an assertion in this suite can pass without testing anything.

**1. Thirteen unawaited `rejects` matchers** (six suites). `expect(...).rejects` returns a promise; Bun does not fail a test for leaving it unawaited, so each of these passed unconditionally and the error path it claims to cover was never asserted.

**2. One focus assertion left on a bare `flush()`.** #405 fixed the timer races in `library-section.test.js` but missed the one that was actually turning CI red: it polled the six kebab-focus assertions and left `expect(document.activeElement).toBe(panel)` unguarded. That panel claims focus from its own `oncreate`, which runs only once the repository send resolves and Mithril commits that redraw — so a fixed `flush()` is a bet on how many turns that takes. Gecko shard 5/8 kept losing it, with the same uninformative `actual: {} / expected: {}` signature #405 quoted.

Item 1 is split out of #394. That branch salvaged three separable things from the closed identity PR (#360); this is the piece that is both independent and still missing from `main`. Its other two are tied to a premise that has since shipped — the corrected identity design landed (`web-identity/`, device certificates, enrollment, `self-*` sync), so "salvage the safe subset while the design is redone" no longer describes the situation.

Relates to #394

## Checklist

- [x] `bun run preflight` passes (tests, typecheck, lint, in-browser, dweb-boundary, no manifest drift) — see verification below
- [x] Only original or permissively-licensed code — **no GPL / AGPL / copyleft**
- [x] Tests added or updated (or N/A) — test-only change
- [x] No hand-edited generated files (`manifest.json`, `shared/channel-config.js`)
- [x] Called out below if this touches a **danger zone** (egress / vault / gates / runner & sandbox boundaries / dweb)

## Notes for reviewers

**Danger zone: yes, in coverage terms.** Six of the thirteen are in `identity-capsule` and `recovery-record` — capsule tamper detection, wrong-passphrase rejection, forged-record and invalid-keypair paths. Exactly the assertions you'd least want silently disabled. The rest cover `SkillNotFoundError` / `SkillExistsError`, a missing-notebook default, a bad skill-install URL, and export passphrase failure.

**None of the six suites changed behavior once the assertions began running** — 75 pass, 0 fail. Pure coverage recovery, not a bug fix.

**The focus fix is proven, not assumed**, using #405's own method:

| | assertion |
|---|---|
| panel focus rescheduled onto a 250ms timer, no poll | fails with exactly the CI signature (`op: toBe`, `actual: {}`, `expected: {}`) |
| same delay, with the poll | 935 pass, 0 fail |
| delay removed, with the poll | 935 pass, 0 fail across three consecutive runs |

No product code changed — the 250ms delay was temporary instrumentation and is not in the diff.

Deliberately **not** included from #394, left for you to decide separately:
- `scripts/firefox/run-runtime-tests.mjs` (+253) — a non-gating Firefox background-page capability probe. Its one-time findings were already posted to #376, and part of its rationale is outdated now that main has a real Firefox background-page module-Worker actor host.
- `identity-mesh-join.test.ts` + the `RESTORE=1` two-peer mode — worth confirming the restored-DID-joins-mesh proof is still uncovered, given main now carries its own recovery/enrollment/self-sync suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzsXYVJxBjZgHcSfVyByjg