### PR TITLE
Fix scheduler durable write races

### DIFF
--- a/badges/functional-tests.json
+++ b/badges/functional-tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "Functional Tests",
-  "message": "6411/6411 passing",
+  "message": "6418/6418 passing",
   "color": "brightgreen",
   "namedLogo": "bun",
   "logoColor": "white"

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -2324,7 +2324,7 @@ const buildToolContext = async (/** @type {any} */ {
     // Routines (loop/scheduler.js). Resolved lazily — `scheduler` is built after
     // this fn (same late-dep dance as goalRunner). Routines are GLOBAL (not
     // per-session), so these are present regardless of sessionId.
-    scheduleAdd: (/** @type {any} */ req) => scheduler?.add(req) ?? { ok: false, error: 'schedule_unavailable' },
+    scheduleAdd: async (/** @type {any} */ req) => scheduler?.add(req) ?? { ok: false, error: 'schedule_unavailable' },
     scheduleList: () => scheduler?.list() ?? [],
     scheduleRemove: (/** @type {string} */ id) => scheduler?.remove(id) ?? false,
     // why: the todo_* tools mutate the session's plan-of-record through this

--- a/extension/peerd-runtime/loop/scheduler.js
+++ b/extension/peerd-runtime/loop/scheduler.js
@@ -1,39 +1,16 @@
 // @ts-check
 // peerd-runtime/loop/scheduler — the background Routine runner.
 //
-// A Routine is a standing task that fires unattended on a cadence (see
-// loop/schedule.js for the "when"). This is the imperative shell around that
-// math: it holds the live routines, mirrors them durably to storage.local, and
-// on each WAKE decides which are due and fires them. It is the time-triggered
-// sibling of loop/goal-runner.js and copies that file's durability contract —
-// an in-memory map authoritative within one SW lifetime, mirrored to a kv key,
-// rehydrated by load() on boot — because an MV3 service worker is evicted after
-// ~30s idle and a routine must outlive that.
+// A Routine is an unattended standing task. This shell holds live routines,
+// mirrors them to storage.local, and fires due work. load() restores state after
+// MV3 service-worker eviction. loop/schedule.js owns the schedule math.
 //
-// The "run it as soon as peerd is back on" requirement is met by making tick()
-// a CATCH-UP pass: it fires every routine whose nextRunAt has already passed,
-// regardless of HOW MANY cadence slots elapsed while the browser was off or the
-// SW was dead (a routine advances to the next FUTURE slot, so a long downtime
-// collapses to a single catch-up run, never a burst). The SW calls tick() from
-// three wakes — a chrome.alarms fire, the cold-boot path, and vault unlock — so
-// whichever happens first drives the due work.
+// tick() collapses any missed cadence slots into one catch-up run. It advances
+// and persists nextRunAt before it fires. This gives at-most-once delivery. A
+// crash after that write can skip one run, but it cannot repeat a side effect.
 //
-// DELIVERY SEMANTICS (honest): at-most-once. tick() advances nextRunAt and
-// AWAITS the durable write BEFORE firing, so a crash after the write can't
-// re-fire the slot (no double-fire — important, a firing has side effects). The
-// residual risk is the narrow window where the SW dies AFTER the write commits
-// but BEFORE fireRoutine does durable work — that one firing is skipped, not
-// double-run. We prefer a missed run to a duplicated side effect.
-//
-// Vault-locked case: a firing needs the model key, so tick() REFUSES to fire
-// while the vault is locked — it leaves due routines untouched and arms the
-// alarm for a modest BACKOFF (not the past due time, which would wake-storm the
-// SW ~1/min) so the unlock re-tick drains them promptly and the fallback wake is
-// cheap. Same shape as goal-runner's paused/resume.
-//
-// Functional-core / imperative-shell: fireRoutine, kv, now, setAlarm, isLocked,
-// isRunning and onEvent are all INJECTED, so the control logic is otherwise pure
-// and unit-testable with fakes (scheduler.test.ts).
+// A locked vault leaves due routines unchanged and uses a backoff alarm. Unlock
+// triggers another tick. All IO is injected for focused tests.
 
 import { uuidv7 } from '/shared/util.js';
 import {
@@ -110,23 +87,26 @@ export const makeScheduler = ({
   /** @type {Set<string>} */
   const firing = new Set();
 
-  // tick() serialization. A tick requested while one is running sets a re-tick
-  // request; the running tick re-runs once it settles (instead of the request
-  // being DROPPED — the old bug: an unlock re-tick landing during a locked-path
-  // tick's await would be lost).
+  // A concurrent wake requests one more pass instead of losing the wake.
   let ticking = false;
   let retickRequested = false;
 
   const snapshot = () => [...routines.values()];
 
-  /** Await the durable mirror write (at-most-once needs this awaited before firing). */
-  const persist = async () => {
-    if (!kv) return;
-    /** @type {Record<string, Routine>} */
-    const out = {};
-    for (const [id, r] of routines) out[id] = r;
-    try { await kv.set(SCHEDULE_ROUTINES_KEY, out); }
-    catch { /* best-effort — a lost write just means a routine may re-run once or not resume */ }
+  // why one lane: an older write must not overwrite newer state.
+  /** @type {Promise<void>} */ let persistenceTail = Promise.resolve();
+  /** @type {Promise<number>|null} */ let hydrationPromise = null;
+  const persist = () => {
+    if (!kv) return Promise.resolve();
+    const write = persistenceTail.then(async () => {
+      await hydrate();
+      /** @type {Record<string, Routine>} */
+      const out = {};
+      for (const [id, r] of routines) out[id] = { ...r };
+      await kv.set(SCHEDULE_ROUTINES_KEY, out);
+    });
+    persistenceTail = write.catch(() => {});
+    return write;
   };
 
   // Arm the single alarm for the soonest enabled routine (or clear it). When
@@ -138,6 +118,36 @@ export const makeScheduler = ({
     catch (e) { console.error('[schedule] setAlarm threw', e); }
   };
 
+  const hydrate = () => {
+    if (hydrationPromise) return hydrationPromise;
+    const attempt = (async () => {
+      const stored = await kv?.get(SCHEDULE_ROUTINES_KEY);
+      let loaded = 0;
+      if (stored && typeof stored === 'object') for (const [id, raw] of Object.entries(stored)) {
+        if (!id || routines.has(id)) continue;
+        const rec = /** @type {any} */ (raw);
+        if (!rec || typeof rec.prompt !== 'string' || !rec.schedule) continue;
+        routines.set(id, {
+          id,
+          prompt: rec.prompt,
+          schedule: rec.schedule,
+          mode: rec.mode === 'turn' ? 'turn' : 'goal',
+          enabled: rec.enabled !== false,
+          createdAt: Number(rec.createdAt) || now(),
+          nextRunAt: Number(rec.nextRunAt) || now(),
+          lastRunAt: rec.lastRunAt == null ? null : Number(rec.lastRunAt),
+          lastSessionId: typeof rec.lastSessionId === 'string' ? rec.lastSessionId : null,
+          runCount: Number(rec.runCount) || 0,
+        });
+        loaded += 1;
+      }
+      reschedule();
+      return loaded;
+    })();
+    hydrationPromise = attempt.catch((error) => { hydrationPromise = null; throw error; });
+    return hydrationPromise;
+  };
+
   const emit = (/** @type {string} */ type, /** @type {object} */ extra = {}) => {
     try { onEvent({ type, ...extra }); } catch { /* port closed */ }
   };
@@ -145,17 +155,17 @@ export const makeScheduler = ({
   /** @returns {Routine[]} */
   const list = () => snapshot().map((r) => ({ ...r }));
 
-  /**
-   * Register a new routine. Normalizes the spec through parseSchedule and
-   * enforces the count cap. Returns the created routine or an error object.
-   * @param {{ prompt: string, every?: string, dailyAt?: string, mode?: string }} req
-   * @returns {{ ok: true, routine: Routine } | { ok: false, error: string }}
+  /** Register a validated routine after durable hydration.
+   * @param {{ prompt: string, every?: string, dailyAt?: string, mode?: string, signal?: AbortSignal }} req
+   * @returns {Promise<{ ok: true, routine: Routine } | { ok: false, error: string }>}
    */
-  const add = ({ prompt, every, dailyAt, mode } = /** @type {any} */ ({})) => {
+  const add = async ({ prompt, every, dailyAt, mode, signal } = /** @type {any} */ ({})) => {
     if (typeof prompt !== 'string' || !prompt.trim()) return { ok: false, error: 'prompt-required' };
-    if (routines.size >= MAX_ROUTINES) return { ok: false, error: 'too-many-routines' };
     const schedule = parseSchedule({ every, dailyAt });
     if (!schedule) return { ok: false, error: 'invalid-schedule' };
+    if (kv) await hydrate();
+    if (signal?.aborted) return { ok: false, error: 'schedule-aborted' };
+    if (routines.size >= MAX_ROUTINES) return { ok: false, error: 'too-many-routines' };
     const at = now();
     /** @type {Routine} */
     const routine = {
@@ -170,10 +180,9 @@ export const makeScheduler = ({
       lastSessionId: null,
       runCount: 0,
     };
+    if (signal?.aborted) return { ok: false, error: 'schedule-aborted' };
     routines.set(routine.id, routine);
-    // Fire-and-forget the mirror write on the mutation paths (add/remove/
-    // setEnabled) — only the FIRING path needs the awaited write for at-most-once.
-    void persist();
+    void persist(); // Only the firing path must wait for its durable write.
     reschedule();
     emit('schedule/changed', { routines: list() });
     return { ok: true, routine };
@@ -198,26 +207,16 @@ export const makeScheduler = ({
     return true;
   };
 
-  /**
-   * The wake pass: fire due routines (capped, skipping still-running ones),
-   * advance each to its next FUTURE slot, then re-arm. Deferred while the vault
-   * is locked. Serialized; a concurrent request re-runs once rather than being
-   * dropped.
+  /** Fire due routines, or defer them while the vault is locked.
    * @returns {Promise<{ fired: number, deferred: number, skipped: number }>}
    */
   const tick = async () => {
     if (ticking) { retickRequested = true; return { fired: 0, deferred: 0, skipped: 0 }; }
     ticking = true;
-    // Consume a re-tick requested while we were awaiting, so a wake that landed
-    // mid-tick (e.g. an unlock re-tick during a locked-path pass) is honored in
-    // this same call rather than dropped.
+    // Consume a wake that arrived while this tick awaited IO.
     const consumeRetick = () => { const r = retickRequested; retickRequested = false; return r; };
     const totals = { fired: 0, deferred: 0, skipped: 0 };
-    // Cap firings across the WHOLE tick() call, not per re-tick pass. A concurrent
-    // wake landing during a pass's `await persist()` sets retickRequested, and a
-    // per-pass counter would reset to 0 on the next pass — letting one tick() call
-    // stampede past MAX_FIRINGS_PER_TICK. Hoisting the counter binds the cap to the
-    // whole call; leftovers drain on the next (re-armed, past-due) wake.
+    // The cap covers all re-tick passes in this call.
     let firedThisTick = 0;
     try {
       do {
@@ -233,19 +232,32 @@ export const makeScheduler = ({
         for (const routine of due) {
           if (firedThisTick >= MAX_FIRINGS_PER_TICK) break;  // throttle the herd
           if (firing.has(routine.id)) continue;
+          const running = isRunning(routine);
+          if (routines.get(routine.id) !== routine || !routine.enabled) continue;
           // Skip a routine whose previous firing is still running — advance it a
           // slot so it retries next cadence instead of piling up concurrent runs.
-          if (isRunning(routine)) {
+          if (running) {
             routine.nextRunAt = computeNextRun(routine.schedule, at, routine.createdAt);
+            void persist();
             totals.skipped += 1;
             continue;
           }
-          // Advance + AWAIT the durable write BEFORE firing → no double-fire on a
-          // crash after commit (at-most-once; see the file header).
-          routine.nextRunAt = computeNextRun(routine.schedule, at, routine.createdAt);
+          // Persist the advance before the side effect for at-most-once delivery.
+          const previous = { nextRunAt: routine.nextRunAt, lastRunAt: routine.lastRunAt, runCount: routine.runCount };
+          const attemptedNextRunAt = computeNextRun(routine.schedule, at, routine.createdAt);
+          routine.nextRunAt = attemptedNextRunAt;
           routine.lastRunAt = at;
           routine.runCount += 1;
-          await persist();
+          try { await persist(); } catch (error) {
+            const attemptUnchanged = routines.get(routine.id) === routine
+              && routine.nextRunAt === attemptedNextRunAt
+              && routine.lastRunAt === at
+              && routine.runCount === previous.runCount + 1;
+            if (attemptUnchanged) { Object.assign(routine, previous); void persist(); }
+            reschedule();
+            throw error;
+          }
+          if (routines.get(routine.id) !== routine || !routine.enabled) continue;
           firing.add(routine.id);
           emit('schedule/firing', { id: routine.id, prompt: routine.prompt });
           Promise.resolve()
@@ -269,37 +281,16 @@ export const makeScheduler = ({
     }
   };
 
-  /**
-   * Rehydrate routines from the durable mirror on SW boot. A no-op without kv or
-   * with nothing stored. Does NOT fire — the caller ticks() after. Idempotent.
+  /** Rehydrate routines without firing them.
    * @returns {Promise<{ loaded: number }>}
    */
   const load = async () => {
     if (!kv) return { loaded: 0 };
-    let stored;
-    try { stored = await kv.get(SCHEDULE_ROUTINES_KEY); } catch { return { loaded: 0 }; }
-    if (!stored || typeof stored !== 'object') return { loaded: 0 };
-    let loaded = 0;
-    for (const [id, raw] of Object.entries(stored)) {
-      if (!id || routines.has(id)) continue;
-      const rec = /** @type {any} */ (raw);
-      if (!rec || typeof rec.prompt !== 'string' || !rec.schedule) continue;
-      routines.set(id, {
-        id,
-        prompt: rec.prompt,
-        schedule: rec.schedule,
-        mode: rec.mode === 'turn' ? 'turn' : 'goal',
-        enabled: rec.enabled !== false,
-        createdAt: Number(rec.createdAt) || now(),
-        nextRunAt: Number(rec.nextRunAt) || now(),
-        lastRunAt: rec.lastRunAt == null ? null : Number(rec.lastRunAt),
-        lastSessionId: typeof rec.lastSessionId === 'string' ? rec.lastSessionId : null,
-        runCount: Number(rec.runCount) || 0,
-      });
-      loaded += 1;
+    if (hydrationPromise) {
+      try { await hydrationPromise; } catch { /* retry on the next call */ }
+      return { loaded: 0 };
     }
-    reschedule();
-    return { loaded };
+    try { return { loaded: await hydrate() }; } catch { return { loaded: 0 }; }
   };
 
   return Object.freeze({

--- a/extension/peerd-runtime/tools/defs/schedule-create.js
+++ b/extension/peerd-runtime/tools/defs/schedule-create.js
@@ -63,7 +63,7 @@ export const scheduleCreateTool = {
   origins: () => [],
 
   execute: async (args, ctx) => {
-    const scheduleAdd = /** @type {((req: any) => { ok: boolean, error?: string, routine?: any }) | undefined} */ (
+    const scheduleAdd = /** @type {((req: any) => Promise<{ ok: boolean, error?: string, routine?: any }>) | undefined} */ (
       /** @type {{ scheduleAdd?: unknown }} */ (ctx).scheduleAdd);
     if (typeof scheduleAdd !== 'function') {
       return { ok: false, error: 'schedule_unavailable', content: 'Background scheduling is not available in this context.' };
@@ -119,7 +119,11 @@ export const scheduleCreateTool = {
       every: args.every,
       dailyAt: args.dailyAt,
       mode: args.mode,
+      signal: ctx.abortSignal,
     });
+    if (aborted()) {
+      return { ok: false, error: 'schedule_aborted', content: 'The routine was not armed because the run was stopped.' };
+    }
     if (!res?.ok) {
       const why = res?.error === 'invalid-schedule'
         ? 'Could not parse the cadence. Use `every` like "30m"/"6h"/"1d", or `dailyAt` like "08:00".'

--- a/tests/peerd-runtime/loop/scheduler.test.ts
+++ b/tests/peerd-runtime/loop/scheduler.test.ts
@@ -17,30 +17,40 @@ const settle = async (pred: () => boolean, tries = 200) => {
   for (let i = 0; i < tries && !pred(); i++) await new Promise((r) => setTimeout(r, 0));
 };
 
-function makeHarness(opts: { locked?: boolean } = {}) {
+const deferred = <T>() => Promise.withResolvers<T>();
+
+const routineRecord = (id: string) => ({
+  id, prompt: 'old', schedule: { kind: 'interval' as const, everyMs: HOUR }, mode: 'goal',
+  enabled: true, createdAt: 1_000_000, nextRunAt: 1_000_000 + HOUR,
+  lastRunAt: null, lastSessionId: null, runCount: 0,
+});
+
+function makeHarness(opts: { locked?: boolean; kv?: { get(k: string): Promise<any>; set(k: string, v: any): Promise<void> } } = {}) {
   let clock = 1_000_000;
   let locked = opts.locked ?? false;
   const store = new Map<string, any>();
   const fired: any[] = [];
   const alarms: (number | null)[] = [];
+  const events: any[] = [];
   const running = new Set<string>();          // routineIds whose prior run is "still going"
   let idSeq = 0;
 
   const scheduler = makeScheduler({
     fireRoutine: async (routine: any) => { fired.push(routine); return { sessionId: `sess-${routine.id}` }; },
-    kv: {
+    kv: opts.kv ?? {
       get: async (k: string) => store.get(k),
       set: async (k: string, v: any) => { store.set(k, v); },
     },
     isLocked: () => locked,
     isRunning: (routine: any) => running.has(routine.id),
     setAlarm: (when: number | null) => { alarms.push(when); },
+    onEvent: (event: any) => { events.push(event); },
     now: () => clock,
     makeId: () => `r${++idSeq}`,
   });
 
   return {
-    scheduler, store, fired, alarms, running,
+    scheduler, store, fired, alarms, events, running,
     advance: (ms: number) => { clock += ms; },
     now: () => clock,
     lock: () => { locked = true; },
@@ -50,36 +60,74 @@ function makeHarness(opts: { locked?: boolean } = {}) {
 }
 
 describe('makeScheduler — registration', () => {
-  it('adds a routine, computes its next run, persists it, and arms the alarm', () => {
+  it('adds a routine, computes its next run, persists it, and arms the alarm', async () => {
     const h = makeHarness();
-    const res = h.scheduler.add({ prompt: 'do a thing', every: '1h' });
+    const res = await h.scheduler.add({ prompt: 'do a thing', every: '1h' });
     expect(res.ok).toBe(true);
     const r = (res as any).routine;
     expect(r.mode).toBe('goal');
     expect(r.nextRunAt).toBe(h.now() + HOUR);
+    await settle(() => h.stored()[r.id] != null);
     expect(h.stored()[r.id].prompt).toBe('do a thing');
     expect(h.alarms.at(-1)).toBe(h.now() + HOUR);
   });
 
-  it('honors mode: "turn" and rejects bad input', () => {
+  it('honors mode: "turn" and rejects bad input', async () => {
     const h = makeHarness();
-    expect((h.scheduler.add({ prompt: 'x', every: '1h', mode: 'turn' }) as any).routine.mode).toBe('turn');
-    expect(h.scheduler.add({ prompt: '  ', every: '1h' }).ok).toBe(false);
-    expect(h.scheduler.add({ prompt: 'x', every: 'whenever' }).ok).toBe(false);
+    expect(((await h.scheduler.add({ prompt: 'x', every: '1h', mode: 'turn' })) as any).routine.mode).toBe('turn');
+    expect((await h.scheduler.add({ prompt: '  ', every: '1h' })).ok).toBe(false);
+    expect((await h.scheduler.add({ prompt: 'x', every: 'whenever' })).ok).toBe(false);
   });
 
-  it('enforces the routine count cap', () => {
+  it('enforces the routine count cap', async () => {
     const h = makeHarness();
-    for (let i = 0; i < MAX_ROUTINES; i++) expect(h.scheduler.add({ prompt: `r${i}`, every: '1h' }).ok).toBe(true);
-    const over = h.scheduler.add({ prompt: 'one too many', every: '1h' });
+    for (let i = 0; i < MAX_ROUTINES; i++) expect((await h.scheduler.add({ prompt: `r${i}`, every: '1h' })).ok).toBe(true);
+    const over = await h.scheduler.add({ prompt: 'one too many', every: '1h' });
     expect(over.ok).toBe(false);
     expect((over as any).error).toBe('too-many-routines');
     expect(h.scheduler.list()).toHaveLength(MAX_ROUTINES);
   });
 
-  it('removes a routine and clears the alarm when none remain', () => {
+  it('hydrates before a cold add enforces the routine cap', async () => {
+    const stored = Object.fromEntries(Array.from(
+      { length: MAX_ROUTINES }, (_, index) => [`stored-${index}`, routineRecord(`stored-${index}`)],
+    ));
+    let writes = 0;
+    const h = makeHarness({ kv: {
+      get: async () => stored,
+      set: async () => { writes += 1; },
+    } });
+
+    const result = await h.scheduler.add({ prompt: 'one too many', every: '1h' });
+    expect(result).toEqual({ ok: false, error: 'too-many-routines' });
+    expect(h.scheduler.list()).toHaveLength(MAX_ROUTINES);
+    expect(writes).toBe(0);
+  });
+
+  it('an abort during cold hydration prevents the add side effects', async () => {
+    const releaseRead = deferred<void>();
+    const controller = new AbortController();
+    let reads = 0;
+    let writes = 0;
+    const h = makeHarness({ kv: {
+      get: async () => { reads += 1; await releaseRead.promise; },
+      set: async () => { writes += 1; },
+    } });
+    const adding = h.scheduler.add({ prompt: 'stopped', every: '1h', signal: controller.signal });
+    await settle(() => reads === 1);
+    controller.abort();
+    releaseRead.resolve();
+
+    expect(await adding).toEqual({ ok: false, error: 'schedule-aborted' });
+    expect(h.scheduler.list()).toEqual([]);
+    expect(writes).toBe(0);
+    expect(h.events).toEqual([]);
+    expect(h.alarms.filter((when) => when != null)).toEqual([]);
+  });
+
+  it('removes a routine and clears the alarm when none remain', async () => {
     const h = makeHarness();
-    const r = (h.scheduler.add({ prompt: 'x', every: '1h' }) as any).routine;
+    const r = ((await h.scheduler.add({ prompt: 'x', every: '1h' })) as any).routine;
     expect(h.scheduler.remove(r.id)).toBe(true);
     expect(h.scheduler.list()).toHaveLength(0);
     expect(h.alarms.at(-1)).toBeNull();
@@ -90,7 +138,7 @@ describe('makeScheduler — registration', () => {
 describe('makeScheduler — tick fires due routines', () => {
   it('fires a due routine, advances it, and records the session', async () => {
     const h = makeHarness();
-    const r = (h.scheduler.add({ prompt: 'x', every: '1h' }) as any).routine;
+    const r = ((await h.scheduler.add({ prompt: 'x', every: '1h' })) as any).routine;
     h.advance(HOUR + MIN);
     const out = await h.scheduler.tick();
     expect(out.fired).toBe(1);
@@ -104,7 +152,7 @@ describe('makeScheduler — tick fires due routines', () => {
 
   it('does not fire a routine that is not yet due', async () => {
     const h = makeHarness();
-    h.scheduler.add({ prompt: 'x', every: '1h' });
+    await h.scheduler.add({ prompt: 'x', every: '1h' });
     h.advance(30 * MIN);
     expect((await h.scheduler.tick()).fired).toBe(0);
     expect(h.fired).toHaveLength(0);
@@ -112,7 +160,7 @@ describe('makeScheduler — tick fires due routines', () => {
 
   it('collapses many missed slots into ONE catch-up fire', async () => {
     const h = makeHarness();
-    const r = (h.scheduler.add({ prompt: 'x', every: '1h' }) as any).routine;
+    const r = ((await h.scheduler.add({ prompt: 'x', every: '1h' })) as any).routine;
     h.advance(5 * HOUR + 20 * MIN);
     const out = await h.scheduler.tick();
     expect(out.fired).toBe(1);
@@ -121,7 +169,7 @@ describe('makeScheduler — tick fires due routines', () => {
 
   it('caps firings per tick — a catch-up storm does not launch everything at once', async () => {
     const h = makeHarness();
-    for (let i = 0; i < MAX_FIRINGS_PER_TICK + 2; i++) h.scheduler.add({ prompt: `r${i}`, every: '1h' });
+    for (let i = 0; i < MAX_FIRINGS_PER_TICK + 2; i++) await h.scheduler.add({ prompt: `r${i}`, every: '1h' });
     h.advance(2 * HOUR);          // all due
     const out = await h.scheduler.tick();
     expect(out.fired).toBe(MAX_FIRINGS_PER_TICK);   // throttled, not all N
@@ -138,6 +186,7 @@ describe('makeScheduler — tick fires due routines', () => {
     const fired: any[] = [];
     let idSeq = 0;
     let reentered = false;
+    let reentryArmed = false;
     /** @type {any} */
     let sched: ReturnType<typeof makeScheduler>;
     sched = makeScheduler({
@@ -146,13 +195,15 @@ describe('makeScheduler — tick fires due routines', () => {
         get: async (k: string) => store.get(k),
         set: async (k: string, v: any) => {
           store.set(k, v);
-          if (!reentered) { reentered = true; await sched.tick(); } // concurrent wake mid-persist
+          if (reentryArmed && !reentered) { reentered = true; await sched.tick(); } // concurrent wake mid-persist
         },
       },
       now: () => clock,
       makeId: () => `r${++idSeq}`,
     });
-    for (let i = 0; i < MAX_FIRINGS_PER_TICK + 3; i++) sched.add({ prompt: `p${i}`, every: '1h' });
+    for (let i = 0; i < MAX_FIRINGS_PER_TICK + 3; i++) await sched.add({ prompt: `p${i}`, every: '1h' });
+    await settle(() => Object.keys(store.get(SCHEDULE_ROUTINES_KEY) ?? {}).length === MAX_FIRINGS_PER_TICK + 3);
+    reentryArmed = true;
     clock += 2 * HOUR;                       // all due
     await sched.tick();
     expect(reentered).toBe(true);            // the re-entrant wake actually happened
@@ -161,7 +212,7 @@ describe('makeScheduler — tick fires due routines', () => {
 
   it('skips a routine whose previous run is still going (no pile-up)', async () => {
     const h = makeHarness();
-    const r = (h.scheduler.add({ prompt: 'x', every: '1m' }) as any).routine;
+    const r = ((await h.scheduler.add({ prompt: 'x', every: '1m' })) as any).routine;
     h.running.add(r.id);          // its prior goal run is still active
     h.advance(5 * MIN);
     const out = await h.scheduler.tick();
@@ -170,13 +221,73 @@ describe('makeScheduler — tick fires due routines', () => {
     expect(h.fired).toHaveLength(0);
     // advanced a slot so it retries next cadence instead of busy-looping
     expect(h.scheduler.list()[0].nextRunAt).toBeGreaterThan(h.now());
+    await settle(() => h.stored()[r.id]?.nextRunAt > h.now());
+    expect(h.stored()[r.id].nextRunAt).toBeGreaterThan(h.now());
+  });
+
+  it('does not fire or report a routine when its durable advance fails', async () => {
+    let writes = 0;
+    let stored: any;
+    const h = makeHarness({
+      kv: {
+        get: async () => stored,
+        set: async (_key: string, value: any) => {
+          writes += 1;
+          if (writes === 2) throw new Error('disk full');
+          stored = structuredClone(value);
+        },
+      },
+    });
+    const routine = ((await h.scheduler.add({ prompt: 'x', every: '1h' })) as any).routine;
+    const dueAt = routine.nextRunAt;
+    await settle(() => writes === 1);
+    h.advance(2 * HOUR);
+
+    await expect(h.scheduler.tick()).rejects.toThrow('disk full');
+    expect(h.fired).toEqual([]);
+    expect(h.events.some((event) => event.type === 'schedule/firing')).toBe(false);
+    expect(h.scheduler.list()[0]).toMatchObject({ nextRunAt: dueAt, lastRunAt: null, runCount: 0 });
+    expect(h.alarms.at(-1)).toBe(dueAt);
+
+    await settle(() => writes === 3);
+    expect(stored[routine.id]).toMatchObject({ nextRunAt: dueAt, lastRunAt: null, runCount: 0 });
+    expect((await h.scheduler.tick()).fired).toBe(1);
+    await settle(() => h.fired.length === 1);
+    expect(h.fired.map((entry) => entry.id)).toEqual([routine.id]);
+  });
+
+  it.each(['remove', 'disable'] as const)('%s during persistence prevents firing', async (action) => {
+    let writes = 0;
+    const releaseAdvance = deferred<void>();
+    const h = makeHarness({
+      kv: {
+        get: async () => undefined,
+        set: async () => {
+          writes += 1;
+          if (writes === 2) await releaseAdvance.promise;
+        },
+      },
+    });
+    const routine = ((await h.scheduler.add({ prompt: 'x', every: '1h' })) as any).routine;
+    await settle(() => writes === 1);
+    h.advance(2 * HOUR);
+
+    const ticking = h.scheduler.tick();
+    await settle(() => writes === 2);
+    if (action === 'remove') h.scheduler.remove(routine.id);
+    else h.scheduler.setEnabled(routine.id, false);
+    releaseAdvance.resolve();
+
+    expect((await ticking).fired).toBe(0);
+    await settle(() => writes === 3);
+    expect(h.fired).toEqual([]);
   });
 });
 
 describe('makeScheduler — vault-locked deferral', () => {
   it('defers firing while locked and arms a BACKOFF alarm (no past-time wake storm)', async () => {
     const h = makeHarness({ locked: true });
-    const r = (h.scheduler.add({ prompt: 'x', every: '1h' }) as any).routine;
+    const r = ((await h.scheduler.add({ prompt: 'x', every: '1h' })) as any).routine;
     h.advance(HOUR + MIN);
     const deferred = await h.scheduler.tick();
     expect(deferred).toEqual({ fired: 0, deferred: 1, skipped: 0 });
@@ -194,7 +305,7 @@ describe('makeScheduler — vault-locked deferral', () => {
 describe('makeScheduler — enable/disable', () => {
   it('a disabled routine never fires; re-enabling re-anchors it forward', async () => {
     const h = makeHarness();
-    const r = (h.scheduler.add({ prompt: 'x', every: '1h' }) as any).routine;
+    const r = ((await h.scheduler.add({ prompt: 'x', every: '1h' })) as any).routine;
     expect(h.scheduler.setEnabled(r.id, false)).toBe(true);
     h.advance(3 * HOUR);
     expect((await h.scheduler.tick()).fired).toBe(0);
@@ -205,25 +316,99 @@ describe('makeScheduler — enable/disable', () => {
 });
 
 describe('makeScheduler — durability (load on boot)', () => {
+  it('serializes mirror writes so an older snapshot cannot restore removed state', async () => {
+    const releaseFirst = deferred<void>();
+    const completed: number[] = [];
+    let calls = 0;
+    let stored: any;
+    const h = makeHarness({
+      kv: {
+        get: async () => stored,
+        set: async (_key: string, value: any) => {
+          const call = ++calls;
+          const snapshot = structuredClone(value);
+          if (call === 1) await releaseFirst.promise;
+          stored = snapshot;
+          completed.push(call);
+        },
+      },
+    });
+    const routine = ((await h.scheduler.add({ prompt: 'x', every: '1h' })) as any).routine;
+    await settle(() => calls === 1);
+    h.scheduler.remove(routine.id);
+    releaseFirst.resolve();
+    await settle(() => completed.length === 2);
+
+    expect(completed).toEqual([1, 2]);
+    expect(stored).toEqual({});
+  });
+
+  it('keeps local add and remove authoritative across stale IO', async () => {
+    const releaseRead = deferred<void>();
+    const releaseRemove = deferred<void>();
+    let reads = 0;
+    let writes = 0;
+    let finished = 0;
+    let persisted: any;
+    const h = makeHarness({
+      kv: {
+        get: async () => {
+          reads += 1;
+          await releaseRead.promise;
+          return { stale: routineRecord('stale') };
+        },
+        set: async (_key: string, value: any) => {
+          writes += 1;
+          if (writes === 1) persisted = structuredClone(value);
+          else await releaseRemove.promise;
+          finished += 1;
+          if (writes === 2) throw new Error('disk full');
+        },
+      },
+    });
+    const loading = h.scheduler.load();
+    await settle(() => reads === 1);
+    const adding = h.scheduler.add({ prompt: 'local', every: '1h' });
+    releaseRead.resolve();
+
+    expect((await loading).loaded).toBe(1);
+    expect((await adding).ok).toBe(true);
+    await settle(() => finished === 1);
+    expect(h.scheduler.list().map((routine) => routine.id).sort()).toEqual(['r1', 'stale']);
+    expect(Object.keys(persisted).sort()).toEqual(['r1', 'stale']);
+    expect(h.scheduler.remove('r1')).toBe(true);
+    await settle(() => writes === 2);
+    expect((await h.scheduler.load()).loaded).toBe(0);
+    expect(h.scheduler.list().map((routine) => routine.id)).toEqual(['stale']);
+    releaseRemove.resolve();
+    await settle(() => finished === 2);
+    expect((await h.scheduler.load()).loaded).toBe(0);
+    expect(reads).toBe(1);
+  });
+
   it('rehydrates routines from the kv mirror and re-arms', async () => {
     const h1 = makeHarness();
-    const r = (h1.scheduler.add({ prompt: 'survive me', every: '2h' }) as any).routine;
+    const r = ((await h1.scheduler.add({ prompt: 'survive me', every: '2h' })) as any).routine;
+    await settle(() => h1.stored()[r.id] != null);
     const mirror = h1.stored();
 
-    const h2 = makeHarness();
-    h2.store.set(SCHEDULE_ROUTINES_KEY, mirror);
+    let reads = 0;
+    const h2 = makeHarness({ kv: {
+      get: async () => {
+        reads += 1;
+        if (reads === 1) throw new Error('read failed');
+        return mirror;
+      },
+      set: async () => {},
+    } });
+    expect((await h2.scheduler.load()).loaded).toBe(0);
     expect((await h2.scheduler.load()).loaded).toBe(1);
+    expect((await h2.scheduler.load()).loaded).toBe(0);
+    expect(reads).toBe(2);
     const live = h2.scheduler.list()[0];
     expect(live.id).toBe(r.id);
     expect(live.prompt).toBe('survive me');
     expect(h2.alarms.at(-1)).toBe(live.nextRunAt);
   });
 
-  it('load is idempotent and skips ids already live', async () => {
-    const h = makeHarness();
-    const r = (h.scheduler.add({ prompt: 'x', every: '1h' }) as any).routine;
-    h.store.set(SCHEDULE_ROUTINES_KEY, { [r.id]: { ...r } });
-    expect((await h.scheduler.load()).loaded).toBe(0);
-    expect(h.scheduler.list()).toHaveLength(1);
-  });
 });

--- a/tests/peerd-runtime/tools/schedule-create.test.ts
+++ b/tests/peerd-runtime/tools/schedule-create.test.ts
@@ -29,4 +29,26 @@ describe('schedule_create cancellation', () => {
     expect(await pending).toMatchObject({ ok: false, error: 'schedule_aborted' });
     expect(additions).toBe(0);
   });
+
+  test('Stop while scheduleAdd waits cannot report a routine as armed', async () => {
+    const controller = new AbortController();
+    const started = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<any>();
+    let seenSignal: AbortSignal | undefined;
+    const pending = scheduleCreateTool.execute({ prompt: 'check releases', every: '1h' }, {
+      abortSignal: controller.signal,
+      permission: { confirmActions: true },
+      scheduleAdd: async (request: any) => {
+        seenSignal = request.signal;
+        started.resolve();
+        return await release.promise;
+      },
+    } as any);
+    await started.promise;
+    controller.abort();
+    release.resolve({ ok: true, routine: {} });
+
+    expect(seenSignal).toBe(controller.signal);
+    expect(await pending).toMatchObject({ ok: false, error: 'schedule_aborted' });
+  });
 });


### PR DESCRIPTION
Closes #448

Summary:

- Serialize scheduler storage writes.
- Hydrate durable state before a mutation.
- Block unattended firing when its durable advance fails.
- Roll back state and re-arm the alarm after a write failure.
- Stop, disable, and remove prevent queued work.
- Enforce the routine limit after cold hydration.

Validation:

- bun test ./tests --timeout 15000 --reporter=dot: 6418 passed
- bun run typecheck
- bun run lint
- cold service-worker budget: 7 passed
- git diff --check