### PR TITLE
fix(goal): make Stop durable

### DIFF
--- a/badges/functional-tests.json
+++ b/badges/functional-tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "Functional Tests",
-  "message": "6411/6411 passing",
+  "message": "6413/6413 passing",
   "color": "brightgreen",
   "namedLogo": "bun",
   "logoColor": "white"

--- a/extension/background/routes/session-mutations.js
+++ b/extension/background/routes/session-mutations.js
@@ -17,7 +17,7 @@ export const makeSessionMutationRoutes = (deps) => {
     vault, auditLog, pushState, sessions, sessionCache, sessionState, autoMemory,
     resolvePermission, normalizeMode, normalizeConfirmActions, SessionNotFoundError,
     maybeAutoResumeAfterRecovery, haltGoalRun, turnSlots, actorMessaging, nukeSessionWorkspace,
-    purgeLifecycleSession,
+    actorLifecycle, purgeLifecycleSession,
   } = deps;
 
   return {
@@ -44,24 +44,7 @@ export const makeSessionMutationRoutes = (deps) => {
       // why read BEFORE delete: "new chat" is a switch-away from the
       // current session — one of auto-memory's two lifecycle seams.
       const previousId = await sessionCache.sessionGet('currentSessionId');
-      // why: a "new chat" abandons the current one — end its goal run (if any)
-      // so it doesn't keep driving the orphaned session in the background.
-      // (A plain session/switch does NOT halt — that's the "keep running while
-      // I'm in another chat" case.) Awaited: stop() durably forgets the run's
-      // persisted record, so a "new chat" can't be undone by a resume() on the
-      // next unlock even if the SW is torn down right after this handler (#60).
-      if (previousId) await haltGoalRun?.(previousId);
-      // A "new chat" abandons the current session, so its BACKGROUND WORK must
-      // stop — not keep running invisibly. haltGoalRun (above) ends any goal
-      // loop; this ends the live TURN and CASCADES to its in-flight ACTORS (each
-      // runs on its OWN turn slot, so stopping the orchestrator alone leaves
-      // delegated web/VM/App/Notebook work running to completion). why: without
-      // it, New-chat mid-web-task — and the OM2W eval harness, which
-      // session/resets between EVERY task — leaks a live web-actor loop; they
-      // pile up until the SW saturates and every later turn stalls (the harness
-      // "2 tasks then a wall of timeouts"). Mirrors agent/stop's cascade
-      // (routes/sessions.js). Guarded so callers that don't wire the slots (unit
-      // tests) are a no-op.
+      // New chat must stop all work that belongs to the current session.
       if (previousId && turnSlots?.stop?.(previousId)) {
         auditLog.append({ type: 'session_ended', sessionId: previousId, details: { reason: 'session_reset' } }).catch(() => {});
       }
@@ -72,12 +55,16 @@ export const makeSessionMutationRoutes = (deps) => {
           }
         }
       }
+      if (previousId && actorLifecycle?.stopSubtree) {
+        for (const childSessionId of actorLifecycle.stopSubtree(previousId)) {
+          auditLog.append({ type: 'actor_stopped', sessionId: previousId, details: { childSessionId, reason: 'session_reset_cascade' } }).catch(() => {});
+        }
+      }
+      // A failed durable goal removal blocks reset and a later resume.
+      if (previousId) await haltGoalRun?.(previousId);
       await sessionCache.sessionDelete('currentSessionId');
       sessionState.clear();
