### PR TITLE
ci(dependabot): gate both lanes on actual eligibility

### DIFF
--- a/.github/workflows/dependabot-malware-observation.yml
+++ b/.github/workflows/dependabot-malware-observation.yml
@@ -79,7 +79,12 @@ jobs:
   observe:
     name: observe Bun malware window (PR ${{ matrix.pr.number }}, ${{ matrix.pr.head_sha }})
     needs: discover
-    if: needs.discover.result == 'success'
+    # why: a matrix that expands to zero entries fails the whole run rather
+    # than skipping the job, so every scheduled sweep with no open candidate
+    # reported red. Nothing is observed when there is nothing to observe.
+    if: >-
+      needs.discover.result == 'success' &&
+      needs.discover.outputs.matrix != '[]'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dependabot-security-release.yml
+++ b/.github/workflows/dependabot-security-release.yml
@@ -39,11 +39,19 @@ concurrency:
 jobs:
   verify:
     name: verify and generate on a read-only runner
+    # why: route on the group's branch prefix so a routine version-update PR
+    # SKIPS instead of entering and hard-failing on a metadata boundary, which
+    # reported an unrelated reason ("maintainer-edited") on every such PR. This
+    # only ever narrows what enters; the authoritative eligibility check stays
+    # `dependabot-security.ts verify`, which fails closed unless the
+    # authenticated dependency-group is the ecosystem's SECURITY_GROUPS entry.
     if: >-
       github.event.action != 'closed' &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.base.ref == 'main' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
+      (startsWith(github.event.pull_request.head.ref, 'dependabot/bun/bun-security-patches') ||
+        startsWith(github.event.pull_request.head.ref, 'dependabot/github_actions/actions-security-patches')) &&
       !contains(github.event.pull_request.labels.*.name, 'security-autorelease')
     runs-on: ubuntu-latest
     permissions:
@@ -193,6 +201,8 @@ jobs:
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.base.ref == 'main' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
+      (startsWith(github.event.pull_request.head.ref, 'dependabot/bun/bun-security-patches') ||
+        startsWith(github.event.pull_request.head.ref, 'dependabot/github_actions/actions-security-patches')) &&
       !contains(github.event.pull_request.labels.*.name, 'security-autorelease')
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/badges/functional-tests.json
+++ b/badges/functional-tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "Functional Tests",
-  "message": "6411/6411 passing",
+  "message": "6414/6414 passing",
   "color": "brightgreen",
   "namedLogo": "bun",
   "logoColor": "white"

