### PR TITLE
fix(web): activate each scripting click once

### DIFF
--- a/extension/peerd-runtime/tools/defs/click.js
+++ b/extension/peerd-runtime/tools/defs/click.js
@@ -360,11 +360,8 @@ export function clickInjected(selector, nth, walkId, expectedCount, allowedCross
     }
     el.dispatchEvent(new MouseEvent('mousedown', opts));
     el.dispatchEvent(new MouseEvent('mouseup',   { ...opts, buttons: 0 }));
-    el.dispatchEvent(new MouseEvent('click',     { ...opts, buttons: 0 }));
-    // Fallback: also call native click() in case the page only wires
-    // up the HTMLElement.click() activation behaviour (form submit,
-    // <a> navigation). Idempotent for handlers that already fired.
-    try { el.click(); } catch { /* swallow */ }
+    // why: one explicit event supports SVG targets and keeps center coordinates.
+    el.dispatchEvent(new MouseEvent('click', { ...opts, buttons: 0 }));
     return {
       ok: true,
       clicked: walkId != null ? `walk:${walkId}` : selector,

--- a/extension/tests/unit/peerd-runtime/dom-walk.test.js
+++ b/extension/tests/unit/peerd-runtime/dom-walk.test.js
@@ -44,11 +44,8 @@ const walkNodes = (out) => /** @type {WalkNode[]} */ (/** @type {unknown} */ (ou
 
 // A fixture corner of the test page: a small form with the roles the
 // walk must classify. withFixture() removes it after each test.
-// why type="button" on the hidden button: a bare <button> defaults to type=submit, and
-// it sits inside this <form>. The click-tool test below targets it (nth:1), and
-// clickInjected fires a native el.click() — a submit button would submit the form and
-// NAVIGATE the test-runner page, reloading runner.html mid-suite so the result marker is
-// never written (the in-browser run hangs at "Loading…" instead of failing cleanly).
+// why type="button" on the hidden button: a bare button submits this form.
+// A test without a submit listener would navigate the runner mid-suite.
 const FIXTURE_HTML = `
   <h2>Pizza order</h2>
   <form aria-label="Order form">
@@ -173,15 +170,14 @@ describe('snapshot → click/type over walk refs — full chain', () => {
     });
   });
 
-  it('click {ref} fires real handlers on the live element', async () => {
+  it('click {ref} activates a checkbox once', async () => {
     await withFixture(async (host) => {
       const ctx = makeCtx();
-      let clicks = 0;
-      const btn = /** @type {HTMLButtonElement} */ (host.querySelector('#dw-send'));
-      btn.disabled = false;
-      btn.addEventListener('click', () => { clicks += 1; });
+      let clicks = 0, clickX = 0, clickY = 0;
+      const checkbox = /** @type {HTMLInputElement} */ (host.querySelector('#dw-news'));
+      checkbox.addEventListener('click', (event) => { clicks += 1; clickX = event.clientX; clickY = event.clientY; });
       const snap = await snapshotTool.execute({ budget: 30000 }, ctx);
-      const ref = /(@e\d+) button "Send order"/.exec(contentOf(snap))?.[1];
+      const ref = /(@e\d+) checkbox "Newsletter"/.exec(contentOf(snap))?.[1];
       expect(typeof ref).toBe('string');
       const r = await clickTool.execute({ ref }, ctx);
       expect(r.ok).toBe(true);
@@ -189,7 +185,9 @@ describe('snapshot → click/type over walk refs — full chain', () => {
       // matchedCount rides the walk-ref success shape too — a resolved walk
       // ref is exactly one element (issue #36 contract consistency).
       expect(contentOf(r)).toContain('"matchedCount": 1');
-      expect(clicks > 0).toBe(true);
+      expect(clicks).toBe(1);
+      expect(checkbox.checked).toBe(false);
+      expect(clickX > 0 && clickY > 0).toBe(true);
     });
   });
 
@@ -212,24 +210,26 @@ describe('snapshot → click/type over walk refs — full chain', () => {
     });
   });
 
-  it('click {selector, expectedCount} reports the real matchedCount on success', async () => {
+  it('click {selector, expectedCount} submits the selected form once', async () => {
     await withFixture(async (host) => {
       const ctx = makeCtx();
-      let clicks = 0;
-      for (const btn of host.querySelectorAll('button')) {
-        /** @type {HTMLButtonElement} */ (btn).disabled = false;
-        btn.addEventListener('click', () => { clicks += 1; });
-      }
+      const form = /** @type {HTMLFormElement} */ (host.querySelector('form'));
+      const button = host.querySelectorAll('button')[1];
+      button.disabled = false;
+      button.type = 'submit';
+      let clicks = 0, submits = 0;
+      button.addEventListener('click', () => { clicks += 1; });
+      form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        submits += 1;
+      });
       const r = await clickTool.execute({ selector: '#dom-walk-fixture button', expectedCount: 2, nth: 1 }, ctx);
       expect(r.ok).toBe(true);
       expect(contentOf(r)).toContain('"matchedCount": 2');
       expect(contentOf(r)).toContain('"nth": 1');
-      // why >0, not ===1: clickInjected deliberately dispatches a synthetic click event
-      // AND calls native el.click() (so it activates both framework listeners and native
-      // behaviour), so a plain addEventListener('click') counter fires more than once per
-      // tool-click. The test only needs to confirm the nth:1 element actually received the
-      // click — not pin the dispatch count.
-      expect(clicks).toBeGreaterThan(0);
+      // why: one tool click must cause one element activation.
+      expect(clicks).toBe(1);
+      expect(submits).toBe(1);
     });
   });
 


### PR DESCRIPTION
Closes #446.

## Summary

- Remove the second click activation from the scripting fallback.
- Keep one centered MouseEvent for SVG, canvas, forms, links, and controls.
- Require one checkbox toggle and one form submit in browser tests.

## Validation

- In-browser Chrome: 948 passed, 0 failed.
- Bun: 6411 passed, 0 failed.
- TypeScript: passed.
- ESLint for changed files: passed.
- Diff check: passed.