### PR TITLE
ci: draft-gate the browser tier; fix the stale focus-restore steal behind the flaky repo test

### DIFF
--- a/.github/workflows/package-and-release.yml
+++ b/.github/workflows/package-and-release.yml
@@ -4,6 +4,14 @@
 #                     file drift check, then the FULL 2-channel × 2-browser
 #                     artifact matrix (store artifacts are verified to
 #                     contain zero dweb traces as part of packaging).
+#   DRAFT PRs       → the browser tier (in-browser Chrome, Firefox/Gecko,
+#                     e2e, visual, two-peer, packaged page boot) is SKIPPED
+#                     so iteration costs only the fast lanes. Marking the PR
+#                     ready for review re-runs the workflow with the full
+#                     tier on the current head; branch protection can require
+#                     those jobs and the requirement bites exactly at merge
+#                     time, since a draft cannot merge. Pushes to main still
+#                     run everything.
 #   tag push v*     → additionally: signed preview artifacts, a GitHub
 #                     Release titled peerd-preview-v<X.Y.Z> with the
 #                     preview artifacts + update feeds attached, and a
@@ -28,7 +36,11 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+  # why explicit types: ready_for_review is NOT in the default set, and it is
+  # the event that turns a draft into a mergeable PR. Without it, the browser
+  # jobs below would stay skipped on the head that branch protection inspects.
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       security_read_only:
@@ -187,6 +199,7 @@ jobs:
   # branch-protection required checks; this one can be added to that
   # list once it has a green history.
   inbrowser:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: in-browser tests (headless Chrome)
     runs-on: ubuntu-latest
     steps:
@@ -219,6 +232,7 @@ jobs:
   # Runs the Firefox artifact, not only its manifest and AMO validator, then
   # runs the shared browser suite in Gecko. Chrome remains the visual authority.
   firefox-runtime:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: Firefox Store smoke + Gecko suite
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -277,6 +291,7 @@ jobs:
   # signaling node and opens two real browser contexts that must form a WebRTC
   # mesh and exchange gossip — the live peer-to-peer seam no other job covers.
   twopeer:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: dweb two-peer (headless WebRTC)
     runs-on: ubuntu-latest
     steps:
@@ -363,6 +378,7 @@ jobs:
   # history before gating. First test that loads the REAL unpacked extension
   # and drives the live side panel through one full agent turn.
   e2e:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: e2e (side panel)
     runs-on: ubuntu-latest
     steps:
@@ -443,6 +459,8 @@ jobs:
     # A prepared Dependabot head can contain a candidate Action SHA. Never let
     # that candidate share this job's repository-write token.
     if: >-
