### PR TITLE
fix(browser): mark lost page execution unknown

### DIFF
--- a/badges/functional-tests.json
+++ b/badges/functional-tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "Functional Tests",
-  "message": "6411/6411 passing",
+  "message": "6413/6413 passing",
   "color": "brightgreen",
   "namedLogo": "bun",
   "logoColor": "white"

--- a/badges/inbrowser-chrome.json
+++ b/badges/inbrowser-chrome.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "In-Browser (Chrome)",
-  "message": "948/948 passing",
+  "message": "949/949 passing",
   "color": "brightgreen",
   "namedLogo": "googlechrome",
   "logoColor": "white"

--- a/badges/inbrowser-gecko.json
+++ b/badges/inbrowser-gecko.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "In-Browser (Gecko)",
-  "message": "942/942 passing",
+  "message": "943/943 passing",
   "color": "brightgreen",
   "namedLogo": "firefoxbrowser",
   "logoColor": "white"

--- a/extension/background/debugger-pool.js
+++ b/extension/background/debugger-pool.js
@@ -114,7 +114,7 @@ export const createDebuggerPool = () => {
     const set = pendingEvals.get(tabId);
     if (!set) return;
     pendingEvals.delete(tabId);
-    for (const reject of set) reject(new Error(`page_exec: ${why}`));
+    for (const reject of set) reject(hostLostError(`page_exec: ${why}`));
   };
 
   // why: `chrome.debugger` may not exist in this build at all. It's a
