### PR TITLE
fix: improve live actor chat flow

### DIFF
--- a/badges/e2e-chrome.json
+++ b/badges/e2e-chrome.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "E2E (side panel)",
-  "message": "306/306 checks, 41 states",
+  "message": "314/314 checks, 42 states",
   "color": "brightgreen",
   "namedLogo": "googlechrome",
   "logoColor": "white"

--- a/badges/inbrowser-chrome.json
+++ b/badges/inbrowser-chrome.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "In-Browser (Chrome)",
-  "message": "948/948 passing",
+  "message": "949/949 passing",
   "color": "brightgreen",
   "namedLogo": "googlechrome",
   "logoColor": "white"

--- a/badges/inbrowser-gecko.json
+++ b/badges/inbrowser-gecko.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "In-Browser (Gecko)",
-  "message": "942/942 passing",
+  "message": "943/943 passing",
   "color": "brightgreen",
   "namedLogo": "firefoxbrowser",
   "logoColor": "white"

--- a/extension/background/origin-lock-controller.js
+++ b/extension/background/origin-lock-controller.js
@@ -67,7 +67,7 @@ export const makeOriginLockResolver = (deps) => {
             let dropped = false;
             for (const [key, sessionId] of siteActorBindings.entries()) {
               if (sessionId !== actorSessionId) continue;
-              const gap = key.indexOf(' ');
+              const gap = key.indexOf('\u0000');
               if (gap < 0) continue;
               siteActorBindings.drop(key.slice(0, gap), key.slice(gap + 1));
               dropped = true;

--- a/extension/peerd-runtime/actor/web-actor.js
+++ b/extension/peerd-runtime/actor/web-actor.js
@@ -305,9 +305,7 @@ export const parseSiteHandle = (input) => {
  * The (ownerChatId, origin)→session binding store for API actors. Chat-scoped (v1
  * memory is per-chat) and origin-keyed (the origin is the durable handle). Flat
  * composite key so it serializes to chrome.storage.session as Array<[string,string]>
- * exactly like the tab store. A SPACE joins the two halves — a chat id (UUIDv7) and a
- * normalized origin both never contain a space, so the split is unambiguous and the
- * originsFor prefix match can't straddle a key boundary.
+ * exactly like the tab store. A NUL joins values that cannot contain NUL.
  *
  * @returns {{
  *   bind: (ownerChatId: string, origin: string, actorSessionId: string) => void,

--- a/extension/sidepanel/components/actor-fabric.js
+++ b/extension/sidepanel/components/actor-fabric.js
@@ -133,7 +133,7 @@ const renderDetail = (node, detailId, settled) => m('.actor-fabric-detail', {
 export const ActorFabric = {
   /** @param {{ state: ActorFabricState }} vnode */
   oninit(vnode) {
-    vnode.state.expanded = true;
+    vnode.state.expanded = false;
     vnode.state.hadLiveNodes = false;
     vnode.state.settled = false;
     vnode.state.rootSessionId = '';
@@ -162,7 +162,7 @@ export const ActorFabric = {
     if (ui.rootSessionId !== rootSessionId) {
       if (ui.expiryTimer) clearTimeout(ui.expiryTimer);
       ui.rootSessionId = rootSessionId;
-      ui.expanded = true;
+      ui.expanded = false;
       ui.hadLiveNodes = false;
       ui.settled = false;
       ui.selectedId = '';
@@ -181,10 +181,7 @@ export const ActorFabric = {
     if (liveFabric.activeActors > 0) {
       if (ui.expiryTimer) { clearTimeout(ui.expiryTimer); ui.expiryTimer = null; }
       const startingBatch = !ui.hadLiveNodes || ui.settled;
-      if (startingBatch) {
-        ui.expanded = true;
-        ui.selectedId = '';
-      }
+      if (startingBatch) ui.selectedId = '';
       ui.hadLiveNodes = true;
       ui.settled = false;
       ui.lastFabric = startingBatch ? liveFabric : mergeReceipt(ui.lastFabric, liveFabric);

--- a/extension/sidepanel/components/message-list.js
+++ b/extension/sidepanel/components/message-list.js
@@ -103,20 +103,11 @@ const actorOutcomeUnknownFailure = (_text) =>
  * @property {Map<string|undefined, Set<string>>} [seenRecoveryIdsBySession]
  */
 
-// Auto-scroll heuristic: if the user is reading near the bottom, keep
-// them pinned at the bottom across all updates (new messages, growing
-// tool calls, streaming text deltas). If they've scrolled away to read
-// older content, respect their scroll position.
-//
-// "Near the bottom" = within 150px. Generous enough that the
-// expand-result affordance doesn't fight scroll, tight enough that an
-// intentional scroll-up keeps the user where they want.
+// Keep following only while the user stays near the live edge. Record this on
+// scroll because a large redraw can move the edge before onupdate measures it.
 const NEAR_BOTTOM_PX = 150;
 /** @param {HTMLElement} el */
-const scrollIfNearBottom = (el) => {
-  const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
-  if (distance < NEAR_BOTTOM_PX) el.scrollTop = el.scrollHeight;
-};
+const nearBottom = (el) => el.scrollHeight - el.scrollTop - el.clientHeight < NEAR_BOTTOM_PX;
 
 // How many levels of nested actor transcript to render inline before
 // stopping. Deeper runs still exist and are inspectable, but rendering
@@ -274,6 +265,7 @@ export const MessageList = {
   /** @param {{ attrs: TranscriptArgs, state: any }} vnode */
   oninit(vnode) {
     vnode.state.sessionId = vnode.attrs.sessionId;
+    vnode.state.followBottom = true;
     // Existing history on the initial mount is a visual receipt, not a new
     // alert. Keep the baseline per session after that: a receipt first
     // encountered when the user switches chats is new to this surface and must
@@ -299,6 +291,7 @@ export const MessageList = {
   onbeforeupdate(vnode) {
     if (vnode.state.sessionId !== vnode.attrs.sessionId) {
       vnode.state.sessionId = vnode.attrs.sessionId;
+      vnode.state.followBottom = true;
       const receipts = recoveryReceipts(vnode.attrs.messages);
       const existing = vnode.state.seenRecoveryIdsBySession.get(vnode.attrs.sessionId);
       const fresh = existing
@@ -338,7 +331,7 @@ export const MessageList = {
   },
   /** @param {{ dom: HTMLElement, state: any }} vnode */
   onupdate(vnode) {
-    scrollIfNearBottom(vnode.dom);
+    if (vnode.state.followBottom) vnode.dom.scrollTop = vnode.dom.scrollHeight;
     scheduleRecoveryAnnouncementClear(vnode.state);
   },
   /** @param {{ state: any }} vnode */
@@ -348,7 +341,12 @@ export const MessageList = {
 
   /** @param {{ attrs: TranscriptArgs, state: any }} vnode */
   view: ({ attrs: { messages, vmStreams, spawned, actors, scriptOps, loadActor, peerName, tabEvents, confirmEvents, uiActions, send, sessionId, busy }, state }) =>
-    m('.message-list', [
+    m('.message-list', {
+      onscroll: (/** @type {Event & { redraw?: boolean }} */ event) => {
+        state.followBottom = nearBottom(/** @type {HTMLElement} */ (event.currentTarget));
+        event.redraw = false;
+      },
+    }, [
       renderTranscript({
         messages, vmStreams, spawned, actors, scriptOps, loadActor, peerName,
         depth: 0, tabEvents, confirmEvents, uiActions, send, sessionId, busy,

--- a/extension/tests/unit/sidepanel/actor-fabric.test.js
+++ b/extension/tests/unit/sidepanel/actor-fabric.test.js
@@ -41,7 +41,7 @@ describe('ActorFabric', () => {
       asyncTasks: {},
     });
     try {
-      expect(view.root.querySelectorAll('.actor-fabric-node').length).toBe(3); // root + two actors
+      /** @type {HTMLButtonElement} */ (view.root.querySelector('.actor-fabric-toggle')).click(); m.redraw.sync();
       expect(view.root.querySelectorAll('.actor-fabric-node.is-root').length).toBe(1);
       expect(view.root.querySelectorAll('.actor-fabric-node.is-bound').length).toBe(1);
       expect(view.root.querySelectorAll('.actor-fabric-node.is-subactor').length).toBe(1);
@@ -62,9 +62,9 @@ describe('ActorFabric', () => {
       },
     });
     try {
+      /** @type {HTMLButtonElement} */ (view.root.querySelector('.actor-fabric-toggle')).click(); m.redraw.sync();
       const node = /** @type {HTMLButtonElement} */ (view.root.querySelector('[data-node-id="actor:api-1"]'));
       expect(node.getAttribute('aria-pressed')).toBe('false');
-      expect(view.root.querySelector('.actor-fabric-detail')).toBe(null);
       node.click();
       m.redraw.sync();
       expect(node.getAttribute('aria-pressed')).toBe('true');
@@ -82,11 +82,11 @@ describe('ActorFabric', () => {
     });
     try {
       const toggle = /** @type {HTMLButtonElement} */ (view.root.querySelector('.actor-fabric-toggle'));
-      expect(toggle.getAttribute('aria-expanded')).toBe('true');
-      toggle.click();
-      m.redraw.sync();
       expect(toggle.getAttribute('aria-expanded')).toBe('false');
       expect(view.root.querySelector('.actor-fabric-body')).toBe(null);
+      toggle.click();
+      m.redraw.sync();
+      expect(toggle.getAttribute('aria-expanded')).toBe('true');
     } finally { view.unmount(); }
   });
 
@@ -103,6 +103,7 @@ describe('ActorFabric', () => {
     });
     const view = mount(attrs);
     try {
+      /** @type {HTMLButtonElement} */ (view.root.querySelector('.actor-fabric-toggle')).click(); m.redraw.sync();
       expect(view.root.querySelector('.actor-fabric')?.textContent).toContain('private task');
       attrs.session = { sessionId: 'chat-b', messages: [] };
       attrs.actors = {};

--- a/extension/tests/unit/sidepanel/message-list.test.js
+++ b/extension/tests/unit/sidepanel/message-list.test.js
@@ -22,7 +22,26 @@ const mount = (messages, attrs = {}) => {
   return { root, unmount: () => { m.mount(root, null); root.remove(); } };
 };
 
-describe('sidepanel.message-list aborted cards', () => {
+describe('sidepanel.message-list updates and aborted cards', () => {
+  it('follows updates, respects scroll-up, and follows a new chat', async () => {
+    const messages = Array.from({ length: 10 }, (_, index) => ({ role: 'user', id: `u${index}`, content: 'line' }));
+    const attrs = { sessionId: 'scroll-test' };
+    const { root, unmount } = mount(messages, attrs);
+    try {
+      await flush();
+      const list = /** @type {HTMLElement} */ (root.querySelector('.message-list'));
+      list.style.cssText = 'display:block;height:100px;overflow-y:auto';
+      list.scrollTop = list.scrollHeight; list.dispatchEvent(new Event('scroll'));
+      messages.push(...messages.map((message) => ({ ...message, id: `more-${message.id}` }))); m.redraw.sync();
+      expect(list.scrollHeight - list.scrollTop - list.clientHeight).toBeLessThan(2);
+      list.scrollTop = 0; list.dispatchEvent(new Event('scroll'));
+      messages.push({ role: 'user', id: 'detached', content: 'stay here' }); m.redraw.sync();
+      expect(list.scrollTop).toBe(0);
+      attrs.sessionId = 'next-chat'; m.redraw.sync();
+      expect(list.scrollHeight - list.scrollTop - list.clientHeight).toBeLessThan(2);
+    } finally { unmount(); }
+  });
+
   it('an aborted turn shows "cancelled" tool cards, not a perpetual "running…"', async () => {
     const { root, unmount } = mount([{
       role: 'assistant', id: 'a1', content: '', stopReason: 'aborted',

--- a/scripts/cdp/states.mjs
+++ b/scripts/cdp/states.mjs
@@ -24,6 +24,7 @@ import {
   sleep, setEmulatedTheme, PASSPHRASE, PANEL_METRICS, NARROW_PANEL_METRICS,
   NETWORK_GUARD_CONTROLLER_PORT,
 } from './e2e-harness.mjs';
+import { startWebFixtureServer } from './fixtures/web-suite.mjs';
 
 // A compact transcript probe shared by the functional states.
 const probe = (ctx) => evalIn(ctx.page, `(() => {
@@ -184,6 +185,10 @@ let harvestOrchTurn = 0;
 let harvestDelegated = false;
 let harvestActorUsedCode = false;
 let harvestFixtureUrl = '';
+let storeScriptingState = {
+  delegated: false, actorTurn: 0, actorPrompt: '', results: [], wakeBody: '', orderRef: '', sendRef: '',
+};
+let storeScriptingFixtureUrl = '';
 let numericTabAuthorityState = {
   addressed: false,
   tabId: null, refusalBody: '', actorCallsAfterAddress: 0,
@@ -1551,6 +1556,133 @@ export const STATES = [
         await rec.shot('final');
       } finally {
         server.close();
+      }
+    },
+  },
+
+  // This state proves the chrome.scripting fallback in the real browser.
+  {
+    name: 'chrome-scripting-browser-actions', kind: 'functional', phase: 'post-unlock',
+    responder: (callIndex, request) => {
+      const body = (request && request.postData) || '';
+      if (body.includes('<actor_agent>')) {
+        if (!storeScriptingState.actorPrompt) storeScriptingState.actorPrompt = body;
+        storeScriptingState.results = toolResultsIn(body);
+        const latest = storeScriptingState.results.at(-1) || '';
+        const turn = storeScriptingState.actorTurn++;
+        if (turn === 0) return { sse: sseToolCall('navigate', { url: storeScriptingFixtureUrl }) };
+        if (turn === 1) return { sse: sseToolCall('snapshot', {}) };
+        if (turn === 2) {
+          storeScriptingState.orderRef = latest.match(/(@e\d+) textbox "Order ID"/)?.[1] || '';
+          storeScriptingState.sendRef = latest.match(/(@e\d+) button "Send message"/)?.[1] || '';
+          return { sse: sseToolCall('type', {
+            ref: storeScriptingState.orderRef, text: 'STORE-42', expectedCount: 1,
+          }) };
+        }
+        if (turn === 3) return { sse: sseToolCall('click', { ref: storeScriptingState.sendRef, expectedCount: 1 }) };
+        if (latest.includes('TICKET-STORE-42')) {
+          return { sse: sseText('SCRIPTING-ACTOR-DONE TICKET-STORE-42') };
+        }
+        if (turn < 8) return { delayMs: 250, sse: sseToolCall('read_page', {}) };
+        return { sse: sseText('SCRIPTING-ACTOR-DID-NOT-OBSERVE-CONFIRMATION') };
+      }
+      if (!storeScriptingState.delegated) {
+        storeScriptingState.delegated = true;
+        return { sse: sseToolCall('message_actor', {
+          to: 'web',
+          message: `Open ${storeScriptingFixtureUrl}. Enter order STORE-42. Send the form. Report the confirmation code.`,
+        }) };
+      }
+      if (body.includes('you messaged has replied')) {
+        storeScriptingState.wakeBody = body;
+        return { sse: sseText('Chrome scripting completed the form with TICKET-STORE-42.') };
+      }
+      return { sse: sseText('Delegated to the web actor; awaiting its reply.') };
+    },
+    async run(ctx, rec) {
+      storeScriptingState = {
+        delegated: false, actorTurn: 0, actorPrompt: '', results: [], wakeBody: '', orderRef: '', sendRef: '',
+      };
+      const tabsBefore = await evalIn(ctx.page, `(async () =>
+        (await chrome.tabs.query({})).map((tab) => tab.id).filter(Number.isInteger))()`, true);
+      const fixture = await startWebFixtureServer();
+      storeScriptingFixtureUrl = `${fixture.url.replace('127.0.0.1', 'orders.peerd.test')}/contact`;
+      try {
+        const settings = await rpc(ctx.page, {
+          type: 'settings/update',
+          patch: { webActorActionSurface: 'tools', advancedAutomationEnabled: false },
+        });
+        rec.check('fallback settings select discrete tools without advanced automation',
+          settings?.ok === true
+            && settings.settings?.webActorActionSurface === 'tools'
+            && settings.settings?.advancedAutomationEnabled === false,
+          JSON.stringify(settings));
+
+        const sent = await rpc(ctx.page, {
+          type: 'agent/send',
+          text: 'Submit support request STORE-42 and report its confirmation code.',
+        });
+        rec.check('agent/send accepted', !!sent?.ok, JSON.stringify(sent));
+        await waitFor(() => (storeScriptingState.results.at(-1) || '').includes('TICKET-STORE-42'), {
+          budgetMs: 40_000, pollMs: 100,
+        });
+        await ctx.page.send('Page.bringToFront').catch(() => {});
+
+        let out = {};
+        await waitFor(async () => {
+          out = await evalIn(ctx.page, `(() => ({
+            bubbles: [...document.querySelectorAll('.message-assistant .bubble')]
+              .map((bubble) => bubble.textContent.trim()),
+            busy: !!document.querySelector('form.input-bar button.stop'),
+          }))()`) || {};
+          return (out.bubbles || []).includes('Chrome scripting completed the form with TICKET-STORE-42.')
+            && !out.busy;
+        }, { budgetMs: 40_000 });
+
+        const [, snapshotResult = '', typeResult = '', clickResult = ''] = storeScriptingState.results;
+        const readPageResult = storeScriptingState.results
+          .find((result) => result.includes('TICKET-STORE-42')) || '';
+        rec.check('the web actor received the discrete browser tools',
+          storeScriptingState.actorPrompt.includes('tools: snapshot')
+            && !storeScriptingState.actorPrompt.includes('tools: page_code'),
+          storeScriptingState.actorPrompt.slice(0, 500));
+        rec.check('snapshot used the Chrome scripting fallback',
+          snapshotResult.includes('DOM-walk fallback') && snapshotResult.includes('no CDP here'),
+          snapshotResult.slice(0, 1200));
+        rec.check('type and click used DOM-walk refs',
+          typeResult.includes('"typed": "STORE-42"')
+            && /"via"\s*:\s*"dom-walk"/.test(typeResult)
+            && clickResult.includes('"clicked": true')
+            && /"via"\s*:\s*"dom-walk"/.test(clickResult),
+          JSON.stringify({ typeResult, clickResult }));
+        rec.check('the actor observed the submitted result',
+          readPageResult.includes('TICKET-STORE-42'), readPageResult.slice(-1200));
+        rec.check('the actor reply returned through a fenced wake',
+          storeScriptingState.wakeBody.includes('you messaged has replied')
+            && storeScriptingState.wakeBody.includes('<untrusted_web_content')
+            && storeScriptingState.wakeBody.includes('SCRIPTING-ACTOR-DONE TICKET-STORE-42'),
+          storeScriptingState.wakeBody.slice(-1000));
+        rec.check('the final answer renders and the turn is idle',
+          (out.bubbles || []).includes('Chrome scripting completed the form with TICKET-STORE-42.')
+            && out.busy === false,
+          JSON.stringify(out));
+        await rec.shot('final');
+      } finally {
+        await rpc(ctx.page, { type: 'agent/stop' }).catch(() => {});
+        const reset = await rpc(ctx.page, {
+          type: 'settings/reset',
+          keys: ['webActorActionSurface', 'advancedAutomationEnabled'],
+        }).catch((error) => ({ ok: false, error: String(error) }));
+        await evalIn(ctx.page, `(async () => {
+          const before = new Set(${JSON.stringify(tabsBefore)});
+          const tabs = await chrome.tabs.query({});
+          await Promise.all(tabs.filter((tab) => Number.isInteger(tab.id)
+            && (!before.has(tab.id) || tab.url === ${JSON.stringify(storeScriptingFixtureUrl)}))
+            .map((tab) => chrome.tabs.remove(tab.id).catch(() => {})));
+        })()`, true).catch(() => {});
+        await fixture.close().catch(() => {});
+        rec.check('the channel settings reset after the fallback probe', reset?.ok === true, JSON.stringify(reset));
+        if (!reset?.ok) throw new Error(`settings reset failed: ${JSON.stringify(reset)}`);
       }
     },
   },
@@ -4103,15 +4235,8 @@ export const STATES = [
       await rec.shot('script-fanout-done');
     },
   },
-  // --- functional: the actor-model delegation flow (message_actor end to end) --
-  // The headline of #61: the orchestrator delegates a web read to the chat's web
-  // actor via message_actor, gets a SYNC ack and ends its turn (async-everything,
-  // never blocks), the web-actor sub-loop runs on its own slot and replies, and
-  // deliver() re-enters the orchestrator on a LATER synthetic+trusted wake turn
-  // carrying the fenced reply. The actor reply is plain text (no fetch_url) so
-  // there is ZERO real egress — the whole cross-process path runs under the
-  // faked wire. The responder tells orchestrator vs actor turns apart by the
-  // actor system-prompt marker (callIndex is fragile — the two slots interleave).
+  // message_actor ends the first turn. Its isolated reply re-enters later as a
+  // fenced wake. Plain fixture text keeps this cross-process proof egress-free.
   {
     name: 'actor-delegate', kind: 'functional', phase: 'post-unlock',
     responder: (callIndex, request) => {
@@ -4124,15 +4249,10 @@ export const STATES = [
         hasFence: body.includes('<untrusted_web_content'),
         hasActorText: body.includes('PRICE_IS_42'),
       });
-      // ACTOR sub-loop turn: plain text, no tool call → no fetch_url → no egress.
-      // Hold the isolated turn open long enough to inspect the live Actor Fabric
-      // at real side-panel width; without this, the fake reply can settle within
-      // one paint and only the terminal transcript receipt is observable.
-      if (isActor) return { delayMs: 3_500, sse: sseText('PRICE_IS_42') };
-      // ORCHESTRATOR — the async wake turn carrying the fenced reply: final answer.
+      // why: delay the plain reply so the live fabric remains observable.
+      if (isActor) return { delayMs: 5_000, sse: sseText('PRICE_IS_42') };
       if (body.includes('you messaged has replied')) return { sse: sseText('FINAL-ORCH-REPLY') };
-      // ORCHESTRATOR — delegate ONCE; then the post-ack step ends the turn (the
-      // ack tells the model the reply arrives later, so a real model stops here).
+      // The first orchestrator turn delegates once, then ends on the async ack.
       if (actorState.delegates === 0) {
         actorState.delegates += 1;
         return { sse: sseToolCall('message_actor', { to: 'web', message: 'get the price of widget X' }) };
@@ -4147,6 +4267,13 @@ export const STATES = [
         () => evalIn(ctx.page, `!!document.querySelector('.message-assistant .tool-call.tool-actor')`),
         { budgetMs: 15_000, pollMs: 100 });
       rec.check('an inline message_actor card mounts under the orchestrator turn', !!cardSeen);
+      const collapsedFabric = await waitFor(
+        () => evalIn(ctx.page, `document.querySelector('.actor-fabric-toggle')?.getAttribute('aria-expanded')`),
+        { budgetMs: 15_000, pollMs: 100 });
+      rec.check('the live Actor Fabric starts as a compact, accessible disclosure',
+        collapsedFabric === 'false', String(collapsedFabric));
+      if (collapsedFabric) await rec.shot('actor-fabric-collapsed');
+      await evalIn(ctx.page, `document.querySelector('.actor-fabric-toggle')?.click()`);
       const fabric = await waitFor(
         () => evalIn(ctx.page, `(() => {
           const panel = document.querySelector('.actor-fabric');
@@ -4160,7 +4287,6 @@ export const STATES = [
             expanded: toggle.getAttribute('aria-expanded'),
             actorKind: actor.getAttribute('data-node-kind'),
             actorPressed: actor.getAttribute('aria-pressed'),
-            text: panel.textContent ?? '',
             toggleHeight: toggleRect.height,
             withinViewport: panelRect.left >= 0 && panelRect.right <= innerWidth,
             contentFits: !!body && body.scrollWidth <= body.clientWidth
@@ -4168,18 +4294,11 @@ export const STATES = [
           };
         })()`),
         { budgetMs: 15_000, pollMs: 100 });
-      rec.check('the live Actor Fabric mounts expanded with an inspectable bound actor',
+      rec.check('opening the live Actor Fabric reveals an inspectable actor in the panel',
         fabric?.expanded === 'true'
           && fabric?.actorKind === 'bound'
-          && fabric?.actorPressed === 'false',
-        JSON.stringify(fabric));
-      rec.check('the fabric makes exact capability + fenced handoff concrete at a glance',
-        fabric?.text.includes('one web tab ·')
-          && fabric?.text.includes('separate worker')
-          && fabric?.text.includes('fenced reply'),
-        JSON.stringify(fabric?.text));
-      rec.check('the fabric fits the panel and keeps a 44px disclosure target',
-        fabric?.withinViewport === true
+          && fabric?.actorPressed === 'false'
+          && fabric?.withinViewport === true
           && fabric?.contentFits === true
           && fabric?.toggleHeight >= 44,
         JSON.stringify(fabric));
@@ -4188,11 +4307,13 @@ export const STATES = [
         const rehydrated = await waitFor(
           () => evalIn(ctx.page, `(() => {
             const panel = document.querySelector('.actor-fabric');
+            const toggle = panel?.querySelector('.actor-fabric-toggle');
+            if (toggle?.getAttribute('aria-expanded') === 'false') toggle.click();
             const actor = panel?.querySelector('[data-node-id^="actor:"]');
             return panel && actor ? panel.textContent : null;
           })()`),
           { budgetMs: 15_000, pollMs: 50 });
-        rec.check('a freshly reconnected panel rehydrates the still-live actor fabric',
+        rec.check('opening the rehydrated fabric reveals the still-live actor',
           typeof rehydrated === 'string'
             && rehydrated.includes('get the price of widget X')
             && rehydrated.includes('separate worker'),
@@ -4673,10 +4794,7 @@ export const STATES = [
     },
   },
 
-  // --- functional + visual: the real nested Actor Fabric at panel width ----
-  // Two async siblings overlap; one delegates to its bound web actor. This is
-  // the defining topology (root → temporary child → resource-bound child), not
-  // a component fixture, and catches indentation/connector/overflow failures.
+  // A real nested fabric covers root → temporary child → bound child layout.
   {
     name: 'actor-fabric-hierarchy', kind: 'functional', phase: 'post-unlock',
     responder: (callIndex, request) => {
@@ -4718,6 +4836,9 @@ export const STATES = [
         type: 'agent/send', text: 'compare price and warranty with isolated actors',
       });
       rec.check('agent/send accepted', !!sent?.ok, JSON.stringify(sent));
+      await waitFor(() => evalIn(ctx.page,
+        `document.querySelector('.actor-fabric-toggle')?.getAttribute('aria-expanded') === 'false'`));
+      await evalIn(ctx.page, `document.querySelector('.actor-fabric-toggle')?.click()`);
       const hierarchy = await waitFor(
         () => evalIn(ctx.page, `(() => {
           const panel = document.querySelector('.actor-fabric');

--- a/tests/background/origin-lock-controller.test.ts
+++ b/tests/background/origin-lock-controller.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { makeOriginLockResolver } from '../../extension/background/origin-lock-controller.js';
+import { makeApiActorBindings } from '../../extension/peerd-runtime/actor/web-actor.js';
 
 const makeHarness = () => {
   const turnTokens = new Map([['actor', 1]]);
@@ -7,7 +8,9 @@ const makeHarness = () => {
   const released: number[] = [];
   const audits: any[] = [];
   let judgeDeps: any;
-  const state = { mode: 'bound', provisional: false };
+  const state = { mode: 'bound', provisional: true };
+  const siteActorBindings = makeApiActorBindings();
+  siteActorBindings.bind('chat-1', 'https://safe.example', 'actor');
   const deps: any = {
     originStates: {
       read: () => state,
@@ -31,7 +34,7 @@ const makeHarness = () => {
     webActorTabBindings: { tabFor: () => 7, drop: () => true },
     persistWebBindings: () => {},
     pageActivity: { release: async (id: number) => { released.push(id); } },
-    siteActorBindings: { entries: () => [], drop: () => {} }, persistSiteActors: () => {},
+    siteActorBindings, persistSiteActors: () => {},
     auditLog: { append: async (event: any) => { audits.push(event); } },
     originPhrase: (url: string) => new URL(url).origin,
     isKnownIdp: () => false, isKnownIdpHost: () => false,
@@ -45,7 +48,7 @@ const makeHarness = () => {
     liveSiteClientLandingFor: async () => ({ status: 'none' }),
   };
   const resolve = makeOriginLockResolver(deps);
-  return { resolve, turnTokens, stopped, released, audits, getJudgeDeps: () => judgeDeps };
+  return { resolve, turnTokens, stopped, released, audits, siteActorBindings, getJudgeDeps: () => judgeDeps };
 };
 
 describe('origin lock controller', () => {
@@ -65,17 +68,16 @@ describe('origin lock controller', () => {
     });
   });
 
-  test('stops the current turn, releases its binding, and narrows audit URLs', async () => {
+  test('stops the current turn, drops its bindings, and narrows audit URLs', async () => {
     const harness = makeHarness();
     harness.resolve('actor');
     await harness.getJudgeDeps().onStop({
       action: 'handoff', from: 'https://safe.example/',
       to: 'https://other.example/attacker-controlled?payload=1',
     });
-    await Promise.resolve();
-
     expect(harness.stopped).toEqual(['actor']);
     expect(harness.released).toEqual([7]);
+    expect(harness.siteActorBindings.resolve('chat-1', 'https://safe.example')).toBeNull();
     expect(harness.audits[0].details.to).toBe('https://other.example');
     expect(JSON.stringify(harness.audits[0])).not.toContain('attacker-controlled');
   });


### PR DESCRIPTION
Summary

- Keep chat pinned to live output until the user scrolls away.
- Resume live following when the user changes chats.
- Collapse Actor Fabric by default.
- Clear stale site actor bindings correctly.
- Add Chrome scripting fallback E2E coverage.

Checks

- bun test ./tests --timeout 15000
- bun scripts/cdp/run-inbrowser-tests.mjs
- bun run lint
- bun run typecheck
- bun run e2e:verify --functional