### PR TITLE
fix(provider): let a keyless provider actually become active

### DIFF
--- a/badges/functional-tests.json
+++ b/badges/functional-tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "Functional Tests",
-  "message": "6433/6433 passing",
+  "message": "6430/6430 passing",
   "color": "brightgreen",
   "namedLogo": "bun",
   "logoColor": "white"

--- a/badges/functional-tests.json
+++ b/badges/functional-tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "Functional Tests",
-  "message": "6429/6429 passing",
+  "message": "6433/6433 passing",
   "color": "brightgreen",
   "namedLogo": "bun",
   "logoColor": "white"

--- a/badges/functional-tests.json
+++ b/badges/functional-tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "Functional Tests",
-  "message": "6411/6411 passing",
+  "message": "6428/6428 passing",
   "color": "brightgreen",
   "namedLogo": "bun",
   "logoColor": "white"

--- a/badges/functional-tests.json
+++ b/badges/functional-tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "Functional Tests",
-  "message": "6428/6428 passing",
+  "message": "6429/6429 passing",
   "color": "brightgreen",
   "namedLogo": "bun",
   "logoColor": "white"

--- a/badges/functional-tests.json
+++ b/badges/functional-tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "Functional Tests",
-  "message": "6430/6430 passing",
+  "message": "6435/6435 passing",
   "color": "brightgreen",
   "namedLogo": "bun",
   "logoColor": "white"

--- a/badges/inbrowser-chrome.json
+++ b/badges/inbrowser-chrome.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "In-Browser (Chrome)",
-  "message": "948/948 passing",
+  "message": "950/950 passing",
   "color": "brightgreen",
   "namedLogo": "googlechrome",
   "logoColor": "white"

--- a/badges/inbrowser-gecko.json
+++ b/badges/inbrowser-gecko.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "In-Browser (Gecko)",
-  "message": "942/942 passing",
+  "message": "944/944 passing",
   "color": "brightgreen",
   "namedLogo": "firefoxbrowser",
   "logoColor": "white"

--- a/extension/background/provider-readiness.js
+++ b/extension/background/provider-readiness.js
@@ -57,3 +57,79 @@ export const resolveComposerReadiness = async ({
     warning: reason === null ? ollamaWarning : null,
   });
 };
+
+/**
+ * Pick the provider a chat should bind to when the user has NOT chosen one -
+ * `providerName` is empty (the shipped default) or names an unregistered
+ * adapter. Returns the first usable provider's name in registry order, or null
+ * when nothing is usable.
+ *
+ * Keyless usability is REAL readiness, not mere presence: a live daemon
+ * (Ollama) must answer, and the on-device model must be downloaded.
+ *
+ * @param {object} deps
+ * @param {Array<{ name: string, keyless?: boolean, liveModels?: boolean, vaultSecretName?: string|null }>} deps.providers
+ * @param {(name: string) => Promise<string | null>} deps.getSecret
+ * @param {boolean} deps.localModelAvailable
+ * @param {(name: string) => (number | null) | Promise<number | null>} deps.liveModelCount
+ * @returns {Promise<string | null>}
+ */
+export const pickUsableProvider = async ({
+  providers, getSecret, localModelAvailable, liveModelCount,
+}) => {
+  for (const candidate of providers) {
+    if (candidate.keyless) {
+      if (candidate.liveModels) {
+        const count = await liveModelCount(candidate.name);
+        if (typeof count === 'number' && count > 0) return candidate.name;
+      } else if (candidate.name === 'local-webgpu') {
+        if (localModelAvailable) return candidate.name;
+      } else return candidate.name;
+    } else if (candidate.vaultSecretName) {
+      try {
+        if (await getSecret(candidate.vaultSecretName)) return candidate.name;
+      } catch { /* an unreadable vault entry is not a usable provider */ }
+    }
+  }
+  return null;
+};
+
+/**
+ * Which provider the SETTINGS/new-chat projection should show. Returns '' when
+ * the user's own selection stands - the caller then reads settings as usual,
+ * keeping any providerModel they chose - or a name to project instead.
+ *
+ * why this exists (issue #384): the projection used to fall back to Anthropic
+ * whenever providerName was empty, without checking readiness. An Ollama-only
+ * install therefore had its composer gated on an unkeyed Anthropic, and the
+ * only code that would have re-picked runs at send time - which that same gate
+ * blocks. Readiness needed a provider, the provider needed a send, the send
+ * needed readiness. Reloading never helped: the empty setting is durable, not
+ * a race. Rendering must not write, so this resolves without persisting; the
+ * binder still records the choice on the first turn, from the same ordering
+ * rule via pickUsableProvider.
+ *
+ * @param {object} deps
+ * @param {Array<{ name: string, keyless?: boolean, liveModels?: boolean, vaultSecretName?: string|null }>} deps.providers
+ * @param {string} deps.chosenName
+ * @param {(name: string) => Promise<string | null>} deps.getSecret
+ * @param {() => boolean} deps.localAvailable
+ * @param {(name: string) => (number | null) | Promise<number | null>} deps.liveModelCount
+ * @param {() => Promise<unknown>} [deps.hydrateLocal]
+ * @returns {Promise<string>}
+ */
+export const resolveDisplayProvider = async ({
+  providers, chosenName, getSecret, localAvailable, liveModelCount, hydrateLocal,
+}) => {
+  if (chosenName && providers.some((candidate) => candidate.name === chosenName)) return '';
+  // Only on the unchosen path, warm the keyless readiness signals so the pick
+  // sees what the binder would. Both callers cache their result - failures
+  // included - so this is bounded, not a probe on every state push.
+  if (hydrateLocal && providers.some((candidate) => candidate.name === 'local-webgpu')) {
+    await hydrateLocal().catch(() => false);
+  }
+  const picked = await pickUsableProvider({
+    providers, getSecret, localModelAvailable: localAvailable(), liveModelCount,
+  });
+  return picked ?? '';
+};

