### PR TITLE
fix(web): return landed URL from page.goto

### DIFF
--- a/extension/peerd-runtime/actor/page-api.js
+++ b/extension/peerd-runtime/actor/page-api.js
@@ -76,7 +76,7 @@ const PAGE_METHODS = {
       }
       return { url };
     },
-    shape: (c) => ({ ok: true, url: c?.url ?? null, ...(c?.origin ? { origin: c.origin } : {}) }),
+    shape: (c) => ({ ok: true, url: c?.finalUrl ?? null, ...(c?.origin ? { origin: c.origin } : {}) }),
   },
 
   // page.click(selector, { nth }) — Playwright locator STRICTNESS: the selector

--- a/tests/peerd-runtime/page-api.test.ts
+++ b/tests/peerd-runtime/page-api.test.ts
@@ -101,12 +101,16 @@ describe('pageCallToToolCall — web capability parity', () => {
 });
 
 describe('shapePageResult — tool result -> Playwright-ish return', () => {
-  test('goto returns the landed url + origin', () => {
+  test('goto returns navigate\'s final URL after a redirect', () => {
     const r = shapePageResult('goto', {
       ok: true,
-      content: JSON.stringify({ url: 'https://example.com/', origin: 'https://example.com' }),
+      content: JSON.stringify({
+        requested: 'https://example.com/start',
+        finalUrl: 'https://example.com/landed',
+        tabId: 42,
+      }),
     });
-    expect(r).toEqual({ ok: true, url: 'https://example.com/', origin: 'https://example.com' });
+    expect(r).toEqual({ ok: true, url: 'https://example.com/landed' });
   });
 
   test('click surfaces matchedCount + navigated when present', () => {


### PR DESCRIPTION
## Summary

- Return the final landed URL from `page.goto()`.
- Cover the real `navigate` redirect result shape.

## Checks

- `bun test ./tests --timeout 15000 --reporter=dot`
- `bun run lint`
- `bun run typecheck`
- `bun run check:tscheck`
- `bun run check:boundary`

Closes #453