### PR TITLE
Release 0.7.3: update Gecko badge

### DIFF
--- a/badges/inbrowser-gecko.json
+++ b/badges/inbrowser-gecko.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "In-Browser (Gecko)",
-  "message": "938/938 passing",
+  "message": "942/942 passing",
   "color": "brightgreen",
   "namedLogo": "firefoxbrowser",
   "logoColor": "white"


### PR DESCRIPTION
## Summary
- record the 942/942 passing Gecko count measured by the v0.7.3 release run
- keep the latest-release README badge truthful and green

## Evidence
- v0.7.3 Firefox Store smoke + Gecko suite completed 942/942 tests successfully
- the release failed only at the checked-in badge drift guard