### PR TITLE
revert(home): restore the one-shot repository-focus claim

### DIFF
--- a/.github/workflows/package-and-release.yml
+++ b/.github/workflows/package-and-release.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Generated-file drift (dev manifest + channel-config + tscheck and supply-chain badges)
         run: |
           bun run gen:dev
-          git diff --exit-code extension/manifest.json extension/shared/channel-config.js badges/tscheck.json badges/runtime-deps.json badges/vendor-integrity.json badges/actions-pinned.json badges/no-build.json || {
+          git diff --exit-code extension/manifest.json extension/shared/channel-config.js badges/tscheck.json badges/vendor-integrity.json badges/actions-pinned.json badges/no-build.json || {
             echo '::error::A generated file (manifest.json, channel-config.js, or a badges/*.json written by gen:dev) is out of sync with its generator. Run `bun run gen:dev` and commit.'
             exit 1
           }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 [![E2E side panel](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/NotASithLord/peerd/main/badges/e2e-chrome.json)](scripts/cdp/run-e2e-verify.mjs)
 [![Red Team](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/NotASithLord/peerd/main/badges/red-team.json)](docs/security/RED-TEAM-RESULTS.md)
 [![No build step](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/NotASithLord/peerd/main/badges/no-build.json)](CONTRIBUTING.md)
-[![Runtime npm deps](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/NotASithLord/peerd/main/badges/runtime-deps.json)](#dependencies-and-license)
 [![Vendored code](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/NotASithLord/peerd/main/badges/vendor-integrity.json)](extension/vendor/vendor.lock.json)
 [![Actions pinned](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/NotASithLord/peerd/main/badges/actions-pinned.json)](packaging/check-action-pins.ts)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)

--- a/badges/functional-tests.json
+++ b/badges/functional-tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "Functional Tests",
-  "message": "6312/6312 passing",
+  "message": "6310/6310 passing",
   "color": "brightgreen",
   "namedLogo": "bun",
   "logoColor": "white"

--- a/badges/runtime-deps.json
+++ b/badges/runtime-deps.json
@@ -1,8 +1,0 @@
-{
-  "schemaVersion": 1,
-  "label": "Runtime npm deps",
-  "message": "0",
-  "color": "brightgreen",
-  "namedLogo": "npm",
-  "logoColor": "white"
-}

--- a/extension/home/library-section.js
+++ b/extension/home/library-section.js
@@ -114,24 +114,6 @@ const focusLibraryAction = (appId, action) => {
   });
 };
 
