### PR TITLE
gitignore the generated update feeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,16 @@ scripts/cdp/bench-results/
 # Headless test output
 /test-output/
 
+# Auto-update feeds: generated at release time by
+# packaging/gen-update-feeds.ts (which mkdir -p's the directory) and
+# published only as GitHub Release assets. peerd-site downloads those assets
+# and deploys them to peerd.ai/updates/, and update-feed-monitor.yml checks
+# the live feed against the latest release tag. why ignore rather than leave
+# untracked: a tracked feed is a second value nothing reads. The last one sat
+# at v0.6.0 through two releases while the assets were correct, because the
+# release workflow could never push its refresh past branch protection.
+/update-feeds/
+
 # Online-Mind2Web (gated dataset + exported trajectories/screenshots + the
 # upstream scorer repo cloned on demand by score.mjs)
 scripts/cdp/om2w/data/


### PR DESCRIPTION
## What & why

**Mostly superseded by #423, which landed while this was open.** That PR did the substance: it removed the tracked feed files, dropped the never-succeeding mirror-commit step from the release workflow, rewrote `release.ts`'s step 5 to generate assets without committing, cleaned the stale `/dist/` gitignore block, and updated CLAUDE.md to say release packaging generates the feeds as assets for the site repo to deploy. I rebased this branch onto it and dropped everything it already covers.

One thing is left: `update-feeds/` is untracked but **not ignored**. `gen-update-feeds.ts` does `mkdirSync(recursive)` and rewrites both files on every release build, so they reappear in `git status` as untracked noise on any machine that has cut a release. That is how the stale copy got committed in the first place.

This adds the ignore rule so the release asset stays the only value anything reads.

Original context, since it explains the failure mode the comment records: the tracked copy sat at **v0.6.0** through v0.7.0 and v0.7.1 while the release assets were correct. `git log -- update-feeds/` showed exactly one commit ever touching the directory. The release workflow's mirror-commit step never once succeeded, because branch protection rejects a direct push from `github-actions[bot]` and the step is deliberately best-effort so it cannot fail a published release.

## Checklist

- [ ] `bun run preflight` passes (tests, typecheck, lint, in-browser, dweb-boundary, no manifest drift)
- [x] Only original or permissively-licensed code — **no GPL / AGPL / copyleft**
- [x] Tests added or updated (or N/A) — N/A, one gitignore rule
- [x] No hand-edited generated files (`manifest.json`, `shared/channel-config.js`)
- [x] Called out below if this touches a **danger zone** (egress / vault / gates / runner & sandbox boundaries / dweb)

## Notes for reviewers

Not a danger-zone change any more; the release-path edits went out with #423.

Verified locally: after `bun packaging/gen-update-feeds.ts --version=0.7.1`, both generated files are present and `git status --untracked-files=all update-feeds/` is empty. `bun run check:copy` passes.

`packaging/check-copy-hygiene.ts` still lists `update-feeds/` in `EXCLUDED_PREFIXES`, which is now consistent with the directory being ignored rather than a special case.

Peered with NotASithLord/peerd-site#18, which fixes the site's stale claims about this release and, more importantly, a bug where the feed sync commits new feeds and reports success without ever deploying them.