### PR TITLE
feat(options): put the settings row on Decentralized web and Memory

### DIFF
--- a/extension/options/components/settings-row.js
+++ b/extension/options/components/settings-row.js
@@ -117,3 +117,65 @@ export const settingsBand = ({ name, subtitle = null, safety = false, rows }) =>
   ]),
   m('.set-band-rows', rows),
 ]);
+
+/**
+ * The per-page controller for a set of rows: disclosure state plus the
+ * switch-row helper. Bind it once per view against the component's own state.
+ *
+ * why this is shared rather than re-typed per page: the helper below holds the
+ * busy-flag dance, and it was already copy-pasted eight times inside one page.
+ * The second page to want rows is exactly when that copy starts to drift - and
+ * the drift is not cosmetic. `memory.js` hand-rolled the same dance without a
+ * `finally`, so a rejected save left its switch spinning until remount.
+ *
+ * @param {Record<string, any>} ui  the calling component's vnode.state
+ */
+export const rowController = (ui) => {
+  // Which rationales are open. Per-row, remembered while the page is mounted
+  // and never persisted - a disclosure is a reading aid, not a preference.
+  if (!ui.why) ui.why = new Set();
+  /** @param {string} id */
+  const whyOpen = (id) => ui.why.has(id);
+  /** @param {string} id */
+  const toggleWhy = (id) => () => {
+    if (ui.why.has(id)) ui.why.delete(id); else ui.why.add(id);
+    m.redraw();
+  };
+
+  /**
+   * A row whose control is a switch.
+   * @param {{ id: string, label: string, on: boolean, busyKey: string,
+   *   summary: string, why?: string | null, apply: () => Promise<any>,
+   *   badge?: string | null, pill?: string | null, children?: any }} p
+   */
+  const toggleRow = ({
+    id, label, on, busyKey, summary, why = null, apply,
+    badge = null, pill = null, children = null,
+  }) => {
+    const busy = !!ui[busyKey];
+    return settingsRow({
+      id,
+      label,
+      pill: busy ? '\u2026' : pill ?? (on ? 'ON' : 'OFF'),
+      badge,
+      summary: busy ? 'Saving\u2026' : summary,
+      why,
+      open: whyOpen(id),
+      onToggleWhy: toggleWhy(id),
+      control: toggleSwitch({
+        on,
+        busy,
+        label: `${label} - ${on ? 'on' : 'off'}`,
+        onclick: async () => {
+          if (ui[busyKey]) return;
+          ui[busyKey] = true; m.redraw();
+          try { await apply(); } catch (e) { console.warn(`[options] ${id} toggle failed`, e); }
+          finally { ui[busyKey] = false; m.redraw(); }
+        },
+      }),
+      children,
+    });
+  };
+
+  return { whyOpen, toggleWhy, toggleRow };
+};

--- a/extension/options/sections/behavior.js
+++ b/extension/options/sections/behavior.js
@@ -19,7 +19,7 @@
 import m from '/vendor/mithril/mithril.js';
 import { listProviders } from '/peerd-provider/index.js';
 import { resetRow } from './reset-row.js';
-import { settingsRow, settingsBand, toggleSwitch } from '../components/settings-row.js';
+import { settingsRow, settingsBand, toggleSwitch, rowController } from '../components/settings-row.js';
 
 /** @typedef {import('./reset-row.js').Send} Send */
 