-      // The caller may send the first message of the new chat immediately
-      // after this route resolves. Finish projecting the empty chat first so
-      // this reset snapshot cannot arrive after that turn's live events and
-      // wipe the new transcript back to the welcome screen.
+      // Finish the empty state first. A late reset must not erase a new turn.
       await pushState();
       if (previousId) {
         autoMemory.maybeExtract(previousId, 'switch')
@@ -119,14 +106,8 @@ export const makeSessionMutationRoutes = (deps) => {
     'session/archive': async ({ sessionId }) => {
       if (vault.isLocked()) return { ok: false, error: 'locked' };
       try {
-        await sessions.archive(sessionId);
-        // Archiving wraps the chat up — end its goal run (if any) so it can't
-        // keep running on a put-away session. Awaited: durably forget the run so
-        // it can't resurrect on the next unlock (#60).
-        await haltGoalRun?.(sessionId);
-        // Archive is also Stop. End the root turn and every delegated actor
-        // before cleaning up durable state so no hidden work can continue on
-        // a put-away chat.
+        if (!await sessions.get(sessionId)) return { ok: false, error: 'session-not-found' };
+        // Archive must stop all work before it changes durable state.
         if (turnSlots?.stop?.(sessionId)) {
           auditLog.append({ type: 'session_ended', sessionId, details: { reason: 'session_archive' } }).catch(() => {});
         }
@@ -140,35 +121,31 @@ export const makeSessionMutationRoutes = (deps) => {
             }
           }
         }
-        // Settle lifecycle records before returning. For dispatched Class D/E
-        // actions this preserves uncertainty and a verification notice instead
-        // of falsely reporting cancellation.
-        // Tool operations are keyed to the execution session, not only the
-        // owning root chat. Settle every stopped actor too, before archive
-        // returns, so a crash cannot strand its dispatched D/E action until a
-        // later boot or hide its verification notice in an archived chat.
+        if (actorLifecycle?.stopSubtree) {
+          for (const childSessionId of actorLifecycle.stopSubtree(sessionId)) {
+            actorSessionIds.push(childSessionId);
+            auditLog.append({ type: 'actor_stopped', sessionId, details: { childSessionId, reason: 'session_archive_cascade' } }).catch(() => {});
+          }
+        }
+        // A failed durable goal Stop leaves the session available for a retry.
+        await haltGoalRun?.(sessionId);
+        await sessions.archive(sessionId);
+        // Settle each execution session. Keep uncertain side effects visible.
         for (const lifecycleSessionId of new Set([sessionId, ...actorSessionIds])) {
           await purgeLifecycleSession?.(lifecycleSessionId);
         }
-        // If the archived session was the active one, drop the cache so
-        // the next agent/send creates a fresh session.
+        // Clear the active cache when it points to the archived session.
         const currentId = await sessionCache.sessionGet('currentSessionId');
         if (currentId === sessionId) {
           await sessionCache.sessionDelete('currentSessionId');
           sessionState.clear();
         }
         pushState();
-        // Auto-memory lifecycle seam: archiving IS the session wrapping
-        // up. Fire-and-forget so archive stays instant.
+        // Archive starts a best-effort memory extraction.
         autoMemory.maybeExtract(sessionId, 'archive')
           .catch((/** @type {unknown} */ e) => console.warn('[sw] auto-memory extract failed', e));
-        // Tear down the session's durable script workspace
-        // (['peerd-workspace', sid] in OPFS). why HERE: archive is the terminal
-        // session-lifecycle event today — no session-delete route exists (the
-        // sessions view's "×" archives) — so this is where "the session is torn
-        // down" lives; if a true delete route ever lands, it must nuke too.
-        // Fire-and-forget + guarded: workspace bytes are agent scratch,
-        // best-effort cleanup must never fail the archive.
+        // why: Archive is the terminal session event. Remove its script files.
+        // Cleanup is best-effort and must not fail archive.
         Promise.resolve(nukeSessionWorkspace?.(sessionId)).catch(() => {});
         return { ok: true };
       } catch (e) {

--- a/extension/background/routes/sessions.js
+++ b/extension/background/routes/sessions.js
@@ -38,30 +38,13 @@ export const makeSessionRoutes = (deps) => {
   return {
     // --- agent ---
     'agent/stop': async () => {
-      // Idempotent — silent if there's nothing in flight. Scoped to the
-      // CURRENT chat: Stop must never reach across conversations and kill
-      // a turn streaming elsewhere (turn slots are per-session).
+      // Stop only the current chat. Other chats have separate turn slots.
       const sessionId = await sessionCache.sessionGet('currentSessionId');
-      // Stop ends the whole goal run (not just the in-flight turn) so it can't
-      // auto-continue after the abort. Awaited: haltGoalRun durably removes the
-      // run's persisted record, so a Stop can't be undone by a resume() on the
-      // next unlock even if the SW is torn down right after this handler returns.
-      if (sessionId && haltGoalRun) await haltGoalRun(/** @type {any} */ (sessionId));
       if (sessionId && turnSlots.stop(sessionId)) {
         auditLog.append({ type: 'session_ended', details: { reason: 'user_stop' } })
           .catch(() => {});
       }
-      // DESIGN-17 P1 — CASCADE the stop to this chat's in-flight ACTORS. They
-      // run on their OWN turn slots (an actor is a separate session), so the line
-      // above only aborted the orchestrator; without this, delegated VM/App/Notebook
-      // work keeps mutating to completion after the user hit Stop — sharper now that
-      // goal mode can autonomously drive actors. stopActorsFor bumps a per-
-      // sender Stop generation (so an actor turn still QUEUED behind another on the
-      // same slot skips when drained) AND returns the RUNNING actor sessions to
-      // abort. Aborting a slot lands at its loop's next checkpoint (interruptible per
-      // the spec); the aborted turn settles through the normal path, delivering a
-      // "stopped before a reply" note and clearing its durable mailbox entry — so a
-      // redrain can't resurrect it.
+      // Actors use separate slots. Stop them and invalidate queued actor turns.
       if (sessionId && actorMessaging?.stopActorsFor) {
         for (const actorSessionId of actorMessaging.stopActorsFor(/** @type {any} */ (sessionId))) {
           if (turnSlots.stop(actorSessionId)) {
@@ -69,17 +52,19 @@ export const makeSessionRoutes = (deps) => {
           }
         }
       }
-      // PR #134 phase 5 — cascade the Stop through the ACTOR subtree too.
-      // Children run under their own turn slots now (spawn.js claims one per
-      // child), so the line above never reached them; without this, spawned
-      // work — including grandchildren, since one Stop must end the whole
-      // delegation graph — kept running after the user hit Stop. stopSubtree
-      // walks the live-children registry transitively and aborts each slot.
-      // (Actor turns those children had in flight are already covered: the
-      // actor bookkeeping is keyed by the lineage ROOT, i.e. this chat.)
+      // Spawned descendants also use separate slots.
       if (sessionId && actorLifecycle?.stopSubtree) {
         for (const childSessionId of actorLifecycle.stopSubtree(/** @type {any} */ (sessionId))) {
           auditLog.append({ type: 'actor_stopped', details: { childSessionId, reason: 'user_stop_cascade' } }).catch(() => {});
+        }
+      }
+      // Stop the live work even if the durable goal removal fails. Report that
+      // failure because a stale record can resume after the next worker start.
+      if (sessionId && haltGoalRun) {
+        try { await haltGoalRun(/** @type {any} */ (sessionId)); }
+        catch {
+          postChatNote('Goal Stop was not saved. Retry before you close peerd.');
+          return { ok: false, error: 'goal-stop-persistence-failed' };
         }
       }
       return { ok: true };

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -8219,7 +8219,7 @@ browser.runtime.onMessage.addListener(/** @type {any} */ (makeDispatcher({
     // session/reset (New chat) must stop the abandoned session's live turn AND
     // cascade to its in-flight actors — same primitives agent/stop uses — so
     // background web/VM/App work doesn't keep running on the orphaned session.
-    turnSlots, actorMessaging,
+    turnSlots, actorMessaging, actorLifecycle,
     // Session teardown drops the durable script workspace subtree.
     nukeSessionWorkspace,
     // …and the session's lifecycle state (§2.5 cancellation dominance).

--- a/extension/peerd-runtime/loop/goal-runner.js
+++ b/extension/peerd-runtime/loop/goal-runner.js
@@ -96,11 +96,19 @@ export const makeGoalRunner = ({
 }) => {
   /** @type {Map<string, GoalRun>} */
   const runs = new Map();
+  /** @type {Set<string>} */
+  const stopping = new Set();
+  /** @type {Promise<void>} */
+  let persistenceTail = Promise.resolve();
+  // why: Queue mirror changes so Stop wins over older writes.
+  /** @param {() => Promise<void>} operation */
+  const queuePersistence = (operation) => {
+    const pending = persistenceTail.then(operation);
+    persistenceTail = pending.catch(() => {});
+    return pending;
+  };
 
-  // Mirror the live (non-terminal) runs to storage. Fire-and-forget: the
-  // in-memory map is authoritative within an SW lifetime; this is the seam that
-  // lets resume() pick up after a restart. Best-effort — a write failure just
-  // means that run won't resume, not that the live run breaks.
+  // Mirror active runs. A mirror failure must not stop a live run.
   const persist = () => {
     if (!kv) return;
     /** @type {Record<string, { goal: string, iteration: number, startedAt: number }>} */
@@ -109,7 +117,7 @@ export const makeGoalRunner = ({
       if (r.completed || r.halted) continue;
       out[sid] = { goal: r.goal, iteration: r.iteration, startedAt: r.startedAt };
     }
-    Promise.resolve(kv.set(GOAL_RUNS_KEY, out)).catch(() => {});
+    queuePersistence(() => kv.set(GOAL_RUNS_KEY, out)).catch(() => {});
   };
 
   /** @param {string} sid @returns {GoalRun | null} */
@@ -118,11 +126,7 @@ export const makeGoalRunner = ({
   const isActive = (sid) => { const r = runs.get(sid); return !!r && !r.completed && !r.halted; };
 
   /**
-   * Is a run for this session recorded in the DURABLE mirror — i.e. live OR
-   * merely not-yet-resumed after an SW restart OR vault-lock-paused (evicted
-   * from the map but kept in the mirror for resume)? Prewalk's reconcile
-   * consults this so a mid-restart/paused run is never mistaken for a dead one
-   * and wrongly restored to the planner model. A no-op (false) without kv.
+   * Check the live map and durable mirror for a run.
    * @param {string} sid @returns {Promise<boolean>}
    */
   const isPersisted = async (sid) => {
@@ -172,37 +176,27 @@ export const makeGoalRunner = ({
   /** Stop / steer-takeover: end the run without declaring success. @param {string} sid */
   const halt = (sid) => { const r = runs.get(sid); if (r) { r.halted = true; persist(); } };
 
-  // Durably drop ONE session's record from the mirror (read-modify-write).
-  // why not persist(): persist() writes a snapshot of the in-memory MAP, which a
-  // PAUSED run (vault-lock) is no longer in — so it can't remove a paused run's
-  // record, and a live run's persist() is fire-and-forget. forget() is keyed by
-  // sid and reaches the record either way. Best-effort, like persist(). No kv → no-op.
+  // A paused run is not in the map, so remove its durable record by id. Report
+  // storage errors. Success must mean that the run cannot resume.
   /** @param {string} sid */
   const forget = async (sid) => {
     if (!kv) return;
-    try {
+    await queuePersistence(async () => {
       const stored = await kv.get(GOAL_RUNS_KEY);
-      if (stored && typeof stored === 'object' && Object.hasOwn(stored, sid)) {
-        const next = { ...stored };
-        delete next[sid];
-        await kv.set(GOAL_RUNS_KEY, next);
-      }
-    } catch { /* best-effort — a lost write just means it may resume once more */ }
+      if (!stored || typeof stored !== 'object' || !Object.hasOwn(stored, sid)) return;
+      const next = { ...stored };
+      delete next[sid];
+      await kv.set(GOAL_RUNS_KEY, next);
+    });
   };
 
-  /**
-   * Durable user-initiated Stop (Stop button, steer-takeover, new-chat, archive).
-   * Halts any live run AND awaits removal of the persisted record, so a Stop can't
-   * be silently undone by resume() on the next vault unlock. Unlike halt() (the
-   * internal supersede/error mark, in-memory only), this is keyed by sid and works
-   * even when the run was PAUSED and evicted from the map, or when a live run's
-   * fire-and-forget persist() hasn't committed yet.
-   * @param {string} sid
-   */
+  /** Stop a live or paused run. @param {string} sid */
   const stop = async (sid) => {
+    stopping.add(sid);
     const r = runs.get(sid);
     if (r) r.halted = true;  // its drive() loop sees !alive() and exits to the terminal finally
     await forget(sid);
+    stopping.delete(sid);
   };
 
   /** @param {string} sid @param {'running'|'done'|'halted'|'capped'} phase */
@@ -300,15 +294,12 @@ export const makeGoalRunner = ({
     }
   };
 
-  /**
-   * Start (or supersede) a goal run for a session. Fire-and-forget — returns
-   * immediately; the turns stream over the port like any chat.
-   * @param {{ sessionId: string, goal: string }} req
-   */
+  /** Start or replace a goal run. @param {{ sessionId: string, goal: string }} req */
   const start = async ({ sessionId, goal }) => {
     if (!sessionId || typeof goal !== 'string' || !goal.trim()) {
       return { ok: false, error: 'goal-required' };
     }
+    stopping.delete(sessionId);
     if (runs.has(sessionId)) halt(sessionId);  // supersede any prior run
     runs.set(sessionId, {
       goal: goal.trim(), iteration: 0, completed: false, halted: false,
@@ -322,40 +313,32 @@ export const makeGoalRunner = ({
     return { ok: true };
   };
 
-  /**
-   * Re-drive any persisted active runs after an SW restart (called once the
-   * vault is unlocked — a turn needs the key). Each rehydrated run continues
-   * from its persisted iteration (so it sends a synthetic continuation, not a
-   * fresh goal). A no-op without kv or with nothing stored. Idempotent: skips a
-   * session that already has a live run.
-   * @returns {Promise<{ resumed: number }>}
-   */
+  /** Restore durable runs after restart. Skip live and stopping runs.
+   * @returns {Promise<{ resumed: number }>} */
   const resume = async () => {
     if (!kv) return { resumed: 0 };
-    let stored;
-    try { stored = await kv.get(GOAL_RUNS_KEY); } catch { return { resumed: 0 }; }
-    if (!stored || typeof stored !== 'object') return { resumed: 0 };
     let resumed = 0;
-    for (const [sid, raw] of Object.entries(stored)) {
-      if (!sid || runs.has(sid)) continue;
-      const rec = /** @type {{ goal?: unknown, iteration?: unknown, startedAt?: unknown }} */ (raw);
-      if (!rec || typeof rec.goal !== 'string' || !rec.goal) continue;
-      // why clamp at the cap: persist() records the iteration ABOUT to run, so a
-      // crash resumes there. But if the SW died DURING the final allowed turn, the
-      // stored iteration === maxIterations and drive()'s `iteration < maxIterations`
-      // would be false immediately — declaring 'capped' for a turn that never
-      // actually ran. Rewind one so that interrupted final turn re-runs once.
-      const storedIteration = Number(rec.iteration) || 0;
-      const iteration = storedIteration >= maxIterations ? Math.max(0, maxIterations - 1) : storedIteration;
-      runs.set(sid, {
-        goal: rec.goal,
-        iteration,
-        completed: false, halted: false, summary: null, lastError: null,
-        startedAt: Number(rec.startedAt) || now(),
-      });
-      drive(sid).catch((e) => { console.error('[goal] resume drive threw', e); halt(sid); });
-      resumed += 1;
-    }
+    await queuePersistence(async () => {
+      let stored;
+      try { stored = await kv.get(GOAL_RUNS_KEY); } catch { return; }
+      if (!stored || typeof stored !== 'object') return;
+      for (const [sid, raw] of Object.entries(stored)) {
+        if (!sid || runs.has(sid) || stopping.has(sid)) continue;
+        const rec = /** @type {{ goal?: unknown, iteration?: unknown, startedAt?: unknown }} */ (raw);
+        if (!rec || typeof rec.goal !== 'string' || !rec.goal) continue;
+        // A crash during the final allowed turn must re-run that turn once.
+        const storedIteration = Number(rec.iteration) || 0;
+        const iteration = storedIteration >= maxIterations ? Math.max(0, maxIterations - 1) : storedIteration;
+        runs.set(sid, {
+          goal: rec.goal,
+          iteration,
+          completed: false, halted: false, summary: null, lastError: null,
+          startedAt: Number(rec.startedAt) || now(),
+        });
+        drive(sid).catch((e) => { console.error('[goal] resume drive threw', e); halt(sid); });
+        resumed += 1;
+      }
+    });
     return { resumed };
   };
 

--- a/tests/background/routes-session-mutations.test.ts
+++ b/tests/background/routes-session-mutations.test.ts
@@ -34,6 +34,7 @@ const baseDeps = (over: any = {}) => {
     // Defaults = "nothing in flight" so the other reset tests are unaffected.
     turnSlots: { stop: () => false },
     actorMessaging: { stopActorsFor: () => [] },
+    actorLifecycle: { stopSubtree: () => [] },
     resolvePermission: async (s: any) => ({ mode: s ? 'act' : 'plan', confirmActions: false }),
     normalizeMode: (m: string) => (m === 'plan' ? 'plan' : 'act'),
     normalizeConfirmActions: (c: any) => c === true,
@@ -94,17 +95,20 @@ describe('session/reset + switch + archive auto-memory seams', () => {
     expect(calls.cacheSet).toEqual({ sessionId: 's2' });
     expect(calls.extract).toEqual([['cur', 'switch']]);
   });
-  test('reset STOPS the abandoned session\'s turn AND cascades to its in-flight actors', async () => {
+  test('reset stops the root, bound actors, and spawned descendants', async () => {
     // The current chat is 'cur' with two actors in flight. "New chat" must abort
     // the orchestrator turn AND both actor slots — else they run on as zombies
     // (the OM2W harness wedge). Mirrors agent/stop's cascade.
     const stopped: string[] = [];
+    const subtreeRoots: string[] = [];
     const { deps } = baseDeps({
       turnSlots: { stop: (sid: string) => { stopped.push(sid); return true; } },
       actorMessaging: { stopActorsFor: (sid: string) => (sid === 'cur' ? ['res-1', 'res-2'] : []) },
+      actorLifecycle: { stopSubtree: (sid: string) => { subtreeRoots.push(sid); return ['child-1']; } },
     });
     await makeSessionMutationRoutes(deps)['session/reset']();
     expect(stopped).toEqual(['cur', 'res-1', 'res-2']);   // orchestrator first, then its actors
+    expect(subtreeRoots).toEqual(['cur']);
   });
   test('reset with nothing in flight does not over-stop', async () => {
     const stopped: string[] = [];
@@ -146,6 +150,7 @@ describe('session/reset + switch + archive auto-memory seams', () => {
     const { deps } = baseDeps({
       turnSlots: { stop: (sid: string) => { events.push(`stop:${sid}`); return true; } },
       actorMessaging: { stopActorsFor: () => ['actor-1', 'actor-2'] },
+      actorLifecycle: { stopSubtree: (sid: string) => { events.push(`subtree:${sid}`); return ['child-1']; } },
       purgeLifecycleSession: async (sid: string) => {
         events.push(`purge:${sid}`);
         await new Promise((resolve) => setTimeout(resolve, 10));
@@ -155,7 +160,7 @@ describe('session/reset + switch + archive auto-memory seams', () => {
     await makeSessionMutationRoutes(deps)['session/archive']({ sessionId: 's2' });
     expect(events).toEqual([
       'stop:s2', 'stop:actor-1', 'stop:actor-2',
-      'purge:s2', 'purge:actor-1', 'purge:actor-2',
+      'subtree:s2', 'purge:s2', 'purge:actor-1', 'purge:actor-2', 'purge:child-1',
     ]);
     expect(settled).toBe(true);
   });
@@ -214,7 +219,8 @@ describe('session/reset + switch + archive auto-memory seams', () => {
     expect(calls.extract).toEqual([['cur', 'archive']]);
   });
   test('archive maps SessionNotFoundError', async () => {
-    const { deps } = baseDeps({ sessions: { archive: async () => { throw new SessionNotFoundError(); } } });
+    const { deps } = baseDeps({ sessions: { get: async () => ({ sessionId: 'x' }),
+      archive: async () => { throw new SessionNotFoundError(); } } });
     expect(await makeSessionMutationRoutes(deps)['session/archive']({ sessionId: 'x' })).toEqual({ ok: false, error: 'session-not-found' });
   });
   // Archive is the terminal session-lifecycle event (there is no delete route),
@@ -236,7 +242,7 @@ describe('session/reset + switch + archive auto-memory seams', () => {
   test('a FAILED archive (unknown session) does not nuke the workspace', async () => {
     const nuked: string[] = [];
     const { deps } = baseDeps({
-      sessions: { archive: async () => { throw new SessionNotFoundError(); } },
+      sessions: { get: async () => null },
       nukeSessionWorkspace: (sid: string) => { nuked.push(sid); return Promise.resolve(); },
     });
     await makeSessionMutationRoutes(deps)['session/archive']({ sessionId: 'ghost' });
@@ -260,10 +266,7 @@ describe('permission/set', () => {
   });
 });
 
-// #60 (related): new-chat and archive must AWAIT the durable goal Stop, so the
-// run's persisted record is forgotten before the handler returns — otherwise an
-// SW teardown right after could let resume() resurrect the stopped run. A
-// late-resolving haltGoalRun reverts-proves the await (un-awaited → not done yet).
+// A route must finish durable Goal Stop before it resets or archives a session.
 describe('durable goal Stop is awaited on new-chat / archive (#60)', () => {
   const slowHalt = () => {
     let done = false;
@@ -280,8 +283,13 @@ describe('durable goal Stop is awaited on new-chat / archive (#60)', () => {
 
   test('session/archive awaits the durable Stop before returning', async () => {
     const halt = slowHalt();
-    const { deps } = baseDeps({ haltGoalRun: halt.haltGoalRun });
+    let archivedAfterHalt = false;
+    const { deps } = baseDeps({
+      haltGoalRun: halt.haltGoalRun,
+      sessions: { get: async () => ({ sessionId: 'cur' }),
+        archive: async () => { archivedAfterHalt = halt.isDone(); } },
+    });
     await makeSessionMutationRoutes(deps)['session/archive']({ sessionId: 'cur' });
-    expect(halt.isDone()).toBe(true);
+    expect(archivedAfterHalt).toBe(true);
   });
 });

--- a/tests/background/routes-sessions.test.ts
+++ b/tests/background/routes-sessions.test.ts
@@ -131,15 +131,17 @@ describe('session read routes', () => {
     expect(await makeSessionRoutes(deps)['agent/stop']()).toEqual({ ok: true });
     expect(audited).toBe(true);
   });
-  test('agent/stop CASCADES to the chat’s in-flight actors (DESIGN-17 P1)', async () => {
+  test('agent/stop CASCADES before it reports a durable goal Stop failure', async () => {
     // The current chat is 'a'; it has two actors in flight. Stop must abort the
     // orchestrator AND both actor slots (an actor runs on its own slot).
     const stopped: string[] = [];
     const { deps } = baseDeps({
+      haltGoalRun: async () => { throw new Error('storage unavailable'); },
       turnSlots: { stop: (sid: string) => { stopped.push(sid); return true; } },
       actorMessaging: { stopActorsFor: (sid: string) => (sid === 'a' ? ['res-1', 'res-2'] : []) },
     });
-    expect(await makeSessionRoutes(deps)['agent/stop']()).toEqual({ ok: true });
+    expect(await makeSessionRoutes(deps)['agent/stop']())
+      .toEqual({ ok: false, error: 'goal-stop-persistence-failed' });
     expect(stopped).toEqual(['a', 'res-1', 'res-2']);   // orchestrator first, then its actors
   });
   test('agent/stop with no actors only stops the orchestrator', async () => {

--- a/tests/peerd-runtime/goal-runner.test.ts
+++ b/tests/peerd-runtime/goal-runner.test.ts
@@ -219,20 +219,18 @@ describe('makeGoalRunner — persistence + resume (survives SW restart / other c
     let seenWhileLive: any = null;
     let runner: ReturnType<typeof makeGoalRunner>;
     runner = makeGoalRunner({
-      runTurn: async () => { seenWhileLive = kv.store.get(GOAL_RUNS_KEY); runner.halt('s1'); },
+      runTurn: async () => { await Promise.resolve(); seenWhileLive = kv.store.get(GOAL_RUNS_KEY); runner.halt('s1'); },
       kv,
     });
     await runner.start({ sessionId: 's1', goal: 'do it' });
     await settle(() => !runner.isActive('s1'));
-    // Was mirrored to storage while the run was live (so an SW restart finds it).
+    await settle(() => JSON.stringify(kv.store.get(GOAL_RUNS_KEY)) === '{}');
     expect(seenWhileLive?.s1).toMatchObject({ goal: 'do it' });
-    // Cleared once the run ends — a terminal run must not resume.
     expect(kv.store.get(GOAL_RUNS_KEY)).toEqual({});
   });
 
   it('resume() rehydrates a persisted run and continues it as a synthetic continuation', async () => {
     const kv = makeKv();
-    // Seed storage as if the SW died mid-run at iteration 2.
     kv.store.set(GOAL_RUNS_KEY, { sBoot: { goal: 'keep building', iteration: 2, startedAt: 1 } });
     const calls: TurnArgs[] = [];
     let runner: ReturnType<typeof makeGoalRunner>;
@@ -243,10 +241,9 @@ describe('makeGoalRunner — persistence + resume (survives SW restart / other c
     const res = await runner.resume();
     expect(res.resumed).toBe(1);
     await settle(() => !runner.isActive('sBoot'));
-    // Continues from the persisted iteration → a HIDDEN continuation that still
-    // carries the goal, NOT the goal replayed as a fresh visible message.
     expect(calls[0].synthetic).toBe(true);
     expect(calls[0].userText).toContain('keep building');
+    await settle(() => JSON.stringify(kv.store.get(GOAL_RUNS_KEY)) === '{}');
     expect(kv.store.get(GOAL_RUNS_KEY)).toEqual({});
   });
 
@@ -258,7 +255,6 @@ describe('makeGoalRunner — persistence + resume (survives SW restart / other c
 
   it('resume() re-runs a final turn interrupted at the cap, not dropping it as capped', async () => {
     const kv = makeKv();
-    // SW died DURING the last allowed turn → stored iteration === maxIterations.
     kv.store.set(GOAL_RUNS_KEY, { s: { goal: 'finish it', iteration: 3, startedAt: 1 } });
     const calls: TurnArgs[] = [];
     const events: any[] = [];
@@ -270,8 +266,6 @@ describe('makeGoalRunner — persistence + resume (survives SW restart / other c
     });
     await runner.resume();
     await settle(() => !runner.isActive('s'));
-    // The interrupted final turn re-ran exactly once, THEN the run caps — without
-    // the clamp the loop would exit immediately (0 turns) and still report capped.
     expect(calls.length).toBe(1);
     expect(events[events.length - 1].phase).toBe('capped');
   });
@@ -380,18 +374,25 @@ describe('makeGoalRunner — outcome hardening (no runaway on failure)', () => {
     });
     await runner.start({ sessionId: 's', goal: 'keep going' });
     await settle(() => !runner.isActive('s'));
-    // Paused, NOT terminal: no onRunEnd, and the record survives in kv for resume.
     expect(ends).toHaveLength(0);
     expect(kv.store.get(GOAL_RUNS_KEY).s).toMatchObject({ goal: 'keep going' });
-    // resume() re-drives; this time it completes → terminal, onRunEnd, kv cleared.
     await runner.resume();
     await settle(() => !runner.isActive('s'));
     expect(ends).toHaveLength(1);
+    await settle(() => JSON.stringify(kv.store.get(GOAL_RUNS_KEY)) === '{}');
     expect(kv.store.get(GOAL_RUNS_KEY)).toEqual({});
   });
 
   it('stop() on a vault-lock-PAUSED run drops its kv record so it does NOT resurrect on resume()', async () => {
     const kv = makeKv();
+    const set = kv.set;
+    let releaseFirstWrite = () => {};
+    const firstWrite = new Promise<void>((resolve) => { releaseFirstWrite = resolve; });
+    let delayWrite = true;
+    kv.set = async (key, value) => {
+      if (delayWrite) { delayWrite = false; await firstWrite; }
+      await set(key, value);
+    };
     let throwOnce = true;
     const calls: TurnArgs[] = [];
     let runner: ReturnType<typeof makeGoalRunner>;
@@ -404,19 +405,57 @@ describe('makeGoalRunner — outcome hardening (no runaway on failure)', () => {
     });
     await runner.start({ sessionId: 's', goal: 'keep going' });
     await settle(() => !runner.isActive('s'));
-    // Paused: evicted from the in-memory map, but the record survives in kv.
     expect(runner.get('s')).toBe(null);
-    expect(kv.store.get(GOAL_RUNS_KEY).s).toMatchObject({ goal: 'keep going' });
 
-    // The user clicks Stop on the (still-visible) paused run. halt() alone would
-    // be a no-op (not in the map); stop() durably forgets the record.
-    await runner.stop('s');
+    // Stop waits for the late mirror write, then removes what it wrote.
+    const stopping = runner.stop('s');
+    releaseFirstWrite();
+    await stopping;
     expect(kv.store.get(GOAL_RUNS_KEY)).toEqual({});
 
-    // resume() must NOT re-drive a stopped run.
     const before = calls.length;
     await runner.resume();
     await settle(() => true, 5);
     expect(calls.length).toBe(before);
+  });
+
+  it('stop() reports a failed durable removal', async () => {
+    const kv = makeKv();
+    kv.store.set(GOAL_RUNS_KEY, { s: { goal: 'keep going', iteration: 1, startedAt: 1 } });
+    kv.set = async () => { throw new Error('storage unavailable'); };
+    let calls = 0;
+    const runner = makeGoalRunner({ runTurn: async () => { calls += 1; }, kv });
+
+    await expect(runner.stop('s')).rejects.toThrow('storage unavailable');
+    expect(kv.store.get(GOAL_RUNS_KEY).s).toMatchObject({ goal: 'keep going' });
+    expect(await runner.resume()).toEqual({ resumed: 0 });
+    expect(calls).toBe(0);
+  });
+
+  it('stop() wins a race with resume()', async () => {
+    const kv = makeKv();
+    kv.store.set(GOAL_RUNS_KEY, { s: { goal: 'keep going', iteration: 1, startedAt: 1 } });
+    const get = kv.get;
+    let releaseRead!: () => void;
+    let signalRead!: () => void;
+    const readBlocked = new Promise<void>((resolve) => { releaseRead = resolve; });
+    const readStarted = new Promise<void>((resolve) => { signalRead = resolve; });
+    kv.get = async (key) => {
+      const value = await get(key);
+      kv.get = get;
+      signalRead();
+      await readBlocked;
+      return value;
+    };
+    let calls = 0;
+    const runner = makeGoalRunner({ runTurn: async () => { calls += 1; }, kv });
+
+    const resuming = runner.resume();
+    await readStarted;
+    const stopping = runner.stop('s');
+    releaseRead();
+    expect(await resuming).toEqual({ resumed: 0 });
+    await stopping;
+    expect([runner.isActive('s'), calls, kv.store.get(GOAL_RUNS_KEY)]).toEqual([false, 0, {}]);
   });
 });


### PR DESCRIPTION
## Summary

- Serialize goal mirror writes, Stop, and restart resume.
- Stop root, bound actor, and spawned actor work before durable removal.
- Report durable Stop failures and block reset or archive until retry.

## Verification

- bun run preflight
- bun run test:e2e:stop