### PR TITLE
fix(provider): stop local generation before startup

### DIFF
--- a/badges/functional-tests.json
+++ b/badges/functional-tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "Functional Tests",
-  "message": "6411/6411 passing",
+  "message": "6413/6413 passing",
   "color": "brightgreen",
   "namedLogo": "bun",
   "logoColor": "white"

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -4033,22 +4033,21 @@ const generateLocalForAdapter = (/** @type {any} */ opts) => {
     error: hostError,
   };
   localGens.set(genId, state);
-  // Stop must actually stop a 30B on-device generation: the engine holds a
-  // generation lease per instance, so an orphaned run would block every
-  // follow-up local turn with "is already generating" until it exhausts its
-  // token budget. The host aborts by genId; fired when the caller's signal
-  // aborts AND from the generator's finally (a consumer that abandons the
-  // stream without a signal still releases the lease). Best-effort: aborting a
-  // settled run is a no-op on the host.
+  // A local generation holds an exclusive engine lease. Stop must release it.
+  // An orphan blocks the next local turn until its token budget ends.
+  // Abort by genId on caller cancellation and generator cleanup.
+  // A consumer without a signal also releases the lease. Host abort is idempotent.
   const abortHostGeneration = () => {
+    state.done = true; wakeLocalGen(state);
     try {
       browser.runtime.sendMessage({ type: 'local-model/host/abort', genId })?.catch?.(() => { /* offscreen gone */ });
     } catch { /* messaging unavailable */ }
   };
   if (hostAvailable) {
     if (opts.signal) opts.signal.addEventListener('abort', abortHostGeneration, { once: true });
-    ensureOffscreen()
-      .then(() => browser.runtime.sendMessage({
+    if (opts.signal?.aborted) abortHostGeneration();
+    else ensureOffscreen()
+      .then(() => opts.signal?.aborted ? abortHostGeneration() : browser.runtime.sendMessage({
         type: 'local-model/host/generate', genId, model: opts.model, messages: opts.messages, system: opts.system, tools: opts.tools,
         // Token budget per ENGINE: the muse model spends its Harmony reasoning
         // channel out of the same budget as the visible answer, and a measured

--- a/extension/peerd-provider/adapters/local-webgpu.js
+++ b/extension/peerd-provider/adapters/local-webgpu.js
@@ -211,19 +211,18 @@ export async function* callLocalWebgpu({ messages, system, model = LOCAL_MODEL_I
     })();
     yield* parseLocalStream(tokenStream);
   } catch (e) {
-    // why the cast (not `e instanceof Error`): a DOMException isn't an
-    // instanceof Error in browsers but does carry `.message`, and WebGPU
-    // rejects with DOMExceptions — so keep the original `e?.message ?? String(e)`
-    // exactly, just typed (the cast is erased at runtime).
-    const msg = /** @type {{ message?: string }} */ (e)?.message ?? String(e);
-    yield { type: 'error', error: `local inference failed: ${msg}` };
-    return;
+    if (!signal?.aborted) {
+      // why: WebGPU can reject with a DOMException that is not an Error.
+      const msg = /** @type {{ message?: string }} */ (e)?.message ?? String(e);
+      yield { type: 'error', error: `local inference failed: ${msg}` };
+      return;
+    }
   }
   // why synthetic usage: on-device generation has no billed token counts, but the
   // eval scorecard's "runner tokens" split needs a number to stay honest about
   // where work went (output tokens only; prefill is local + free).
-  yield { type: 'usage', usage: { inputTokens: 0, outputTokens: outTokens, cacheReadTokens: 0, cacheWriteTokens: 0 } };
-  yield { type: 'message-stop', stopReason: 'end_turn' };
+  if (!signal?.aborted) yield { type: 'usage', usage: { inputTokens: 0, outputTokens: outTokens, cacheReadTokens: 0, cacheWriteTokens: 0 } };
+  yield { type: 'message-stop', stopReason: signal?.aborted ? 'aborted' : 'end_turn' };
 }
 
 /**

--- a/tests/background/local-model-stop-wiring.test.ts
+++ b/tests/background/local-model-stop-wiring.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { EXTENSION_DIR } from '../../packaging/lib.ts';
+
+// The service worker registers browser listeners at load. Check the local
+// model dispatch order without importing the full worker.
+const serviceWorker = readFileSync(join(EXTENSION_DIR, 'background/service-worker.js'), 'utf8');
+
+describe('local model Stop wiring', () => {
+  test('Stop during offscreen startup settles the stream before dispatch', () => {
+    const start = serviceWorker.indexOf('const generateLocalForAdapter =');
+    const end = serviceWorker.indexOf('setLocalGenerate(', start);
+    const bridge = serviceWorker.slice(start, end);
+    const abortStart = bridge.indexOf('const abortHostGeneration =');
+    const abortEnd = bridge.indexOf('};', abortStart);
+    const abort = bridge.slice(abortStart, abortEnd);
+    const listener = bridge.indexOf("opts.signal.addEventListener('abort', abortHostGeneration", abortEnd);
+    const preAborted = bridge.indexOf('if (opts.signal?.aborted) abortHostGeneration();', listener);
+    const startup = bridge.indexOf('else ensureOffscreen()', preAborted);
+    const postStartupCheck = bridge.indexOf('opts.signal?.aborted', startup);
+    const settle = bridge.indexOf('abortHostGeneration()', postStartupCheck);
+    const dispatch = bridge.indexOf("type: 'local-model/host/generate'", startup);
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(abort).toContain('state.done = true;');
+    expect(abort).toContain('wakeLocalGen(state);');
+    expect(listener).toBeGreaterThan(abortEnd);
+    expect(preAborted).toBeGreaterThan(listener);
+    expect(startup).toBeGreaterThan(preAborted);
+    expect(postStartupCheck).toBeGreaterThan(startup);
+    expect(settle).toBeGreaterThan(postStartupCheck);
+    expect(dispatch).toBeGreaterThan(settle);
+  });
+});

--- a/tests/peerd-provider/local-webgpu-adapter.test.ts
+++ b/tests/peerd-provider/local-webgpu-adapter.test.ts
@@ -77,6 +77,15 @@ describe('callLocalWebgpu', () => {
     setLocalGenerate(null);
   });
 
+  test('Stop ends the call with an aborted stop reason', async () => {
+    const controller = new AbortController();
+    setLocalGenerate(() => (async function* () { controller.abort(); })());
+    const out = await collect(callLocalWebgpu({ messages: [], system: 'sys', signal: controller.signal } as any));
+    expect(out.at(-1)).toEqual({ type: 'message-stop', stopReason: 'aborted' });
+    expect(out.some((event) => event.type === 'usage')).toBe(false);
+    setLocalGenerate(null);
+  });
+
   test('projects messages before the local provider transport', async () => {
     let received: any = null;
     setLocalGenerate((request) => {


### PR DESCRIPTION
## Summary

- settle Local WebGPU streams as soon as Stop arrives
- prevent a late Generate command after offscreen startup
- report stopped local calls as aborted

## Checks

- 6413/6413 functional tests pass
- lint passes
- typecheck passes
- TS-check coverage passes
- badge check passes
- independent review found no blockers

Closes #457