--- a/tests/dependabot-security.test.ts
+++ b/tests/dependabot-security.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -399,5 +399,73 @@ describe('Dependabot security automation policy', () => {
     expect(() => assertRecentUtcDate('2026-08-10', now)).not.toThrow();
     expect(() => assertRecentUtcDate('2026-08-09', now)).not.toThrow();
     expect(() => assertRecentUtcDate('2026-08-08', now)).toThrow('current UTC date');
+  });
+});
+
+// Minimal, dependency-free readers for the two policy manifests. why: these
+// gates live only in YAML, so nothing else in the suite would notice a
+// regression, and a real YAML parser is not a declared dependency here.
+const readRepoFile = (path: string): string[] =>
+  readFileSync(join(import.meta.dir, '..', path), 'utf8').split('\n');
+
+const jobCondition = (workflow: string, job: string): string => {
+  const lines = readRepoFile(join('.github/workflows', workflow));
+  const jobStart = lines.findIndex((line) => line === `  ${job}:`);
+  if (jobStart < 0) throw new Error(`${workflow} has no job ${job}`);
+  const keyIndex = lines.findIndex(
+    (line, index) => index > jobStart && /^    if:/.test(line),
+  );
+  const blockEnd = lines.findIndex(
+    (line, index) => index > jobStart && /^  \S/.test(line),
+  );
+  if (keyIndex < 0 || (blockEnd >= 0 && keyIndex > blockEnd)) {
+    throw new Error(`${workflow} job ${job} has no if condition`);
+  }
+  const condition = [lines[keyIndex].replace(/^    if:\s*>?-?\s*/, '')];
+  for (let index = keyIndex + 1; index < lines.length; index += 1) {
+    if (!/^ {5,}\S/.test(lines[index])) break;
+    condition.push(lines[index].trim());
+  }
+  return condition.join(' ').split(/\s+/).filter(Boolean).join(' ');
+};
+
+const securityUpdateGroups = (): string[] => {
+  const lines = readRepoFile('.github/dependabot.yml');
+  const groups: string[] = [];
+  let current = '';
+  for (const line of lines) {
+    const name = /^      ([\w-]+):\s*$/.exec(line);
+    if (name) current = name[1];
+    else if (current && /^\s+applies-to:\s*security-updates\s*$/.test(line)) {
+      groups.push(current);
+      current = '';
+    }
+  }
+  return groups;
+};
+
+describe('Dependabot workflow eligibility gates', () => {
+  test('the malware observation matrix job requires a non-empty candidate set', () => {
+    // why: a matrix expanding to zero entries fails the run instead of skipping
+    // the job, which reported every candidate-free scheduled sweep as red.
+    expect(jobCondition('dependabot-malware-observation.yml', 'observe'))
+      .toContain("needs.discover.outputs.matrix != '[]'");
+  });
+
+  test('the security release admits only the authenticated security groups', () => {
+    // why: without a group gate, routine version-update PRs enter the no-human
+    // release workflow and hard-fail on an unrelated metadata boundary.
+    for (const job of ['verify', 'publish']) {
+      const condition = jobCondition('dependabot-security-release.yml', job);
+      expect(condition).toContain("'dependabot/bun/bun-security-patches'");
+      expect(condition).toContain("'dependabot/github_actions/actions-security-patches'");
+    }
+  });
+
+  test('every security group declared in dependabot.yml is routable', () => {
+    const groups = securityUpdateGroups();
+    expect(groups.sort()).toEqual(['actions-security-patches', 'bun-security-patches']);
+    const condition = jobCondition('dependabot-security-release.yml', 'verify');
+    for (const group of groups) expect(condition).toContain(`/${group}'`);
   });
 });


### PR DESCRIPTION
## What broke

Two Dependabot lanes report red for reasons unrelated to their subject.

**Malware observation: 28/28 scheduled runs failed.** `discover` correctly resolves zero candidates and emits `matrix=[]`, but `observe` was gated only on `needs.discover.result == 'success'`. An empty matrix does not skip the job - GitHub fails the *run* at expansion, so no `observe` job appears at all. Confirmed on run 32351529169: `discover` success, `requeue` success, run conclusion failure. main has been red every four hours since the lane landed, which also means a genuine failure there would be invisible.

**Security release admits PRs it cannot process.** `verify` and `publish` accept any Dependabot PR from an in-repo branch to main, with no group check. Routine `bun-dependencies` PRs enter the no-human release lane and fail on the first metadata boundary they trip - PR #427 reports `maintainer-edited Dependabot PR requires human review`, which is not the real disqualifier.

## What changed

- `observe` also requires `needs.discover.outputs.matrix != '[]'`.
- `verify` and `publish` route on the group's branch prefix, the same gate `discover` already used, covering both security groups (`bun-security-patches`, `actions-security-patches`).

This only ever narrows what enters the lane. The authoritative eligibility check is untouched and still fails closed: `dependabot-security.ts verify` rejects any authenticated `dependency-group` that is not the ecosystem's `SECURITY_GROUPS` entry. `loadMalwareObservations` matches on the exact job name, so candidate-free runs contribute nothing to the 72-hour window either before or after.

## How it was verified

Three tests in `tests/dependabot-security.test.ts`, read without a YAML dependency (`yaml` is only a hoisted transitive here). The third asserts every `security-updates` group in `dependabot.yml` is routable, so adding an ecosystem cannot silently strand its security lane.

Revert-proofed: restoring either condition fails the matching tests. Full local gate set green - typecheck, lint, boundary, imports, tscheck, copy, hygiene, invariants, zero `gen:dev` drift, `bun test ./tests` 6414 pass / 0 fail.

## Note

No `*-security-patches` branch has ever existed, so the `observe` path and the auto-release happy path have never executed in production. Worth one `workflow_dispatch` against a synthetic candidate before relying on either.