### PR TITLE
fix(boundary): close the hyphen hole, and correct the context files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,9 +29,9 @@ Each maps to one letter and color in the brand wordmark:
 
 | Letter | Color | Module | Role |
 |---|---|---|---|
-| `p` | cyan    | `peerd-provider/`     | Model adapters (Anthropic, OpenRouter, OpenAI, Z.ai GLM keyed; Ollama and the on-device WebGPU runner keyless — `registry.js` is the live list) |
+| `p` | cyan    | `peerd-provider/`     | Model adapters (Anthropic, OpenRouter, OpenAI, Z.ai GLM keyed; Ollama and the on-device WebGPU runner keyless - `registry.js` is the live list) |
 | `e` | red     | `peerd-egress/`       | Security: vault, allowlist (`safeFetch`), denylist, audit |
-| `e` | amber   | `peerd-engine/`       | Execution instances — Sandboxes. FOUR kinds run in their own visible tab: WebVMs (CheerpX Linux), Notebooks (sealed JS worker + OPFS), Pods, Apps (opaque-origin iframe). A fifth, the **headless worker** (`script`), runs the Notebook's sealed worker offscreen with no tab — the agent's own quick compute, and the only kind with no registry because it persists no instances. Also here: browser-native Git (`repository/`, exported from `index.js`). The sandbox is the isolate; a tab is one way to host it (taxonomy in `registry-factory.js`). |
+| `e` | amber   | `peerd-engine/`       | Execution instances - Sandboxes. FOUR kinds run in their own visible tab: WebVMs (CheerpX Linux), Notebooks (sealed JS worker + OPFS), Pods, Apps (opaque-origin iframe). A fifth, the **headless worker** (`script`), runs the Notebook's sealed worker offscreen with no tab - the agent's own quick compute, and the only kind with no registry because it persists no instances. Also here: browser-native Git (`repository/`, exported from `index.js`). The sandbox is the isolate; a tab is one way to host it (taxonomy in `registry-factory.js`). |
 | `r` | green   | `peerd-runtime/`      | Agent loop, tools + per-environment actors (`message_actor`), sessions, profiles, skills, memory, permissions (Plan/Act), review, goal mode (autonomous loop), composer, cost, transfer, voice, clock, web tool policy |
 | `d` | magenta | `peerd-distributed/` | The dweb. An always-on P2P base network (offscreen mesh + DHT + gossip), did:key identity, signed content addressing, the dwapp bridge, and a peer-to-peer app store that **users AND the agent** build, share, and run dwapps on. Chrome preview only until Firefox has a mesh host. |
 
@@ -39,10 +39,10 @@ The extension *chassis* lives outside these modules: `background/`,
 `offscreen/`, `sidepanel/`, `home/`, `options/`, `engine-tabs/`,
 `permissions/`, `eval/`, `shared/`, `tests/`, `vendor/`, `icons/`. Each
 tab-hosted `peerd-engine` execution kind owns a dedicated page under
-`engine-tabs/` (`vm-tab/`, `notebook-tab/`, `pod-tab/`, `app-tab/`) — grouped so the
+`engine-tabs/` (`vm-tab/`, `notebook-tab/`, `pod-tab/`, `app-tab/`) - grouped so the
 four engine host surfaces sit together; `permissions/` hosts user-gesture surfaces such as
 the mic-permission grant page; `eval/` is the live end-to-end eval
