### PR TITLE
test(framework): drain deferred work between tests

### DIFF
--- a/extension/tests/framework.js
+++ b/extension/tests/framework.js
@@ -202,6 +202,30 @@ export const countTests = () => {
   return suites.reduce((total, suite) => total + countSuite(suite), 0);
 };
 
+// why: a test can finish with requestAnimationFrame or setTimeout(0) work
+// still pending (a scheduled focus restore, a queued redraw). Component code
+// schedules these at module level, so they outlive the test's unmount, and
+// without a drain they fire DURING the next test and mutate its DOM. That is
+// the cross-test flake class: it reproduces only when a callback lands in
+// exactly the wrong later test, which under CI load it eventually does. One
+// macrotask turn drains timer work; one frame tick then flushes every rAF
+// callback the test registered (rAF callbacks run in registration order)
+// while the finished test's DOM is still the current one. A callback that
+// chains a FURTHER rAF from inside a frame is not covered: one frame per
+// test is the cost ceiling (a second tick measurably doubled the suite),
+// so deferred effects that chain must precondition-check when they fire,
+// as focusLibraryAction does. The cap bounds the wait where frames are
+// throttled or absent; a callback the browser has not delivered by then
+// was equally undeliverable mid-test.
+const drainDeferredWork = async () => {
+  await new Promise((resolve) => { setTimeout(resolve, 0); });
+  if (typeof requestAnimationFrame !== 'function') return;
+  await Promise.race([
+    new Promise((resolve) => { requestAnimationFrame(() => resolve(undefined)); }),
+    new Promise((resolve) => { setTimeout(resolve, 50); }),
+  ]);
+};
+
 /**
  * @param {Suite} suite
  * @param {(name: string) => void} onTestStart
@@ -234,6 +258,7 @@ const runSuite = async (suite, onTestStart, parents, selected) => {
         },
       });
     }
+    await drainDeferredWork();
   }
   const nextParents = [...parents, suite.name];
   for (const c of suite.children) out.children.push(await runSuite(c, onTestStart, nextParents, selected));

--- a/extension/tests/framework.js
+++ b/extension/tests/framework.js
@@ -214,9 +214,15 @@ export const countTests = () => {
 // chains a FURTHER rAF from inside a frame is not covered: one frame per
 // test is the cost ceiling (a second tick measurably doubled the suite),
 // so deferred effects that chain must precondition-check when they fire,
-// as focusLibraryAction does. The cap bounds the wait where frames are
-// throttled or absent; a callback the browser has not delivered by then
-// was equally undeliverable mid-test.
+// as focusLibraryAction does. The cap bounds the wait where frames stall,
+// which makes the whole guarantee CONDITIONAL on frames being delivered:
+// the headless CI lanes deliver them, so the drain flushes everything, but
+// a hidden runner tab suspends rAF entirely, so capped drains flush
+// nothing and the browser delivers the accumulated backlog at the next
+// visible frame, into whichever test is then current. The drain is
+// strictly monotone (a callback it cannot flush would have fired mid-test
+// anyway, only later), but it cannot protect a run whose frames stall;
+// effects that must stay safe there also precondition-check at fire time.
 const drainDeferredWork = async () => {
   await new Promise((resolve) => { setTimeout(resolve, 0); });
   if (typeof requestAnimationFrame !== 'function') return;


### PR DESCRIPTION
## What &amp; why

The structural half of the History &amp; Git flake, now that the product half (the `focusLibraryAction` token + guard) is on main: the in-browser runner executed tests back-to-back with no drain, so `requestAnimationFrame` / `setTimeout(0)` callbacks scheduled during test N could fire inside test N+1&#39;s DOM. Component code schedules this work at module level, so it survives `unmount()`. That is how a stale focus restore from a delete test landed in the History &amp; Git test under CI load, and the class would recur with the next deferred DOM effect anyone writes.

`runSuite` now drains after every test (pass and fail paths alike): one macrotask turn for timer work, then one animation-frame tick raced against a 50ms cap, skipped where rAF does not exist. Stale callbacks fire while the finished test&#39;s own unmounted DOM is still current, where their selectors miss and they no-op.

**The deliberate limits, stated in the code comment:**
- **One frame, not two.** rAF callbacks run in registration order, so a single tick flushes everything a test registered. A second tick (covering rAF-chained-from-rAF, which no current code path produces) measurably doubled the suite: 24s to 49s. One tick lands at 35s. Deferred effects that chain must precondition-check at fire time, as `focusLibraryAction` now does.
- **The 50ms cap** bounds the wait where frames are throttled or absent; a callback the browser has not delivered by then was equally undeliverable mid-test.

## Verification

- In-browser Chrome suite: 939 passed, 0 failed, twice with the final single-frame drain (and twice more with the rejected two-frame variant).
- ESLint, `bun run typecheck`, `check:copy` green.
- A four-lens adversarially-verified review swarm (event-loop correctness, Gecko behavior, framework contract/sharding, does-it-fix-the-class) is running; confirmed findings, if any, land here before this PR is marked ready.

Opened as draft, which also exercises the draft-gate from #415: the browser tier should skip on this push and run when the PR is marked ready.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYyJu5uaSHaypMnpkzkn6P)_