@@ -332,7 +332,7 @@ export const createDebuggerPool = () => {
         const set = pendingEvals.get(tabId) ?? new Set();
         pendingEvals.set(tabId, set);
         const timer = setTimeout(() => {
-          fail(new Error(`page_exec: the page script did not settle within ${Math.round(timeoutMs / 1000)}s — hung promise or unresponsive page`));
+          fail(hostLostError(`page_exec: the page script did not settle within ${Math.round(timeoutMs / 1000)}s - hung promise or unresponsive page`));
         }, timeoutMs);
         /** @param {Error} e */
         const fail = (e) => { cleanup(); reject(e); };

--- a/extension/tests/unit/peerd-runtime/page-exec.test.js
+++ b/extension/tests/unit/peerd-runtime/page-exec.test.js
@@ -172,6 +172,23 @@ describe('page_exec — outer tool', () => {
     expect(errOf(r).includes('debugger_detached')).toBe(true);
   });
 
+  it('marks a lost debugger result as unknown after dispatch', async () => {
+    const ctx = mockCtx(OK_RESULT, {
+      debuggerPool: {
+        evaluate: async () => {
+          const error = Object.assign(new Error('page script timed out'), {
+            outcomeKind: /** @type {const} */ ('host-lost'),
+          });
+          throw error;
+        },
+      },
+    });
+    const r = await pageExecTool.execute({ expression: 'x' }, ctx);
+    expect(r.ok).toBe(false);
+    expect(errOf(r).startsWith('page_exec_outcome_unknown')).toBe(true);
+    expect(/** @type {any} */ (r).outcomeKind).toBe('host-lost');
+  });
+
   it('discards all page output when the checked document changed', async () => {
     const ctx = mockCtx(OK_RESULT, {
       debuggerPool: {

--- a/tests/background/debugger-pool-timeout.test.ts
+++ b/tests/background/debugger-pool-timeout.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+
+describe('debugger pool evaluate deadline', () => {
+  const probe = (mode: string) => {
+    const processResult = Bun.spawnSync([
+      process.execPath,
+      join(import.meta.dir, 'fixtures', 'debugger-pool-timeout-probe.ts'),
+      mode,
+    ]);
+    const stdout = new TextDecoder().decode(processResult.stdout).trim().split('\n');
+    const result = JSON.parse(stdout.at(-1) ?? '{}');
+
+    expect(processResult.exitCode).toBe(0);
+    return result;
+  };
+
+  test('marks a timed-out dispatched script as host-lost', () => {
+    expect(probe('timeout').outcomeKind).toBe('host-lost');
+  });
+
+  test('marks debugger loss after dispatch as host-lost', () => {
+    expect(probe('detach').outcomeKind).toBe('host-lost');
+  });
+});

--- a/tests/background/fixtures/debugger-pool-timeout-probe.ts
+++ b/tests/background/fixtures/debugger-pool-timeout-probe.ts
@@ -1,0 +1,94 @@
+type Listener = (...args: any[]) => void;
+
+const makeEvent = () => {
+  const listeners = new Set<Listener>();
+  return {
+    addListener: (listener: Listener) => { listeners.add(listener); },
+    removeListener: (listener: Listener) => { listeners.delete(listener); },
+    emit: (...args: any[]) => { for (const listener of listeners) listener(...args); },
+  };
+};
+
+const expectedDocument = {
+  origin: 'https://example.com',
+  href: 'https://example.com/',
+  documentId: 'document-1',
+  timeOrigin: 123,
+};
+const debuggerEvents = makeEvent();
+const debuggerDetachEvents = makeEvent();
+const mode = process.argv[2] ?? 'timeout';
+const api = {
+  runtime: { id: 'peerd-test' },
+  tabs: { onRemoved: makeEvent(), onUpdated: makeEvent() },
+  scripting: {
+    executeScript: async () => [{
+      documentId: expectedDocument.documentId,
+      result: {
+        origin: expectedDocument.origin,
+        href: expectedDocument.href,
+        timeOrigin: expectedDocument.timeOrigin,
+      },
+    }],
+  },
+  debugger: {
+    onEvent: debuggerEvents,
+    onDetach: debuggerDetachEvents,
+    attach: async () => {},
+    detach: async () => {},
+    sendCommand: async (
+      target: { tabId: number },
+      method: string,
+      params?: { expression?: string },
+    ): Promise<any> => {
+      if (method === 'Runtime.enable') {
+        debuggerEvents.emit(target, 'Runtime.executionContextCreated', {
+          context: {
+            id: 7,
+            origin: expectedDocument.origin,
+            auxData: { frameId: 'frame-1', isDefault: true },
+          },
+        });
+        return {};
+      }
+      if (method === 'Page.getFrameTree') {
+        return { frameTree: { frame: {
+          id: 'frame-1', loaderId: 'loader-1', url: expectedDocument.href,
+        } } };
+      }
+      if (method === 'Runtime.evaluate'
+          && params?.expression?.startsWith('({ origin:')) {
+        return { result: { value: {
+          origin: expectedDocument.origin,
+          href: expectedDocument.href,
+          timeOrigin: expectedDocument.timeOrigin,
+        } } };
+      }
+      if (method === 'Runtime.evaluate') {
+        if (mode === 'detach') {
+          setTimeout(() => debuggerDetachEvents.emit(target, 'target_closed'), 0);
+        }
+        return new Promise(() => {});
+      }
+      return {};
+    },
+  },
+};
+
+(globalThis as unknown as { chrome: unknown }).chrome = api;
+(globalThis as unknown as { browser: unknown }).browser = api;
+
+const { createDebuggerPool } = await import('../../../extension/background/debugger-pool.js');
+const pool = createDebuggerPool() as {
+  evaluate: (tabId: number, expression: string, options: unknown) => Promise<unknown>;
+};
+const error = await pool.evaluate(1, 'await new Promise(() => {})', {
+  expectedDocument,
+  timeoutMs: mode === 'timeout' ? 1 : 100,
+}).then(() => null, (value: unknown) => value);
+
+process.stdout.write(`${JSON.stringify({
+  outcomeKind: (error as { outcomeKind?: string } | null)?.outcomeKind ?? null,
+})}\n`);
+
+export {};


### PR DESCRIPTION
## Summary

- Classify a `page_exec` deadline as host loss after dispatch.
- Classify tab close and debugger detach the same way.
- Use the existing unknown-outcome warning before any retry.
- Add isolated debugger-pool tests and the outer tool mapping test.

## Verification

- `bun run test`
- `bun run typecheck`
- `bun run lint`
- Chrome in-browser lane
- Firefox Store smoke and Gecko lane
- Badge, boundary, hygiene, and invariant checks

Closes #460