### PR TITLE
Clarify source-direct badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![In-Browser Gecko](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/NotASithLord/peerd/main/badges/inbrowser-gecko.json)](scripts/firefox/run-runtime-tests.mjs)
 [![E2E side panel](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/NotASithLord/peerd/main/badges/e2e-chrome.json)](scripts/cdp/run-e2e-verify.mjs)
 [![Red Team](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/NotASithLord/peerd/main/badges/red-team.json)](docs/security/RED-TEAM-RESULTS.md)
-[![No development build step](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/NotASithLord/peerd/main/badges/no-build.json)](CONTRIBUTING.md)
+[![App source: no development build and unbundled](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/NotASithLord/peerd/main/badges/no-build.json)](CONTRIBUTING.md)
 [![Vendored code](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/NotASithLord/peerd/main/badges/vendor-integrity.json)](extension/vendor/vendor.lock.json)
 [![Actions pinned](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/NotASithLord/peerd/main/badges/actions-pinned.json)](packaging/check-action-pins.ts)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)

--- a/badges/no-build.json
+++ b/badges/no-build.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "label": "Dev build step",
-  "message": "none (source-direct)",
+  "label": "App source",
+  "message": "no dev build · unbundled",
   "color": "brightgreen",
   "namedLogo": "javascript",
   "logoColor": "white"

--- a/packaging/supply-chain.ts
+++ b/packaging/supply-chain.ts
@@ -148,8 +148,10 @@ export const scanBuildStep = (
 
 export const buildStepBadge = (scan: BuildStepScan): ShieldsBadge => ({
   schemaVersion: 1,
-  label: 'Dev build step',
-  message: scan.offenders.length === 0 ? 'none (source-direct)' : 'present',
+  label: 'App source',
+  message: scan.offenders.length === 0
+    ? 'no dev build · unbundled'
+    : 'build or bundling present',
   color: scan.offenders.length === 0 ? 'brightgreen' : 'red',
   ...laneLogo('javascript'),
 });

--- a/tests/meta/supply-chain-badges.test.ts
+++ b/tests/meta/supply-chain-badges.test.ts
@@ -81,7 +81,7 @@ describe('no-development-build-step invariant', () => {
   test('reports none when source development does not bundle, transpile, emit, or build', () => {
     expect(scanBuildStep(clean, tsconfig).offenders).toEqual([]);
     expect(buildStepBadge({ offenders: [] })).toMatchObject({
-      label: 'Dev build step', message: 'none (source-direct)', color: 'brightgreen',
+      label: 'App source', message: 'no dev build · unbundled', color: 'brightgreen',
     });
   });
 
@@ -108,7 +108,7 @@ describe('no-development-build-step invariant', () => {
 
   test('goes red rather than quietly claiming none', () => {
     expect(buildStepBadge({ offenders: ['dependency "vite" is a bundler or transpiler'] }))
-      .toMatchObject({ message: 'present', color: 'red' });
+      .toMatchObject({ message: 'build or bundling present', color: 'red' });
   });
 });
 


### PR DESCRIPTION
## What changed

- combine the source-development and bundling claims into one generated badge
- qualify the claim as applying to authored app source, since vendored third-party bundles still exist
- update the README alt text and badge tests

## Why

Release packaging now compacts a disposable staging copy, while development remains source-direct and authored modules remain unbundled. The badge should communicate both guarantees without implying that the repository contains no vendor bundles or release transformation.

## Validation

- `bun test tests/meta/supply-chain-badges.test.ts`
- `bun packaging/check-test-badges.ts`
- `git diff --check`