### PR TITLE
fix(firefox): stop racing the request counter in the remote-module checks

### DIFF
--- a/extension/home/library-section.js
+++ b/extension/home/library-section.js
@@ -114,6 +114,24 @@ const focusLibraryAction = (appId, action) => {
   });
 };
 
+/**
+ * Claim focus for a freshly opened repository panel.
+ *
+ * Called from both oncreate and onupdate, and safe to call repeatedly: it is a
+ * no-op unless this app's focus intent is still standing. The intent retires
+ * only when the panel has its repository DATA and focus landed on that node,
+ * which is what makes it survive the placeholder being replaced. Retiring on
+ * data (rather than never) also stops it stealing focus back from a user who
+ * moved on after the open finished.
+ *
+ * @param {any} ui @param {App} app @param {unknown} repo @param {HTMLElement} dom
+ */
+const claimRepositoryFocus = (ui, app, repo, dom) => {
+  if (ui.repositoryFocusId !== app.id) return;
+  dom.focus({ preventScroll: true });
+  if (repo && document.activeElement === dom) ui.repositoryFocusId = null;
+};
+
 export const LibrarySection = {
   /** @param {{ state: any, attrs: { send: Send, dweb?: boolean } }} vnode */
   oninit(vnode) {
@@ -885,11 +903,17 @@ export const LibrarySection = {
     const panelAttrs = {
       role: 'region', 'aria-label': `History and Git for ${app.name}`, tabindex: '-1',
       'data-library-repository-id': app.id,
-      oncreate: (/** @type {{dom:HTMLElement}} */ v) => {
-        if (ui.repositoryFocusId !== app.id) return;
-        ui.repositoryFocusId = null;
-        v.dom.focus({ preventScroll: true });
-      },
+      // why the intent survives the placeholder: this panel renders first as
+      // "Loading repository..." and again once the send resolves, and that
+      // second render can REPLACE the node rather than patch it. Nulling the
+      // intent on the first oncreate spent it on a node about to be discarded,
+      // so the replacement never claimed focus and activeElement fell back to
+      // the body. That is the flake behind "History & Git shows status/log and
+      // restore requires a second click", which has now failed in BOTH Chrome
+      // and Gecko. Claim on every render while the intent stands, and retire it
+      // only once the panel is showing DATA and focus actually landed there.
+      oncreate: (/** @type {{dom:HTMLElement}} */ v) => claimRepositoryFocus(ui, app, repo, v.dom),
+      onupdate: (/** @type {{dom:HTMLElement}} */ v) => claimRepositoryFocus(ui, app, repo, v.dom),
     };
     if (!repo) return m('.library-repository', panelAttrs, m('p.muted', 'Loading repository…'));
     const changed = repo.status?.changed ?? [];

--- a/extension/home/library-section.js
+++ b/extension/home/library-section.js
@@ -114,24 +114,6 @@ const focusLibraryAction = (appId, action) => {
   });
 };
 
-/**
- * Claim focus for a freshly opened repository panel.
- *
- * Called from both oncreate and onupdate, and safe to call repeatedly: it is a
- * no-op unless this app's focus intent is still standing. The intent retires
- * only when the panel has its repository DATA and focus landed on that node,
- * which is what makes it survive the placeholder being replaced. Retiring on
- * data (rather than never) also stops it stealing focus back from a user who
- * moved on after the open finished.
- *
- * @param {any} ui @param {App} app @param {unknown} repo @param {HTMLElement} dom
- */
-const claimRepositoryFocus = (ui, app, repo, dom) => {
-  if (ui.repositoryFocusId !== app.id) return;
-  dom.focus({ preventScroll: true });
-  if (repo && document.activeElement === dom) ui.repositoryFocusId = null;
-};
-
 export const LibrarySection = {
   /** @param {{ state: any, attrs: { send: Send, dweb?: boolean } }} vnode */
   oninit(vnode) {
@@ -903,17 +885,11 @@ export const LibrarySection = {
     const panelAttrs = {
       role: 'region', 'aria-label': `History and Git for ${app.name}`, tabindex: '-1',
       'data-library-repository-id': app.id,
-      // why the intent survives the placeholder: this panel renders first as
-      // "Loading repository..." and again once the send resolves, and that
-      // second render can REPLACE the node rather than patch it. Nulling the
-      // intent on the first oncreate spent it on a node about to be discarded,
-      // so the replacement never claimed focus and activeElement fell back to
-      // the body. That is the flake behind "History & Git shows status/log and
-      // restore requires a second click", which has now failed in BOTH Chrome
-      // and Gecko. Claim on every render while the intent stands, and retire it
-      // only once the panel is showing DATA and focus actually landed there.
-      oncreate: (/** @type {{dom:HTMLElement}} */ v) => claimRepositoryFocus(ui, app, repo, v.dom),
-      onupdate: (/** @type {{dom:HTMLElement}} */ v) => claimRepositoryFocus(ui, app, repo, v.dom),
+      oncreate: (/** @type {{dom:HTMLElement}} */ v) => {
+        if (ui.repositoryFocusId !== app.id) return;
+        ui.repositoryFocusId = null;
+        v.dom.focus({ preventScroll: true });
+      },
     };
     if (!repo) return m('.library-repository', panelAttrs, m('p.muted', 'Loading repository…'));
     const changed = repo.status?.changed ?? [];

--- a/extension/tests/unit/home/library-section.test.js
+++ b/extension/tests/unit/home/library-section.test.js
@@ -397,8 +397,26 @@ describe('home.library', () => {
         const live = root.querySelector('.library-repository');
         return !!live && document.activeElement === live;
       };
+      // why a diagnosis string instead of toBe(true): this assertion has now
+      // flaked in Chrome AND Gecko across three different focus-claim
+      // implementations (the original one-shot oncreate, #412's claim-on-update,
+      // and its corrected retry), so the claim logic is not the whole story and
+      // `actual: false` tells us nothing. When it next fails, the actual value
+      // names WHERE focus went and whether the panel was even in the DOM, which
+      // is the evidence a real fix needs. Green runs are byte-identical to the
+      // old assertion.
+      const focusDiagnosis = () => {
+        if (panelFocused()) return 'panel-focused';
+        const active = document.activeElement;
+        const name = !active || active === document.body
+          ? 'body'
+          : `${active.tagName.toLowerCase()}`
+            + `${active.className ? `.${String(active.className).trim().split(/\s+/).join('.')}` : ''}`
+            + `${active.getAttribute('data-library-action') ? `[action=${active.getAttribute('data-library-action')}]` : ''}`;
+        return `focus-on:${name} panel-in-dom:${!!root.querySelector('.library-repository')}`;
+      };
       await focusSettles(panelFocused);
-      expect(panelFocused()).toBe(true);
+      expect(focusDiagnosis()).toBe('panel-focused');
       expect(root.textContent).toContain('1 uncommitted change');
       expect(root.textContent).toContain('checkpoint');
       clickText(root, '.library-commit button', 'Diff');

--- a/scripts/firefox/run-runtime-tests.mjs
+++ b/scripts/firefox/run-runtime-tests.mjs
@@ -3749,15 +3749,31 @@ return {
       });
     })().catch((error) => done({ error: error?.message || String(error) }));
   `, [notebookId, slowUrl, slowStatusUrl]);
+  // why a bounded wait instead of reading the counter straight away: the count
+  // increments when the request REACHES this server, and the run that triggers
+  // it is being cancelled at the same moment. The in-page settle above does not
+  // cover the hop from Firefox's socket to this process, so a request already
+  // in flight read as "not yet counted" and turned the assertion below red on
+  // main with `requests: 1` where 2 was due. Waiting for the count to arrive
+  // keeps the assertion exact: it still demands the precise number, it just
+  // stops racing the network to check.
+  const slowModuleRequestsSettle = async (expected, budgetMs = 5_000) => {
+    const deadline = Date.now() + budgetMs;
+    while (providerServer.slowModuleRequests < expected && Date.now() < deadline) {
+      await delay(50);
+    }
+    return providerServer.slowModuleRequests;
+  };
+  const stoppedRequests = await slowModuleRequestsSettle(1);
   assert(stoppedFetch?.sawRequest === true
     && stoppedFetch?.abort?.stopped === true
     && stoppedFetch?.run?.result?.stopped === true
     && stoppedFetch.elapsedMs < 3_000
-    && providerServer.slowModuleRequests === 1
+    && stoppedRequests === 1
     && stoppedFetch.status === 'Notebook run stopped.'
     && !stoppedFetch.output.includes(REMOTE_MODULE_SLOW_PATH),
   'Stop cancels the Firefox host fetch operation without late resolver output',
-  JSON.stringify({ stoppedFetch, requests: providerServer.slowModuleRequests }));
+  JSON.stringify({ stoppedFetch, requests: stoppedRequests }));
   const timedOutFetch = await driver.executeAsync(`
     const [id, url] = arguments;
     const done = arguments[arguments.length - 1];
@@ -3783,15 +3799,16 @@ return {
       });
     })().catch((error) => done({ error: error?.message || String(error) }));
   `, [notebookId, slowUrl]);
+  const timedOutRequests = await slowModuleRequestsSettle(2);
   assert(/timed out/.test(timedOutFetch?.run?.result?.error ?? '')
     && timedOutFetch?.run?.result?.errorCode === 'notebook_run_timeout'
     && timedOutFetch?.run?.result?.stopped !== true
     && timedOutFetch.elapsedMs < 3_000
     && timedOutFetch.status === 'Notebook run timed out.'
-    && providerServer.slowModuleRequests === 2
+    && timedOutRequests === 2
     && !timedOutFetch.output.includes(REMOTE_MODULE_SLOW_PATH),
   'the Firefox import deadline cancels host work and recovers without late output',
-  JSON.stringify({ timedOutFetch, requests: providerServer.slowModuleRequests }));
+  JSON.stringify({ timedOutFetch, requests: timedOutRequests }));
   writeFileSync(join(OUTPUT, 'preview-notebook-remote-restricted.png'),
     Buffer.from(await driver.screenshot(), 'base64'));
 };


### PR DESCRIPTION
## What & why

The Firefox lane is the last thing red on `main`, and it is **not** the flake that was there before. #413 fixed the Chrome in-browser lane (confirmed: it passed on `main` at `d3ed854`). What remains is a separate race in the Firefox harness.

Two consecutive checks share one server-side counter of requests for the slow remote module, and each asserts an exact count:

- `Stop cancels the Firefox host fetch operation without late resolver output` expects **1**
- `the Firefox import deadline cancels host work and recovers without late output` expects **2**

The count increments when the request *reaches* the harness server, and the run that triggers it is being cancelled at that same moment. The in-page settle covers the browser side but not the hop from Firefox's socket to this process, so a request already in flight reads as "not yet counted".

Both failures on `main` reported `requests: 1` where 2 was due, with **every other conjunct satisfied**: the deadline fired, `error` and `errorCode` were right, elapsed stayed under budget (866ms and 1108ms against a 3s bound), and no late output leaked. The only thing wrong was the counter read.

## The fix

Each check now waits for its expected count to arrive, bounded at 5s, before asserting.

The assertions are unchanged in strength. They still demand the exact number, and a count that never arrives still fails the check. They just stop racing the network to read it. I applied it to both checks rather than only the failing one, since the same race exists on the `=== 1` read and has simply not lost yet.

## Verification

**I cannot verify this locally.** This environment has no Firefox and Mozilla downloads are blocked by the sandbox proxy, so the CI Gecko job is the check on it. `lint`, `typecheck`, and a parse check pass here; the harness exits on "Firefox not found" as expected.

## Notes for reviewers

This was the third occurrence tonight, which is what moved it from "flake, re-run it" to "fix it": failed on `b7277e7`, passed on re-run, failed again on `main` at `d3ed854`.

For the branch-protection work: this removes one of the three blockers to making the Firefox lane a required check. Remaining is the `e2e` lane's `browser-network-floor` / `portable-identity` intermittency.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYyJu5uaSHaypMnpkzkn6P)_