### PR TITLE
fix(dweb): settle A2A asks during send

### DIFF
--- a/badges/functional-tests.json
+++ b/badges/functional-tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "Functional Tests",
-  "message": "6411/6411 passing",
+  "message": "6414/6414 passing",
   "color": "brightgreen",
   "namedLogo": "bun",
   "logoColor": "white"

--- a/extension/peerd-runtime/actor/a2a-dispatch.js
+++ b/extension/peerd-runtime/actor/a2a-dispatch.js
@@ -52,12 +52,9 @@ export const makeMeshDispatch = (deps) => {
     conversations = null,
   } = deps;
 
-  // reqId → { resolve, timer, did } for asks awaiting a reply. Lives across the
-  // single a2a_run worker call (the worker relays each op to the SW; the pending
-  // map is SW-side so a reply that lands after the op returns still resolves it).
-  // why `did`: a reply is bound to the peer the ask was SENT to — an inbound
-  // 'reply' is only honored when its authenticated mesh sender equals that did,
-  // so a third peer who guesses/observes a reqId can't forge the answer.
+  // Register before send so a fast reply cannot race the pending map.
+  // why `did`: only the authenticated target peer can resolve the ask.
+  // A third peer cannot use an observed reqId.
   /** @type {Map<string, { resolve: (v: any) => void, timer: any, did: string, convId?: string }>} */
   const pendingAsks = new Map();
   // Inbound a2a messages (ask/tell) received during a run, drained by inbox().
