### PR TITLE
Use one approval for release publication

### DIFF
--- a/.github/workflows/package-and-release.yml
+++ b/.github/workflows/package-and-release.yml
@@ -20,15 +20,19 @@
 # Store uploads (Chrome Web Store / AMO) stay MANUAL — download the
 # verified store artifacts from the release run and submit them after QA.
 #
-# Secrets used by the release job (Settings → Secrets → Actions):
+# Signing secrets used by the release job (Settings → Secrets → Actions):
 #   CRX_PRIVATE_KEY   contents of key.pem (the CRX preview signing key —
 #                     same key forever, or every preview install breaks)
 #   AMO_JWT_ISSUER    addons.mozilla.org API credentials used by
 #   AMO_JWT_SECRET    `web-ext sign` for the Firefox preview package
+# Secret used by the notification job (Settings → Environments →
+# release-notify; leave that environment without required reviewers):
 #   PEERD_SITE_DISPATCH_TOKEN  fine-grained token scoped only to the private
 #                     NotASithLord/peerd-site repo with Contents:write. The
 #                     isolated notify-site job fails visibly if it is absent
-#                     and can be retried without replaying AMO signing.
+#                     and can be retried without replaying AMO signing. Its
+#                     separate unprotected environment scopes the credential
+#                     without asking for a second release approval.
 
 name: package-and-release
 
@@ -955,11 +959,13 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Reuse the release environment's narrowly held cross-repository secret,
-    # but keep notification in its own job. If delivery fails after AMO and
-    # the GitHub release are complete, "re-run failed jobs" retries only this
-    # safe dispatch instead of attempting to publish the Firefox version again.
-    environment: release
+    # why a separate unprotected environment: GitHub requests approval per job,
+    # even when two jobs use the same protected environment. This keeps the
+    # cross-repository credential scoped to its only consumer while one human
+    # approval authorizes the release chain once. Keeping notification in its
+    # own job means "re-run failed jobs" retries only this safe dispatch instead
+    # of attempting to publish the irreversible Firefox version again.
+    environment: release-notify
     permissions:
       contents: read
     steps:
@@ -974,7 +980,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "$GH_TOKEN" ]; then
-            echo "::error::PEERD_SITE_DISPATCH_TOKEN is not set in the release environment. Add a fine-grained token scoped to NotASithLord/peerd-site with Contents:write, then re-run this failed job."
+            echo "::error::PEERD_SITE_DISPATCH_TOKEN is not set in the release-notify environment. Add a fine-grained token scoped to NotASithLord/peerd-site with Contents:write, then re-run this failed job."
             exit 1
           fi
           gh api --method POST repos/NotASithLord/peerd-site/dispatches \

--- a/tests/packaging/release-hook.test.ts
+++ b/tests/packaging/release-hook.test.ts
@@ -11,7 +11,8 @@ describe('release feed publication hook', () => {
   test('dispatches the exact released tag from an isolated post-release job', () => {
     const notify = workflow.slice(workflow.indexOf('\n  notify-site:'));
     expect(notify).toContain('needs: release');
-    expect(notify).toContain('environment: release');
+    expect(notify).toContain('environment: release-notify');
+    expect(notify).not.toContain('environment: release\n');
     expect(notify).toContain('secrets.PEERD_SITE_DISPATCH_TOKEN');
     expect(notify).toContain('repos/NotASithLord/peerd-site/dispatches');
     expect(notify).toContain('-f event_type=peerd-release');


### PR DESCRIPTION
## What changed

- move the post-release site notification job from the protected `release` environment to a dedicated `release-notify` environment
- keep notification isolated so failed delivery can be retried without repeating irreversible AMO signing
- update the release-hook regression test and missing-secret diagnostic

## Why

GitHub approves environments per job. Using the protected `release` environment for both signing and notification caused two approval prompts for one release chain.

The `release-notify` environment has no required reviewers, remains restricted to `v*` tags, and scopes the cross-repository credential to its sole consumer. The protected signing environment is unchanged.

## Validation

- release-hook unit test: pass
- workflow YAML parse: pass
- ESLint: pass
- strict typecheck: pass
- full Bun suite: 6,339 passed; two unrelated operation-log stress tests exceeded their existing five-second timeout locally (no runtime or lifecycle files differ from `main`); CI remains the merge gate