### PR TITLE
release: v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,26 @@ and storage formats may move until the surface stabilizes.
 
 ## [Unreleased]
 
-## [0.7.0] - 2026-08-15
+## [0.7.1] - 2026-08-16
+
+### Changed
+
+- The extension runtime is substantially lighter to start. The MV3 service
+  worker now loads exact background and offscreen module surfaces instead of
+  whole-module barrels, and Acorn-backed toolbox validation no longer sits in
+  the Chrome service worker's cold graph. That static graph drops from about
+  4.63 MB to 2.02 MB, and the combined service worker and offscreen cold graph
+  drops by about half, so the worker wakes with far less to parse.
+- Release staging compacts authored cold-path JavaScript in the disposable
+  packaging tree only, preserving modules, names, lazy imports, and vendored
+  bytes. Development is unchanged and still runs the source directly with no
+  build step.
+
+### Fixed
+
+- Privileged UI, keepalive, local-model, and toolbox-parser messaging is now
+  pinned to the exact document that owns it, so a message cannot be answered by
+  a surface that was never meant to handle it.
 
 ### Added
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "peerd (dev)",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "An AI assistant that automates tasks in your browser. Local-first: your own API key, no account, no servers, no tracking.",
   "side_panel": {
     "default_path": "sidepanel/sidepanel.html"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "peerd",
   "private": true,
   "type": "module",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Browser-native AI agent harness. Source runs directly with no development build step; Bun is used for tests and release tooling.",
   "license": "Apache-2.0",
   "homepage": "https://peerd.ai",


### PR DESCRIPTION
Cuts v0.7.1. One commit since v0.7.0: the extension runtime slimming and hardening work (#418). The changelog section was empty, so this writes it.

Recorded as user-facing:
- **Changed**: the MV3 service worker loads exact background and offscreen module surfaces instead of whole-module barrels, and Acorn-backed toolbox validation leaves the Chrome service worker cold graph. That static graph goes from about 4.63 MB to 2.02 MB, so the worker wakes with far less to parse.
- **Changed**: release staging compacts authored cold-path JavaScript in the disposable packaging tree only. Development stays source-direct with no build step.
- **Fixed**: privileged UI, keepalive, local-model, and toolbox-parser messaging is pinned to its exact owning document.

Verified locally: 6347 bun tests pass, strict typecheck, eslint, docpaths, copy hygiene, and the release-notes extractor renders the section cleanly.

Heads up on the approval gate: `prevent_self_review` is back ON for the `release` environment (restored after v0.7.0), so the signing job will pause and you will not be able to approve your own run. Either jonybur or fpolica91 can approve it, or say the word and I will temporarily flip the setting again and restore it after publish.