### PR TITLE
Decouple base startup from rendezvous

### DIFF
--- a/badges/functional-tests.json
+++ b/badges/functional-tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "Functional Tests",
-  "message": "6347/6347 passing",
+  "message": "6348/6348 passing",
   "color": "brightgreen",
   "namedLogo": "bun",
   "logoColor": "white"

--- a/extension/peerd-distributed/client.js
+++ b/extension/peerd-distributed/client.js
@@ -121,7 +121,13 @@ export const createDwebClient = () => {
     /** @param {{ identity: import('./transport/mesh.js').Identity, url?: string, audit?: import('./transport/mesh.js').AuditFn,
      *   admitDwappMeta?: ((candidate: { dwappId: string, publisher: string, seq: number, versionId: string }) => Promise<boolean>) | null }} opts */
     joinBaseNetwork: async ({ identity, url = DEFAULT_SIGNALING[0], audit = null, admitDwappMeta = null } = /** @type {any} */ ({})) => {
-      const room = await joinRoom({ roomId: BASE_TOPIC, identity, url, audit });
+      // The base host is a local runtime with a separately observable
+      // rendezvous state. Do not make identity recovery, unlock, or MV3 startup
+      // wait on an external bootstrap node: assemble immediately, then let the
+      // room's existing backoff loop establish discovery in the background.
+      const room = await joinRoom({
+        roomId: BASE_TOPIC, identity, url, audit, awaitInitialRendezvous: false,
+      });
       // why kind: the lobby presence beacon carries `kind:'extension'` so other
       // members (e.g. an ephemeral peer the peerd.ai landing page joins) can tell
       // a real extension apart from a website visitor in the live network view.

--- a/extension/peerd-distributed/transport/rooms.js
+++ b/extension/peerd-distributed/transport/rooms.js
@@ -61,6 +61,7 @@ const ANSWER_TIMEOUT_MS = 15_000;
  *   budget?: number,
  *   caps?: string[],
  *   kind?: string,
+ *   awaitInitialRendezvous?: boolean,
  * }} opts
  */
 export const joinRoom = async ({
@@ -76,6 +77,7 @@ export const joinRoom = async ({
   budget,
   caps = ['content', 'pubsub'],
   kind: peerKind,             // 'website' = observe-only visitor (own rendezvous cap pool); omitted/default = extension
+  awaitInitialRendezvous = true,
 } = /** @type {{ roomId: string, identity: import('./mesh.js').Identity }} */ ({})) => {
   const t = transport ?? createWebrtcTransport({ iceServers });
   const mesh = createRoomMesh({ roomId, identity, now, budget, audit });
@@ -360,34 +362,47 @@ export const joinRoom = async ({
     await Promise.allSettled(session.members.map(dial));
   };
 
+  /** @param {any} e */
+  const noteConnectFailure = (e) => {
+    if (left) return;
+    reconnectFailures += 1;
+    if (!outageSince) outageSince = Date.now();
+    const downMs = Date.now() - outageSince;
+    // Stay quiet while the backoff rides out the expected transient; warn
+    // once the outage has truly persisted, and only once per outage — a
+    // blip that recovers before OUTAGE_WARN_MS never surfaces a warning.
+    if (!outageWarned && downMs >= OUTAGE_WARN_MS) {
+      outageWarned = true;
+      dwarn('room', `rendezvous unreachable for ${Math.round(downMs / 1000)}s (${reconnectFailures} attempts): ${e?.message ?? e} — still retrying`);
+    } else {
+      dlog('room', `rendezvous reconnect failed (attempt ${reconnectFailures}): ${e?.message ?? e} — retrying`);
+    }
+    backoffMs = Math.min(backoffMs * 2, RECONNECT_MAX_MS); // grow only on a real failed attempt
+    scheduleReconnect();
+  };
+
   const scheduleReconnect = () => {
     if (left || reconnectTimer) return;
     setStatus('connecting');
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null;
-      connectRendezvous().catch((e) => {
-        reconnectFailures += 1;
-        if (!outageSince) outageSince = Date.now();
-        const downMs = Date.now() - outageSince;
-        // Stay quiet while the backoff rides out the expected transient; warn
-        // once the outage has truly persisted, and only once per outage — a
-        // blip that recovers before OUTAGE_WARN_MS never surfaces a warning.
-        if (!outageWarned && downMs >= OUTAGE_WARN_MS) {
-          outageWarned = true;
-          dwarn('room', `rendezvous unreachable for ${Math.round(downMs / 1000)}s (${reconnectFailures} attempts): ${e?.message ?? e} — still retrying`);
-        } else {
-          dlog('room', `rendezvous reconnect failed (attempt ${reconnectFailures}): ${e?.message ?? e} — retrying`);
-        }
-        backoffMs = Math.min(backoffMs * 2, RECONNECT_MAX_MS); // grow only on a real failed attempt
-        scheduleReconnect();
-      });
+      connectRendezvous().catch(noteConnectFailure);
     }, backoffMs);
   };
 
   // ---- assemble -----------------------------------------------------------
 
   dlog('room', `joining room "${roomId}" as ${short(identity.did)} via ${url}`);
-  if (url) await connectRendezvous();
+  if (url) {
+    const initialConnect = connectRendezvous();
+    // An always-on host can be useful before its bootstrap node answers: its
+    // identity, local mesh, invite/relay paths and lifecycle controls are all
+    // independent of rendezvous reachability. Callers that opt out of waiting
+    // get a live room in `connecting` state while the normal retry loop heals
+    // discovery in the background. Interactive joins keep the strict default.
+    if (awaitInitialRendezvous) await initialConnect;
+    else void initialConnect.catch(noteConnectFailure);
+  }
 
   mesh.start();
   dlog('room', `room "${roomId}" assembled — ${mesh.peers().length} live peer link(s)`);

--- a/extension/peerd-distributed/transport/rooms.js
+++ b/extension/peerd-distributed/transport/rooms.js
@@ -369,13 +369,13 @@ export const joinRoom = async ({
     if (!outageSince) outageSince = Date.now();
     const downMs = Date.now() - outageSince;
     // Stay quiet while the backoff rides out the expected transient; warn
-    // once the outage has truly persisted, and only once per outage — a
+    // once the outage has truly persisted, and only once per outage. A
     // blip that recovers before OUTAGE_WARN_MS never surfaces a warning.
     if (!outageWarned && downMs >= OUTAGE_WARN_MS) {
       outageWarned = true;
-      dwarn('room', `rendezvous unreachable for ${Math.round(downMs / 1000)}s (${reconnectFailures} attempts): ${e?.message ?? e} — still retrying`);
+      dwarn('room', `rendezvous unreachable for ${Math.round(downMs / 1000)}s (${reconnectFailures} attempts): ${e?.message ?? e}; still retrying`);
     } else {
-      dlog('room', `rendezvous reconnect failed (attempt ${reconnectFailures}): ${e?.message ?? e} — retrying`);
+      dlog('room', `rendezvous reconnect failed (attempt ${reconnectFailures}): ${e?.message ?? e}; retrying`);
     }
     backoffMs = Math.min(backoffMs * 2, RECONNECT_MAX_MS); // grow only on a real failed attempt
     scheduleReconnect();

--- a/tests/peerd-distributed/client-self-runtime.test.ts
+++ b/tests/peerd-distributed/client-self-runtime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { createDwebClient } from '../../extension/peerd-distributed/client.js';
+import { generateIdentity } from '../../extension/peerd-distributed/identity/keypair.js';
 
 describe('live dweb client self-device boundary', () => {
   test('exposes every operation the offscreen self-device host calls', () => {
@@ -12,6 +13,30 @@ describe('live dweb client self-device boundary', () => {
       'loadCoordinatorInputs',
     ]) {
       expect(typeof client[operation], operation).toBe('function');
+    }
+  });
+
+  test('starts the base host while its bootstrap rendezvous is offline', async () => {
+    const client = createDwebClient() as any;
+    const identity = await generateIdentity();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const host = await Promise.race([
+        client.joinBaseNetwork({
+          identity,
+          // Port 1 is intentionally unavailable on the CI runner. A strict
+          // rendezvous join would wait for the signaling timeout here.
+          url: 'ws://127.0.0.1:1/rendezvous',
+        }),
+        new Promise((_, reject) => {
+          timer = setTimeout(() => reject(new Error('base host waited on bootstrap')), 1_000);
+        }),
+      ]) as any;
+      expect(host.base.did).toBe(identity.did);
+      expect(host.room.rendezvous()).toBe('connecting');
+      host.close();
+    } finally {
+      clearTimeout(timer);
     }
   });
 });


### PR DESCRIPTION
## What changed

- assemble the always-on base host immediately instead of blocking on the external bootstrap rendezvous
- keep strict, blocking rendezvous semantics as the default for interactive room joins
- reuse the existing reconnect/backoff loop for base-host discovery
- add a full-client regression that starts against an intentionally unavailable bootstrap endpoint

## Root cause

The v0.7.1 release changed only version metadata. Its required pre-merge E2E passed, but the main-branch run later timed out in `portable-identity` while `dweb/base/start` waited for `bootstrap.peerd.ai`. Local identity recovery and host activation were incorrectly coupled to external rendezvous availability.

## Impact

Identity restore, unlock, and MV3 host startup now complete under the local identity even during a bootstrap outage. Rendezvous status remains observable as `connecting` and heals in the background. The regression runs in the already-required `bun test` check, so this failure mode is gated before merge.

## Validation

- full `bun test`
- `bun run lint`
- `bun run typecheck`
- portable-identity E2E: 9/9 checks
- all four release artifacts built and verified
- packaged import graph, dweb boundary, security invariants, and tscheck floor