### PR TITLE
release: v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ and storage formats may move until the surface stabilizes.
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-08-16
+
+### Changed
+
+- Removed obsolete root-level prototypes, generated update feeds, VM image
+  scaffolding, and superseded design notes. The remaining web shell now has one
+  packaging-owned template, with no change to the source-direct development
+  workflow or extension runtime behavior.
+- The hosted identity ceremony source and deployment checks now live with
+  `peerd-site`; the extension keeps the opener, protocol validation, and
+  cryptographic custody boundary.
+
+### Fixed
+
+- Releases publish their update-feed descriptors as immutable release assets
+  and dispatch `peerd-site` from an isolated required job. A missing token or
+  failed delivery is now visible and fails the release workflow instead of
+  silently leaving the public feeds stale.
+
 ## [0.7.1] - 2026-08-16
 
 ### Changed

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "peerd (dev)",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "An AI assistant that automates tasks in your browser. Local-first: your own API key, no account, no servers, no tracking.",
   "side_panel": {
     "default_path": "sidepanel/sidepanel.html"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "peerd",
   "private": true,
   "type": "module",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Browser-native AI agent harness. Source runs directly with no development build step; Bun is used for tests and release tooling.",
   "license": "Apache-2.0",
   "homepage": "https://peerd.ai",


### PR DESCRIPTION
## Summary

- bump the package and extension manifest to 0.7.2
- document the root ownership cleanup and hosted identity source move
- document required, retryable release-feed delivery to peerd-site

## Validation

- generated development files remain in sync
- release notes parse for 0.7.2
- release hook, release notes, and update feed tests: 11/11 passing

This PR contains only the conventional three release files.