### PR TITLE
fix(actor): retry uncommitted async results

### DIFF
--- a/badges/functional-tests.json
+++ b/badges/functional-tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "Functional Tests",
-  "message": "6411/6411 passing",
+  "message": "6415/6415 passing",
   "color": "brightgreen",
   "namedLogo": "bun",
   "logoColor": "white"

--- a/badges/inbrowser-chrome.json
+++ b/badges/inbrowser-chrome.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "In-Browser (Chrome)",
-  "message": "948/948 passing",
+  "message": "949/949 passing",
   "color": "brightgreen",
   "namedLogo": "googlechrome",
   "logoColor": "white"

--- a/badges/inbrowser-gecko.json
+++ b/badges/inbrowser-gecko.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "In-Browser (Gecko)",
-  "message": "942/942 passing",
+  "message": "943/943 passing",
   "color": "brightgreen",
   "namedLogo": "firefoxbrowser",
   "logoColor": "white"

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -5945,7 +5945,7 @@ const actorMailbox = {
 };
 
 onSessionMessageAppended = async (_sessionId, message) => {
-  const deliveryIds = actorDeliveryIdsFromMessage(message);
+  const deliveryIds = actorDeliveryIdsFromMessage(message).filter((id) => !asyncActorsOrchestrator.acknowledgeDelivery(id));
   await Promise.all(deliveryIds.map((id) => actorMailbox.remove(id)));
 };
 

--- a/extension/peerd-runtime/actor/async-actors.js
+++ b/extension/peerd-runtime/actor/async-actors.js
@@ -32,7 +32,7 @@
  * @param {(sessionId: string) => string[]} [deps.stopSubtree]
  *   Transitively stop a cancelled child's OWN descendants (spawn.js
  *   stopSubtree) — a cancel must end the whole subtree, like Stop does.
- * @param {(opts: { userText: string, sessionId: string, synthetic: boolean, actorReply?: { kind: string, instanceId: string, failed: boolean, outcomeKnown?: boolean, parentToolUseId?: string, parentToolUseIds?: string[], correlationComplete?: boolean }, turnLease?: { controller: AbortController, release: () => void } }) => Promise<unknown>} deps.reenter
+ * @param {(opts: { userText: string, sessionId: string, synthetic: boolean, actorReply?: { kind: string, instanceId: string, failed: boolean, outcomeKnown?: boolean, actorDeliveryId?: string, parentToolUseId?: string, parentToolUseIds?: string[], correlationComplete?: boolean }, turnLease?: { controller: AbortController, release: () => void } }) => Promise<unknown>} deps.reenter
  *   Re-enter a session with a (synthetic) turn — the SW's runAgentTurn.
  * @param {() => Promise<string|null>} deps.getActiveSessionId
  * @param {() => boolean} deps.isVaultLocked
@@ -43,13 +43,16 @@
  *   Fired on every task status transition (spawn/settle/cancel/deliver) so a UI
  *   can mirror the live task list. No-op by default (tests omit it).
  * @param {() => number} [deps.now]