-harness. (There is no `content/` directory — DOM work happens via
+harness. (There is no `content/` directory - DOM work happens via
 injected functions, not a persistent content script.) Outside
 `extension/`, the repo also carries `signaling-node/` (the dweb
 rendezvous server shells sharing the pure signaling reducer). The
@@ -265,15 +265,15 @@ exists today:
    Everything depends on this; build it first.
 3. **`peerd-provider`** — Anthropic + OpenRouter adapters. Schema
    conversions, streaming, error handling.
-4. **`peerd-engine`** — Sandboxes: five execution kinds (taxonomy in
-   `registry-factory.js`). Four are hosted in their own visible tab —
+4. **`peerd-engine`** - Sandboxes: five execution kinds (taxonomy in
+   `registry-factory.js`). Four are hosted in their own visible tab -
    WebVM (CheerpX), Notebook (sealed JS worker + OPFS), Pod, App
-   (opaque-origin iframe) — each with a registry in `peerd-engine`, a
+   (opaque-origin iframe) - each with a registry in `peerd-engine`, a
    runtime in its tab page under `engine-tabs/` (`vm-tab/`,
    `notebook-tab/`, `pod-tab/`, `app-tab/`), and a tab tracker + RPC
    client in `background/`. The fifth, the **headless worker** (`script`),
    runs the Notebook's sealed worker in the offscreen document with no tab
-   (`offscreen/job-runner.js`) — the agent's own quick compute, same
+   (`offscreen/job-runner.js`) - the agent's own quick compute, same
    substrate as a Notebook, different host.
 5. **`peerd-runtime`** — agent loop, tool dispatcher, and the tool
    inventory. Registered tools are assembled from `BUILTIN_TOOLS`, clock,
@@ -380,10 +380,10 @@ gotchas to know going in:
 - Voice — local transcription via Moonshine (WASM, SRI-pinned model
   download, OPFS-cached) with a Web Speech API fallback. Hosted in the
   offscreen doc (`peerd-runtime/voice/`).
-- Sandboxes — five execution kinds (taxonomy in the `peerd-engine/` code).
+- Sandboxes - five execution kinds (taxonomy in the `peerd-engine/` code).
   Four run in their
-  own browser tab — WebVM (CheerpX), Notebook (sealed JS worker + OPFS),
-  Pod, App (opaque-origin iframe) — each with its own registry + tab
+  own browser tab - WebVM (CheerpX), Notebook (sealed JS worker + OPFS),
+  Pod, App (opaque-origin iframe) - each with its own registry + tab
   tracker + RPC client. The fifth, the headless worker (`script`), is the
   same sealed worker run offscreen with no tab, for the agent's own quick
   compute (code mode).
@@ -422,7 +422,7 @@ gotchas to know going in:
   dwapp bridge (it builds p2p dwapps that users and agents both use).
   Chrome-preview only until Firefox has a mesh host. Other artifacts prune the
   module and CI verifies the package boundary. See the `peerd-distributed/` code.
-- The **dweb actor** — one more bound-actor kind (`actorType:'dweb'`; the live
+- The **dweb actor** - one more bound-actor kind (`actorType:'dweb'`; the live
   set is `ACTOR_CAPABILITY_MANIFESTS`, not a number to memorize) and the
   first DAEMON actor: an opt-in (`dwebAgentEnabled`, Chrome-preview-only, default
   off), persistent, GLOBAL singleton addressable as `message_actor("dweb",…)`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,18 +29,18 @@ Each maps to one letter and color in the brand wordmark:
 
 | Letter | Color | Module | Role |
 |---|---|---|---|
-| `p` | cyan    | `peerd-provider/`     | Model adapters (Anthropic, OpenRouter, OpenAI, Z.ai GLM, and keyless Ollama shipped; local WebGPU gated on the resident engine — `registry.js` is the live list) |
+| `p` | cyan    | `peerd-provider/`     | Model adapters (Anthropic, OpenRouter, OpenAI, Z.ai GLM keyed; Ollama and the on-device WebGPU runner keyless — `registry.js` is the live list) |
 | `e` | red     | `peerd-egress/`       | Security: vault, allowlist (`safeFetch`), denylist, audit |
-| `e` | amber   | `peerd-engine/`       | Execution instances — Sandboxes. Three kinds run in their own visible tab: WebVMs (CheerpX Linux), Notebooks (sealed JS worker + OPFS), Apps (opaque-origin iframe). A fourth, the **headless worker** (`script`), runs the Notebook's sealed worker offscreen with no tab — the agent's own quick compute. The sandbox is the isolate; a tab is one way to host it (taxonomy in the `peerd-engine/` code). |
+| `e` | amber   | `peerd-engine/`       | Execution instances — Sandboxes. FOUR kinds run in their own visible tab: WebVMs (CheerpX Linux), Notebooks (sealed JS worker + OPFS), Pods, Apps (opaque-origin iframe). A fifth, the **headless worker** (`script`), runs the Notebook's sealed worker offscreen with no tab — the agent's own quick compute, and the only kind with no registry because it persists no instances. Also here: browser-native Git (`repository/`, exported from `index.js`). The sandbox is the isolate; a tab is one way to host it (taxonomy in `registry-factory.js`). |
 | `r` | green   | `peerd-runtime/`      | Agent loop, tools + per-environment actors (`message_actor`), sessions, profiles, skills, memory, permissions (Plan/Act), review, goal mode (autonomous loop), composer, cost, transfer, voice, clock, web tool policy |
 | `d` | magenta | `peerd-distributed/` | The dweb. An always-on P2P base network (offscreen mesh + DHT + gossip), did:key identity, signed content addressing, the dwapp bridge, and a peer-to-peer app store that **users AND the agent** build, share, and run dwapps on. Chrome preview only until Firefox has a mesh host. |
 
 The extension *chassis* lives outside these modules: `background/`,
-`offscreen/`, `sidepanel/`, `engine-tabs/`, `permissions/`, `eval/`,
-`shared/`, `tests/`, `vendor/`, `icons/`. Each `peerd-engine` execution
-kind owns a dedicated tab page under `engine-tabs/` (`engine-tabs/vm-tab/`,
-`engine-tabs/notebook-tab/`, `engine-tabs/app-tab/`) — grouped so the
-three engine host surfaces sit together; `permissions/` hosts user-gesture surfaces such as
+`offscreen/`, `sidepanel/`, `home/`, `options/`, `engine-tabs/`,
+`permissions/`, `eval/`, `shared/`, `tests/`, `vendor/`, `icons/`. Each
+tab-hosted `peerd-engine` execution kind owns a dedicated page under
+`engine-tabs/` (`vm-tab/`, `notebook-tab/`, `pod-tab/`, `app-tab/`) — grouped so the
+four engine host surfaces sit together; `permissions/` hosts user-gesture surfaces such as
 the mic-permission grant page; `eval/` is the live end-to-end eval
 harness. (There is no `content/` directory — DOM work happens via
 injected functions, not a persistent content script.) Outside
@@ -51,8 +51,13 @@ vendors snapshots of the VM-demo runtime + the `peerd-distributed`
 transport. Release packaging generates auto-update feeds as release assets;
 the site repository downloads and deploys them.
 
-The brand IS the architecture. If you find yourself adding a sixth
-top-level peerd-* directory, stop and reconsider.
+The brand IS the architecture: the five letters are the five modules.
+There is one deliberate exception on disk - `peerd-voice-host/`, a lazily
+imported offscreen host - so the rule is not "count the directories" but
+"a new top-level peerd-* directory needs a reason the five letters cannot
+absorb". Stop and reconsider before adding one. Note the cross-module
+import gate matches on `peerd-[a-z-]+/`, hyphen included; a name that
+falls outside that pattern is a name outside the boundary.
 
 ---
 
@@ -260,13 +265,13 @@ exists today:
    Everything depends on this; build it first.
 3. **`peerd-provider`** — Anthropic + OpenRouter adapters. Schema
    conversions, streaming, error handling.
-4. **`peerd-engine`** — Sandboxes: four execution kinds (taxonomy in
-   the module code). Three are hosted in their own visible tab — WebVM
-   (CheerpX), Notebook (sealed JS worker + OPFS), App (opaque-origin
-   iframe) — each with a registry in `peerd-engine`, a runtime in its tab
-   page under `engine-tabs/` (`engine-tabs/vm-tab/`, `engine-tabs/notebook-tab/`,
-   `engine-tabs/app-tab/`), and a tab tracker + RPC
-   client in `background/`. The fourth, the **headless worker** (`script`),
+4. **`peerd-engine`** — Sandboxes: five execution kinds (taxonomy in
+   `registry-factory.js`). Four are hosted in their own visible tab —
+   WebVM (CheerpX), Notebook (sealed JS worker + OPFS), Pod, App
+   (opaque-origin iframe) — each with a registry in `peerd-engine`, a
+   runtime in its tab page under `engine-tabs/` (`vm-tab/`,
+   `notebook-tab/`, `pod-tab/`, `app-tab/`), and a tab tracker + RPC
+   client in `background/`. The fifth, the **headless worker** (`script`),
    runs the Notebook's sealed worker in the offscreen document with no tab
    (`offscreen/job-runner.js`) — the agent's own quick compute, same
    substrate as a Notebook, different host.
@@ -375,12 +380,12 @@ gotchas to know going in:
 - Voice — local transcription via Moonshine (WASM, SRI-pinned model
   download, OPFS-cached) with a Web Speech API fallback. Hosted in the
   offscreen doc (`peerd-runtime/voice/`).
-- Sandboxes — four execution kinds (taxonomy in the `peerd-engine/` code).
-  Three run in their
+- Sandboxes — five execution kinds (taxonomy in the `peerd-engine/` code).
+  Four run in their
   own browser tab — WebVM (CheerpX), Notebook (sealed JS worker + OPFS),
-  App (opaque-origin iframe) — each with its own registry + tab tracker +
-  RPC client. The fourth, the headless worker (`script`), is the same
-  sealed worker run offscreen with no tab, for the agent's own quick
+  Pod, App (opaque-origin iframe) — each with its own registry + tab
+  tracker + RPC client. The fifth, the headless worker (`script`), is the
+  same sealed worker run offscreen with no tab, for the agent's own quick
   compute (code mode).
 - Policy-gated dispatcher with full lineage attached to every tool
   result. The live stack is defined in `gates.js` plus the default
@@ -417,7 +422,8 @@ gotchas to know going in:
   dwapp bridge (it builds p2p dwapps that users and agents both use).
   Chrome-preview only until Firefox has a mesh host. Other artifacts prune the
   module and CI verifies the package boundary. See the `peerd-distributed/` code.
-- The **dweb actor** — a fifth bound-actor kind (`actorType:'dweb'`) and the
+- The **dweb actor** — one more bound-actor kind (`actorType:'dweb'`; the live
+  set is `ACTOR_CAPABILITY_MANIFESTS`, not a number to memorize) and the
   first DAEMON actor: an opt-in (`dwebAgentEnabled`, Chrome-preview-only, default
   off), persistent, GLOBAL singleton addressable as `message_actor("dweb",…)`.
   It ABSORBS the dweb tools (they leave the orchestrator unconditionally —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,18 +29,18 @@ Each maps to one letter and color in the brand wordmark:
 
 | Letter | Color | Module | Role |
 |---|---|---|---|
-| `p` | cyan    | `peerd-provider/`     | Model adapters (Anthropic, OpenRouter, OpenAI, Z.ai GLM, and keyless Ollama shipped; local WebGPU gated on the resident engine — `registry.js` is the live list) |
+| `p` | cyan    | `peerd-provider/`     | Model adapters (Anthropic, OpenRouter, OpenAI, Z.ai GLM keyed; Ollama and the on-device WebGPU runner keyless — `registry.js` is the live list) |
 | `e` | red     | `peerd-egress/`       | Security: vault, allowlist (`safeFetch`), denylist, audit |
-| `e` | amber   | `peerd-engine/`       | Execution instances — Sandboxes. Three kinds run in their own visible tab: WebVMs (CheerpX Linux), Notebooks (sealed JS worker + OPFS), Apps (opaque-origin iframe). A fourth, the **headless worker** (`script`), runs the Notebook's sealed worker offscreen with no tab — the agent's own quick compute. The sandbox is the isolate; a tab is one way to host it (taxonomy in the `peerd-engine/` code). |
+| `e` | amber   | `peerd-engine/`       | Execution instances — Sandboxes. FOUR kinds run in their own visible tab: WebVMs (CheerpX Linux), Notebooks (sealed JS worker + OPFS), Pods, Apps (opaque-origin iframe). A fifth, the **headless worker** (`script`), runs the Notebook's sealed worker offscreen with no tab — the agent's own quick compute, and the only kind with no registry because it persists no instances. Also here: browser-native Git (`repository/`, exported from `index.js`). The sandbox is the isolate; a tab is one way to host it (taxonomy in `registry-factory.js`). |
 | `r` | green   | `peerd-runtime/`      | Agent loop, tools + per-environment actors (`message_actor`), sessions, profiles, skills, memory, permissions (Plan/Act), review, goal mode (autonomous loop), composer, cost, transfer, voice, clock, web tool policy |
 | `d` | magenta | `peerd-distributed/` | The dweb. An always-on P2P base network (offscreen mesh + DHT + gossip), did:key identity, signed content addressing, the dwapp bridge, and a peer-to-peer app store that **users AND the agent** build, share, and run dwapps on. Chrome preview only until Firefox has a mesh host. |
 
 The extension *chassis* lives outside these modules: `background/`,
-`offscreen/`, `sidepanel/`, `engine-tabs/`, `permissions/`, `eval/`,
-`shared/`, `tests/`, `vendor/`, `icons/`. Each `peerd-engine` execution
-kind owns a dedicated tab page under `engine-tabs/` (`engine-tabs/vm-tab/`,
-`engine-tabs/notebook-tab/`, `engine-tabs/app-tab/`) — grouped so the
-three engine host surfaces sit together; `permissions/` hosts user-gesture surfaces such as
+`offscreen/`, `sidepanel/`, `home/`, `options/`, `engine-tabs/`,
+`permissions/`, `eval/`, `shared/`, `tests/`, `vendor/`, `icons/`. Each
+tab-hosted `peerd-engine` execution kind owns a dedicated page under
+`engine-tabs/` (`vm-tab/`, `notebook-tab/`, `pod-tab/`, `app-tab/`) — grouped so the
+four engine host surfaces sit together; `permissions/` hosts user-gesture surfaces such as
 the mic-permission grant page; `eval/` is the live end-to-end eval
 harness. (There is no `content/` directory — DOM work happens via
 injected functions, not a persistent content script.) Outside
@@ -53,15 +53,21 @@ extension-side ceremony protocol and authenticator verification under
 and the `peerd-distributed` transport. Release packaging generates auto-update
 feeds as release assets; the site repository downloads and deploys them.
 
-The brand IS the architecture. If you find yourself adding a sixth
-top-level peerd-* directory, stop and reconsider.
+The brand IS the architecture: the five letters are the five modules.
+There is one deliberate exception on disk - `peerd-voice-host/`, a lazily
+imported offscreen host - so the rule is not "count the directories" but
+"a new top-level peerd-* directory needs a reason the five letters cannot
+absorb". Stop and reconsider before adding one. Note the cross-module
+import gate matches on `peerd-[a-z-]+/`, hyphen included; a name that
+falls outside that pattern is a name outside the boundary.
 
 ---
 
 ## What to read, in order
 
 The code is the spec. There is no separate design-doc corpus; the
-prose orientation is this file, and the rest is the source itself.
+prose orientation is this file, four architecture notes under `docs/`,
+and the rest is the source itself.
 
 1. **`CLAUDE.md`** (this file) — orientation. Start here every session.
 2. **The module code** — `extension/peerd-provider/`, `peerd-egress/`,
@@ -69,7 +75,12 @@ prose orientation is this file, and the rest is the source itself.
    module's `index.js` is its universal public surface; read it first, then the
    files it exports. An explicit environment entry point such as
    `background.js` may expose a cold-start-safe subset for that host.
-3. **The code.** For concrete behavior (vault crypto, denylist matcher,
+3. **`docs/`** — the few places a decision does NOT live in one module:
+   `EXTENSION-HOSTS.md` (normative: which host runs what, and why a
+   surface belongs there), `APP-ACTORS.md`, `DWAPP-BUNDLE.md`,
+   `BROWSER-COMPATIBILITY.md`, plus `docs/security/` and `docs/store/`.
+   Read `EXTENSION-HOSTS.md` before adding any new host surface.
+4. **The code.** For concrete behavior (vault crypto, denylist matcher,
    agent loop, tool dispatcher, prompt-injection defenses, the manifest,
    the MV3 keepalive trick), read the source in the relevant module. It
    is authoritative; prose drifts, code does not.
@@ -285,13 +296,13 @@ exists today:
    Everything depends on this; build it first.
 3. **`peerd-provider`** — Anthropic + OpenRouter adapters. Schema
    conversions, streaming, error handling.
-4. **`peerd-engine`** — Sandboxes: four execution kinds (taxonomy in
-   the module code). Three are hosted in their own visible tab — WebVM
-   (CheerpX), Notebook (sealed JS worker + OPFS), App (opaque-origin
-   iframe) — each with a registry in `peerd-engine`, a runtime in its tab
-   page under `engine-tabs/` (`engine-tabs/vm-tab/`, `engine-tabs/notebook-tab/`,
-   `engine-tabs/app-tab/`), and a tab tracker + RPC
-   client in `background/`. The fourth, the **headless worker** (`script`),
+4. **`peerd-engine`** — Sandboxes: five execution kinds (taxonomy in
+   `registry-factory.js`). Four are hosted in their own visible tab —
+   WebVM (CheerpX), Notebook (sealed JS worker + OPFS), Pod, App
+   (opaque-origin iframe) — each with a registry in `peerd-engine`, a
+   runtime in its tab page under `engine-tabs/` (`vm-tab/`,
+   `notebook-tab/`, `pod-tab/`, `app-tab/`), and a tab tracker + RPC
+   client in `background/`. The fifth, the **headless worker** (`script`),
    runs the Notebook's sealed worker in the offscreen document with no tab
    (`offscreen/job-runner.js`) — the agent's own quick compute, same
    substrate as a Notebook, different host.
@@ -400,12 +411,12 @@ gotchas to know going in:
 - Voice — local transcription via Moonshine (WASM, SRI-pinned model
   download, OPFS-cached) with a Web Speech API fallback. Hosted in the
   offscreen doc (`peerd-runtime/voice/`).
-- Sandboxes — four execution kinds (taxonomy in the `peerd-engine/` code).
-  Three run in their
+- Sandboxes — five execution kinds (taxonomy in the `peerd-engine/` code).
+  Four run in their
   own browser tab — WebVM (CheerpX), Notebook (sealed JS worker + OPFS),
-  App (opaque-origin iframe) — each with its own registry + tab tracker +
-  RPC client. The fourth, the headless worker (`script`), is the same
-  sealed worker run offscreen with no tab, for the agent's own quick
+  Pod, App (opaque-origin iframe) — each with its own registry + tab
+  tracker + RPC client. The fifth, the headless worker (`script`), is the
+  same sealed worker run offscreen with no tab, for the agent's own quick
   compute (code mode).
 - Policy-gated dispatcher with full lineage attached to every tool
   result. The live stack is defined in `gates.js` plus the default
@@ -463,8 +474,9 @@ gotchas to know going in:
   CONTENTS sync to a proven self device); permission grants, audit history,
   device keys, and live engine handles are excluded on both. Routine mesh
   signing still uses the root: the wire verifier must accept
-  certificate-backed identity everywhere first (03-device-subkeys.md).
-- The **dweb actor** — a fifth bound-actor kind (`actorType:'dweb'`) and the
+  certificate-backed identity everywhere first.
+- The **dweb actor** — one more bound-actor kind (`actorType:'dweb'`; the live
+  set is `ACTOR_CAPABILITY_MANIFESTS`, not a number to memorize) and the
   first DAEMON actor: an opt-in (`dwebAgentEnabled`, Chrome-preview-only, default
   off), persistent, GLOBAL singleton addressable as `message_actor("dweb",…)`.
   It ABSORBS the dweb tools (they leave the orchestrator unconditionally —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,9 +29,9 @@ Each maps to one letter and color in the brand wordmark:
 
 | Letter | Color | Module | Role |
 |---|---|---|---|
-| `p` | cyan    | `peerd-provider/`     | Model adapters (Anthropic, OpenRouter, OpenAI, Z.ai GLM keyed; Ollama and the on-device WebGPU runner keyless — `registry.js` is the live list) |
+| `p` | cyan    | `peerd-provider/`     | Model adapters (Anthropic, OpenRouter, OpenAI, Z.ai GLM keyed; Ollama and the on-device WebGPU runner keyless - `registry.js` is the live list) |
 | `e` | red     | `peerd-egress/`       | Security: vault, allowlist (`safeFetch`), denylist, audit |
-| `e` | amber   | `peerd-engine/`       | Execution instances — Sandboxes. FOUR kinds run in their own visible tab: WebVMs (CheerpX Linux), Notebooks (sealed JS worker + OPFS), Pods, Apps (opaque-origin iframe). A fifth, the **headless worker** (`script`), runs the Notebook's sealed worker offscreen with no tab — the agent's own quick compute, and the only kind with no registry because it persists no instances. Also here: browser-native Git (`repository/`, exported from `index.js`). The sandbox is the isolate; a tab is one way to host it (taxonomy in `registry-factory.js`). |
+| `e` | amber   | `peerd-engine/`       | Execution instances - Sandboxes. FOUR kinds run in their own visible tab: WebVMs (CheerpX Linux), Notebooks (sealed JS worker + OPFS), Pods, Apps (opaque-origin iframe). A fifth, the **headless worker** (`script`), runs the Notebook's sealed worker offscreen with no tab - the agent's own quick compute, and the only kind with no registry because it persists no instances. Also here: browser-native Git (`repository/`, exported from `index.js`). The sandbox is the isolate; a tab is one way to host it (taxonomy in `registry-factory.js`). |
 | `r` | green   | `peerd-runtime/`      | Agent loop, tools + per-environment actors (`message_actor`), sessions, profiles, skills, memory, permissions (Plan/Act), review, goal mode (autonomous loop), composer, cost, transfer, voice, clock, web tool policy |
 | `d` | magenta | `peerd-distributed/` | The dweb. An always-on P2P base network (offscreen mesh + DHT + gossip), did:key identity, signed content addressing, the dwapp bridge, and a peer-to-peer app store that **users AND the agent** build, share, and run dwapps on. Chrome preview only until Firefox has a mesh host. |
 
@@ -39,10 +39,10 @@ The extension *chassis* lives outside these modules: `background/`,
 `offscreen/`, `sidepanel/`, `home/`, `options/`, `engine-tabs/`,
 `permissions/`, `eval/`, `shared/`, `tests/`, `vendor/`, `icons/`. Each
 tab-hosted `peerd-engine` execution kind owns a dedicated page under
-`engine-tabs/` (`vm-tab/`, `notebook-tab/`, `pod-tab/`, `app-tab/`) — grouped so the
+`engine-tabs/` (`vm-tab/`, `notebook-tab/`, `pod-tab/`, `app-tab/`) - grouped so the
 four engine host surfaces sit together; `permissions/` hosts user-gesture surfaces such as
 the mic-permission grant page; `eval/` is the live end-to-end eval
-harness. (There is no `content/` directory — DOM work happens via
+harness. (There is no `content/` directory - DOM work happens via
 injected functions, not a persistent content script.) Outside
 `extension/`, the repo also carries `signaling-node/` (the dweb
 rendezvous server shells sharing the pure signaling reducer). The peerd.ai
@@ -66,8 +66,7 @@ falls outside that pattern is a name outside the boundary.
 ## What to read, in order
 
 The code is the spec. There is no separate design-doc corpus; the
-prose orientation is this file, four architecture notes under `docs/`,
-and the rest is the source itself.
+prose orientation is this file, and the rest is the source itself.
 
 1. **`CLAUDE.md`** (this file) — orientation. Start here every session.
 2. **The module code** — `extension/peerd-provider/`, `peerd-egress/`,
@@ -75,12 +74,7 @@ and the rest is the source itself.
    module's `index.js` is its universal public surface; read it first, then the
    files it exports. An explicit environment entry point such as
    `background.js` may expose a cold-start-safe subset for that host.
-3. **`docs/`** — the few places a decision does NOT live in one module:
-   `EXTENSION-HOSTS.md` (normative: which host runs what, and why a
-   surface belongs there), `APP-ACTORS.md`, `DWAPP-BUNDLE.md`,
-   `BROWSER-COMPATIBILITY.md`, plus `docs/security/` and `docs/store/`.
-   Read `EXTENSION-HOSTS.md` before adding any new host surface.
-4. **The code.** For concrete behavior (vault crypto, denylist matcher,
+3. **The code.** For concrete behavior (vault crypto, denylist matcher,
    agent loop, tool dispatcher, prompt-injection defenses, the manifest,
    the MV3 keepalive trick), read the source in the relevant module. It
    is authoritative; prose drifts, code does not.
@@ -296,15 +290,15 @@ exists today:
    Everything depends on this; build it first.
 3. **`peerd-provider`** — Anthropic + OpenRouter adapters. Schema
    conversions, streaming, error handling.
-4. **`peerd-engine`** — Sandboxes: five execution kinds (taxonomy in
-   `registry-factory.js`). Four are hosted in their own visible tab —
+4. **`peerd-engine`** - Sandboxes: five execution kinds (taxonomy in
+   `registry-factory.js`). Four are hosted in their own visible tab -
    WebVM (CheerpX), Notebook (sealed JS worker + OPFS), Pod, App
-   (opaque-origin iframe) — each with a registry in `peerd-engine`, a
+   (opaque-origin iframe) - each with a registry in `peerd-engine`, a
    runtime in its tab page under `engine-tabs/` (`vm-tab/`,
    `notebook-tab/`, `pod-tab/`, `app-tab/`), and a tab tracker + RPC
    client in `background/`. The fifth, the **headless worker** (`script`),
    runs the Notebook's sealed worker in the offscreen document with no tab
-   (`offscreen/job-runner.js`) — the agent's own quick compute, same
+   (`offscreen/job-runner.js`) - the agent's own quick compute, same
    substrate as a Notebook, different host.
 5. **`peerd-runtime`** — agent loop, tool dispatcher, and the tool
    inventory. Registered tools are assembled from `BUILTIN_TOOLS`, clock,
@@ -411,10 +405,10 @@ gotchas to know going in:
 - Voice — local transcription via Moonshine (WASM, SRI-pinned model
   download, OPFS-cached) with a Web Speech API fallback. Hosted in the
   offscreen doc (`peerd-runtime/voice/`).
-- Sandboxes — five execution kinds (taxonomy in the `peerd-engine/` code).
+- Sandboxes - five execution kinds (taxonomy in the `peerd-engine/` code).
   Four run in their
-  own browser tab — WebVM (CheerpX), Notebook (sealed JS worker + OPFS),
-  Pod, App (opaque-origin iframe) — each with its own registry + tab
+  own browser tab - WebVM (CheerpX), Notebook (sealed JS worker + OPFS),
+  Pod, App (opaque-origin iframe) - each with its own registry + tab
   tracker + RPC client. The fifth, the headless worker (`script`), is the
   same sealed worker run offscreen with no tab, for the agent's own quick
   compute (code mode).
@@ -475,7 +469,7 @@ gotchas to know going in:
   device keys, and live engine handles are excluded on both. Routine mesh
   signing still uses the root: the wire verifier must accept
   certificate-backed identity everywhere first.
-- The **dweb actor** — one more bound-actor kind (`actorType:'dweb'`; the live
+- The **dweb actor** - one more bound-actor kind (`actorType:'dweb'`; the live
   set is `ACTOR_CAPABILITY_MANIFESTS`, not a number to memorize) and the
   first DAEMON actor: an opt-in (`dwebAgentEnabled`, Chrome-preview-only, default
   off), persistent, GLOBAL singleton addressable as `message_actor("dweb",…)`.

--- a/badges/functional-tests.json
+++ b/badges/functional-tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "Functional Tests",
-  "message": "6411/6411 passing",
+  "message": "6419/6419 passing",
   "color": "brightgreen",
   "namedLogo": "bun",
   "logoColor": "white"

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,8 +42,11 @@ import globals from 'globals';
 // re-list every rule EXCEPT the eval one (a flat-config override REPLACES the
 // whole rule, so the patterns it keeps must be spelled out).
 const CROSS_MODULE_IMPORT = {
-  // any `peerd-<name>/<deeper>` path that isn't a declared public entry point
-  regex: '(^|/)peerd-[a-z]+/(?!index\\.js$|background\\.js$|offscreen\\.js$).+',
+  // any `peerd-<name>/<deeper>` path that isn't a declared public entry point.
+  // why the hyphen is in the class: `peerd-voice-host` is a real module and
+  // `[a-z]+` silently stopped matching at its first hyphen, leaving it outside
+  // the boundary this rule exists to enforce.
+  regex: '(^|/)peerd-[a-z-]+/(?!index\\.js$|background\\.js$|offscreen\\.js$).+',
   message: 'Cross-module imports must go through a declared /peerd-<name> public entry point.',
 };
 // The dweb module is stricter: NOTHING outside it may import it — not even its

--- a/packaging/check-doc-paths.ts
+++ b/packaging/check-doc-paths.ts
@@ -19,7 +19,12 @@ import { REPO_ROOT } from './lib.ts';
 // against the code it names. (Caught a real one: the roadmap cited
 // peerd-runtime/tools/provider-call-api.js, which lives under actor/.)
 export const CHECKED_DOCS = [
-  'README.md', 'CLAUDE.md', 'SECURITY.md', 'CONTRIBUTING.md',
+  // AGENTS.md is CLAUDE.md's twin for other harnesses. It was outside this
+  // gate, so its path claims could rot independently of the file everyone
+  // diffs - which is exactly how the two drifted apart.
+  'README.md', 'CLAUDE.md', 'AGENTS.md', 'SECURITY.md', 'CONTRIBUTING.md',
+  'docs/EXTENSION-HOSTS.md', 'docs/APP-ACTORS.md',
+  'docs/DWAPP-BUNDLE.md', 'docs/BROWSER-COMPATIBILITY.md',
   'docs/security/THREAT-MODEL.md',
   'docs/security/LIFECYCLE-CONTRACT.md',
   'docs/security/HARDENING-ROADMAP.md',

--- a/tests/meta/module-boundary-regex.test.ts
+++ b/tests/meta/module-boundary-regex.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { readdirSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { EXTENSION_DIR, REPO_ROOT } from '../../packaging/lib.ts';
+import { readdirSync } from 'node:fs';
+import { EXTENSION_DIR } from '../../packaging/lib.ts';
 
 /**
  * `no-restricted-imports` is what makes "index.js is the public API per module"
@@ -19,16 +18,28 @@ const moduleNames = (): string[] => readdirSync(EXTENSION_DIR, { withFileTypes: 
   .filter((entry) => entry.isDirectory() && entry.name.startsWith('peerd-'))
   .map((entry) => entry.name);
 
-const boundaryRegex = (): RegExp => {
-  const config = readFileSync(join(REPO_ROOT, 'eslint.config.js'), 'utf8');
-  const match = /regex:\s*'((?:[^'\\]|\\.)*)'/.exec(config);
-  if (!match) throw new Error('no cross-module import regex in eslint.config.js');
-  return new RegExp(JSON.parse(`"${match[1].replace(/"/g, '\\"')}"`));
+const boundaryRegex = async (): Promise<RegExp> => {
+  // Read the LIVE config object rather than scraping the source. The rule's
+  // pattern is a JS string full of backslashes, and un-escaping it by hand is
+  // both fragile and a genuine incomplete-sanitization bug - importing gives
+  // the exact value ESLint itself enforces.
+  const config = (await import('../../eslint.config.js')).default as Array<{
+    rules?: Record<string, unknown>;
+  }>;
+  for (const block of config) {
+    const rule = block.rules?.['no-restricted-imports'];
+    if (!Array.isArray(rule)) continue;
+    const options = rule[1] as { patterns?: Array<{ regex?: string }> } | undefined;
+    for (const pattern of options?.patterns ?? []) {
+      if (pattern.regex?.includes('peerd-')) return new RegExp(pattern.regex);
+    }
+  }
+  throw new Error('no cross-module import regex in eslint.config.js');
 };
 
 describe('cross-module import boundary', () => {
-  test('every peerd-* module on disk is inside the gate', () => {
-    const regex = boundaryRegex();
+  test('every peerd-* module on disk is inside the gate', async () => {
+    const regex = await boundaryRegex();
     const names = moduleNames();
     expect(names.length).toBeGreaterThan(0);
     for (const name of names) {
@@ -36,13 +47,13 @@ describe('cross-module import boundary', () => {
     }
   });
 
-  test('a hyphenated module name does not escape the gate', () => {
+  test('a hyphenated module name does not escape the gate', async () => {
     // The exact shape that was slipping through.
-    expect(boundaryRegex().test('/peerd-voice-host/internal/deep.js')).toBe(true);
+    expect((await boundaryRegex()).test('/peerd-voice-host/internal/deep.js')).toBe(true);
   });
 
-  test('the declared public entry points stay reachable', () => {
-    const regex = boundaryRegex();
+  test('the declared public entry points stay reachable', async () => {
+    const regex = await boundaryRegex();
     for (const name of moduleNames()) {
       for (const entry of ['index.js', 'background.js', 'offscreen.js']) {
         expect(regex.test(`/${name}/${entry}`)).toBe(false);

--- a/tests/meta/module-boundary-regex.test.ts
+++ b/tests/meta/module-boundary-regex.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { EXTENSION_DIR, REPO_ROOT } from '../../packaging/lib.ts';
+
+/**
+ * `no-restricted-imports` is what makes "index.js is the public API per module"
+ * an enforced rule rather than a convention, and it enforces it through ONE
+ * regex. That regex is the whole gate, and a character class is an easy place
+ * to be quietly wrong.
+ *
+ * why this test: the class was `[a-z]+`, which stops at the first hyphen - so
+ * `peerd-voice-host` sat outside the boundary entirely and a deep import into
+ * it would have linted clean. Nothing failed, because the module happens to
+ * contain only index.js today. This asserts the regex covers every module that
+ * actually exists, so adding a hyphenated one cannot reopen the hole.
+ */
+const moduleNames = (): string[] => readdirSync(EXTENSION_DIR, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory() && entry.name.startsWith('peerd-'))
+  .map((entry) => entry.name);
+
+const boundaryRegex = (): RegExp => {
+  const config = readFileSync(join(REPO_ROOT, 'eslint.config.js'), 'utf8');
+  const match = /regex:\s*'((?:[^'\\]|\\.)*)'/.exec(config);
+  if (!match) throw new Error('no cross-module import regex in eslint.config.js');
+  return new RegExp(JSON.parse(`"${match[1].replace(/"/g, '\\"')}"`));
+};
+
+describe('cross-module import boundary', () => {
+  test('every peerd-* module on disk is inside the gate', () => {
+    const regex = boundaryRegex();
+    const names = moduleNames();
+    expect(names.length).toBeGreaterThan(0);
+    for (const name of names) {
+      expect(regex.test(`/${name}/internal/deep.js`)).toBe(true);
+    }
+  });
+
+  test('a hyphenated module name does not escape the gate', () => {
+    // The exact shape that was slipping through.
+    expect(boundaryRegex().test('/peerd-voice-host/internal/deep.js')).toBe(true);
+  });
+
+  test('the declared public entry points stay reachable', () => {
+    const regex = boundaryRegex();
+    for (const name of moduleNames()) {
+      for (const entry of ['index.js', 'background.js', 'offscreen.js']) {
+        expect(regex.test(`/${name}/${entry}`)).toBe(false);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Two findings from auditing `CLAUDE.md` against the code. One is a real gate hole; the rest is drift in the file every session reads first.

## The gate hole

`no-restricted-imports` is what makes "`index.js` is the public API per module" **enforced** rather than conventional, and it does it through a single regex:

```
(^|/)peerd-[a-z]+/(?!index\.js$|background\.js$|offscreen\.js$).+
```

`[a-z]+` stops at the first hyphen, so **`peerd-voice-host` was outside the boundary entirely** - a deep import into it linted clean.

Latent, not exploited: that module contains only `index.js`, and its one external import (`offscreen/offscreen.js:177`) uses that entry. But the hole was real, and the next file added there would have been ungated.

Widened to `peerd-[a-z-]+/`. Revert-proofed - with the fix, `import '/peerd-voice-host/internal/secret.js'` is flagged; without it, silently allowed. The meta test asserts every `peerd-*` directory **on disk** is inside the gate, so this cannot reopen by adding a hyphenated module.

## The context files

Both `CLAUDE.md` and `AGENTS.md` described an engine that no longer exists. **Pod is a shipped execution kind and appeared in neither** - `pod` was literally zero occurrences. "Three kinds in a tab, a fourth headless" is really four in a tab plus the headless fifth (`registry-factory.js:2-4`), and `engine-tabs/` has four pages.

Also corrected:
- Browser-native Git (`peerd-engine/repository/`, exported from `index.js`) was missing entirely.
- The on-device WebGPU runner was still "gated on the resident engine"; it ships as a registered keyless adapter.
- `home/` and `options/` were absent from the chassis list.
- The dweb actor was "a fifth bound-actor kind" - the live set is `ACTOR_CAPABILITY_MANIFESTS` and is not a number worth memorizing.
- A dangling `03-device-subkeys.md` anchor survived the `docs/design` removal. It has no slash, so `check-doc-paths` structurally cannot see it.

The **"never add a sixth `peerd-*` directory"** rule was already false - `peerd-voice-host` is the sixth. It now states the exception and the actual test, and points at the import gate whose pattern defines the boundary.

Added `docs/` to the reading order: four architecture notes live there, `EXTENSION-HOSTS.md` normatively, and the orientation never mentioned them.

## Why AGENTS.md had every error independently

It was outside `check-doc-paths`' `CHECKED_DOCS`, so its path claims could rot without anyone noticing. It and the four `docs/` notes are now covered - the gate went from 8 documents to 13 and passes.

## Verification

Full gate set green: typecheck, lint, boundary, imports, tscheck, copy, hygiene, invariants, docpaths, zero `gen:dev` drift, `bun test ./tests` 6419/6419.

No runtime code changed - the only `extension/` effect is that a previously-unreachable lint rule now reaches one more module.