### PR TITLE
Retry release feed dispatch

### DIFF
--- a/.github/workflows/package-and-release.yml
+++ b/.github/workflows/package-and-release.yml
@@ -983,7 +983,26 @@ jobs:
             echo "::error::PEERD_SITE_DISPATCH_TOKEN is not set in the release-notify environment. Add a fine-grained token scoped to NotASithLord/peerd-site with Contents:write, then re-run this failed job."
             exit 1
           fi
-          gh api --method POST repos/NotASithLord/peerd-site/dispatches \
-            -f event_type=peerd-release \
-            -F "client_payload[tag]=$GITHUB_REF_NAME"
+          # why retry here: this is the only cross-repository handoff. Brief
+          # GitHub API failures should not require a human re-run, while the
+          # bounded loop still leaves a visible failure for the hourly repair
+          # workflow in peerd-site to reconcile after a longer outage.
+          dispatched=false
+          for attempt in 1 2 3; do
+            if gh api --method POST repos/NotASithLord/peerd-site/dispatches \
+              -f event_type=peerd-release \
+              -F "client_payload[tag]=$GITHUB_REF_NAME"; then
+              dispatched=true
+              break
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              delay=$((attempt * 10))
+              echo "::warning::peerd-site dispatch attempt $attempt failed; retrying in ${delay}s"
+              sleep "$delay"
+            fi
+          done
+          if [ "$dispatched" != true ]; then
+            echo "::error::peerd-site dispatch failed after 3 attempts; the hourly site reconciliation remains the repair path"
+            exit 1
+          fi
           echo "dispatched peerd release $GITHUB_REF_NAME to peerd-site"

--- a/tests/packaging/release-hook.test.ts
+++ b/tests/packaging/release-hook.test.ts
@@ -17,6 +17,9 @@ describe('release feed publication hook', () => {
     expect(notify).toContain('repos/NotASithLord/peerd-site/dispatches');
     expect(notify).toContain('-f event_type=peerd-release');
     expect(notify).toContain('-F "client_payload[tag]=$GITHUB_REF_NAME"');
+    expect(notify).toContain('for attempt in 1 2 3');
+    expect(notify).toContain('sleep "$delay"');
+    expect(notify).toContain('dispatch failed after 3 attempts');
   });
 
   test('a missing hook credential is visible and retryable, never a green skip', () => {


### PR DESCRIPTION
## What changed

- retry the cross-repository `peerd-site` dispatch up to three times with bounded backoff
- preserve a visible terminal failure so the notification job remains safely retryable
- extend the release-hook regression test to lock in the retry posture

## Why

A brief GitHub API outage between release publication and site notification should not require a human rerun. Longer outages still fail visibly and are reconciled by the site’s hourly state repair, without replaying irreversible AMO signing.

The receiving workflow is idempotent, so duplicate delivery after an ambiguous API response is harmless.

## Validation

- release-hook unit test
- workflow YAML and embedded Bash syntax
- ESLint
- strict typecheck
- action-pin validation
- copy-hygiene validation