- * @param {{ outstanding?: number, lifetime?: number, resultChars?: number, ringLines?: number, rateCap?: number, rateWindowMs?: number }} [deps.caps]
+ * @param {(fn: () => void, delayMs: number) => unknown} [deps.schedule]
+ * @param {() => string} [deps.makeDeliveryId]
+ * @param {{ outstanding?: number, lifetime?: number, resultChars?: number, ringLines?: number, rateCap?: number, rateWindowMs?: number, retryMs?: number }} [deps.caps]
  * @param {(...args: unknown[]) => void} [deps.log]  injected logger (console in the SW, silent in tests)
  */
 export const makeAsyncActors = (deps) => {
   const {
     spawnActor, turnSlots, reenter, getActiveSessionId, isVaultLocked,
     wrapUntrusted, forwardEvent, notify, stopSubtree, now = Date.now, caps = {},
+    schedule = (fn, delayMs) => setTimeout(fn, delayMs), makeDeliveryId = () => globalThis.crypto.randomUUID(),
     // Mirror the live task list to a UI on each status transition. No-op in
     // tests / headless contexts that don't render it.
     onTasksChanged = () => {},
@@ -71,7 +74,7 @@ export const makeAsyncActors = (deps) => {
    * @typedef {Object} ChildEntry
    * @property {string} taskId
    * @property {string} task
-   * @property {'running' | 'done' | 'cancelled'} status
+   * @property {'running' | 'done' | 'delivering' | 'delivered' | 'cancelled'} status
    * @property {string} result
    * @property {boolean} exceeded
    * @property {boolean} interrupted
@@ -81,7 +84,6 @@ export const makeAsyncActors = (deps) => {
    * @property {boolean} outcomeKnown false when effects may have landed before failure
    * @property {string | null} childSessionId
    * @property {string[] | null} grantedTools  server-resolved grant set once the child starts
-   * @property {boolean} reintegrated
    * @property {string[]} ring
    * @property {string | null} parentToolUseId the actor_create call that launched it
    * @property {number} parentStopGeneration  Stop epoch captured at launch
@@ -89,6 +91,8 @@ export const makeAsyncActors = (deps) => {
 
   /** @type {Map<string, Map<string, ChildEntry>>} parentSessionId -> Map<taskId, entry>. In-memory: in-session durability only. */
   const children = new Map();
+  /** @type {Map<string, { id: string, generation: number, children: ChildEntry[], retryScheduled: boolean, envelope: any }>} */
+  const deliveryBatches = new Map();
   /** @type {Map<string, number[]>} parentSessionId -> recent spawn timestamps (the rate-based runaway guard). */
   const recentSpawns = new Map();
   let seq = 0;
@@ -108,7 +112,7 @@ export const makeAsyncActors = (deps) => {
     return [...kids.values()].map((c) => ({
       taskId: c.taskId,
       task: c.task.slice(0, 80),
-      status: c.reintegrated ? 'delivered' : c.status,
+      status: c.status === 'delivering' ? 'done' : c.status,
       lastOutput: c.ring.join('').slice(-500),
       childSessionId: c.childSessionId,
       grantedTools: c.grantedTools,
@@ -127,7 +131,7 @@ export const makeAsyncActors = (deps) => {
   const actorCancel = (parentSessionId, taskId) => {
     const entry = children.get(parentSessionId)?.get(taskId ?? '');
     if (!entry) return { ok: false, error: 'no_such_task' };
-    if (entry.status !== 'running') return { ok: false, error: `task already ${entry.reintegrated ? 'delivered' : entry.status}` };
+    if (entry.status !== 'running') return { ok: false, error: `task already ${entry.status}` };
     entry.status = 'cancelled';
     if (entry.childSessionId) {
       stopSubtree?.(entry.childSessionId);
@@ -137,9 +141,7 @@ export const makeAsyncActors = (deps) => {
     return { ok: true, content: `actor ${taskId} cancelled — its work is being stopped and its result will not come back` };
   };
 
-  // Coalesce all of a parent's finished-but-unreintegrated children into ONE
-  // synthetic wake turn. Idempotent (flips `reintegrated` before re-entry) and
-  // vault-aware (defers while locked, re-drains on unlock).
+  // Freeze each batch until the post-commit hook acknowledges it; retry the same id after failure.
   /**
    * @param {string} parentSessionId
    * @param {{ controller: AbortController, release: () => void } | undefined} [turnLease]
@@ -147,99 +149,88 @@ export const makeAsyncActors = (deps) => {
   const drainReintegration = async (parentSessionId, turnLease = undefined) => {
     const kids = children.get(parentSessionId);
     if (!kids) return;
-    const waiting = [...kids.values()].filter((c) => c.status === 'done' && !c.reintegrated);
-    if (waiting.length === 0) return;
-
-    // Stop is a mailbox boundary, not merely an AbortSignal for work that is
-    // still running. A child may have finished just before Stop while its wake
-    // sat behind the parent's live turn (or while the vault was locked). Drop
-    // every result launched in an older parent epoch so it cannot start a fresh
-    // synthetic turn after the user explicitly stopped that task.
     const parentStopGeneration = turnSlots.generation?.(parentSessionId) ?? 0;
+    let batch = deliveryBatches.get(parentSessionId);
+    if (batch && batch.generation !== parentStopGeneration) {
+      for (const child of batch.children) child.status = 'cancelled';
+      deliveryBatches.delete(parentSessionId);
+      batch = undefined;
+      onTasksChanged(parentSessionId);
+    }
+    const waiting = [...kids.values()].filter((c) => c.status === 'done');
     const stale = waiting.filter((c) => c.parentStopGeneration !== parentStopGeneration);
     for (const child of stale) child.status = 'cancelled';
     const finished = waiting.filter((c) => c.parentStopGeneration === parentStopGeneration);
     if (stale.length > 0) onTasksChanged(parentSessionId);
-    if (finished.length === 0) return;
+    if (!batch && finished.length === 0) return;
 
-    // Vault-locked: the model key is gated — cannot run the wake turn. Hold the
-    // results, notify generically, re-drain on unlock (onVaultUnlock).
-    if (isVaultLocked()) { notify(finished.length); return; }
+    if (isVaultLocked()) { notify(batch?.children.length ?? finished.length); return; }
+    if (batch?.retryScheduled) return;
+    if (!batch) {
+      const blocks = finished.map((c) => {
+        let body = c.result || '(actor returned no text)';
+        if (body.length > RESULT_CHARS) {
+          body = `${body.slice(0, RESULT_CHARS)}\n…[truncated - open the actor card in the side panel for the full transcript]`;
+        }
+        // why: child output can include page data. Fence it and use the ISO
+        // timestamp shape that wrapUntrusted writes verbatim.
+        const wrapped = wrapUntrusted({ origin: 'spawned', tool: 'actor_create', body, retrievedAt: new Date(now()).toISOString() });
+        const outcomeUnknown = c.executionFailed && c.outcomeKnown === false;
+        const flag = outcomeUnknown
+          ? ' (execution failed after work began; outcome unknown; do not retry automatically)'
+          : c.executionFailed ? ' (failed before target work ran)'
+          : c.interrupted ? ' (interrupted before finishing, partial)'
+          : c.timedOut ? ' (hit its wall-clock timeout, partial)'
+          : c.stopped ? ' (stopped before finishing, partial)'
+          : c.exceeded ? ' (hit its step cap, may be incomplete)' : '';
+        return `Actor "${c.task.slice(0, 80)}"${flag}:\n${wrapped}`;
+      });
+      const hasUnknownOutcome = finished.some((entry) => entry.executionFailed && entry.outcomeKnown === false);
+      const hasKnownFailure = finished.some((entry) => entry.executionFailed && entry.outcomeKnown !== false);
+      const lead = finished.length === 1
+        ? (hasUnknownOutcome
+          ? 'An actor you started earlier stopped after execution began. Its outcome is unknown. Do not retry automatically. Here is the failure:'
+          : hasKnownFailure ? 'An actor you started earlier failed before target work ran. Here is the failure:'
+          : 'An actor you started earlier has finished. Here is its result:')
+        : (hasUnknownOutcome
+          ? `${finished.length} spawned actors completed or failed. Review each result and do not automatically retry an unknown outcome:`
+          : hasKnownFailure ? `${finished.length} spawned actors completed or failed before target work ran. Review each result:`
+          : `${finished.length} actors you started earlier have finished. Here are their results:`);
+      const parentToolUseIds = [...new Set(finished.flatMap((child) => child.parentToolUseId ? [child.parentToolUseId] : []))];
+      const correlationComplete = finished.every((child) => !!child.parentToolUseId);
+      const id = makeDeliveryId();
+      batch = {
+        id, generation: parentStopGeneration, children: finished, retryScheduled: false,
+        envelope: {
+          userText: `${lead}\n\n${blocks.join('\n\n')}`, sessionId: parentSessionId, synthetic: true,
+          actorReply: {
+            kind: 'spawned', instanceId: 'spawned', actorDeliveryId: id, failed: hasUnknownOutcome || hasKnownFailure,
+            ...(hasUnknownOutcome ? { outcomeKnown: false } : {}),
+            ...(parentToolUseIds.length === 1 ? { parentToolUseId: parentToolUseIds[0] } : {}),
+            ...(parentToolUseIds.length > 0 ? { parentToolUseIds } : {}),
+            ...(correlationComplete ? {} : { correlationComplete: false }),
+          },
+        },
+      };
+      for (const child of finished) child.status = 'delivering';
+      deliveryBatches.set(parentSessionId, batch);
+      onTasksChanged(parentSessionId);
+      Promise.resolve(getActiveSessionId())
+        .then((active) => { if (active !== parentSessionId) notify(finished.length); })
+        .catch(() => {});
+    }
 
-    // Idempotency: flip BEFORE re-entry so a redelivered drain is a no-op.
-    finished.forEach((c) => { c.reintegrated = true; });
-    onTasksChanged(parentSessionId); // delivered → drop off the live bar
-
-    const blocks = finished.map((c) => {
-      let body = c.result || '(actor returned no text)';
-      if (body.length > RESULT_CHARS) {
-        body = `${body.slice(0, RESULT_CHARS)}\n…[truncated — open the actor card in the side panel for the full transcript]`;
+    try { await reenter({ ...batch.envelope, ...(turnLease ? { turnLease } : {}) }); }
+    catch { /* commit acknowledgement, not the turn outcome, decides delivery */ }
+    if (deliveryBatches.get(parentSessionId) !== batch) return;
+    batch.retryScheduled = true;
+    schedule(() => {
+      if (deliveryBatches.get(parentSessionId) === batch) {
+        batch.retryScheduled = false; queueReintegration(parentSessionId);
       }
-      // why UNTRUSTED: the child's result is model-authored from a fresh context
-      // over possibly page-derived bytes. Only the one-line framing is trusted.
-      // why toISOString: wrapUntrusted stamps retrieved_at="…" verbatim and
-      // expects an ISO string; passing the raw epoch from now() (a number) put
-      // a bare millisecond count in the wrapper. Keep the injected `now` for
-      // determinism, formatted correctly.
-      const wrapped = wrapUntrusted({ origin: 'spawned', tool: 'actor_create', body, retrievedAt: new Date(now()).toISOString() });
-      const outcomeUnknown = c.executionFailed && c.outcomeKnown === false;
-      const flag = outcomeUnknown
-        ? ' (execution failed after work began; outcome unknown; do not retry automatically)'
-        : c.executionFailed ? ' (failed before target work ran)'
-        : c.interrupted ? ' (interrupted before finishing, partial)'
-        : c.timedOut ? ' (hit its wall-clock timeout, partial)'
-        : c.stopped ? ' (stopped before finishing, partial)'
-        : c.exceeded ? ' (hit its step cap, may be incomplete)' : '';
-      return `Actor "${c.task.slice(0, 80)}"${flag}:\n${wrapped}`;
-    });
-    const hasUnknownOutcome = finished.some((entry) => entry.executionFailed && entry.outcomeKnown === false);
-    const hasKnownFailure = finished.some((entry) => entry.executionFailed && entry.outcomeKnown !== false);
-    const lead = finished.length === 1
-      ? hasUnknownOutcome
-        ? 'An actor you started earlier stopped after execution began. Its outcome is unknown. Do not retry automatically. Here is the failure:'
-        : hasKnownFailure
-          ? 'An actor you started earlier failed before target work ran. Here is the failure:'
-        : 'An actor you started earlier has finished. Here is its result:'
-      : hasUnknownOutcome
-        ? `${finished.length} spawned actors completed or failed. Review each result and do not automatically retry an unknown outcome:`
-        : hasKnownFailure
-          ? `${finished.length} spawned actors completed or failed before target work ran. Review each result:`
-        : `${finished.length} actors you started earlier have finished. Here are their results:`;
-    const wakeText = `${lead}\n\n${blocks.join('\n\n')}`;
-
-    const parentToolUseIds = [...new Set(finished.flatMap((child) =>
-      typeof child.parentToolUseId === 'string' && child.parentToolUseId
-        ? [child.parentToolUseId]
-        : []))];
-    const correlationComplete = finished.every((child) =>
-      typeof child.parentToolUseId === 'string' && child.parentToolUseId.length > 0);
-
-    // Passive surfacing is informational and must not sit between the claimed
-    // idle slot and re-entry. Start it independently: otherwise its storage read
-    // creates a gap in which a human turn can claim the session, only for this
-    // older synthetic wake to claim again and steer-abort the user.
-    Promise.resolve(getActiveSessionId())
-      .then((active) => { if (active !== parentSessionId) notify(finished.length); })
-      .catch(() => {});
-
-    await reenter({
-      userText: wakeText, sessionId: parentSessionId, synthetic: true,
-      actorReply: {
-        kind: 'spawned', instanceId: 'spawned',
-        failed: hasUnknownOutcome || hasKnownFailure,
-        ...(hasUnknownOutcome ? { outcomeKnown: false } : {}),
-        ...(parentToolUseIds.length === 1 ? { parentToolUseId: parentToolUseIds[0] } : {}),
-        ...(parentToolUseIds.length > 0 ? { parentToolUseIds } : {}),
-        ...(correlationComplete ? {} : { correlationComplete: false }),
-      },
-      ...(turnLease ? { turnLease } : {}),
-    });
+    }, caps.retryMs ?? 1_000);
   };
 
-  // Claim the parent synchronously at dequeue, then thread that exact lease
-  // into the turn driver. This is the actor-mailbox analogue of an Erlang
-  // process taking one message from its mailbox: one receiver owns the next
-  // turn, and later arrivals queue instead of stealing it.
   const queueReintegration = (/** @type {string} */ parentSessionId) => {
     const start = (/** @type {{ controller: AbortController, release: () => void } | undefined} */ turnLease) => {
       Promise.resolve(drainReintegration(parentSessionId, turnLease))
@@ -251,6 +242,17 @@ export const makeAsyncActors = (deps) => {
     } else {
       turnSlots.runWhenIdle(parentSessionId, () => start(undefined));
     }
+  };
+
+  const acknowledgeDelivery = (/** @type {string} */ id) => {
+    const match = [...deliveryBatches].find(([, candidate]) => candidate.id === id);
+    if (!match) return false;
+    const [parentSessionId, batch] = match;
+    for (const child of batch.children) child.status = 'delivered';
+    deliveryBatches.delete(parentSessionId);
+    onTasksChanged(parentSessionId);
+    if ([...(children.get(parentSessionId)?.values() ?? [])].some((child) => child.status === 'done')) queueReintegration(parentSessionId);
+    return true;
   };
 
   // The non-blocking spawn. Registers the child, waits only for its durable
@@ -289,7 +291,7 @@ export const makeAsyncActors = (deps) => {
       taskId, task: String(req.task ?? ''), status: 'running', result: '',
       exceeded: false, interrupted: false, timedOut: false, stopped: false,
       executionFailed: false, outcomeKnown: true,
-      childSessionId: null, reintegrated: false, ring: [],
+      childSessionId: null, ring: [],
       parentToolUseId: typeof req.parentToolUseId === 'string' ? req.parentToolUseId : null,
       parentStopGeneration: turnSlots.generation?.(parentSessionId) ?? 0,
       grantedTools: null,
@@ -407,14 +409,11 @@ export const makeAsyncActors = (deps) => {
     };
   };
 
-  // On vault unlock, re-drain any parent with finished-but-undelivered children.
   const onVaultUnlock = () => {
     for (const [parentSessionId, kids] of children) {
-      if ([...kids.values()].some((c) => c.status === 'done' && !c.reintegrated)) {
-        queueReintegration(parentSessionId);
-      }
+      if ([...kids.values()].some((c) => c.status === 'done' || c.status === 'delivering')) queueReintegration(parentSessionId);
     }
   };
 
-  return { spawnActorAsync, drainReintegration, actorTasks, actorCancel, onVaultUnlock };
+  return { spawnActorAsync, drainReintegration, acknowledgeDelivery, actorTasks, actorCancel, onVaultUnlock };
 };

--- a/extension/peerd-runtime/loop/agent-loop.js
+++ b/extension/peerd-runtime/loop/agent-loop.js
@@ -360,7 +360,7 @@ export async function* runUserTurn(ctx) {
       // chat renders it as its own attributed bubble instead of hiding it
       // with the other synthetic plumbing turns (resume/truncation nudges).
       ...(actorReply ? { actorReply } : {}),
-      id: uuidv7(now),
+      id: synthetic && typeof actorReply?.actorDeliveryId === 'string' ? actorReply.actorDeliveryId : uuidv7(now),
       when: now(),
     };
     session = await sessions.appendMessage(sessionId, userMsg);

--- a/extension/tests/unit/peerd-runtime/agent-loop.test.js
+++ b/extension/tests/unit/peerd-runtime/agent-loop.test.js
@@ -109,6 +109,23 @@ describe('agent loop — runUserTurn', () => {
     expect(audited[0].sessionId).toBe(session.sessionId);
   });
 
+  it('uses the actor delivery id for a retry-safe synthetic message', async () => {
+    const { sessions, ctx } = buildCtx({
+      synthetic: true,
+      actorReply: {
+        kind: 'spawned', instanceId: 'spawned', failed: false,
+        actorDeliveryId: 'delivery-stable',
+      },
+    });
+    const session = await sessions.create();
+    ctx.sessionId = session.sessionId;
+
+    await drain(runUserTurn(asRunCtx(ctx)));
+
+    const stored = present(await sessions.get(session.sessionId));
+    expect(stored.messages[0].id).toBe('delivery-stable');
+  });
+
   it('auto-continues a thinking-only max_tokens truncation via a hidden user nudge', async () => {
     // The field 'silent timeout': adaptive thinking burns the whole
     // output ceiling, the step ends at max_tokens with NO text and NO

--- a/tests/peerd-runtime/actor/async-actors.test.ts
+++ b/tests/peerd-runtime/actor/async-actors.test.ts
@@ -22,13 +22,27 @@ const baseDeps = (over = {}) => ({
   ...over,
 });
 
+const makeCommittedAsyncActors = (over: any = {}) => {
+  let actors: ReturnType<typeof makeAsyncActors>;
+  const reenter = over.reenter ?? (async () => {});
+  actors = makeAsyncActors(baseDeps({
+    ...over,
+    reenter: (opts: any) => {
+      const running = reenter(opts);
+      actors.acknowledgeDelivery(opts.actorReply.actorDeliveryId);
+      return running;
+    },
+  }));
+  return actors;
+};
+
 describe('makeAsyncActors', () => {
   test('spawn returns a handle immediately, result re-enters as a synthetic wake', async () => {
     const reenters: any[] = [];
-    const as = makeAsyncActors(baseDeps({
+    const as = makeCommittedAsyncActors({
       spawnActor: async () => ({ result: 'BROMANTANE FACTS', sessionId: 'c1' }),
       reenter: async (o: any) => { reenters.push(o); },
-    }));
+    });
 
     const handle = await as.spawnActorAsync({
       task: 'research bromantane', parentSessionId: 'parent', parentToolUseId: 'spawn-tool-1',
@@ -46,6 +60,7 @@ describe('makeAsyncActors', () => {
       kind: 'spawned', instanceId: 'spawned', parentToolUseId: 'spawn-tool-1',
       parentToolUseIds: ['spawn-tool-1'],
     });
+    expect(typeof reenters[0].actorReply.actorDeliveryId).toBe('string');
     expect(reenters[0].userText).toContain('BROMANTANE FACTS');
     expect(reenters[0].userText).toContain('[UNTRUSTED]'); // child result is wrapped
   });
@@ -55,10 +70,10 @@ describe('makeAsyncActors', () => {
   // just stopped, so a reintegration wake would restart it seconds after Stop.
   test('a Stop-aborted child does not wake the parent (dropped like a cancel)', async () => {
     const reenters: any[] = [];
-    const as = makeAsyncActors(baseDeps({
+    const as = makeCommittedAsyncActors({
       spawnActor: async () => ({ result: 'partial', sessionId: 'c1', stopped: true }),
       reenter: async (o: any) => { reenters.push(o); },
-    }));
+    });
     await as.spawnActorAsync({ task: 'long', parentSessionId: 'parent' });
     await flush();
     expect(reenters).toHaveLength(0); // no synthetic wake after a user Stop
@@ -66,13 +81,13 @@ describe('makeAsyncActors', () => {
 
   test('a post-start Worker failure wakes the parent with unknown-outcome guidance', async () => {
     const reenters: any[] = [];
-    const as = makeAsyncActors(baseDeps({
+    const as = makeCommittedAsyncActors({
       spawnActor: async () => ({
         result: 'The actor worker crashed. Its outcome is unknown and must not be retried automatically.',
         sessionId: 'c1', stopped: true, executionFailed: true, outcomeKnown: false,
       }),
       reenter: async (o: any) => { reenters.push(o); },
-    }));
+    });
     await as.spawnActorAsync({ task: 'write once', parentSessionId: 'parent' });
     await flush();
     expect(reenters).toHaveLength(1);
@@ -87,10 +102,10 @@ describe('makeAsyncActors', () => {
     const failure = Object.assign(new Error('transcript write failed'), {
       executionFailed: true, performed: true, outcomeKnown: false, retryable: false,
     });
-    const as = makeAsyncActors(baseDeps({
+    const as = makeCommittedAsyncActors({
       spawnActor: async () => { throw failure; },
       reenter: async (o: any) => { reenters.push(o); },
-    }));
+    });
     await as.spawnActorAsync({ task: 'write once', parentSessionId: 'parent' });
     await flush();
     expect(reenters).toHaveLength(1);
@@ -101,13 +116,13 @@ describe('makeAsyncActors', () => {
 
   test('a graceful pre-tool failure is not described as an unknown outcome', async () => {
     const reenters: any[] = [];
-    const as = makeAsyncActors(baseDeps({
+    const as = makeCommittedAsyncActors({
       spawnActor: async () => ({
         result: 'The actor model request was not run.', sessionId: 'c1',
         stopped: true, executionFailed: true, outcomeKnown: true,
       }),
       reenter: async (o: any) => { reenters.push(o); },
-    }));
+    });
     await as.spawnActorAsync({ task: 'write once', parentSessionId: 'parent' });
     await flush();
     expect(reenters).toHaveLength(1);
@@ -119,10 +134,10 @@ describe('makeAsyncActors', () => {
   // wants the partial, so a timed-out child DOES reintegrate.
   test('a timed-out child still wakes the parent with its partial', async () => {
     const reenters: any[] = [];
-    const as = makeAsyncActors(baseDeps({
+    const as = makeCommittedAsyncActors({
       spawnActor: async () => ({ result: 'partial', sessionId: 'c1', timedOut: true }),
       reenter: async (o: any) => { reenters.push(o); },
-    }));
+    });
     await as.spawnActorAsync({ task: 'slow', parentSessionId: 'parent' });
     await flush();
     expect(reenters).toHaveLength(1);
@@ -133,10 +148,10 @@ describe('makeAsyncActors', () => {
   // never goes stale. Spawn makes the task appear; settle flips it done.
   test('onTasksChanged fires on spawn and on settle (feeds the live status bar)', async () => {
     const calls: string[] = [];
-    const as = makeAsyncActors(baseDeps({
+    const as = makeCommittedAsyncActors({
       spawnActor: async () => ({ result: 'ok', sessionId: 'c1' }),
       onTasksChanged: (sid: string) => { calls.push(sid); },
-    }));
+    });
     await as.spawnActorAsync({ task: 'T', parentSessionId: 'parent' });
     await flush();
     // Pushes for the active parent only, and more than once: spawn (task
@@ -149,12 +164,12 @@ describe('makeAsyncActors', () => {
 
   test('task snapshots gain the child id + server-resolved grants when the actor starts', async () => {
     let finish!: (value: any) => void;
-    const as = makeAsyncActors(baseDeps({
+    const as = makeCommittedAsyncActors({
       spawnActor: async (req: any) => {
         req.onEvent({ type: 'actor-start', sessionId: 'c1', grantedTools: ['script', 'message_actor'] });
         return new Promise((resolve) => { finish = resolve; });
       },
-    }));
+    });
     await as.spawnActorAsync({ task: 'T', parentSessionId: 'parent' });
     const live = as.actorTasks('parent')[0];
     expect(live).toMatchObject({
@@ -169,13 +184,13 @@ describe('makeAsyncActors', () => {
   test('a re-spawning wake turn is bounded by the rate cap (runaway guard)', async () => {
     let childRuns = 0;
     let as: any;
-    as = makeAsyncActors(baseDeps({
+    as = makeCommittedAsyncActors({
       caps: { rateCap: 5, rateWindowMs: 60_000, outstanding: 4 },
       // child "fails" fast (the live case: interrupted/empty) so the model retries
       spawnActor: async () => { childRuns += 1; return { result: 'failed', interrupted: true }; },
       // the model reacting to the wake by RE-SPAWNING — the loop engine
       reenter: async ({ sessionId }: any) => { await as.spawnActorAsync({ task: 'retry', parentSessionId: sessionId }); },
-    }));
+    });
 
     await as.spawnActorAsync({ task: 'start', parentSessionId: 'parent' });
     await flush(); await flush(); await flush();
@@ -192,13 +207,13 @@ describe('makeAsyncActors', () => {
 
   test('outstanding cap refuses a 5th concurrent child (separate from the rate cap)', async () => {
     // children never settle → they stay "running" and fill the outstanding cap
-    const as = makeAsyncActors(baseDeps({
+    const as = makeCommittedAsyncActors({
       caps: { outstanding: 4, rateCap: 100 },
       spawnActor: (req: any) => {
         req.onEvent({ type: 'actor-start', sessionId: `child-${req.task}`, grantedTools: [] });
         return new Promise(() => {});
       }, // never resolves after allocation
-    }));
+    });
     for (let i = 0; i < 4; i++) {
       expect((await as.spawnActorAsync({ task: `t${i}`, parentSessionId: 'parent' })).ok).toBe(true);
     }
@@ -211,10 +226,10 @@ describe('makeAsyncActors', () => {
     const reenters: any[] = [];
     const slots = makeTurnSlots();
     const live = slots.claim('parent'); // a parent turn is in flight → wakes queue
-    const as = makeAsyncActors(baseDeps({
+    const as = makeCommittedAsyncActors({
       turnSlots: slots,
       reenter: async (o: any) => { reenters.push(o); },
-    }));
+    });
 
     await as.spawnActorAsync({ task: 'A', parentSessionId: 'parent', parentToolUseId: 'spawn-a' });
     await as.spawnActorAsync({ task: 'B', parentSessionId: 'parent', parentToolUseId: 'spawn-b' });
@@ -234,6 +249,118 @@ describe('makeAsyncActors', () => {
     expect(reenters).toHaveLength(1);
   });
 
+  test('a failed uncommitted wake retries the same batch before a later child', async () => {
+    const reenters: any[] = [];
+    const scheduled: Array<() => void> = [];
+    let as: ReturnType<typeof makeAsyncActors>;
+    as = makeAsyncActors(baseDeps({
+      schedule: (fn: () => void) => { scheduled.push(fn); },
+      reenter: async (opts: any) => {
+        reenters.push(opts);
+        if (reenters.length > 1) as.acknowledgeDelivery(opts.actorReply.actorDeliveryId);
+        return { ok: false };
+      },
+    }));
+
+    await as.spawnActorAsync({ task: 'A', parentSessionId: 'parent' });
+    await flush();
+    expect(reenters).toHaveLength(1);
+    expect(scheduled).toHaveLength(1);
+
+    await as.spawnActorAsync({ task: 'B', parentSessionId: 'parent' });
+    await flush();
+    expect(reenters).toHaveLength(1);
+    expect(scheduled).toHaveLength(1);
+
+    scheduled.shift()?.();
+    await flush();
+    expect(reenters).toHaveLength(3);
+    expect(reenters[1].userText).toBe(reenters[0].userText);
+    expect(reenters[1].actorReply).toEqual(reenters[0].actorReply);
+    expect(reenters[2].userText).toContain('R:B');
+    expect(reenters[2].userText).not.toContain('R:A');
+    expect(reenters[2].actorReply.actorDeliveryId)
+      .not.toBe(reenters[0].actorReply.actorDeliveryId);
+  });
+
+  test('a committed batch stays delivered when reentry throws later', async () => {
+    const scheduled: Array<() => void> = [];
+    let as: ReturnType<typeof makeAsyncActors>;
+    as = makeAsyncActors(baseDeps({
+      schedule: (fn: () => void) => { scheduled.push(fn); },
+      reenter: async (opts: any) => {
+        as.acknowledgeDelivery(opts.actorReply.actorDeliveryId);
+        throw new Error('post-commit failure');
+      },
+    }));
+
+    await as.spawnActorAsync({ task: 'A', parentSessionId: 'parent' });
+    await flush();
+    expect(scheduled).toHaveLength(0);
+    expect(as.actorTasks('parent')[0].status).toBe('delivered');
+  });
+
+  test('a committed coalesced batch excludes a child that finishes later', async () => {
+    const slots = makeTurnSlots();
+    const live = slots.claim('parent');
+    const reenters: any[] = [];
+    const finishes: Array<() => void> = [];
+    let as: ReturnType<typeof makeAsyncActors>;
+    as = makeAsyncActors(baseDeps({
+      turnSlots: slots,
+      reenter: (opts: any) => {
+        reenters.push(opts);
+        return new Promise<void>((resolve) => { finishes.push(resolve); });
+      },
+    }));
+
+    await as.spawnActorAsync({ task: 'A', parentSessionId: 'parent' });
+    await as.spawnActorAsync({ task: 'B', parentSessionId: 'parent' });
+    await flush();
+    live.release();
+    await flush();
+    expect(reenters).toHaveLength(1);
+    expect(reenters[0].userText).toContain('R:A');
+    expect(reenters[0].userText).toContain('R:B');
+
+    await as.spawnActorAsync({ task: 'C', parentSessionId: 'parent' });
+    await flush();
+    as.acknowledgeDelivery(reenters[0].actorReply.actorDeliveryId);
+    finishes.shift()?.();
+    await flush();
+    expect(reenters).toHaveLength(2);
+    expect(reenters[1].userText).toContain('R:C');
+    expect(reenters[1].userText).not.toContain('R:A');
+    expect(reenters[1].actorReply.actorDeliveryId)
+      .not.toBe(reenters[0].actorReply.actorDeliveryId);
+
+    as.acknowledgeDelivery(reenters[1].actorReply.actorDeliveryId);
+    finishes.shift()?.();
+    await flush();
+  });
+
+  test('Stop cancels a frozen batch before its delayed retry', async () => {
+    const slots = makeTurnSlots();
+    const reenters: any[] = [];
+    const scheduled: Array<() => void> = [];
+    const as = makeAsyncActors(baseDeps({
+      turnSlots: slots,
+      schedule: (fn: () => void) => { scheduled.push(fn); },
+      reenter: async (opts: any) => { reenters.push(opts); return { ok: false }; },
+    }));
+
+    await as.spawnActorAsync({ task: 'A', parentSessionId: 'parent' });
+    await flush();
+    expect(reenters).toHaveLength(1);
+    expect(scheduled).toHaveLength(1);
+
+    slots.stop('parent');
+    scheduled.shift()?.();
+    await flush();
+    expect(reenters).toHaveLength(1);
+    expect(as.actorTasks('parent')[0].status).toBe('cancelled');
+  });
+
   test('claims the idle parent before setup so a human turn cannot be stolen', async () => {
     const slots = makeTurnSlots();
     let resolveActive: ((id: string) => void) | undefined;
@@ -241,7 +368,7 @@ describe('makeAsyncActors', () => {
     let finishReentry: (() => void) | undefined;
     const heldReentry = new Promise<void>((resolve) => { finishReentry = resolve; });
     const reenters: any[] = [];
-    const as = makeAsyncActors(baseDeps({
+    const as = makeCommittedAsyncActors({
       turnSlots: slots,
       getActiveSessionId: () => active,
       reenter: async (opts: any) => {
@@ -252,7 +379,7 @@ describe('makeAsyncActors', () => {
         await heldReentry;
         lease.release();
       },
-    }));
+    });
 
     await as.spawnActorAsync({
       task: 'A', parentSessionId: 'parent', parentToolUseId: 'spawn-a',
@@ -276,10 +403,10 @@ describe('makeAsyncActors', () => {
     const slots = makeTurnSlots({ forceReleaseMs: 1 });
     const liveParent = slots.claim('parent');
     const reenters: any[] = [];
-    const as = makeAsyncActors(baseDeps({
+    const as = makeCommittedAsyncActors({
       turnSlots: slots,
       reenter: async (opts: any) => { reenters.push(opts); },
-    }));
+    });
 
     await as.spawnActorAsync({
       task: 'done just before Stop', parentSessionId: 'parent', parentToolUseId: 'spawn-a',
@@ -302,7 +429,7 @@ describe('makeAsyncActors', () => {
     let childLease: ReturnType<typeof slots.claim> | undefined;
     let publishStart!: () => void;
     let finishChild!: (value: any) => void;
-    const as = makeAsyncActors(baseDeps({
+    const as = makeCommittedAsyncActors({
       turnSlots: slots,
       stopSubtree: (sessionId: string) => { stoppedSubtrees.push(sessionId); return [sessionId]; },
       spawnActor: (req: any) => new Promise((resolve) => {
@@ -313,7 +440,7 @@ describe('makeAsyncActors', () => {
         finishChild = resolve;
       }),
       reenter: async (opts: any) => { reenters.push(opts); },
-    }));
+    });
 
     const spawning = as.spawnActorAsync({ task: 'delayed allocation', parentSessionId: 'parent' });
     await Promise.resolve();
@@ -337,11 +464,11 @@ describe('makeAsyncActors', () => {
     const reenters: any[] = [];
     let locked = true;
     let notified = 0;
-    const as = makeAsyncActors(baseDeps({
+    const as = makeCommittedAsyncActors({
       isVaultLocked: () => locked,
       reenter: async (o: any) => { reenters.push(o); },
       notify: () => { notified += 1; },
-    }));
+    });
 
     await as.spawnActorAsync({ task: 'X', parentSessionId: 'parent' });
     await flush();
@@ -357,13 +484,13 @@ describe('makeAsyncActors', () => {
 
   test('cancel drops the result (no wake) and frees the slot', async () => {
     const reenters: any[] = [];
-    const as = makeAsyncActors(baseDeps({
+    const as = makeCommittedAsyncActors({
       spawnActor: (req: any) => {
         req.onEvent({ type: 'actor-start', sessionId: 'child-cancel', grantedTools: [] });
         return new Promise(() => {});
       }, // never settles on its own
       reenter: async (o: any) => { reenters.push(o); },
-    }));
+    });
     const h = await as.spawnActorAsync({ task: 'cancel me', parentSessionId: 'parent' });
     const c = as.actorCancel('parent', h.taskId);
     expect(c.ok).toBe(true);


### PR DESCRIPTION
## Summary

- freeze one async actor result batch until its session message commits
- retry the same message ID after a failed commit
- cancel delayed retries after Stop
- keep later child results in a separate batch

## Checks

- 6415/6415 functional tests pass
- 949/949 Chrome in-browser tests pass
- lint passes
- typecheck passes
- boundary and badge checks pass
- independent review found no blockers

## Limit

Async child state remains limited to the service worker lifetime.

Closes #452