### PR TITLE
release: v0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and storage formats may move until the surface stabilizes.
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-08-18
+
+### Fixed
+
+- Release publication now requires only one manual approval. The peerd.ai
+  notification job keeps its own narrowly scoped environment, so a failed
+  notification can be retried without repeating irreversible Firefox signing.
+
 ## [0.7.2] - 2026-08-16
 
 ### Changed

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "peerd (dev)",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "An AI assistant that automates tasks in your browser. Local-first: your own API key, no account, no servers, no tracking.",
   "side_panel": {
     "default_path": "sidepanel/sidepanel.html"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "peerd",
   "private": true,
   "type": "module",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Browser-native AI agent harness. Source runs directly with no development build step; Bun is used for tests and release tooling.",
   "license": "Apache-2.0",
   "homepage": "https://peerd.ai",


### PR DESCRIPTION
## What changed

- bump the package and generated development manifest to 0.7.3
- add release notes for the single-approval publication workflow fix

## Why

This patch release carries the post-0.7.2 release automation change. Release publication now needs one manual approval while the peerd.ai notification remains independently retryable. There is no extension runtime change.

## Validation

- release notes parse for 0.7.3
- focused release hook, release notes, and update-feed tests: 11/11 passing
- full local preflight: pass, including 6,341/6,341 functional tests
- all four channel/browser artifacts build with closed import graphs
- Firefox package validation: zero errors

The v0.7.3 tag and release publication remain intentionally separate until this PR is reviewed and merged.