### PR TITLE
release: v0.7.0 changelog for the commits after the original tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and storage formats may move until the surface stabilizes.
 
 ## [Unreleased]
 
-## [0.7.0] - 2026-08-12
+## [0.7.0] - 2026-08-15
 
 ### Added
 
@@ -59,6 +59,17 @@ and storage formats may move until the surface stabilizes.
   consistently across Chrome and Firefox.
 - Provider readiness survives worker restarts, preview updates avoid disrupting
   active work, and established vaults no longer regress into first-run setup.
+- Passkey signup could stall right after the biometric prompt: the first
+  message from the UI could reach the service worker before its route
+  dispatcher had registered, and the browser could then retire the worker with
+  that message still unclaimed. Early messages are now held until the
+  dispatcher is ready.
+- Settings no longer hides a configured Ollama provider during a temporary
+  outage, an available local WebGPU host can be chosen as the default, a
+  locked vault offers a direct unlock instead of misleading fallback copy, and
+  the Ollama recovery commands are safe to copy and paste.
+- An invalid Pod URL now reaches its visible failure state instead of leaving
+  the tab in an indeterminate one.
 
 ## [0.6.0] - 2026-08-08
 


### PR DESCRIPTION
The `v0.7.0` tag was pushed on 2026-08-12, but **that tag push never fired the release workflow** — there is no CI run for it and `gh release view v0.7.0` returns "release not found", while v0.2.8 through v0.6.0 all published normally. `package.json` and the changelog were already prepped at 0.7.0; the release just never shipped.

Re-cutting at current HEAD, which carries 9 commits past that tag. This PR adds changelog entries for the three user-facing ones and dates the section to the actual ship date:

- the passkey-signup service-worker boot race (an early UI message could arrive before the route dispatcher registered, and the worker could be retired with it unclaimed)
- the Settings provider-readiness edge cases (#404): local WebGPU as default, a configured Ollama surviving a transient outage, direct unlock copy on a locked vault, copy-pasteable recovery commands
- the Pod invalid-URL visible failure state (#403)

The other six commits are test, CI, and docs internals (#405, #406, #407, #391, and two CI/test commits) and are deliberately left out of a product changelog.

No version bump needed (already 0.7.0). After merge I'll move the `v0.7.0` tag to the merge commit and push it to fire the pipeline that never ran.

Verified locally: 6239 bun tests pass, strict typecheck, eslint, docpaths, no generated-file drift, and the release-notes extractor renders the section cleanly.