### PR TITLE
fix(web): report successful page clicks

### DIFF
--- a/extension/peerd-runtime/actor/page-api.js
+++ b/extension/peerd-runtime/actor/page-api.js
@@ -94,7 +94,7 @@ const PAGE_METHODS = {
     },
     shape: (c) => ({
       ok: true,
-      clicked: c?.clicked === true,
+      clicked: true,
       ...(typeof c?.matchedCount === 'number' ? { matchedCount: c.matchedCount } : {}),
       ...(c?.navigated ? { navigated: true } : {}),
       ...(c?.browserPolicy ? { browserPolicy: c.browserPolicy } : {}),

--- a/tests/peerd-runtime/page-api.test.ts
+++ b/tests/peerd-runtime/page-api.test.ts
@@ -109,10 +109,10 @@ describe('shapePageResult — tool result -> Playwright-ish return', () => {
     expect(r).toEqual({ ok: true, url: 'https://example.com/', origin: 'https://example.com' });
   });
 
-  test('click surfaces matchedCount + navigated when present', () => {
+  test('click reports selector success and surfaces matchedCount + navigated', () => {
     const r = shapePageResult('click', {
       ok: true,
-      content: JSON.stringify({ clicked: true, matchedCount: 1, navigated: true }),
+      content: JSON.stringify({ clicked: '#submit', matchedCount: 1, navigated: true }),
     });
     expect(r).toEqual({ ok: true, clicked: true, matchedCount: 1, navigated: true });
   });


### PR DESCRIPTION
Closes #450

Summary:

- Treat the successful click tool envelope as the page API success authority.
- Normalize selector, walk-ref, and CDP click results to clicked:true.
- Test the real selector-string result shape.

Validation:

- bun test ./tests --timeout 15000 --reporter=dot: 6411 passed
- bun run lint
- bun run typecheck
- bun run check:tscheck
- bun run check:boundary
- git diff --check