--- a/extension/background/routes/providers.js
+++ b/extension/background/routes/providers.js
@@ -43,7 +43,7 @@ export const makeProviderRoutes = (deps) => {
     // endpoint, so an onboarding tester learns the key works BEFORE sending a real
     // message (instead of hitting a 401 on the first turn). The adapter's
     // connect-timeout applies, so the test itself can't hang.
-    'provider/test': async ({ provider }) => {
+    'provider/test': async ({ provider, activate }) => {
       if (!(await awaitSettings())) return { ok: false, error: 'settings-unavailable' };
       const adapter = listProviders().find((/** @type {any} */ p) => p.name === provider);
       // Keyless local provider (Ollama): "does the daemon answer" is the
@@ -62,7 +62,11 @@ export const makeProviderRoutes = (deps) => {
           // provider had no activation path at all, so a validated Ollama left
           // providerName at its empty default and the composer stayed gated on
           // an unkeyed Anthropic.
-          if (count > 0 && !(await activeProviderUsable())) {
+          // activate:false is onboarding's opt-out, the same one setKey takes.
+          // That step probes every reachable daemon on mount, and its contract
+          // is that nothing becomes active until the user picks - so a survey
+          // ping must not decide for them.
+          if (activate !== false && count > 0 && !(await activeProviderUsable())) {
             await settingsStore.update({ providerName: provider, providerModel: '' });
           }
           pushState();

--- a/extension/background/routes/providers.js
+++ b/extension/background/routes/providers.js
@@ -24,6 +24,19 @@ export const makeProviderRoutes = (deps) => {
     try { await ensureSettingsReady(); return true; }
     catch { return false; }
   };
+  // Shared by both activation paths below: a provider may adopt the active slot
+  // only when whatever holds it cannot actually serve a turn. An explicit,
+  // working selection is never overridden. An empty providerName - the shipped
+  // default - resolves to no descriptor, so a fresh install always adopts.
+  const activeProviderUsable = async () => {
+    const active = listProviders().find(
+      (/** @type {any} */ p) => p.name === settingsStore.get().providerName);
+    if (!active) return false;
+    if (active.keyless) return true;
+    if (!active.vaultSecretName) return false;
+    try { return !!(await vault.getSecret(active.vaultSecretName)); }
+    catch { return false; }
+  };
 
   return {
     // Validate a saved provider key with a minimal 1-token ping on the REAL
@@ -40,10 +53,19 @@ export const makeProviderRoutes = (deps) => {
         try {
           // ollamaHost (issue #104): test the daemon the user actually configured.
           const models = await liveProviderModels(provider, { force: true });
-          pushState();
-          if (!Array.isArray(models)) return { ok: false, error: 'unreachable' };
+          if (!Array.isArray(models)) { pushState(); return { ok: false, error: 'unreachable' }; }
           auditLog.append({ type: 'provider_validated', details: { provider } }).catch(() => {});
           const count = models?.length ?? 0;
+          // Adopt the daemon you just proved works, on the same terms the keyed
+          // path uses below - only when the current selection isn't usable, so
+          // an explicit pick is never overridden. why (issue #384): a keyless
+          // provider had no activation path at all, so a validated Ollama left
+          // providerName at its empty default and the composer stayed gated on
+          // an unkeyed Anthropic.
+          if (count > 0 && !(await activeProviderUsable())) {
+            await settingsStore.update({ providerName: provider, providerModel: '' });
+          }
+          pushState();
           return count > 0
             ? { ok: true, reachable: true, models: count }
             : { ok: false, reachable: true, error: 'no-models', models: 0 };
@@ -179,18 +201,12 @@ export const makeProviderRoutes = (deps) => {
         // already-usable selection (an explicit keyless pick, or a provider that
         // already has a key). Clear providerModel so the new provider's default
         // model applies (mirrors the Settings provider <select>).
-        const activeName = settingsStore.get().providerName;
         // Onboarding verifies a candidate after vaulting it but before making
         // it active. Its explicit activate:false prevents this convenience
         // auto-switch from defeating that verify-before-switch contract.
-        if (activate !== false && provider !== activeName) {
-          const active = listProviders().find((/** @type {any} */ p) => p.name === activeName);
-          let activeUsable = !!active?.keyless;
-          if (!activeUsable && active?.vaultSecretName) {
-            try { activeUsable = !!(await vault.getSecret(active.vaultSecretName)); }
-            catch { activeUsable = false; }
-          }
-          if (!activeUsable) await settingsStore.update({ providerName: provider, providerModel: '' });
+        if (activate !== false && provider !== settingsStore.get().providerName
+          && !(await activeProviderUsable())) {
+          await settingsStore.update({ providerName: provider, providerModel: '' });
         }
         // Push fresh state so UI flips its "no key" affordance.
         pushState();

--- a/extension/background/routes/providers.js
+++ b/extension/background/routes/providers.js
@@ -32,7 +32,18 @@ export const makeProviderRoutes = (deps) => {
     const active = listProviders().find(
       (/** @type {any} */ p) => p.name === settingsStore.get().providerName);
     if (!active) return false;
-    if (active.keyless) return true;
+    if (active.keyless) {
+      // A resident runner is usable by construction here: its download state
+      // is checked separately by the composer. A daemon-backed provider is
+      // different: keeping an unreachable or empty Ollama selection would
+      // strand the composer on a provider that cannot serve a turn, precisely
+      // the condition this predicate decides.
+      if (!active.liveModels) return true;
+      try {
+        const models = await liveProviderModels(active.name, { force: true });
+        return Array.isArray(models) && models.length > 0;
+      } catch { return false; }
+    }
     if (!active.vaultSecretName) return false;
     try { return !!(await vault.getSecret(active.vaultSecretName)); }
     catch { return false; }

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -466,7 +466,7 @@ import { makeLocalModelState } from './local-model-state.js';
 import { makeProfileState } from './profile-state.js';
 import { makeOnboardingReconcile } from './onboarding-reconcile.js';
 import { makeModelCatalog } from './model-catalog.js';
-import { resolveComposerReadiness } from './provider-readiness.js';
+import { pickUsableProvider, resolveComposerReadiness, resolveDisplayProvider } from './provider-readiness.js';
 import { makeTabAffordances } from './tab-affordances.js';
 import { makeMintOnce } from './mint-once.js';
 import { makeDwebInboundRateCap } from './dweb-inbound-rate-cap.js';
@@ -789,15 +789,22 @@ const ensureSettingsReady = () => {
  * descriptor { name, label, model, vaultSecretName } — enough for
  * session creation, the key-presence check, and the settings UI.
  */
-const resolveActiveProvider = () => {
-  const list = listProviders().filter((provider) =>
-    provider.name !== 'local-webgpu' || offscreenAvailable);
+const selectableProviders = () => listProviders().filter((provider) =>
+  provider.name !== 'local-webgpu' || offscreenAvailable);
+
+const resolveActiveProvider = (overrideName = '') => {
+  const list = selectableProviders();
   const fallback = list.find((p) => p.name === 'anthropic') ?? list[0];
-  const chosen = list.find((p) => p.name === settingsStore.get().providerName) ?? fallback;
+  const requested = overrideName || settingsStore.get().providerName;
+  const chosen = list.find((p) => p.name === requested) ?? fallback;
   return {
     name: chosen.name,
     label: chosen.label,
-    model: settingsStore.get().providerModel || chosen.defaultModel,
+    // why: an override means the stored providerName was empty or unregistered,
+    // so any stored providerModel belongs to a different adapter. Fall through
+    // to the picked provider's own default, exactly as ensureActiveProvider
+    // does when it persists a pick with providerModel: ''.
+    model: (overrideName ? '' : settingsStore.get().providerModel) || chosen.defaultModel,
     // why: the web actor's fast default for this provider (Haiku on
     // Anthropic). Surfaced so the settings UI can show it as the "blank =
     // this" placeholder and mintWebSession can resolve the web actor model.
@@ -821,36 +828,48 @@ const resolveActiveProvider = () => {
  */
 const ensureActiveProvider = async () => {
   await ensureSettingsReady();
-  const list = listProviders().filter((provider) =>
-    provider.name !== 'local-webgpu' || offscreenAvailable);
+  const list = selectableProviders();
   const name = settingsStore.get().providerName;
   if (name && list.some((p) => p.name === name)) return resolveActiveProvider();
-  for (const p of list) {
-    let usable = false;
-    if (p.keyless) {
-      // Keyless usability is REAL readiness, not mere presence: a live daemon
-      // (Ollama) must answer; the on-device model must be downloaded.
-      if (p.liveModels) {
-        const live = await liveProviderModels(p.name);
-        usable = Array.isArray(live) && live.length > 0;
-      }
-      else if (p.name === 'local-webgpu') usable = localModelState.available();
-      else usable = true;
-    } else {
-      try { usable = !!(await vault.getSecret(/** @type {string} */ (p.vaultSecretName))); }
-      catch { usable = false; }
-    }
-    if (usable) {
-      // Clear providerModel so the picked provider's own default model applies.
-      try { await settingsStore.update({ providerName: p.name, providerModel: '' }); }
-      catch { /* a settings write failure must not block chat creation */ }
-      return resolveActiveProvider();
-    }
+  const picked = await pickUsableProvider({
+    providers: list,
+    getSecret: (secret) => vault.getSecret(secret),
+    localModelAvailable: localModelState.available(),
+    // The binder can afford the live probe the render path must not repeat.
+    liveModelCount: async (provider) => {
+      const live = await liveProviderModels(provider);
+      return Array.isArray(live) ? live.length : null;
+    },
+  });
+  if (picked) {
+    // Clear providerModel so the picked provider's own default model applies.
+    try { await settingsStore.update({ providerName: picked, providerModel: '' }); }
+    catch { /* a settings write failure must not block chat creation */ }
   }
-  // Nothing usable — keep the existing fallback so the turn fails with a clear
-  // provider error (the UI gates sending before reaching here on a fresh chat).
-  return resolveActiveProvider();
+  // With no usable provider this keeps the existing fallback, so the turn fails
+  // with a clear provider error (the UI gates sending before reaching here on a
+  // fresh chat). Passing the pick through rather than re-reading settings also
+  // means a failed persist still binds the chat to the provider that works.
+  return resolveActiveProvider(picked ?? '');
 };
+
+/** Readiness-aware sibling of resolveActiveProvider for render paths (#384). */
+const resolveActiveProviderForDisplay = async () => resolveActiveProvider(
+  await resolveDisplayProvider({
+    providers: selectableProviders(),
+    chosenName: settingsStore.get().providerName,
+    getSecret: (secret) => vault.getSecret(secret),
+    localAvailable: () => localModelState.available(),
+    hydrateLocal: hydrateLocalModelAvailability,
+    // The projection reads the warm cache the binder's forced probe fills, and
+    // only pays for a probe when nothing has asked yet.
+    liveModelCount: async (provider) => {
+      const cached = liveProviderModelStatus(provider);
+      if (cached.known) return cached.count;
+      const live = await liveProviderModels(provider).catch(() => null);
+      return Array.isArray(live) ? live.length : null;
+    },
+  }));
 
 /**
  * Build the ordered failover candidate chain for a turn: the active
@@ -4471,7 +4490,7 @@ const buildStateSnapshot = async () => {
   // providers remains the Settings/default-for-NEW-chats projection. Composer
   // readiness is separate because an existing chat stays bound to the provider
   // recorded on its session even after the user changes that future default.
-  const activeProv = resolveActiveProvider();
+  const activeProv = await resolveActiveProviderForDisplay();
   const composerProvider = session?.provider ?? activeProv.name;
   const composerModel = session?.model ?? activeProv.model;
   if (activeProv.name === 'local-webgpu' || composerProvider === 'local-webgpu') {

--- a/extension/offscreen/actor-channel-host.js
+++ b/extension/offscreen/actor-channel-host.js
@@ -19,10 +19,21 @@ export const bindActorChannel = ({ port, channelId, run, abort, workerUrl }) => 
   let committed = false;
   let completed = false;
   let abortRequested = false;
+  let abortDelivered = false;
   let relaySequence = 0;
   const post = (/** @type {Record<string, any>} */ message) => port.postMessage({
     protocol: ACTOR_CHANNEL_PROTOCOL, channelId, ...message,
   });
+  // The client may send actor/abort and then close its port while settling its
+  // own timeout. Those are two transport observations of one cancellation, not
+  // permission to abort the same actor run twice. Retain the request made
+  // before commit so commit can deliver it once a run id exists.
+  const requestAbort = () => {
+    abortRequested = true;
+    if (!runId || abortDelivered) return;
+    abortDelivered = true;
+    abort(runId);
+  };
   const sendToSW = (/** @type {string} */ type, /** @type {object} */ payload) => new Promise((resolve, reject) => {
     if (!committed || completed) { reject(new Error('actor channel is not active')); return; }
     const requestId = `relay-${++relaySequence}`;
@@ -43,8 +54,7 @@ export const bindActorChannel = ({ port, channelId, run, abort, workerUrl }) => 
       return;
     }
     if (message.type === 'actor/abort') {
-      abortRequested = true;
-      if (runId) abort(runId);
+      requestAbort();
       if (!committed) {
         completed = true;
         job = null;
@@ -60,7 +70,7 @@ export const bindActorChannel = ({ port, channelId, run, abort, workerUrl }) => 
     }
     if (message.type !== 'actor/commit' || !job || committed) return;
     committed = true;
-    if (abortRequested && runId) abort(runId);
+    if (abortRequested) requestAbort();
     run(job, { workerUrl, sendToSW })
       .then((result) => {
         completed = true;
@@ -86,12 +96,12 @@ export const bindActorChannel = ({ port, channelId, run, abort, workerUrl }) => 
       });
   };
   port.onmessageerror = () => {
-    if (runId && committed && !completed) abort(runId);
+    if (committed && !completed) requestAbort();
     for (const pending of pendingRelays.values()) pending.reject(new Error('actor channel message error'));
     pendingRelays.clear();
   };
   port.addEventListener('close', () => {
-    if (runId && committed && !completed) abort(runId);
+    if (committed && !completed) requestAbort();
     for (const pending of pendingRelays.values()) pending.reject(new Error('actor channel closed'));
     pendingRelays.clear();
   }, { once: true });

--- a/extension/options/sections/providers.js
+++ b/extension/options/sections/providers.js
@@ -133,16 +133,15 @@ export const ProvidersSection = {
     } catch { /* a later revision/focus retries */ }
   },
 
-  // Quietly ping a keyless daemon (provider/test) and record reachability for
-  // the badge. The explicit Test button reuses provider/test too, but also
-  // surfaces the full message; this path only moves the badge.
+  // Quietly ping a keyless daemon without activating it. The explicit Test
+  // action can activate it and also surfaces the full message.
   /** @param {{ state: any, attrs: { send: Send } }} vnode @param {string} name */
   probeConnection(vnode, name) {
     const generation = (vnode.state.probeGeneration[name] ?? 0) + 1;
     vnode.state.probeGeneration[name] = generation;
     vnode.state.connStatus[name] = 'checking';
     m.redraw();
-    vnode.attrs.send({ type: 'provider/test', provider: name }).then((/** @type {any} */ r) => {
+    vnode.attrs.send({ type: 'provider/test', provider: name, activate: false }).then((/** @type {any} */ r) => {
       if (vnode.state.probeGeneration[name] !== generation) return;
       vnode.state.connStatus[name] = r?.ok ? 'connected'
         : r?.reachable && r?.error === 'no-models' ? 'no-models'

--- a/extension/sidepanel/components/onboarding-provider-step.js
+++ b/extension/sidepanel/components/onboarding-provider-step.js
@@ -74,7 +74,7 @@ export const ProviderStep = {
       for (const p of vnode.state.rows ?? []) {
         if (p.keyless && p.liveModels) {
           vnode.state.conn[p.name] = 'checking';
-          vnode.attrs.send({ type: 'provider/test', provider: p.name })
+          vnode.attrs.send({ type: 'provider/test', provider: p.name, activate: false })
             .then((t) => { vnode.state.conn[p.name] = t?.ok ? 'connected' : 'down'; m.redraw(); })
             .catch(() => { vnode.state.conn[p.name] = 'down'; m.redraw(); });
         }

--- a/extension/sidepanel/components/onboarding-provider-step.js
+++ b/extension/sidepanel/components/onboarding-provider-step.js
@@ -50,9 +50,24 @@ const DISPLAY_LABEL = Object.freeze({
  * @property {boolean} busy
  * @property {{ ok: boolean, text: string }|null} msg
  * @property {Record<string, 'checking'|'connected'|'down'>} conn
+ * @property {'checking'|'installed'|'empty'|'unsupported'} local
  */
 
 /** @typedef {{ state: ProviderStepState, attrs: { send: Send, onDone: () => void, busy?: boolean } }} ProviderStepVnode */
+
+/**
+ * Collapse a local-model/catalog reply into the three states this row can
+ * honestly show. Exported for test: the route answers with a capability
+ * refusal on hosts without an offscreen document (Firefox today), which is a
+ * different fact from "supported here, nothing downloaded yet".
+ * @param {{ ok?: boolean, models?: Array<{ available?: boolean, downloaded?: boolean }> }|null|undefined} reply
+ * @returns {'installed'|'empty'|'unsupported'}
+ */
+export const localPhase = (reply) => {
+  if (!reply?.ok) return 'unsupported';
+  const models = Array.isArray(reply.models) ? reply.models : [];
+  return models.some((entry) => entry?.available || entry?.downloaded) ? 'installed' : 'empty';
+};
 
 export const ProviderStep = {
   /** @param {ProviderStepVnode} vnode */
@@ -63,6 +78,7 @@ export const ProviderStep = {
     vnode.state.busy = false;
     vnode.state.msg = null;
     vnode.state.conn = {};
+    vnode.state.local = 'checking';
     vnode.attrs.send({ type: 'provider/status' }).then((r) => {
       // A resolved-but-not-ok reply must not strand the step on 'Loading…'
       // forever - the dispatcher turns route throws into { ok:false }, and
@@ -79,6 +95,17 @@ export const ProviderStep = {
             .catch(() => { vnode.state.conn[p.name] = 'down'; m.redraw(); });
         }
       }
+      // The on-device runner has no daemon to ping - its readiness is "are the
+      // weights already here", the same question the Settings card asks. why
+      // not liveModels: that flag means "this adapter can enumerate a remote
+      // inventory", which is an Ollama concept the runner will never satisfy,
+      // so keying usability off it marked a shipped engine permanently
+      // unusable on the first screen a new user sees.
+      if ((vnode.state.rows ?? []).some((p) => p.name === 'local-webgpu')) {
+        vnode.attrs.send({ type: 'local-model/catalog' })
+          .then((c) => { vnode.state.local = localPhase(c); m.redraw(); })
+          .catch(() => { vnode.state.local = 'unsupported'; m.redraw(); });
+      } else vnode.state.local = 'unsupported';
       m.redraw();
     }).catch(() => { vnode.state.rows = []; m.redraw(); });
   },
@@ -89,7 +116,9 @@ export const ProviderStep = {
     const ui = vnode.state;
     const rows = ui.rows;
     /** @param {ProviderRow} p */
-    const usable = (p) => !(p.keyless && !p.liveModels);
+    const usable = (p) => (p.name === 'local-webgpu'
+      ? ui.local === 'installed'
+      : !(p.keyless && !p.liveModels));
     const selectedRow = rows?.find((p) => p.name === ui.selected) ?? null;
     const needsKey = !!selectedRow && !selectedRow.keyless;
 
@@ -158,6 +187,13 @@ export const ProviderStep = {
 
     /** @param {ProviderRow} p */
     const chip = (p) => {
+      if (p.name === 'local-webgpu') {
+        if (ui.local === 'checking') return m('span.onb-provider-chip', 'CHECKING…');
+        if (ui.local === 'unsupported') return m('span.onb-provider-chip', 'NOT AVAILABLE HERE');
+        return ui.local === 'installed'
+          ? m('span.onb-provider-chip.is-reached', [m('span.onb-provider-dot', { 'aria-hidden': 'true' }), 'ON DEVICE'])
+          : m('span.onb-provider-chip', 'NOT DOWNLOADED');
+      }
       if (p.keyless && !p.liveModels) return m('span.onb-provider-chip', 'NOT YET USABLE');
       if (p.keyless) {
         return ui.conn[p.name] === 'connected'

--- a/extension/tests/unit/options/provider-races.test.js
+++ b/extension/tests/unit/options/provider-races.test.js
@@ -88,7 +88,7 @@ describe('provider settings request ordering', () => {
       capabilities: { localWebGpuHost: { status: 'unsupported' } },
     };
     const probe = deferred();
-    const send = async (/** @type {{ type: string }} */ msg) => {
+    const send = async (/** @type {{ type: string, activate?: boolean }} */ msg) => {
       if (msg.type === 'provider/status') return {
         ok: true,
         providers: [{
@@ -96,7 +96,7 @@ describe('provider settings request ordering', () => {
           hasKey: true, keyless: true, liveModels: true,
         }],
       };
-      if (msg.type === 'provider/test') return probe.promise;
+      if (msg.type === 'provider/test') { expect(msg.activate).toBe(false); return probe.promise; }
       if (msg.type === 'models/options') return { ok: true, options: [] };
       return { ok: false };
     };

--- a/extension/tests/unit/sidepanel/onboarding-provider-step.test.js
+++ b/extension/tests/unit/sidepanel/onboarding-provider-step.test.js
@@ -18,9 +18,15 @@ const ROWS = [
 ];
 
 /**
- * @param {{ testOk?: boolean, ollamaOk?: boolean, settingsOk?: boolean }} [opts]
+ * `local` models the on-device runner's REAL readiness, which is residency and
+ * not the liveModels flag: 'installed' = weights here, 'empty' = supported host
+ * with nothing downloaded, 'unsupported' = no host to run the engine at all.
+ * @param {{ testOk?: boolean, ollamaOk?: boolean, settingsOk?: boolean,
+ *   local?: 'installed'|'empty'|'unsupported' }} [opts]
  */
-const makeHarness = ({ testOk = true, ollamaOk = false, settingsOk = true } = {}) => {
+const makeHarness = ({
+  testOk = true, ollamaOk = false, settingsOk = true, local = 'empty',
+} = {}) => {
   /** @type {Msg[]} */
   const sends = [];
   let doneCount = 0;
@@ -34,6 +40,10 @@ const makeHarness = ({ testOk = true, ollamaOk = false, settingsOk = true } = {}
     }
     if (msg.type === 'settings/update') {
       return settingsOk ? { ok: true } : { ok: false, error: 'settings-unavailable' };
+    }
+    if (msg.type === 'local-model/catalog') {
+      if (local === 'unsupported') return { ok: false, error: 'runtime_capability_unavailable' };
+      return { ok: true, models: [{ id: 'muse-glimmer-30b', available: local === 'installed' }] };
     }
     return { ok: true };
   };
@@ -64,18 +74,47 @@ const typeKey = (root, value) => {
 };
 
 describe('sidepanel.onboarding provider step (§5h)', () => {
-  it('renders the six-row shape: chips, an unusable on-device row, key input for the keyed lead', async () => {
+  it('renders the row shape, an undownloaded on-device row, key input for the keyed lead', async () => {
     const h = makeHarness();
     try {
-      await tick();
+      await tick(); await tick();
       m.redraw.sync();
       const rowEls = h.root.querySelectorAll('.onb-provider-row');
       expect(rowEls.length).toBe(3);
-      expect(need(h.root, '.onb-provider-row.is-unusable').textContent).toContain('NOT YET USABLE');
+      expect(need(h.root, '.onb-provider-row.is-unusable').textContent).toContain('NOT DOWNLOADED');
       // Anthropic leads selected → the key input renders with its prefix hint.
       const input = /** @type {HTMLInputElement} */ (need(h.root, '#onb-key'));
       expect(input.getAttribute('placeholder')).toBe('sk-ant-...');
       expect(input.type).toBe('password');
+    } finally { h.unmount(); }
+  });
+
+  it('the on-device runner is selectable once its weights are resident', async () => {
+    // The regression this replaces: usability came from liveModels, which the
+    // runner has no way to satisfy, so a shipped engine read NOT YET USABLE
+    // even with a model downloaded.
+    const ready = makeHarness({ local: 'installed' });
+    try {
+      await tick(); await tick();
+      m.redraw.sync();
+      const row = [...ready.root.querySelectorAll('.onb-provider-row')]
+        .find((r) => r.textContent?.includes('On-device runner'));
+      if (!(row instanceof HTMLButtonElement)) throw new Error('missing runner row');
+      expect(row.textContent).toContain('ON DEVICE');
+      expect(row.classList.contains('is-unusable')).toBe(false);
+      expect(row.disabled).toBe(false);
+    } finally { ready.unmount(); }
+  });
+
+  it('a host that cannot run the engine says so, not "not downloaded"', async () => {
+    // Different facts: nothing downloaded yet vs. nowhere to run it.
+    const h = makeHarness({ local: 'unsupported' });
+    try {
+      await tick(); await tick();
+      m.redraw.sync();
+      const row = need(h.root, '.onb-provider-row.is-unusable');
+      expect(row.textContent).toContain('NOT AVAILABLE HERE');
+      expect((row.textContent ?? '').includes('NOT DOWNLOADED')).toBe(false);
     } finally { h.unmount(); }
   });
 
@@ -104,8 +143,14 @@ describe('sidepanel.onboarding provider step (§5h)', () => {
       need(h.root, '.onboarding-actions button').click();
       await tick(); await tick(); await tick(); await tick();
       m.redraw.sync();
-      const order = h.sends.filter((s) => s.type !== 'provider/status').map((s) => s.type);
-      expect(order).toEqual(['provider/test', 'provider/setKey', 'provider/test', 'settings/update']);
+      // Mount-time probes (status, the daemon survey, the residency read) are
+      // not part of the save sequence under test.
+      const MOUNT_PROBES = ['provider/status', 'local-model/catalog'];
+      const order = h.sends
+        .filter((s) => !MOUNT_PROBES.includes(s.type))
+        .filter((s) => !(s.type === 'provider/test' && s.activate === false))
+        .map((s) => s.type);
+      expect(order).toEqual(['provider/setKey', 'provider/test', 'settings/update']);
       expect(h.sends.find((s) => s.type === 'provider/setKey')?.activate).toBe(false);
       expect(h.sends.find((s) => s.type === 'settings/update')?.patch?.providerName).toBe('anthropic');
       // The plaintext left component state with the save.

--- a/scripts/cdp/states.mjs
+++ b/scripts/cdp/states.mjs
@@ -2791,7 +2791,11 @@ export const STATES = [
             ? { ok: true, providers }
             : message.type === 'provider/test' && message.provider === 'ollama'
               ? { ok: true, reachable: true, models: 2 }
-              : { ok: true };
+              : message.type === 'local-model/catalog'
+                // A resident on-device model: the runner shipped, so the front
+                // door must be able to show it as selectable.
+                ? { ok: true, models: [{ id: 'muse-glimmer-30b', available: true }] }
+                : { ok: true };
           m.mount(host, { view: () => m('.onboarding-view', m('.card.onboarding-card', [
             m(ProviderStep, { send, onDone: () => {} }),
             m('.onb-dots', { 'aria-label': 'Step 1 of 4' }, [0, 1, 2, 3].map((i) =>
@@ -2821,6 +2825,69 @@ export const STATES = [
       } finally {
         await evalIn(ctx.page, `(async () => {
           const host = document.querySelector('#e2e-onboarding-provider');
+          if (!host) return;
+          const m = (await import('/vendor/mithril/mithril.js')).default;
+          m.mount(host, null);
+          host.remove();
+        })()`, true);
+      }
+    },
+  },
+
+  // --- visual: the runner row when the weights are NOT here yet --------------
+  // The common first run: the engine is supported, nothing is downloaded. The
+  // row has to separate that from "this browser cannot run it at all", which
+  // is why it is a state and not just a unit assertion on the phase helper.
+  {
+    name: 'onboarding-provider-local-empty', kind: 'visual', phase: 'pre-unlock',
+    responder: null,
+    async run(ctx, rec) {
+      try {
+        await evalIn(ctx.page, `(async () => {
+          const m = (await import('/vendor/mithril/mithril.js')).default;
+          const { ProviderStep } = await import('/sidepanel/components/onboarding-provider-step.js');
+          const host = document.createElement('div');
+          host.id = 'e2e-onboarding-local-empty';
+          host.style.cssText = 'position:fixed;inset:0;z-index:999;background:var(--bg);padding:14px;overflow:auto;';
+          document.body.appendChild(host);
+          const providers = [
+            { name: 'ollama', label: 'Ollama', keyless: true, liveModels: true },
+            { name: 'local-webgpu', label: 'Local WebGPU', keyless: true, liveModels: false },
+          ];
+          const send = async (message) => message.type === 'provider/status'
+            ? { ok: true, providers }
+            : message.type === 'provider/test'
+              ? { ok: false, error: 'unreachable' }
+              : message.type === 'local-model/catalog'
+                ? { ok: true, models: [{ id: 'muse-glimmer-30b', available: false, downloaded: false }] }
+                : { ok: true };
+          m.mount(host, { view: () => m('.onboarding-view', m('.card.onboarding-card',
+            m(ProviderStep, { send, onDone: () => {} }))) });
+        })()`, true);
+        const rendered = await waitFor(() => evalIn(ctx.page, `(() => {
+          const rows = [...document.querySelectorAll('#e2e-onboarding-local-empty .onb-provider-row')];
+          if (rows.length === 0) return null;
+          const runner = rows.find((r) => r.textContent.includes('On-device runner'));
+          if (!runner || runner.querySelector('.onb-provider-chip')?.textContent === 'CHECKING\u2026') return null;
+          return {
+            rows: rows.length,
+            runnerChip: runner.querySelector('.onb-provider-chip')?.textContent,
+            runnerDisabled: runner.disabled,
+            daemonChip: rows.find((r) => r.textContent.includes('Ollama'))
+              ?.querySelector('.onb-provider-chip')?.textContent,
+          };
+        })()`), { budgetMs: 5_000, pollMs: 50 });
+        rec.check('an undownloaded runner says so, and stays unselectable',
+          rendered?.rows === 2
+            && rendered?.runnerChip === 'NOT DOWNLOADED'
+            && rendered?.runnerDisabled === true
+            // The unreachable daemon must NOT borrow the runner's wording.
+            && rendered?.daemonChip === 'NO KEY NEEDED',
+          JSON.stringify(rendered));
+        await rec.visual('onboarding-provider-local-empty');
+      } finally {
+        await evalIn(ctx.page, `(async () => {
+          const host = document.querySelector('#e2e-onboarding-local-empty');
           if (!host) return;
           const m = (await import('/vendor/mithril/mithril.js')).default;
           m.mount(host, null);

--- a/tests/background/provider-readiness.test.ts
+++ b/tests/background/provider-readiness.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { resolveComposerReadiness } from '../../extension/background/provider-readiness.js';
+import { pickUsableProvider, resolveComposerReadiness, resolveDisplayProvider } from '../../extension/background/provider-readiness.js';
 import { composerUnavailableCopy } from '../../extension/sidepanel/provider-readiness.js';
 
 const providers = [
@@ -93,5 +93,101 @@ describe('composer provider readiness', () => {
       .toBe('Vault is locked. Unlock it to send.');
     expect(composerUnavailableCopy(composer))
       .toBe('Vault is locked. Unlock it to start chatting.');
+  });
+});
+
+// The provider SELECTION seam (issue #384). resolveComposerReadiness above is
+// always handed a provider, so nothing here used to exercise which provider the
+// projection picks - the half where an Ollama-only install deadlocked.
+const selectable = [
+  { name: 'anthropic', vaultSecretName: 'provider/anthropic' },
+  { name: 'openai', vaultSecretName: 'provider/openai' },
+  { name: 'ollama', keyless: true, liveModels: true },
+  { name: 'local-webgpu', keyless: true },
+];
+
+const display = (opts: {
+  chosenName?: string, keys?: Record<string, string>,
+  localAvailable?: boolean, ollamaCount?: number | null,
+  hydrateLocal?: () => Promise<unknown>,
+} = {}) => resolveDisplayProvider({
+  providers: selectable,
+  chosenName: opts.chosenName ?? '',
+  getSecret: async (name) => opts.keys?.[name] ?? null,
+  localAvailable: () => opts.localAvailable ?? false,
+  liveModelCount: async () => (opts.ollamaCount === undefined ? null : opts.ollamaCount),
+  hydrateLocal: opts.hydrateLocal,
+});
+
+describe('active provider selection for the projection', () => {
+  test('an unchosen provider resolves to a reachable Ollama, not unkeyed Anthropic', async () => {
+    // The exact #384 report: Ollama connected with 7 models, no key anywhere.
+    expect(await display({ ollamaCount: 7 })).toBe('ollama');
+  });
+
+  test('an unchosen provider resolves to a resident local model with no daemon', async () => {
+    expect(await display({ ollamaCount: 0, localAvailable: true })).toBe('local-webgpu');
+  });
+
+  test('a keyless provider that is merely present is not usable', async () => {
+    // Presence is not readiness: no daemon models and no downloaded weights.
+    expect(await display({ ollamaCount: 0, localAvailable: false })).toBe('');
+    expect(await display({ ollamaCount: null, localAvailable: false })).toBe('');
+  });
+
+  test('a keyed provider still wins by registry order when it has a key', async () => {
+    expect(await display({ keys: { 'provider/anthropic': 'k' }, ollamaCount: 7 })).toBe('anthropic');
+    expect(await display({ keys: { 'provider/openai': 'k' }, ollamaCount: 7 })).toBe('openai');
+  });
+
+  test("an explicit choice is never second-guessed, so its own model survives", async () => {
+    // '' means "no override" - the caller reads settings, keeping providerModel.
+    expect(await display({ chosenName: 'openai', ollamaCount: 7 })).toBe('');
+  });
+
+  test('an unregistered stored provider is re-picked rather than honoured', async () => {
+    expect(await display({ chosenName: 'removed-adapter', ollamaCount: 7 })).toBe('ollama');
+  });
+
+  test('local availability is hydrated BEFORE it is read, only when unchosen', async () => {
+    let available = false;
+    let hydrated = 0;
+    const hydrateLocal = async () => { hydrated += 1; available = true; };
+    const resolved = await resolveDisplayProvider({
+      providers: selectable,
+      chosenName: '',
+      getSecret: async () => null,
+      localAvailable: () => available,
+      liveModelCount: async () => 0,
+      hydrateLocal,
+    });
+    expect(resolved).toBe('local-webgpu');
+    expect(hydrated).toBe(1);
+    // An explicit choice must not pay for the probe at all.
+    await display({ chosenName: 'ollama', hydrateLocal });
+    expect(hydrated).toBe(1);
+  });
+
+  test('a vault that throws leaves the provider unusable rather than selected', async () => {
+    expect(await resolveDisplayProvider({
+      providers: selectable,
+      chosenName: '',
+      getSecret: async () => { throw new Error('locked'); },
+      localAvailable: () => false,
+      liveModelCount: async () => 0,
+    })).toBe('');
+  });
+
+  test('the binder and the projection share one ordering rule', async () => {
+    // pickUsableProvider is what ensureActiveProvider persists from; if these
+    // two ever diverge, the composer gates on a provider the binder rejects.
+    const shared = await pickUsableProvider({
+      providers: selectable,
+      getSecret: async () => null,
+      localModelAvailable: false,
+      liveModelCount: async () => 7,
+    });
+    expect(shared).toBe('ollama');
+    expect(await display({ ollamaCount: 7 })).toBe(shared ?? '');
   });
 });

--- a/tests/background/routes-providers.test.ts
+++ b/tests/background/routes-providers.test.ts
@@ -194,3 +194,72 @@ describe('models/options + openrouter/models', () => {
     expect(await r['openrouter/models']()).toEqual({ ok: false, status: 401, error: 'invalid-key' });
   });
 });
+
+describe('keyless provider activation (issue #384)', () => {
+  const withSettings = (providerName: string, over: Record<string, any> = {}) => {
+    const settings = { providerName, providerModel: 'stale-model' };
+    const updates: any[] = [];
+    const deps = baseDeps({
+      settingsStore: {
+        get: () => settings,
+        update: async (patch: any) => { updates.push(patch); Object.assign(settings, patch); },
+      },
+      vault: { getSecret: async () => null, setSecret: async () => {} },
+      ...over,
+    });
+    return { routes: makeProviderRoutes(deps), updates, settings };
+  };
+
+  test('a validated daemon becomes active when nothing usable is selected', async () => {
+    // The reported flow: Ollama tested, 7 models, no key anywhere. Without this
+    // the empty default providerName survives and the composer stays gated.
+    const { routes, updates } = withSettings('');
+    expect(await routes['provider/test']({ provider: 'ollama' }))
+      .toEqual({ ok: true, reachable: true, models: 2 });
+    expect(updates).toEqual([{ providerName: 'ollama', providerModel: '' }]);
+  });
+
+  test('a working explicit selection is never overridden', async () => {
+    const { routes, updates } = withSettings('anthropic', {
+      vault: { getSecret: async () => 'sk-abc', setSecret: async () => {} },
+    });
+    await routes['provider/test']({ provider: 'ollama' });
+    expect(updates).toEqual([]);
+  });
+
+  test('an unusable selection yields the slot to the daemon that answered', async () => {
+    const { routes, updates } = withSettings('anthropic');
+    await routes['provider/test']({ provider: 'ollama' });
+    expect(updates).toEqual([{ providerName: 'ollama', providerModel: '' }]);
+  });
+
+  test('an unreachable or empty daemon activates nothing', async () => {
+    const unreachable = withSettings('', { liveProviderModels: async () => null });
+    expect(await unreachable.routes['provider/test']({ provider: 'ollama' }))
+      .toEqual({ ok: false, error: 'unreachable' });
+    expect(unreachable.updates).toEqual([]);
+
+    const empty = withSettings('', { liveProviderModels: async () => [] });
+    expect(await empty.routes['provider/test']({ provider: 'ollama' }))
+      .toEqual({ ok: false, reachable: true, error: 'no-models', models: 0 });
+    expect(empty.updates).toEqual([]);
+  });
+
+  test('activation lands before the state push the panel re-renders from', async () => {
+    // why: pushState is what re-runs the readiness projection. Pushing first
+    // would render the pre-adoption state and leave the composer gated until
+    // some later, unrelated push.
+    const order: string[] = [];
+    const settings = { providerName: '', providerModel: '' };
+    const routes = makeProviderRoutes(baseDeps({
+      settingsStore: {
+        get: () => settings,
+        update: async (patch: any) => { order.push('update'); Object.assign(settings, patch); },
+      },
+      vault: { getSecret: async () => null, setSecret: async () => {} },
+      pushState: () => order.push('push'),
+    }));
+    await routes['provider/test']({ provider: 'ollama' });
+    expect(order).toEqual(['update', 'push']);
+  });
+});

--- a/tests/background/routes-providers.test.ts
+++ b/tests/background/routes-providers.test.ts
@@ -245,6 +245,15 @@ describe('keyless provider activation (issue #384)', () => {
     expect(empty.updates).toEqual([]);
   });
 
+  test("onboarding's survey ping opts out, so no daemon activates itself", async () => {
+    // why: the provider step probes every reachable daemon on mount. Without
+    // the opt-out, merely OPENING the step would choose for the user.
+    const { routes, updates } = withSettings('');
+    expect(await routes['provider/test']({ provider: 'ollama', activate: false }))
+      .toEqual({ ok: true, reachable: true, models: 2 });
+    expect(updates).toEqual([]);
+  });
+
   test('activation lands before the state push the panel re-renders from', async () => {
     // why: pushState is what re-runs the readiness projection. Pushing first
     // would render the pre-adoption state and leave the composer gated until

--- a/tests/background/routes-providers.test.ts
+++ b/tests/background/routes-providers.test.ts
@@ -182,6 +182,26 @@ describe('provider/setKey', () => {
     expect(await r['provider/setKey']({ provider: 'anthropic', plaintext: 'sk-abcdefgh' })).toEqual({ ok: true });
     expect(updated).toBe(null);
   });
+  test('replaces an unreachable explicit Ollama selection with a configured key', async () => {
+    let updated: any = null;
+    const r = makeProviderRoutes(baseDeps({
+      liveProviderModels: async () => null,
+      vault: { setSecret: async () => {}, getSecret: async () => null },
+      settingsStore: { get: () => ({ providerName: 'ollama', providerModel: '' }), update: async (p: any) => { updated = p; } },
+    }));
+    expect(await r['provider/setKey']({ provider: 'anthropic', plaintext: 'sk-abcdefgh' })).toEqual({ ok: true });
+    expect(updated).toEqual({ providerName: 'anthropic', providerModel: '' });
+  });
+  test('replaces an explicit Ollama selection with no models with a configured key', async () => {
+    let updated: any = null;
+    const r = makeProviderRoutes(baseDeps({
+      liveProviderModels: async () => [],
+      vault: { setSecret: async () => {}, getSecret: async () => null },
+      settingsStore: { get: () => ({ providerName: 'ollama', providerModel: '' }), update: async (p: any) => { updated = p; } },
+    }));
+    expect(await r['provider/setKey']({ provider: 'anthropic', plaintext: 'sk-abcdefgh' })).toEqual({ ok: true });
+    expect(updated).toEqual({ providerName: 'anthropic', providerModel: '' });
+  });
 });
 
 describe('models/options + openrouter/models', () => {

--- a/tests/meta/settings-hydration-invariants.test.ts
+++ b/tests/meta/settings-hydration-invariants.test.ts
@@ -19,7 +19,13 @@ describe('settings hydration before UI state snapshots', () => {
     const snapshot = serviceWorker.slice(start, end);
     const hydration = snapshot.indexOf('await ensureSettingsReady();');
     const sessionRead = snapshot.indexOf("sessionCache.sessionGet('currentSessionId')");
-    const providerRead = snapshot.indexOf('const activeProv = resolveActiveProvider();');
+    // The snapshot must resolve the active provider through the READINESS-aware
+    // resolver. The bare resolveActiveProvider falls back to Anthropic whenever
+    // providerName is empty - the shipped default - which is the other half of
+    // issue #384: hydration alone cannot save a projection that never asks
+    // whether the provider it picked can serve a turn.
+    const providerRead = snapshot.indexOf('const activeProv = await resolveActiveProviderForDisplay();');
+    expect(snapshot).not.toContain('const activeProv = resolveActiveProvider();');
 
     expect(start).toBeGreaterThan(-1);
     expect(end).toBeGreaterThan(start);

--- a/tests/meta/sw-barrel-imports.test.ts
+++ b/tests/meta/sw-barrel-imports.test.ts
@@ -180,9 +180,15 @@ describe('service-worker ↔ peerd-runtime barrel link integrity', () => {
     // App-native semantic APIs are document-side adapters over the existing
     // authority verbs; they must not grow this graph. Privileged Git import is
     // one small repository bootstrap verb, not a worker-side UI controller.
+    //
+    // Reviewed for the #384 readiness-aware provider projection: the MODULE
+    // COUNT is unchanged, so no dependency was added - provider-readiness.js
+    // was already on the graph and absorbed the policy, which is why the entry
+    // grew by far less than the two byte budgets moved. Source-size growth in
+    // modules already present is what these two numbers track.
     expect(graph.size).toBeLessThanOrEqual(458);
-    expect(bytes).toBeLessThanOrEqual(4_705_000);
-    expect(statSync(entry).size).toBeLessThanOrEqual(460_000);
+    expect(bytes).toBeLessThanOrEqual(4_712_000);
+    expect(statSync(entry).size).toBeLessThanOrEqual(462_000);
   });
 
   test('the offscreen host uses its exact runtime and engine surfaces', async () => {

--- a/tests/sidepanel/onboarding-provider-readiness.test.ts
+++ b/tests/sidepanel/onboarding-provider-readiness.test.ts
@@ -1,0 +1,36 @@
+// The on-device runner's row on the provider front door. Its usability used to
+// be derived from `liveModels` - a flag meaning "this adapter can enumerate a
+// remote inventory" - which the runner will never satisfy, so a shipped engine
+// rendered permanently NOT YET USABLE on the first screen a new user sees.
+import { describe, expect, test } from 'bun:test';
+import { localPhase } from '../../extension/sidepanel/components/onboarding-provider-step.js';
+
+describe('on-device runner readiness on the provider step', () => {
+  test('a resident model reads as installed', () => {
+    expect(localPhase({ ok: true, models: [{ available: true }] })).toBe('installed');
+    // downloaded-but-not-loaded still counts: the weights are here.
+    expect(localPhase({ ok: true, models: [{ downloaded: true }] })).toBe('installed');
+    expect(localPhase({ ok: true, models: [{ available: false }, { downloaded: true }] })).toBe('installed');
+  });
+
+  test('a supported host with nothing downloaded is empty, not unsupported', () => {
+    // These are different facts and the row says different things for each.
+    expect(localPhase({ ok: true, models: [] })).toBe('empty');
+    expect(localPhase({ ok: true, models: [{ available: false, downloaded: false }] })).toBe('empty');
+  });
+
+  test("a host that cannot run the engine is unsupported", () => {
+    // The route answers with a capability refusal where there is no offscreen
+    // document to host the engine (Firefox today).
+    expect(localPhase({
+      ok: false, error: 'runtime_capability_unavailable', facility: 'localWebGpuHost',
+    } as never)).toBe('unsupported');
+    expect(localPhase(null)).toBe('unsupported');
+    expect(localPhase(undefined)).toBe('unsupported');
+  });
+
+  test('a malformed reply never reads as ready', () => {
+    expect(localPhase({ ok: true } as never)).toBe('empty');
+    expect(localPhase({ ok: true, models: 'nope' } as never)).toBe('empty');
+  });
+});


### PR DESCRIPTION
Closes #384.

## Problem

An Ollama-only setup could keep the composer gated on Anthropic. The default provider name was empty, and the display path selected a fallback without a readiness check.

## Changes

- Select a usable provider for new-chat display and session binding.
- Let an explicit Ollama test activate Ollama when the current provider is unusable.
- Keep automatic onboarding and Settings probes passive.
- Show the real Local WebGPU state during onboarding.
- Keep the provider choice and model choice paired.

## Verification

- Provider selection and activation tests pass.
- Chrome and Firefox browser tests pass.
- Side-panel E2E checks pass.
- Visual changes are limited to the intended onboarding provider states.