-/**
- * Move focus to a freshly opened repository panel, at most once per open.
- *
- * The intent (`ui.repositoryFocusId`) is consumed on either of two conditions,
- * and the distinction is the whole point:
- *   - focus LANDED, so the job is done; or
- *   - the panel now has its repository data, meaning the open finished and a
- *     later steal would yank focus out from under a user who moved on.
- * Anything else leaves the intent standing so the next render retries it.
- *
- * @param {any} ui @param {App} app @param {unknown} repo @param {HTMLElement} dom
- */
-const claimRepositoryFocus = (ui, app, repo, dom) => {
-  if (ui.repositoryFocusId !== app.id) return;
-  dom.focus({ preventScroll: true });
-  if (document.activeElement === dom || repo) ui.repositoryFocusId = null;
-};
-
 export const LibrarySection = {
   /** @param {{ state: any, attrs: { send: Send, dweb?: boolean } }} vnode */
   oninit(vnode) {
@@ -191,11 +173,7 @@ export const LibrarySection = {
     // live rename / share dialog / armed delete would be clobbered by a swap).
     vnode.state._listTimer = setInterval(() => {
       const s = vnode.state;
-      // repositoryFocusId joins the skip list for the same reason as the rest:
-      // a catalog swap mid-open re-renders the card that the pending focus is
-      // aimed at, and a focus intent is exactly as clobberable as a live rename.
-      if (document.hidden || s.menuOpenId || s.renamingId || s.shareEditId
-        || s.armedDeleteId || s.busyId || s.repositoryFocusId) return;
+      if (document.hidden || s.menuOpenId || s.renamingId || s.shareEditId || s.armedDeleteId || s.busyId) return;
       LibrarySection.quietRefresh(vnode);
     }, 15000);
     // Returning to the tab should feel current at once, not after the next tick.
@@ -907,15 +885,11 @@ export const LibrarySection = {
     const panelAttrs = {
       role: 'region', 'aria-label': `History and Git for ${app.name}`, tabindex: '-1',
       'data-library-repository-id': app.id,
-      // why claim on update too, and why consume only once focus LANDS: the
-      // panel renders first as a "Loading repository…" placeholder and again
-      // with its data, and a background quietRefresh can swap the catalog
-      // underneath it. A one-shot oncreate that nulled the intent before
-      // focusing spent it on whichever render happened to come first, so any
-      // later re-render dropped focus for good, leaving activeElement on the
-      // body. That is what kept Gecko shard 5/8 intermittently red.
-      oncreate: (/** @type {{dom:HTMLElement}} */ v) => claimRepositoryFocus(ui, app, repo, v.dom),
-      onupdate: (/** @type {{dom:HTMLElement}} */ v) => claimRepositoryFocus(ui, app, repo, v.dom),
+      oncreate: (/** @type {{dom:HTMLElement}} */ v) => {
+        if (ui.repositoryFocusId !== app.id) return;
+        ui.repositoryFocusId = null;
+        v.dom.focus({ preventScroll: true });
+      },
     };
     if (!repo) return m('.library-repository', panelAttrs, m('p.muted', 'Loading repository…'));
     const changed = repo.status?.changed ?? [];

--- a/packaging/check-copy-hygiene.ts
+++ b/packaging/check-copy-hygiene.ts
@@ -54,7 +54,6 @@ const EXCLUDED_FILES = Object.freeze(new Set([
   'badges/inbrowser-gecko.json',
   'badges/no-build.json',
   'badges/red-team.json',
-  'badges/runtime-deps.json',
   'badges/tscheck.json',
   'badges/vendor-integrity.json',
   'bun.lock',

--- a/packaging/check-test-badges.ts
+++ b/packaging/check-test-badges.ts
@@ -20,7 +20,7 @@ import { INBROWSER_CHROME_BADGE } from './gen-inbrowser-test-badge.ts';
 import { E2E_BADGE } from './gen-e2e-badge.ts';
 import { RED_TEAM_BADGE } from './gen-red-team-badge.ts';
 import {
-  ACTIONS_BADGE, BUILD_STEP_BADGE, RUNTIME_DEPS_BADGE, VENDOR_BADGE,
+  ACTIONS_BADGE, BUILD_STEP_BADGE, VENDOR_BADGE,
 } from './gen-supply-chain-badges.ts';
 import { laneCountProblem, type ShieldsBadge } from './test-badges.ts';
 
@@ -30,7 +30,7 @@ const LANE_BADGES = [INBROWSER_CHROME_BADGE, GECKO_BADGE];
 /** Every committed badge, lane or not, that must parse as a Shields endpoint. */
 const ALL_BADGES = [
   ...LANE_BADGES, E2E_BADGE, RED_TEAM_BADGE, 'functional-tests.json', 'tscheck.json',
-  RUNTIME_DEPS_BADGE, VENDOR_BADGE, ACTIONS_BADGE, BUILD_STEP_BADGE,
+  VENDOR_BADGE, ACTIONS_BADGE, BUILD_STEP_BADGE,
 ];
 
 const readBadge = (file: string): ShieldsBadge => {

--- a/packaging/gen-supply-chain-badges.ts
+++ b/packaging/gen-supply-chain-badges.ts
@@ -1,6 +1,5 @@
 // Generate the three supply-chain badges from repo state.
 //
-//   badges/runtime-deps.json      npm packages the shipped extension needs
 //   badges/vendor-integrity.json  third-party runtime files pinned by SHA-256
 //   badges/actions-pinned.json    third-party GitHub Actions at a full SHA
 //
@@ -16,11 +15,10 @@ import { join } from 'node:path';
 import { REPO_ROOT } from './lib.ts';
 import { writeBadge } from './test-badges.ts';
 import {
-  actionsPinnedBadge, buildStepBadge, countRuntimeDependencies, countVendorLockedFiles,
-  runtimeDepsBadge, scanActionPins, scanBuildStep, vendorIntegrityBadge,
+  actionsPinnedBadge, buildStepBadge, countVendorLockedFiles,
+  scanActionPins, scanBuildStep, vendorIntegrityBadge,
 } from './supply-chain.ts';
 
-export const RUNTIME_DEPS_BADGE = 'runtime-deps.json';
 export const VENDOR_BADGE = 'vendor-integrity.json';
 export const ACTIONS_BADGE = 'actions-pinned.json';
 export const BUILD_STEP_BADGE = 'no-build.json';
@@ -39,7 +37,6 @@ export const readWorkflows = (): { file: string; text: string }[] =>
 
 const generate = () => {
   const packageJson = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8'));
-  const runtimeDeps = countRuntimeDependencies(packageJson);
   const buildStep = scanBuildStep(
     packageJson,
     readFileSync(join(REPO_ROOT, 'tsconfig.json'), 'utf8'),
@@ -60,7 +57,6 @@ const generate = () => {
 
   for (const [file, badge] of [
     [BUILD_STEP_BADGE, buildStepBadge(buildStep)],
-    [RUNTIME_DEPS_BADGE, runtimeDepsBadge(runtimeDeps)],
     [VENDOR_BADGE, vendorIntegrityBadge(vendorFiles)],
     [ACTIONS_BADGE, actionsPinnedBadge(scan)],
   ] as const) {

--- a/packaging/preflight.ts
+++ b/packaging/preflight.ts
@@ -37,7 +37,7 @@ const main = () => {
     'extension/manifest.json', 'extension/shared/channel-config.js', 'badges/tscheck.json',
     // The supply-chain badges ride gen:dev too: pure reads of package.json,
     // vendor.lock.json and the workflows, so they drift exactly like a manifest.
-    'badges/runtime-deps.json', 'badges/vendor-integrity.json', 'badges/actions-pinned.json',
+    'badges/vendor-integrity.json', 'badges/actions-pinned.json',
     'badges/no-build.json',
   ].map((p) => join(REPO_ROOT, p));
   const before = genFiles.map((f) => readFileSync(f));

--- a/packaging/supply-chain.ts
+++ b/packaging/supply-chain.ts
@@ -3,14 +3,10 @@
 // Three facts about how code gets INTO peerd, each derived from repo state
 // rather than asserted in prose:
 //
-//   1. runtime npm dependencies. The extension ships none. package.json has no
-//      `dependencies` at all, and packaging/package.ts stages extension/
-//      verbatim without ever resolving a node_modules path, so the build-time
-//      tree cannot reach a user. A number that must stay 0.
-//   2. vendored files. Third-party runtime code lives in extension/vendor/ and
+//   1. vendored files. Third-party runtime code lives in extension/vendor/ and
 //      ships verbatim, so every byte is pinned by SHA-256 in vendor.lock.json
 //      and check-vendor.ts fails on any divergence.
-//   3. GitHub Action pins. A major tag is a mutable ref the publisher can move,
+//   2. GitHub Action pins. A major tag is a mutable ref the publisher can move,
 //      which means arbitrary code in release CI. Every third-party action is
 //      pinned to a full commit SHA.
 //
@@ -82,15 +78,6 @@ export const scanActionPins = (
   };
 };
 
-/** npm packages the SHIPPED extension depends on at runtime. Must be zero. */
-export const countRuntimeDependencies = (packageJson: unknown): number => {
-  const dependencies = (packageJson as { dependencies?: Record<string, string> })?.dependencies;
-  if (dependencies !== undefined && typeof dependencies !== 'object') {
-    throw new Error('package.json "dependencies" is not an object');
-  }
-  return Object.keys(dependencies ?? {}).length;
-};
-
 /** Files carrying a SHA-256 in extension/vendor/vendor.lock.json. */
 export const countVendorLockedFiles = (lock: unknown): number => {
   const files = (lock as { files?: Record<string, string> })?.files;
@@ -141,6 +128,14 @@ export const scanBuildStep = (
     const hit = BUILD_TOOLCHAINS.find((tool) => name.startsWith(tool));
     if (hit) offenders.push(`dependency "${name}" is a bundler or transpiler`);
   }
+  // A runtime dependency is the same claim from the other side: it would mean
+  // npm code reaching an installed extension, which cannot happen while
+  // packaging stages extension/ verbatim. This lived on its own badge until it
+  // folded in here; the fact still needs a gate even without a plate on the
+  // README.
+  for (const name of Object.keys(pkg?.dependencies ?? {})) {
+    offenders.push(`"${name}" is a RUNTIME dependency; the shipped extension takes none`);
+  }
   if (pkg?.scripts && Object.hasOwn(pkg.scripts, 'build')) {
     offenders.push('package.json declares a "build" script');
   }
@@ -157,16 +152,6 @@ export const buildStepBadge = (scan: BuildStepScan): ShieldsBadge => ({
   message: scan.offenders.length === 0 ? 'none (vanilla JS)' : 'present',
   color: scan.offenders.length === 0 ? 'brightgreen' : 'red',
   ...laneLogo('javascript'),
-});
-
-export const runtimeDepsBadge = (count: number): ShieldsBadge => ({
-  schemaVersion: 1,
-  label: 'Runtime npm deps',
-  message: String(count),
-  // why red at one: the invariant is not "few", it is "none". Any number
-  // other than zero means npm code can reach an installed extension.
-  color: count === 0 ? 'brightgreen' : 'red',
-  ...laneLogo('npm'),
 });
 
 export const vendorIntegrityBadge = (files: number): ShieldsBadge => ({

--- a/tests/meta/supply-chain-badges.test.ts
+++ b/tests/meta/supply-chain-badges.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
-  actionsPinnedBadge, buildStepBadge, countRuntimeDependencies, countVendorLockedFiles,
-  runtimeDepsBadge, scanActionPins, scanBuildStep, vendorIntegrityBadge,
+  actionsPinnedBadge, buildStepBadge, countVendorLockedFiles,
+  scanActionPins, scanBuildStep, vendorIntegrityBadge,
 } from '../../packaging/supply-chain.ts';
 import { readWorkflows } from '../../packaging/gen-supply-chain-badges.ts';
 import { REPO_ROOT } from '../../packaging/lib.ts';
@@ -62,22 +62,6 @@ describe('action pin scanning', () => {
   });
 });
 
-describe('runtime dependency count', () => {
-  test('reports zero when package.json declares no dependencies at all', () => {
-    expect(countRuntimeDependencies({ devDependencies: { eslint: '1' } })).toBe(0);
-    expect(runtimeDepsBadge(0)).toMatchObject({ message: '0', color: 'brightgreen' });
-  });
-
-  test('goes red at the first runtime dependency, not at some threshold', () => {
-    expect(countRuntimeDependencies({ dependencies: { mithril: '2' } })).toBe(1);
-    expect(runtimeDepsBadge(1).color).toBe('red');
-  });
-
-  test('refuses a malformed dependencies field', () => {
-    expect(() => countRuntimeDependencies({ dependencies: 'nope' })).toThrow(/not an object/);
-  });
-});
-
 describe('vendor lock count', () => {
   test('counts the pinned files', () => {
     expect(countVendorLockedFiles({ files: { 'a/LICENSE': 'aa', 'a/index.js': 'bb' } })).toBe(2);
@@ -106,6 +90,13 @@ describe('no-build-step invariant', () => {
       const scan = scanBuildStep({ devDependencies: { [name]: '1' } }, tsconfig);
       expect(scan.offenders.join(' ')).toContain(name);
     }
+  });
+
+  test('catches a runtime dependency, which would ship npm code to a user', () => {
+    // This invariant used to carry its own badge; the no-build scan owns it now.
+    expect(scanBuildStep({ dependencies: { mithril: '2' } }, tsconfig).offenders.join(' '))
+      .toMatch(/"mithril" is a RUNTIME dependency/);
+    expect(scanBuildStep(clean, tsconfig).offenders).toEqual([]);
   });
 
   test('catches a build script and a tsconfig that could emit', () => {


### PR DESCRIPTION
## What & why

This reverts the home-surface behavior change from #412. It was my mistake, and CI is unambiguous about it:

| commit | focus code | test | Chrome | Gecko |
|---|---|---|---|---|
| `0b68673` | original one-shot `oncreate` | #408's re-queried poll | ✅ | ✅ |
| `2b5be59` | my `oncreate` + `onupdate` claim | same | ❌ | ✅ |

I diagnosed the Gecko flake as a product race in how the repository panel claims focus. **#408 had already fixed it in the test**, and correctly: the test captured the panel element once and compared identity, which races a redraw that *replaces* the node, so it failed with the uninformative `actual: {} / expected: {}`. Re-querying the live panel inside the poll fixed that without touching product code, and both browser lanes were green on `0b68673`.

Layering a product change on top of an already-fixed flake solved nothing that was still broken and turned the Chrome in-browser lane red on `main`. So this restores the original one-shot `oncreate`, and drops the `quietRefresh` skip that rode along with it.

**What stays from #412:** the badges, 100% type coverage, `check:actions`, and the no-build gate. Only the home-surface behavior change is reverted.

## Verification

`typecheck`, `lint`, and the in-browser Chrome lane green three consecutive runs at 939/939 after the revert.

Worth stating plainly, because it is the lesson from the failure: local runs of this suite do **not** discriminate here. The broken version also passed locally five times in a row; only CI caught it. The evidence I am acting on is the CI result on `0b68673` versus `2b5be59`, not my local runs.

## Notes for reviewers

`main` is red on this right now, so this is the fix for that.

Separately: the `e2e (side panel)` job failed on `0b68673` and passed on `2b5be59`, so that lane is intermittent independent of this change. It matters for the "block merges on a red build" work, since making an intermittently-failing job required will block merges at random. That flake wants a fix or a quarantine before the branch rule leans on it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYyJu5uaSHaypMnpkzkn6P)_