@@ -81,11 +78,8 @@ export const makeMeshDispatch = (deps) => {
     const reqId = mkReqId();
     const env = /** @type {A2AEnvelope} */ ({ __a2a: 1, kind: 'ask', reqId, message });
     if (convId) env.convId = convId;
-    const sent = await sendDm(did, env);
-    if (!sent?.ok) return { ok: false, error: sent?.error ?? 'ask: could not reach the peer' };
-    if (signal?.aborted) return { ok: false, error: 'a2a: aborted after send' };
     const ms = typeof timeoutMs === 'number' ? timeoutMs : defaultTimeoutMs;
-    return await new Promise((resolve) => {
+    const reply = new Promise((resolve) => {
       /** @param {any} value */
       const finish = (value) => {
         clearTimeout(timer);
@@ -99,6 +93,14 @@ export const makeMeshDispatch = (deps) => {
       signal?.addEventListener('abort', onAbort, { once: true });
       if (signal?.aborted) onAbort();
     });
+    Promise.resolve().then(() => pendingAsks.has(reqId)
+      ? sendDm(did, env) : { ok: true, error: undefined }).then(
+      (sent) => {
+        if (!sent?.ok) pendingAsks.get(reqId)?.resolve({ ok: false, error: sent?.error ?? 'ask: could not reach the peer' });
+      },
+      (error) => pendingAsks.get(reqId)?.resolve(Promise.reject(error)),
+    );
+    return await reply;
   };
 
   /**
@@ -186,8 +188,6 @@ export const makeMeshDispatch = (deps) => {
       // orphan reply is dropped, never resolved — but still CONSUMED, so a forged
       // reply can't wake the actor either.
       if (pending && pending.did === from) {
-        clearTimeout(pending.timer);
-        pendingAsks.delete(env.reqId);
         pending.resolve({ ok: true, from, reply: String(env.message ?? ''), ...(pending.convId ? { convId: pending.convId } : {}) });
       }
       return { consumed: true };   // a reply is plumbing, never a wake

--- a/tests/peerd-runtime/a2a-dispatch.test.ts
+++ b/tests/peerd-runtime/a2a-dispatch.test.ts
@@ -61,17 +61,38 @@ describe('the first-contact signing gate', () => {
 });
 
 describe('ask / reply correlation', () => {
-  test('ask sends a tagged request and resolves when the matching reply lands', async () => {
-    const d = harness();
-    const p = d.dispatch('ask', { did: DID, message: 'free Tuesday?', timeoutMs: 5000 }, { signs: true, allowed: () => true });
+  test('ask accepts a matching reply while sendDm stays pending', async () => {
+    let envelope: any;
+    const d = harness({ sendDm: (_to: string, env: any) => {
+      envelope = env;
+      return new Promise<{ ok: boolean }>(() => {});
+    } });
+    const ask = d.dispatch('ask', { did: DID, message: 'free Tuesday?', timeoutMs: 5000 }, { signs: true, allowed: () => true });
     await tick();
-    expect(d.sent[0].env).toMatchObject({ __a2a: 1, kind: 'ask', reqId: 'r1', message: 'free Tuesday?' });
-    expect(d._pendingCount()).toBe(1);
-    // the peer replies with the same reqId
-    const routed = d.handleInbound(DID, { __a2a: 1, kind: 'reply', reqId: 'r1', message: 'yes, 2pm' });
-    expect(routed.consumed).toBe(true);            // a reply is plumbing, never a wake
-    expect(await p).toEqual({ ok: true, from: DID, reply: 'yes, 2pm' });
+    expect(envelope).toMatchObject({ __a2a: 1, kind: 'ask', reqId: 'r1', message: 'free Tuesday?' });
+    d.handleInbound(DID, { __a2a: 1, kind: 'reply', reqId: envelope.reqId, message: 'yes, 2pm' });
+    expect(await Promise.race([ask, tick().then(() => ({ pending: true }))]))
+      .toEqual({ ok: true, from: DID, reply: 'yes, 2pm' });
     expect(d._pendingCount()).toBe(0);
+  });
+
+  test('ask returns an abort while sendDm stays pending', async () => {
+    const d = harness({ sendDm: () => new Promise<{ ok: boolean }>(() => {}) });
+    const controller = new AbortController();
+    const ask = d.dispatch('ask', { did: DID, message: 'ping', timeoutMs: 5000 }, { signs: true, allowed: () => true, signal: controller.signal });
+    await tick();
+    controller.abort();
+    expect(d._pendingCount()).toBe(0);
+    expect(await Promise.race([ask, tick().then(() => ({ pending: true }))]))
+      .toEqual({ ok: false, error: 'a2a: aborted while awaiting reply' });
+  });
+
+  test('ask returns a timeout while sendDm stays pending', async () => {
+    const d = harness({ sendDm: () => new Promise<{ ok: boolean }>(() => {}) });
+    const ask = d.dispatch('ask', { did: DID, message: 'ping', timeoutMs: 0 }, { signs: true, allowed: () => true });
+    const result = await Promise.race([ask, tick().then(() => ({ pending: true }))]);
+    expect(d._pendingCount()).toBe(0);
+    expect(result).toEqual({ ok: true, from: null, reply: null, timedOut: true });
   });
 
   test('a reply from a DIFFERENT did than the ask targeted does NOT resolve it (forgery protection)', async () => {
@@ -101,6 +122,13 @@ describe('ask / reply correlation', () => {
     const d = harness({ sendDm: async () => ({ ok: false, error: 'no direct link to did' }) });
     const r = await d.dispatch('ask', { did: DID, message: 'x' }, { signs: true, allowed: () => true });
     expect(r.ok).toBe(false);
+    expect(d._pendingCount()).toBe(0);
+  });
+
+  test('ask rejects and clears its correlation when sendDm throws', async () => {
+    const d = harness({ sendDm: () => { throw new Error('transport down'); } });
+    await expect(d.dispatch('ask', { did: DID, message: 'x' }, { signs: true, allowed: () => true }))
+      .rejects.toThrow('transport down');
     expect(d._pendingCount()).toBe(0);
   });
 


### PR DESCRIPTION
## Summary

- Register A2A reply correlation before transport send.
- Let replies, timeout, and Stop settle while the send is pending.
- Preserve sender checks and clean up late transport outcomes.
- Cover fast reply, stalled send, abort, timeout, and thrown transport cases.

## Checks

- `bun run gen:badge:functional` - 6414/6414 passing
- `bun run lint`
- `bun run typecheck`
- `bun run check:tscheck`
- `bun run check:boundary`
- `bun run check:badges`
- `bun test ./tests/meta/sw-barrel-imports.test.ts --timeout 15000`

Closes #455