+      (github.event_name != 'pull_request' ||
+        github.event.pull_request.draft == false) &&
       !(github.event_name == 'pull_request' &&
         github.event.pull_request.user.login == 'dependabot[bot]') &&
       !(github.event_name == 'workflow_dispatch' &&
@@ -634,6 +652,7 @@ jobs:
   # this job to the branch-protection required-checks list once it has a green
   # history (mirrors the note on `inbrowser`).
   packaged-pages:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: packaged page boot
     runs-on: ubuntu-latest
     steps:

--- a/extension/home/library-section.js
+++ b/extension/home/library-section.js
@@ -98,6 +98,18 @@ const downloadEnvelope = (filename, envelope) => {
 /** @param {string} appId */
 const appCardSelector = (appId) => `.library-card[data-app-id="${CSS.escape(appId)}"]`;
 
+// why: restore intents can outlive their moment. requestAnimationFrame is
+// throttled in background documents, so a callback may land long after the
+// interaction that scheduled it. The token lets the newest intent supersede
+// older ones no matter which callback fires first, and lastRestoredTarget
+// distinguishes "our own previous restore parked focus here" (fine to move)
+// from a claim some OTHER surface made, like the History & Git panel's
+// oncreate focus. A stale restore must never steal that claim; that theft
+// was the race behind the flaky repository-focus test.
+let libraryRestoreToken = 0;
+/** @type {Element | null} */
+let lastRestoredTarget = null;
+
 /**
  * Move focus after Mithril has committed a mutation result. The fallback keeps
  * keyboard users inside the Library when the original card no longer exists.
@@ -105,12 +117,21 @@ const appCardSelector = (appId) => `.library-card[data-app-id="${CSS.escape(appI
  * @param {string} action
  */
 const focusLibraryAction = (appId, action) => {
+  const token = ++libraryRestoreToken;
   requestAnimationFrame(() => {
+    if (token !== libraryRestoreToken) return;   // a newer restore superseded this one
+    const active = document.activeElement;
+    const foreignClaim = active && active !== document.body
+      && active !== document.documentElement && active !== lastRestoredTarget;
+    if (foreignClaim) return;
     const card = appId ? document.querySelector(appCardSelector(appId)) : null;
     const target = card?.querySelector(`[data-library-action="${action}"]`)
       ?? document.querySelector('.library-search')
       ?? document.querySelector('.library-refresh');
-    if (target instanceof HTMLElement) target.focus({ preventScroll: true });
+    if (target instanceof HTMLElement) {
+      lastRestoredTarget = target;
+      target.focus({ preventScroll: true });
+    }
   });
 };
 


### PR DESCRIPTION
## What &amp; why

Two changes, one PR because the second is what let the first go green honestly.

### 1. Skip the browser tier on draft PRs, run it when the PR is marked ready

The browser jobs are both the expensive tier and the flaky tier, and most small changes do not need them on every push. This makes drafts cheap and merges strict:

| Event | Fast lanes (bun, lint+drift, netproc, package matrix) | Browser tier (in-browser Chrome, Firefox/Gecko, e2e, visual, two-peer, page boot) |
|---|---|---|
| Draft PR push | run | **skipped** |
| PR marked ready / push to ready PR | run | run |
| Push to `main`, tags, dispatch | run | run (unchanged) |

The mechanics that make this safe rather than just quiet:

- **`ready_for_review` joins the trigger types.** It is not in GitHub&#39;s default set, and it is the event that turns a draft into a mergeable PR. Marking ready re-runs the workflow on the current head with the browser tier live, so the head that branch protection inspects carries real runs, not the skipped conclusions from draft-time pushes.
- **A draft cannot merge**, so a protection rule requiring the browser jobs bites exactly at merge time and never during iteration.
- **`visual` already had an `if:`** (dependabot + security-dispatch exclusions); the draft gate is folded into that expression. A second `if:` key would be rejected by the Actions parser, and the first draft of this change did exactly that before validation caught it.
- The gate condition (`event_name != &#39;pull_request&#39; || draft == false`) also runs the tier on `merge_group` events, so this composes with a merge queue if one is enabled later.

Kept always-on: `bun test` (~1 min), `lint + boundary + drift` (~90s), `netproc` (fast, internally retried), and the package matrix (fast, deterministic, and the dweb-boundary artifact check).

### 2. Fix the stale focus-restore steal (the History &amp; Git flake, finally diagnosed)

This PR&#39;s own Chrome run hit the long-flaky &quot;History &amp; Git shows status/log&quot; test twice in a row, and the diagnostic added in #414 fired both times:

```
"actual": "focus-on:input.library-search panel-in-dom:true"
```

That names the thief: `focusLibraryAction` in `extension/home/library-section.js` runs its restore in a `requestAnimationFrame`, which is throttled in background documents, so a callback can land long after the interaction that scheduled it. A late callback whose card lookup fails falls back to focusing `.library-search`, taking focus the repository panel had already claimed in its `oncreate`.

The fix keeps the restore honest about time:

- a **supersession token**: only the newest restore intent acts, no matter which queued callback fires first, and
- a **foreign-claim guard**: a restore only moves focus when focus is orphaned (on `body`) or parked where our own previous restore put it. It never takes focus from a claim another surface made: the repository panel&#39;s `oncreate`, an open menu&#39;s first item, or anything the user focused since.

## Verification

- YAML validated structurally (trigger types, per-job `if:` placement, duplicate-key scan across all jobs). `check:copy` and `check:actions` green.
- In-browser Chrome suite: **939 passed, 0 failed, four consecutive local runs** with the focus fix (an intermediate version that guarded without the token flipped the race onto a different test, which is why both pieces exist).
- `bun run typecheck` and ESLint green on the touched file.
- This PR is deliberately **not** a draft, so this run itself exercises the ready-PR path with the full tier.

The draft path can only be observed on the next draft PR; nothing about it can break a merge, since skipping jobs on drafts only ever removes runs from heads that cannot merge anyway.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYyJu5uaSHaypMnpkzkn6P)_