### PR TITLE
fix(actor): drop a stopped provisional site actor's binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and storage formats may move until the surface stabilizes.
 
 ## [Unreleased]
 
+### Fixed
+
+- A site helper stopped for leaving its approved site no longer keeps a stale
+  handle, so retrying it starts a fresh helper instead of reopening an
+  abandoned tab.
+
 ## [0.7.3] - 2026-08-18
 
 ### Added

--- a/badges/functional-tests.json
+++ b/badges/functional-tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "Functional Tests",
-  "message": "6411/6411 passing",
+  "message": "6413/6413 passing",
   "color": "brightgreen",
   "namedLogo": "bun",
   "logoColor": "white"

--- a/extension/background/origin-lock-controller.js
+++ b/extension/background/origin-lock-controller.js
@@ -63,16 +63,8 @@ export const makeOriginLockResolver = (deps) => {
           // A provisional site binding that landed elsewhere is a dead handle.
           // Remove it so a retry mints a fresh actor instead of reopening an
           // orphaned tab, while the stopped state remains as a queued-call fence.
-          if (state?.provisional) {
-            let dropped = false;
-            for (const [key, sessionId] of siteActorBindings.entries()) {
-              if (sessionId !== actorSessionId) continue;
-              const gap = key.indexOf(' ');
-              if (gap < 0) continue;
-              siteActorBindings.drop(key.slice(0, gap), key.slice(gap + 1));
-              dropped = true;
-            }
-            if (dropped) persistSiteActors();
+          if (state?.provisional && siteActorBindings.dropBySession(actorSessionId) > 0) {
+            persistSiteActors();
           }
           if (retirement) {
             const durable = await retirement;

--- a/extension/peerd-runtime/actor/web-actor.js
+++ b/extension/peerd-runtime/actor/web-actor.js
@@ -315,6 +315,7 @@ export const parseSiteHandle = (input) => {
  *   drop: (ownerChatId: string, origin: string) => boolean,
  *   originsFor: (ownerChatId: string) => string[],
  *   entries: () => Array<[string, string]>,
+ *   dropBySession: (actorSessionId: string) => number,
  *   load: (entries: Array<[string, string]>) => void,
  * }}
  */
@@ -333,6 +334,18 @@ export const makeApiActorBindings = () => {
       const out = [];
       for (const k of byKey.keys()) if (k.startsWith(prefix)) out.push(k.slice(prefix.length));
       return out;
+    },
+    // Drop every binding pointing at one actor session, and report how many
+    // went. why the MAP owns this rather than a caller splitting the key: the
+    // separator lived in two files and drifted, so the cleanup that runs when a
+    // provisional site actor is stopped silently did nothing (issue #438). A key
+    // shape known in one place cannot drift from itself.
+    dropBySession: (actorSessionId) => {
+      let dropped = 0;
+      for (const [k, s] of byKey) {
+        if (s === actorSessionId && byKey.delete(k)) dropped += 1;
+      }
+      return dropped;
     },
     entries: () => [...byKey.entries()],
     load: (entries) => { for (const [k, s] of entries ?? []) byKey.set(k, s); },

--- a/tests/background/origin-lock-controller.test.ts
+++ b/tests/background/origin-lock-controller.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, test } from 'bun:test';
 import { makeOriginLockResolver } from '../../extension/background/origin-lock-controller.js';
+import { makeApiActorBindings } from '../../extension/peerd-runtime/actor/web-actor.js';
 
-const makeHarness = () => {
+const makeHarness = (over: { provisional?: boolean, siteActorBindings?: any } = {}) => {
   const turnTokens = new Map([['actor', 1]]);
   const stopped: string[] = [];
   const released: number[] = [];
   const audits: any[] = [];
   let judgeDeps: any;
-  const state = { mode: 'bound', provisional: false };
+  const state = { mode: 'bound', provisional: over.provisional ?? false };
+  const persisted: number[] = [];
   const deps: any = {
     originStates: {
       read: () => state,
@@ -31,7 +33,9 @@ const makeHarness = () => {
     webActorTabBindings: { tabFor: () => 7, drop: () => true },
     persistWebBindings: () => {},
     pageActivity: { release: async (id: number) => { released.push(id); } },
-    siteActorBindings: { entries: () => [], drop: () => {} }, persistSiteActors: () => {},
+    siteActorBindings: over.siteActorBindings
+      ?? { entries: () => [], drop: () => {}, dropBySession: () => 0 },
+    persistSiteActors: () => { persisted.push(1); },
     auditLog: { append: async (event: any) => { audits.push(event); } },
     originPhrase: (url: string) => new URL(url).origin,
     isKnownIdp: () => false, isKnownIdpHost: () => false,
@@ -45,7 +49,7 @@ const makeHarness = () => {
     liveSiteClientLandingFor: async () => ({ status: 'none' }),
   };
   const resolve = makeOriginLockResolver(deps);
-  return { resolve, turnTokens, stopped, released, audits, getJudgeDeps: () => judgeDeps };
+  return { resolve, turnTokens, stopped, released, audits, persisted, getJudgeDeps: () => judgeDeps };
 };
 
 describe('origin lock controller', () => {
@@ -78,5 +82,38 @@ describe('origin lock controller', () => {
     expect(harness.released).toEqual([7]);
     expect(harness.audits[0].details.to).toBe('https://other.example');
     expect(JSON.stringify(harness.audits[0])).not.toContain('attacker-controlled');
+  });
+
+  // issue #438. The cleanup used to split the binding key on a space while the
+  // map joined it with a NUL, so it silently dropped nothing - and every test
+  // here passed anyway, because none of them used a real binding map.
+  test('a stopped PROVISIONAL site actor loses its binding, so a retry mints a fresh one', async () => {
+    const siteActorBindings = makeApiActorBindings();
+    siteActorBindings.bind('chat-1', 'https://shop.example', 'actor');
+    siteActorBindings.bind('chat-1', 'https://other.example', 'someone-else');
+    const harness = makeHarness({ provisional: true, siteActorBindings });
+    harness.resolve('actor');
+    await harness.getJudgeDeps().onStop({
+      action: 'handoff', from: 'https://shop.example/', to: 'https://elsewhere.example/',
+    });
+    await Promise.resolve();
+
+    expect(siteActorBindings.resolve('chat-1', 'https://shop.example')).toBe(null);
+    // Another chat's actor on another origin is untouched.
+    expect(siteActorBindings.resolve('chat-1', 'https://other.example')).toBe('someone-else');
+    expect(harness.persisted.length).toBeGreaterThan(0);
+  });
+
+  test('a stopped NON-provisional site actor keeps its binding', async () => {
+    const siteActorBindings = makeApiActorBindings();
+    siteActorBindings.bind('chat-1', 'https://shop.example', 'actor');
+    const harness = makeHarness({ provisional: false, siteActorBindings });
+    harness.resolve('actor');
+    await harness.getJudgeDeps().onStop({
+      action: 'handoff', from: 'https://shop.example/', to: 'https://elsewhere.example/',
+    });
+    await Promise.resolve();
+
+    expect(siteActorBindings.resolve('chat-1', 'https://shop.example')).toBe('actor');
   });
 });


### PR DESCRIPTION
Closes #438.

## What broke

The cleanup that removes a provisional site actor's binding when the actor is stopped split the binding key on a space. The map that writes that key joins with a NUL. `indexOf(' ')` was therefore always `-1`, the loop always hit its `continue`, and the drop never ran.

So a provisional site actor stopped for landing outside its boundary kept a live binding: a retry resolved the stopped session instead of minting a fresh actor, and per the block's own comment could reopen an orphaned tab. The stopped state still fences queued calls, so this is recovery quality, not an authority bypass.

## What changed

The root cause is that the key shape was known in two files. It now lives in one: the binding map gains `dropBySession()`, and the controller asks for the removal instead of taking the key apart itself.

## How it was verified

Two regression tests, driving a REAL binding map - every existing test passed while the cleanup did nothing, because none of them used one. Revert-proven: restoring the old loop turns the provisional test red, and the fix turns it green.

Gates: 6413 bun, 948 in-browser, lint, typecheck, boundary, imports, tscheck, copy.

Found while mapping the dispatcher for #234; filed separately rather than folded into that PR.