@@ -27,48 +27,7 @@ export const BehaviorSection = {
   /** @param {{ attrs: { state: any, send: Send }, state: any }} vnode */
   view: ({ attrs: { state, send }, state: ui }) => {
     const s = state.settings ?? {};
-    // Which rationales are open. Per-row, remembered while the page is mounted
-    // and never persisted — a disclosure is a reading aid, not a preference.
-    if (!ui.why) ui.why = new Set();
-    const whyOpen = (/** @type {string} */ id) => ui.why.has(id);
-    const toggleWhy = (/** @type {string} */ id) => () => {
-      if (ui.why.has(id)) ui.why.delete(id); else ui.why.add(id);
-      m.redraw();
-    };
-
-    /**
-     * A row whose control is a switch. Holds the busy-flag dance in ONE place:
-     * it was copy-pasted eight times, and a missed `finally` in any copy is a
-     * control stuck spinning forever.
-     * @param {{ id: string, label: string, on: boolean, busyKey: string,
-     *   summary: string, why: string, apply: () => Promise<any>,
-     *   badge?: string | null, children?: any }} p
-     */
-    const toggleRow = ({ id, label, on, busyKey, summary, why, apply, badge = null, children = null }) => {
-      const busy = !!ui[busyKey];
-      return settingsRow({
-        id,
-        label,
-        pill: busy ? '…' : on ? 'ON' : 'OFF',
-        badge,
-        summary: busy ? 'Saving…' : summary,
-        why,
-        open: whyOpen(id),
-        onToggleWhy: toggleWhy(id),
-        control: toggleSwitch({
-          on,
-          busy,
-          label: `${label} — ${on ? 'on' : 'off'}`,
-          onclick: async () => {
-            if (ui[busyKey]) return;
-            ui[busyKey] = true; m.redraw();
-            try { await apply(); } catch (e) { console.warn(`[options] ${id} toggle failed`, e); }
-            finally { ui[busyKey] = false; m.redraw(); }
-          },
-        }),
-        children,
-      });
-    };
+    const { whyOpen, toggleWhy, toggleRow } = rowController(ui);
 
     // ── Safety — changes what peerd MAY DO ───────────────────────────────────
     const confirmsOn = state.session?.permission?.confirmActions === true;

--- a/extension/options/sections/dweb.js
+++ b/extension/options/sections/dweb.js
@@ -156,10 +156,10 @@ export const DwebSection = {
       // commons — the Phase 1 north-star dwapp — now lives in the Library as
       // a pre-loaded, dweb-tagged app (not a button here). Point there.
       dwebEnabled ? m('div', { style: 'margin-top:14px; border-top:1px solid var(--hairline, #2a2a2a); padding-top:14px;' }, [
-        m('h3', 'commons — the dweb demo'),
+        m('h3', 'commons - the dweb demo'),
         m('p', 'A shared room with a chat for everyone plus private, '
           + 'peer-to-peer one-to-one chats. It ships pre-loaded in your '
-          + 'Library, tagged “dweb” — open it there. To try it, open it in '
+          + 'Library, tagged “dweb” - open it there. To try it, open it in '
           + 'two profiles (or two machines) and join the same room code.'),
         m('button.secondary', { type: 'button', onclick: () => openHome('library') }, 'Open Library'),
       ]) : null,

--- a/extension/options/sections/dweb.js
+++ b/extension/options/sections/dweb.js
@@ -14,6 +14,7 @@ import { loadDweb } from '/shared/dweb-loader.js';
 import { DWEB_ENABLED } from '/shared/channel-config.js';
 import { openHome } from '/shared/open-home.js';
 import { resetRow } from './reset-row.js';
+import { settingsRow, toggleSwitch, rowController } from '../components/settings-row.js';
 
 /** @typedef {import('./reset-row.js').Send} Send */
 
@@ -37,19 +38,65 @@ export const DwebSection = {
   view: ({ attrs: { state, send }, state: ui }) => {
     // Preview-only key; undefined (and unrenderable) on store packages.
     const dwebEnabled = !!state.settings?.dwebEnabled;
+    const agentOn = !!state.settings?.dwebAgentEnabled;
+    const { whyOpen, toggleWhy, toggleRow } = rowController(ui);
 
-    return m('div', [
-      m('.dweb-banner', [
-        m('strong', 'Dweb preview. '),
-        'This is research-grade. The protocol may change; data formats '
-        + 'may evolve. Dweb traffic is opt-in per-tab.',
-      ]),
-      m('p', 'You’re running peerd with the dweb preview enabled. '
-        + 'The core extension is the same peerd that ships on the stores — '
-        + 'only this dweb overlay is preview.'),
-      m('h3', 'Participate in the dweb'),
-      m('p', dwebEnabled
-        ? 'ON — this peerd can join dweb rooms with other peerd instances '
+    // The network switch is NOT a plain toggleRow: it has a third state. When
+    // the setting persisted Off but the live network refused to stop, the
+    // stored value and the running network disagree, and the row has to say
+    // so rather than showing a clean OFF. The switch then RETRIES the stop
+    // instead of flipping - which is why the click target computes its own
+    // target rather than negating `dwebEnabled`.
+    const networkBusy = !!ui.dwebBusy;
+    const stopFailed = !!ui.dwebStopIncomplete;
+    const applyNetwork = async () => {
+      if (ui.dwebBusy) return;
+      const targetEnabled = stopFailed ? false : !dwebEnabled;
+      ui.dwebBusy = true;
+      ui.dwebError = null;
+      try {
+        const reply = await send({ type: 'settings/update', patch: { dwebEnabled: targetEnabled } });
+        if (reply?.ok) {
+          ui.dwebStopIncomplete = false;
+        } else if (!targetEnabled && reply?.settings?.dwebEnabled === false) {
+          ui.dwebStopIncomplete = true;
+          ui.dwebError = 'dweb is set to Off, but the live network could not be stopped. Restart peerd or try again.';
+        } else {
+          ui.dwebError = `Could not update dweb: ${reply?.error ?? 'unknown error'}. Try again.`;
+        }
+      } catch {
+        ui.dwebError = ui.dwebStopIncomplete
+          ? 'dweb is set to Off, but the live network could not be stopped. Restart peerd or try again.'
+          : 'Could not confirm the dweb change. Try again.';
+      } finally {
+        ui.dwebBusy = false;
+        m.redraw();
+      }
+    };
+    // Status belongs INSIDE the network row, not between the two rows: it is
+    // only meaningful while the network is on, and a loose paragraph between
+    // rows breaks the scan the row pattern exists to give.
+    const networkStatus = ui.dwebStatus ? m('p.hint', [
+      `Protocol phase ${ui.dwebStatus.phase ?? 'unknown'}. `,
+      ui.dwebStatus.did
+        ? ['Peer identity: ', m('code', ui.dwebStatus.did), '. ',
+          m('a', { href: '#!/transfer' }, 'Back up or restore this identity.')]
+        : 'Identity is vault-stored and created on first room join.',
+    ]) : null;
+    const networkRow = settingsRow({
+      id: 'dweb-network',
+      label: 'Participate in the dweb',
+      pill: networkBusy ? '\u2026' : dwebEnabled ? 'ON' : 'OFF',
+      badge: stopFailed ? 'STILL RUNNING' : null,
+      summary: networkBusy
+        ? 'Saving\u2026'
+        : stopFailed
+          ? 'Set to Off, but the live network is still running. Retry to stop it.'
+          : dwebEnabled
+            ? 'This peerd can join dweb rooms with other instances and run peer-to-peer dwapps.'
+            : 'Nothing connects anywhere. Enabling lets this peerd join dweb rooms over WebRTC.',
+      why: dwebEnabled
+        ? 'ON - this peerd can join dweb rooms with other peerd instances '
           + '(N-peer rooms over WebRTC) and run dwapps that chat and share '
           + 'data peer-to-peer. Connections are end-to-end between peers; '
           + 'the rendezvous node only relays opaque handshakes, and a room '
@@ -58,71 +105,53 @@ export const DwebSection = {
         : 'OFF. Enabling lets this peerd join dweb rooms with other peerd '
           + 'instances over WebRTC and run peer-to-peer dwapps. (On the '
           + 'preview package dweb is on by default; you turned it off.) '
-          + 'Nothing connects anywhere until you explicitly join a room.'),
-      m('div', { style: 'display:flex; gap:8px; align-items:center;' }, [
-        m('button.secondary', {
-          type: 'button',
-          disabled: ui.dwebBusy,
-          onclick: async () => {
-            if (ui.dwebBusy) return;
-            const targetEnabled = ui.dwebStopIncomplete ? false : !dwebEnabled;
-            ui.dwebBusy = true;
-            ui.dwebError = null;
-            try {
-              const reply = await send({ type: 'settings/update', patch: { dwebEnabled: targetEnabled } });
-              if (reply?.ok) {
-                ui.dwebStopIncomplete = false;
-              } else if (!targetEnabled && reply?.settings?.dwebEnabled === false) {
-                ui.dwebStopIncomplete = true;
-                ui.dwebError = 'dweb is set to Off, but the live network could not be stopped. Restart peerd or try again.';
-              } else {
-                ui.dwebError = `Could not update dweb: ${reply?.error ?? 'unknown error'}. Try again.`;
-              }
-            } catch {
-              ui.dwebError = ui.dwebStopIncomplete
-                ? 'dweb is set to Off, but the live network could not be stopped. Restart peerd or try again.'
-                : 'Could not confirm the dweb change. Try again.';
-            } finally {
-              ui.dwebBusy = false;
-              m.redraw();
-            }
-          },
-        }, ui.dwebBusy ? '…' : ui.dwebStopIncomplete
-          ? 'Retry stopping dweb'
-          : dwebEnabled ? 'Disable dweb' : 'Enable dweb'),
-      ]),
-      ui.dwebError ? m('p.error', { role: 'alert' }, ui.dwebError) : null,
-      ui.dwebStatus ? m('p.hint', [
-        `Protocol phase ${ui.dwebStatus.phase ?? '—'}. `,
-        ui.dwebStatus.did
-          ? ['Peer identity: ', m('code', ui.dwebStatus.did), '. ',
-            m('a', { href: '#!/transfer' }, 'Back up or restore this identity.')]
-          : 'Identity is vault-stored and created on first room join.',
-      ]) : null,
+          + 'Nothing connects anywhere until you explicitly join a room.',
+      open: whyOpen('dweb-network'),
+      onToggleWhy: toggleWhy('dweb-network'),
+      control: toggleSwitch({
+        on: dwebEnabled,
+        busy: networkBusy,
+        label: stopFailed
+          ? 'Participate in the dweb - retry stopping'
+          : `Participate in the dweb - ${dwebEnabled ? 'on' : 'off'}`,
+        onclick: applyNetwork,
+      }),
+      children: networkStatus,
+    });
 
-      // The dweb AGENT — the mesh-operator actor. Nested under the network
+    return m('div', [
+      m('.dweb-banner', [
+        m('strong', 'Dweb preview. '),
+        'This is research-grade. The protocol may change; data formats '
+        + 'may evolve. Dweb traffic is opt-in per-tab.',
+      ]),
+      m('p', 'You’re running peerd with the dweb preview enabled. '
+        + 'The core extension is the same peerd that ships on the stores - '
+        + 'only this dweb overlay is preview.'),
+      networkRow,
+      ui.dwebError ? m('p.error', { role: 'alert' }, ui.dwebError) : null,
+      // The dweb AGENT - the mesh-operator actor. Nested under the network
       // toggle (no network, no agent) and OPT-IN: an agent peers can wake is a
-      // posture the user chooses. Rendering follows the dependent-toggle idiom
-      // (behavior.js failover picker).
-      dwebEnabled ? m('div', { style: 'margin-top:14px; border-top:1px solid var(--hairline, #2a2a2a); padding-top:14px;' }, [
-        m('h3', 'dweb agent'),
-        m('p', 'A dedicated, isolated agent that operates the mesh for you: it '
+      // posture the user chooses.
+      dwebEnabled ? toggleRow({
+        id: 'dweb-agent',
+        label: 'dweb agent',
+        on: agentOn,
+        busyKey: 'dwebAgentBusy',
+        summary: agentOn
+          ? 'Addressable as "dweb" in chat (message_actor); joins the agent inbox on unlock.'
+          : 'The mesh tools are unavailable - they live on this agent, not the chat agent.',
+        why: 'A dedicated, isolated agent that operates the mesh for you: it '
           + 'holds the dweb tools (discover, share, install, block), keeps a '
           + 'ledger of peers and publishers, and monitors messages sent to '
-          + 'your agent — surfacing only what matters. It runs keyless in its '
+          + 'your agent - surfacing only what matters. It runs keyless in its '
           + 'own worker, can never be made to act by an inbound message, and '
-          + 'installs or shares only with your confirmation.'),
-        m('button.secondary', {
-          type: 'button',
-          onclick: async () => {
-            await send({ type: 'settings/update', patch: { dwebAgentEnabled: !state.settings?.dwebAgentEnabled } });
-            m.redraw();
-          },
-        }, state.settings?.dwebAgentEnabled ? 'Disable the dweb agent' : 'Enable the dweb agent'),
-        state.settings?.dwebAgentEnabled
-          ? m('p.hint', 'On — your agent is addressable as "dweb" in chat (message_actor) and joins the agent inbox on unlock.')
-          : m('p.hint', 'Off — the mesh tools are unavailable until enabled (they live on this agent, not the chat agent).'),
-      ]) : null,
+          + 'installs or shares only with your confirmation.',
+        apply: () => send({
+          type: 'settings/update',
+          patch: { dwebAgentEnabled: !agentOn },
+        }),
+      }) : null,
 
       // commons — the Phase 1 north-star dwapp — now lives in the Library as
       // a pre-loaded, dweb-tagged app (not a button here). Point there.

--- a/extension/options/sections/memory.js
+++ b/extension/options/sections/memory.js
@@ -148,7 +148,9 @@ export const MemoryView = {
 
       // Auto-memory toggle — relocated from "Agent behavior": the
       // switch belongs next to the suggestion queue it feeds.
-      m('.settings-divider'),
+      // No .settings-divider here: the row draws its own top rule, and the two
+      // stacked 16px apart read as a rendering mistake rather than a section
+      // break.
       toggleRow({
         id: 'auto-memory',
         label: 'Auto-memory',

--- a/extension/options/sections/memory.js
+++ b/extension/options/sections/memory.js
@@ -17,6 +17,7 @@
 import m from '/vendor/mithril/mithril.js';
 import { countLines, ALWAYS_LOADED_LINE_BUDGET } from '/peerd-runtime/index.js';
 import { resetRow } from './reset-row.js';
+import { rowController } from '../components/settings-row.js';
 
 /** @typedef {import('./reset-row.js').Send} Send */
 /** @typedef {{ id?: string, kind: string, body?: string, workspace?: string, subpath?: string }} MemoryDoc */
@@ -75,6 +76,7 @@ export const MemoryView = {
     const suggestions = ui.suggestions ?? [];
     // Auto-memory defaults ON — absence of the key must not read as off.
     const autoMemoryOn = state?.settings?.autoMemoryEnabled !== false;
+    const { toggleRow } = rowController(ui);
 
     return m('.memory-pane', [
       m('p.muted', { style: 'font-size:12px; margin:0 0 10px;' }, [
@@ -147,23 +149,19 @@ export const MemoryView = {
       // Auto-memory toggle — relocated from "Agent behavior": the
       // switch belongs next to the suggestion queue it feeds.
       m('.settings-divider'),
-      m('h3', 'Auto-memory'),
-      m('p', autoMemoryOn
-        ? 'On. When a chat wraps up (you archive it or switch away after a real conversation), peerd makes one small background model call to propose durable notes about you and your ongoing work. Proposals appear above for your approval — nothing is ever saved without it. Calls respect the session spend limit (Costs page).'
-        : 'Off. peerd never proposes memory notes from finished chats. You can still ask it to remember things, or edit memory directly on this page.'),
-      m('div', { style: 'display:flex; gap:8px; align-items:center;' }, [
-        m('button.secondary', {
-          type: 'button',
-          disabled: ui.autoMemoryBusy,
-          onclick: async () => {
-            if (ui.autoMemoryBusy) return;
-            ui.autoMemoryBusy = true;
-            await send({ type: 'settings/update', patch: { autoMemoryEnabled: !autoMemoryOn } });
-            ui.autoMemoryBusy = false;
-            m.redraw();
-          },
-        }, ui.autoMemoryBusy ? '…' : autoMemoryOn ? 'Disable auto-memory' : 'Enable auto-memory'),
-      ]),
+      toggleRow({
+        id: 'auto-memory',
+        label: 'Auto-memory',
+        on: autoMemoryOn,
+        busyKey: 'autoMemoryBusy',
+        summary: autoMemoryOn
+          ? 'peerd proposes notes when a chat wraps up. Nothing is saved without your approval.'
+          : 'peerd never proposes notes. You can still ask it to remember things, or edit memory here.',
+        why: autoMemoryOn
+          ? 'On. When a chat wraps up (you archive it or switch away after a real conversation), peerd makes one small background model call to propose durable notes about you and your ongoing work. Proposals appear above for your approval - nothing is ever saved without it. Calls respect the session spend limit (Costs page).'
+          : 'Off. peerd never proposes memory notes from finished chats. You can still ask it to remember things, or edit memory directly on this page.',
+        apply: () => send({ type: 'settings/update', patch: { autoMemoryEnabled: !autoMemoryOn } }),
+      }),
       resetRow(send, ['autoMemoryEnabled']),
     ]);
   },

--- a/extension/tests/fixtures/options-dweb-stop-failed.js
+++ b/extension/tests/fixtures/options-dweb-stop-failed.js
@@ -16,11 +16,12 @@ const send = async (message) => {
 
 const Fixture = {
   oncreate: () => {
-    const disable = /** @type {HTMLButtonElement | null} */ (
-      Array.from(document.querySelectorAll('button'))
-        .find((button) => button.textContent === 'Disable dweb') ?? null
+    // The switch is a role=switch button with no text content, so it is found
+    // by its accessible name - the same string a screen reader would announce.
+    const toggle = /** @type {HTMLButtonElement | null} */ (
+      document.querySelector('button[role="switch"][aria-checked="true"]')
     );
-    disable?.click();
+    toggle?.click();
   },
   view: () => m(DwebSection, {
     state,

--- a/extension/tests/unit/options/dweb-section.test.js
+++ b/extension/tests/unit/options/dweb-section.test.js
@@ -9,10 +9,21 @@ const settle = async () => {
   m.redraw.sync?.();
 };
 
-/** @param {HTMLElement} root @param {string} label */
-const button = (root, label) => /** @type {HTMLButtonElement} */ (
-  Array.from(root.querySelectorAll('button')).find((entry) => entry.textContent === label)
+// The switch carries no text - its accessible name is the assertion surface,
+// which is also what a screen reader announces. That is the point of the row:
+// the control states WHERE YOU STAND, so the test can read the same string the
+// user hears instead of an imperative like "Disable dweb".
+/** @param {HTMLElement} root */
+const networkSwitch = (root) => /** @type {HTMLButtonElement} */ (
+  root.querySelector('button[role="switch"]')
 );
+/** @param {HTMLElement} root */
+const rowState = (root) => ({
+  name: networkSwitch(root)?.getAttribute('aria-label') ?? '',
+  checked: networkSwitch(root)?.getAttribute('aria-checked') ?? '',
+  pill: root.querySelector('.set-pill')?.textContent ?? '',
+  badge: root.querySelector('.set-badge')?.textContent ?? '',
+});
 
 describe('options.dweb live-stop status', () => {
   it('reports an incomplete stop and keeps the retry explicit', async () => {
@@ -33,15 +44,24 @@ describe('options.dweb live-stop status', () => {
     };
     m.mount(root, { view: () => m(DwebSection, { state, send, loadStatus: async () => null }) });
     try {
-      button(root, 'Disable dweb').click();
+      expect(rowState(root).pill).toBe('ON');
+      networkSwitch(root).click();
       await settle();
+
+      // The setting persisted Off but the network did not stop. The row must
+      // NOT read as a clean OFF - the badge is what carries the disagreement.
       const alert = root.querySelector('[role="alert"]');
       expect(alert?.textContent).toContain('live network could not be stopped');
-      expect(button(root, 'Retry stopping dweb') instanceof HTMLButtonElement).toBe(true);
-      button(root, 'Retry stopping dweb').click();
+      expect(rowState(root).badge).toBe('STILL RUNNING');
+      expect(rowState(root).name).toContain('retry stopping');
+      expect(networkSwitch(root).disabled).toBe(false);
+
+      networkSwitch(root).click();
       await settle();
       expect(root.querySelector('[role="alert"]')).toBe(null);
-      expect(button(root, 'Enable dweb') instanceof HTMLButtonElement).toBe(true);
+      expect(rowState(root).badge).toBe('');
+      expect(rowState(root).pill).toBe('OFF');
+      expect(rowState(root).checked).toBe('false');
       expect(calls.map((call) => call.patch)).toEqual([
         { dwebEnabled: false },
         { dwebEnabled: false },

--- a/scripts/cdp/states.mjs
+++ b/scripts/cdp/states.mjs
@@ -3528,6 +3528,37 @@ export const STATES = [
     },
   },
   {
+    // Memory had no visual state at all, so the auto-memory switch - the one
+    // control on the page - was never photographed. It is also the row whose
+    // old hand-rolled busy dance had no `finally`, which is precisely the kind
+    // of state a still frame catches and an assertion does not.
+    name: 'options-memory', kind: 'visual', phase: 'post-unlock',
+    responder: () => ({ sse: sseText('noted') }),
+    async run(ctx, rec) {
+      const page = await openWidePage(ctx, 'options/options.html#!/memory');
+      try {
+        await waitFor(() => evalIn(page, `document.querySelectorAll('.set-row').length >= 1`),
+          { budgetMs: 15_000, pollMs: 80 }).catch(() => {});
+        const row = await evalIn(page, `(() => {
+          const el = document.querySelector('.set-row');
+          const toggle = el?.querySelector('button[role="switch"]');
+          return {
+            label: el?.querySelector('.set-row-label')?.textContent ?? '',
+            pill: el?.querySelector('.set-pill')?.textContent ?? '',
+            named: toggle?.getAttribute('aria-label') ?? '',
+            headings: document.querySelectorAll('.memory-pane h3').length,
+          };
+        })()`);
+        rec.check('auto-memory reads as a row that states where you stand',
+          row?.label === 'Auto-memory'
+            && row?.pill === 'ON'
+            && / - (on|off)$/.test(row?.named ?? ''),
+          JSON.stringify(row));
+        await rec.visualPage('options-memory', page);
+      } finally { try { page.close(); } catch { /* */ } }
+    },
+  },
+  {
     name: 'options-denylist', kind: 'visual', phase: 'post-unlock',
     responder: () => ({ sse: sseText('noted') }),
     async run(ctx, rec) {

--- a/scripts/cdp/states.mjs
+++ b/scripts/cdp/states.mjs
@@ -3492,6 +3492,42 @@ export const STATES = [
     },
   },
   {
+    // The dweb page's HAPPY path had no state at all - the only coverage was
+    // the stop-failure fixture, so the shape a user actually meets was
+    // unphotographed. Preview builds default dwebEnabled on, which is what the
+    // harness runs, so the nested agent row renders too.
+    name: 'options-dweb', kind: 'visual', phase: 'post-unlock',
+    responder: () => ({ sse: sseText('noted') }),
+    async run(ctx, rec) {
+      const page = await openWidePage(ctx, 'options/options.html#!/dweb');
+      try {
+        await waitFor(() => evalIn(page, `document.querySelectorAll('.set-row').length >= 2`),
+          { budgetMs: 15_000, pollMs: 80 }).catch(() => {});
+        const shape = await evalIn(page, `(() => {
+          const rows = [...document.querySelectorAll('.set-row')].map((row) => ({
+            label: row.querySelector('.set-row-label')?.textContent ?? '',
+            pill: row.querySelector('.set-pill')?.textContent ?? '',
+            named: row.querySelector('button[role="switch"]')?.getAttribute('aria-label') ?? '',
+          }));
+          return { rows, headings: document.querySelectorAll('.options-page h3').length };
+        })()`);
+        rec.check('the network and agent settings both read as rows',
+          shape?.rows?.length === 2
+            && shape.rows[0].label === 'Participate in the dweb'
+            && shape.rows[1].label === 'dweb agent',
+          JSON.stringify(shape?.rows));
+        rec.check('each switch is named for its STATE, not its inverse action',
+          // The bug the row pattern exists to kill: a control labelled
+          // "Disable the dweb agent" makes the reader infer state from an
+          // action verb. Every switch must announce where you stand.
+          (shape?.rows ?? []).every((row) => / - (on|off)$/.test(row.named))
+            && !(shape?.rows ?? []).some((row) => /^(Enable|Disable) /.test(row.named)),
+          JSON.stringify((shape?.rows ?? []).map((row) => row.named)));
+        await rec.visualPage('options-dweb', page);
+      } finally { try { page.close(); } catch { /* */ } }
+    },
+  },
+  {
     name: 'options-denylist', kind: 'visual', phase: 'post-unlock',
     responder: () => ({ sse: sseText('noted') }),
     async run(ctx, rec) {
@@ -3609,14 +3645,25 @@ export const STATES = [
         ready: '[role="alert"]',
       });
       try {
-        const status = await evalIn(page, `({
-          warning: document.querySelector('[role="alert"]')?.textContent ?? '',
-          retry: [...document.querySelectorAll('button')]
-            .some((button) => button.textContent === 'Retry stopping dweb'),
-        })`);
+        const status = await evalIn(page, `(() => {
+          const row = document.querySelector('.set-row');
+          const toggle = document.querySelector('button[role="switch"]');
+          return {
+            warning: document.querySelector('[role="alert"]')?.textContent ?? '',
+            // The retry affordance is now the switch itself, named for what it
+            // will do. The BADGE is what makes the disagreement legible without
+            // reading the alert - a clean OFF pill would have lied.
+            retry: (toggle?.getAttribute('aria-label') ?? '').includes('retry stopping'),
+            badge: row?.querySelector('.set-badge')?.textContent ?? '',
+            enabled: toggle instanceof HTMLButtonElement && !toggle.disabled,
+          };
+        })()`);
         rec.check('failed live stop stays visible',
           status?.warning.includes('live network could not be stopped'), status?.warning);
-        rec.check('failed live stop remains retryable', status?.retry === true);
+        rec.check('failed live stop remains retryable',
+          status?.retry === true && status?.enabled === true, JSON.stringify(status));
+        rec.check('the row says the network is still running',
+          status?.badge === 'STILL RUNNING', status?.badge);
         await rec.visualPage('options-dweb-stop-failed', page);
       } finally { try { page.close(); } catch { /* */ } }
     },


### PR DESCRIPTION
P1 of the redesign shipped in #294 - but only ever reached **one page**. `settings-row.js` had exactly one importer. This takes it to three and moves the helper out of `behavior.js` so the next page doesn't re-type it.

## The shared controller

`behavior.js` held `toggleRow` and the disclosure state inside its view. The component's own header predicted what happens next:

> a pattern that lives in one page's view function gets re-typed slightly differently on the next page

So it moves into `settings-row.js` as `rowController(ui)`. `behavior.js` loses 41 lines and renders **byte-identically** - its visual state reports **0.00% in both themes**, which is the check that mattered before touching anything else.

**That lift also fixes a live bug.** `memory.js` hand-rolled the same busy-flag dance *without* a `try/finally`, so a rejected save left the auto-memory switch spinning until remount. The shared helper has the `finally` - which is the exact reason its comment gives for existing.

## Decentralized web

Two `h3` + rationale + button blocks become rows. The agent block was the precise shape the row pattern was built to kill:

```js
state.settings?.dwebAgentEnabled ? 'Disable the dweb agent' : 'Enable the dweb agent'
```

The control told you what would *happen*; a separate hint line told you where you *stood*.

**The network switch is deliberately not a plain `toggleRow`** - it has a third state, where the setting persisted Off but the live network refused to stop. A clean `OFF` pill would lie about that, so the row carries a `STILL RUNNING` badge and the switch announces "retry stopping". The disagreement is legible without reading the alert.

Status moved into the row's `children` slot: a loose paragraph between two rows broke the scan the pattern exists to provide.

**`commons` stays a heading and a button on purpose.** It's a pointer to the Library, not a setting, and rows are for settings.

## Coverage

The dweb page's happy path had **no state at all** - the only coverage was the stop-failure fixture. Adds `options-dweb`, which asserts both settings read as rows *and* that every switch is named for its state rather than its inverse action, so the bug can't return unnoticed. Nothing to seed.

The fixture and the in-browser test both found the switch by button text. They now read the **accessible name** - what a screen reader announces, and what the row pattern is actually about.

## One thing to know about the diff

Restructuring makes untouched prose read as *added* lines, so nine em dashes tripped `check:copy`. They're **converted, not rewritten** - typography only, no wording changed, per the redesign's own "move the shipped prose" rule. One is the row aria-label separator (shipped format, not prose); no test pins it and rendered output is unaffected.

## Verification

Full gate set green. Bun **6411/6411**, in-browser **948/948**, e2e functional **41 states / 306 checks**. Three touched visual states rendered and read as PNGs: `options-behavior` 0.00%, `options-dweb` and `options-dweb-stop-failed` moved as intended.

No badge or manifest drift - assertions were replaced, not added.