### PR TITLE
fix(dweb): rotate consent after App changes

### DIFF
--- a/badges/functional-tests.json
+++ b/badges/functional-tests.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "Functional Tests",
-  "message": "6411/6411 passing",
+  "message": "6445/6445 passing",
   "color": "brightgreen",
   "namedLogo": "bun",
   "logoColor": "white"

--- a/badges/inbrowser-chrome.json
+++ b/badges/inbrowser-chrome.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "In-Browser (Chrome)",
-  "message": "948/948 passing",
+  "message": "963/963 passing",
   "color": "brightgreen",
   "namedLogo": "googlechrome",
   "logoColor": "white"

--- a/badges/inbrowser-gecko.json
+++ b/badges/inbrowser-gecko.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "In-Browser (Gecko)",
-  "message": "942/942 passing",
+  "message": "957/957 passing",
   "color": "brightgreen",
   "namedLogo": "firefoxbrowser",
   "logoColor": "white"

--- a/extension/background/app-client.js
+++ b/extension/background/app-client.js
@@ -1,16 +1,5 @@
 // @ts-check
-// SW-side App client.
-//
-// Apps are multi-file artifacts stored in OPFS at
-// `peerd-apps/<appId>/`. The registry tracks metadata (name, tags,
-// entryFile, timestamps). When an app tab opens, the parent page
-// reads OPFS directly + composes a single HTML body for the
-// sandboxed runner (see peerd-engine/app-compose.js).
-//
-// Note on IDB: the old `peerd-app-bodies` store from the single-blob
-// era stays put -- it's reserved for the future snapshot tier
-// (immutable, addressable "save this version" records). New apps
-// don't touch it.
+// Store multi-file Apps in OPFS and their metadata in the registry.
 
 import {
   inferAppFileKind,
@@ -25,12 +14,28 @@ import { base64ByteLength, fromBase64, toBase64 } from '/shared/bundle/bytes.js'
 
 export const APP_TAB_GROUP_TITLE = 'peerd';
 
-// These are storage-layer rails. Tool schemas keep smaller model-facing writes
-// useful, but every caller, including imports and dweb installs, meets these
-// limits again beside the OPFS write.
+// why: Enforce storage limits at the OPFS boundary for every caller.
 export const MAX_APP_TOTAL_BYTES = 50_000_000;
 export const MAX_APP_FILES = 256;
 const MAX_APP_PATH_CHARS = 512;
+const APP_DATA_PATH_RE = /^data\/[a-z0-9][a-z0-9._-]{0,63}\.json$/i;
+
+/** @param {unknown} value */
+const releaseKindRows = (value) => value && typeof value === 'object' && !Array.isArray(value)
+  ? Object.entries(value).filter(([path]) => !APP_DATA_PATH_RE.test(path))
+    .map(([path, kind]) => `${path}\0${kind}`).sort()
+  : null;
+
+/** @param {any} record */
+export const appReleaseDescriptorMatches = (record) => {
+  const expected = releaseKindRows(record?.dweb?.release_file_kinds);
+  const current = releaseKindRows(record?.fileKinds ?? {});
+  return typeof record?.dweb?.release_entry_file === 'string'
+    && record.entryFile === record.dweb.release_entry_file
+    && expected !== null && current !== null
+    && expected.length === current.length
+    && expected.every((row, index) => row === current[index]);
+};
 
 export class AppFileContentError extends Error {
   /** @param {string} message */
@@ -69,21 +74,23 @@ const validateAppPath = (path) => {
   return path;
 };
 
-/**
- * Normalize one text, byte, or JSON-safe base64 value before any storage write.
- * The encoded-length rail runs before atob so a hostile transport string cannot
- * allocate beyond the App ceiling merely to be rejected afterward.
- *
- * @param {string} path
- * @param {unknown} value
- * @param {unknown} [declaredKind]
- * @returns {{ stored: string | Uint8Array<ArrayBuffer>, size: number, kind: 'text' | 'binary' }}
- */
+/** @param {string} path @param {string|Uint8Array<ArrayBuffer>} stored @param {'text'|'binary'} kind */
+const validateRuntimeData = (path, stored, kind) => {
+  if (!APP_DATA_PATH_RE.test(path)) return;
+  if (kind !== 'text') throw new AppFileContentError(`App runtime data must be text: ${path}`);
+  try { JSON.parse(typeof stored === 'string' ? stored : new TextDecoder().decode(stored)); }
+  catch { throw new AppFileContentError(`App runtime data must be valid JSON: ${path}`); }
+};
+
+/** why: Check encoded size before base64 decoding can allocate excess bytes.
+ * @param {string} path @param {unknown} value @param {unknown} [declaredKind]
+ * @returns {{stored:string|Uint8Array<ArrayBuffer>,size:number,kind:'text'|'binary'}} */
 const normalizeFileContent = (path, value, declaredKind) => {
   if (typeof value === 'string') {
     if (isBinaryAssetPath(path) || declaredKind === 'binary') {
       throw new AppFileContentError(`binary App asset requires bytes or { base64 }: ${path}`);
     }
+    validateRuntimeData(path, value, 'text');
     return { stored: value, size: new TextEncoder().encode(value).byteLength, kind: 'text' };
   }
   /** @type {Uint8Array<ArrayBuffer> | null} */
@@ -120,6 +127,7 @@ const normalizeFileContent = (path, value, declaredKind) => {
   if (kind === 'text' && (isBinaryAssetPath(path) || !isLosslessUtf8Text(stored))) {
     throw new AppFileContentError(`App text file is not lossless UTF-8: ${path}`);
   }
+  validateRuntimeData(path, stored, kind);
   return { stored, size: stored.byteLength, kind };
 };
 
@@ -177,22 +185,13 @@ export const createAppClient = ({
   registry, tracker, beforeOpfsMutation = () => {}, onManifestMutation = () => {},
   resolveOwnerRoot = async (ownerSessionId) => ownerSessionId, repositories = undefined,
 }) => {
-  // why injected: App files are a self-hosted durable surface. The lifecycle
-  // schema guard must run at the physical OPFS boundary, including callers of
-  // the exposed helper, without making the engine module import runtime policy.
+  // why: The injected guard applies policy at each OPFS mutation boundary.
   const guardedOpfsForApp = (/** @type {string} */ appId) =>
     opfsForApp(appId, beforeOpfsMutation);
   /** @type {Map<string, Promise<unknown>>} */
   const mutationTails = new Map();
 
-  /**
-   * Serialize mutations per App so two independently authorized callers cannot
-   * both pass a stale aggregate-size check and overfill the same OPFS tree.
-   * @template T
-   * @param {string} appId
-   * @param {() => Promise<T>} operation
-   * @returns {Promise<T>}
-   */
+  /** why: One App lane prevents concurrent callers from using a stale size check. @template T @param {string} appId @param {()=>Promise<T>} operation @returns {Promise<T>} */
   const withLocalMutation = async (appId, operation) => {
     const prior = mutationTails.get(appId) ?? Promise.resolve();
     const current = prior.catch(() => {}).then(operation);
@@ -202,28 +201,18 @@ export const createAppClient = ({
       if (mutationTails.get(appId) === current) mutationTails.delete(appId);
     }
   };
-  /**
-   * Serialize every App byte mutation with repository restore/checkout/commit.
-   * Tests and embedders that do not install browser Git retain the original
-   * local lane; the production service always supplies the repository lane.
-   * @template T
-   * @param {string} appId
-   * @param {() => Promise<T>} operation
-   * @returns {Promise<T>}
-   */
-  const withMutation = (appId, operation) => repositories?.coordinate
-    ? repositories.coordinate({ kind: 'app', id: appId }, () => withLocalMutation(appId, operation))
-    : withLocalMutation(appId, operation);
+  /** why: Serialize App byte changes with repository changes. @template T @param {string} appId @param {()=>Promise<T>} operation @returns {Promise<T>} */
+  const withMutation = async (appId, operation, invalidateDweb = true) => {
+    const mutate = () => withLocalMutation(appId, () => repositories?.coordinate
+      ? repositories.coordinate({ kind: 'app', id: appId }, operation)
+      : operation());
+    if (!invalidateDweb) return mutate();
+    if (tracker.withDwebAuthority) return tracker.withDwebAuthority(appId, mutate, { invalidate: true });
+    await tracker.invalidateDweb?.(appId);
+    return mutate();
+  };
 
-  /**
-   * Hold the complete App/repository transaction lane. Callers using this must
-   * perform raw workspace operations inside the callback rather than re-entering
-   * a client mutation method.
-   * @template T
-   * @param {string} appId
-   * @param {() => Promise<T>} operation
-   * @returns {Promise<T>}
-   */
+  /** Hold the App lane without re-entering a client mutation. @template T @param {string} appId @param {()=>Promise<T>} operation @returns {Promise<T>} */
   const withWriteLock = (appId, operation) => repositories?.coordinate
     ? repositories.coordinate({ kind: 'app', id: appId }, operation)
     : withLocalMutation(appId, operation);
@@ -411,7 +400,10 @@ export const createAppClient = ({
       const opfs = guardedOpfsForApp(record.id);
       for (const { path, stored } of normalized.files) await opfs.write(path, stored);
       if (repositories?.initApp) {
-        await repositories.initApp(record.id, { message: `create ${record.name}` });
+        await repositories.initApp(record.id, {
+          message: `create ${record.name}`,
+          includeIgnored: source === 'dweb' && typeof dweb?.hash === 'string' && dweb.hash.length > 0,
+        });
       }
       if (sessionId) await registry.setDefaultForSession(sessionId, record.id);
     } catch (error) {
@@ -545,13 +537,13 @@ export const createAppClient = ({
     if (!updated) return null;
     if (sessionId) await registry.setDefaultForSession(sessionId, id);
     if (path === 'peerd.json') await onManifestMutation(id);
-    tracker.reloadTab(id).catch(() => {});
+    await tracker.reloadTab(id).catch(() => {});
     return updated;
   };
 
   /** Write a single file in the app's OPFS subdir.
-   * @param {{ appId?: string, path: string, content: unknown, sessionId?: string, reload?: boolean }} args */
-  const writeFile = async ({ appId, path, content, sessionId, reload = true }) => {
+   * @param {{ appId?: string, path: string, content: unknown, sessionId?: string, reload?: boolean, invalidateDweb?: boolean }} args */
+  const writeFile = async ({ appId, path, content, sessionId, reload = true, invalidateDweb = true }) => {
     const id = await resolveId({ sessionId, appId });
     validateAppPath(path);
     const replacement = { path, ...normalizeFileContent(path, content) };
@@ -570,9 +562,9 @@ export const createAppClient = ({
       } catch (error) {
         return rollbackMutation(error, rollbackBytes, id, rec);
       }
-    });
+    }, invalidateDweb);
     if (path === 'peerd.json') await onManifestMutation(id);
-    if (reload) tracker.reloadTab(id).catch(() => {});
+    if (reload) await tracker.reloadTab(id).catch(() => {});
     return { bytesWritten: replacement.size, kind: replacement.kind };
   };
 
@@ -647,30 +639,29 @@ export const createAppClient = ({
       }
     });
     await onManifestMutation(id);
-    tracker.reloadTab(id).catch(() => {});
+    await tracker.reloadTab(id).catch(() => {});
     return updated;
   };
 
-  /**
-   * Replace a complete App release and record its Git/catalog lineage while the
-   * caller already holds `withWriteLock(appId, ...)`. This deliberately has no
-   * public locking of its own: dweb update needs divergence checks, an optional
-   * fork, byte replacement, commit, and metadata persistence in one outer lane.
-   *
+  /** Caller holds the App lane so version checks, bytes, Git, and metadata stay atomic.
    * @param {{ appId: string, files: Record<string, unknown>, entryFile: string,
    *   fileKinds?: Record<string, unknown>, message?: string,
-   *   metadataForOid?: (oid: string | null, oldRecord: import('/peerd-engine/app-registry.js').AppRecord) => Partial<import('/peerd-engine/app-registry.js').AppRecord> }} args
+   *   metadataForOid?: (oid: string | null, oldRecord: import('/peerd-engine/app-registry.js').AppRecord, fileKinds: Record<string, 'text'|'binary'>) => Partial<import('/peerd-engine/app-registry.js').AppRecord> }} args
    */
   const replaceVersionedFilesUnlocked = async ({
     appId, files, entryFile, fileKinds, message = 'replace App release', metadataForOid = () => ({}),
   }) => {
-    if (!repositories?.replaceWorkingTree) throw new Error('browser Git is unavailable');
+    if (!repositories?.replaceWorkingTree || !repositories?.rollbackWorkingTree || !repositories?.statusApp) {
+      throw new Error('browser Git is unavailable');
+    }
     await beforeOpfsMutation();
     const id = await resolveId({ appId });
     const normalized = normalizeFileMap(files, entryFile, fileKinds);
     const opfs = guardedOpfsForApp(id);
     const oldRecord = await registry.get(id);
     if (!oldRecord) throw new Error(`app not found: ${id}`);
+    const previousOid = (await repositories.statusApp(id)).oid;
+    if (typeof previousOid !== 'string') throw new Error('versioned App has no repository head');
 
     /** @type {Record<string, Uint8Array<ArrayBuffer>>} */
     const oldFiles = Object.create(null);
@@ -690,31 +681,44 @@ export const createAppClient = ({
     /** @type {Record<string, string | Uint8Array<ArrayBuffer>>} */
     const nextFiles = Object.create(null);
     for (const file of normalized.files) nextFiles[file.path] = file.stored;
+    for (const [path, bytes] of Object.entries(oldFiles)) {
+      if (APP_DATA_PATH_RE.test(path)) nextFiles[path] = bytes;
+    }
+    const nextEntries = Object.values(nextFiles);
+    if (nextEntries.length > MAX_APP_FILES) {
+      throw new AppFileLimitError(`App has too many files: ${nextEntries.length} > ${MAX_APP_FILES}`);
+    }
+    let nextTotalBytes = 0;
+    for (const value of nextEntries) {
+      nextTotalBytes += typeof value === 'string' ? new TextEncoder().encode(value).byteLength : value.byteLength;
+      if (nextTotalBytes > MAX_APP_TOTAL_BYTES) {
+        throw new AppFileLimitError(`App is too large: ${nextTotalBytes} > ${MAX_APP_TOTAL_BYTES} bytes`);
+      }
+    }
 
     try {
       const committed = await repositories.replaceWorkingTree(
         { kind: 'app', id },
-        { files: nextFiles, message },
+        { files: nextFiles, message, includeIgnored: true },
       );
       const patch = {
         entryFile,
         fileKinds: normalized.fileKinds,
-        ...metadataForOid(committed.oid ?? null, oldRecord),
+        ...metadataForOid(committed.oid ?? null, oldRecord, normalized.fileKinds),
       };
       const updated = await registry.update(id, /** @type {any} */ (patch));
       if (!updated) throw new Error(`app not found after versioned replacement: ${id}`);
       await onManifestMutation(id);
-      tracker.reloadTab(id).catch(() => {});
+      await tracker.reloadTab(id).catch(() => {});
       return { record: updated, oid: committed.oid ?? null, created: committed.created === true };
     } catch (cause) {
       /** @type {unknown[]} */
       const rollbackFailures = [];
-      // replaceWorkingTree can fail after changing bytes, so every failed
-      // attempt must restore the exact snapshot captured above.
+      // why: Reset the failed release index before ignored local bytes return.
       try {
-        await repositories.replaceWorkingTree(
+        await repositories.rollbackWorkingTree(
           { kind: 'app', id },
-          { files: oldFiles, message: 'rollback failed App release update' },
+          { to: previousOid, files: oldFiles },
         );
       } catch (error) { rollbackFailures.push(error); }
       try { await restoreRecord(id, oldRecord); }
@@ -732,14 +736,10 @@ export const createAppClient = ({
     return guardedOpfsForApp(id).list();
   };
 
-  /**
-   * Capture bytes and their catalog kind under the same per-App lane as every
-   * mutation. Export and sharing therefore see one complete version.
-   * @param {{ appId: string }} args
-   */
+  /** Capture one complete App version. @param {{appId:string}} args */
   const snapshotFiles = async ({ appId }) => {
     const id = await resolveId({ appId });
-    return withMutation(id, async () => {
+    return withWriteLock(id, async () => {
       const record = await registry.get(id);
       if (!record) throw new Error(`app not found: ${id}`);
       const opfs = guardedOpfsForApp(id);
@@ -776,8 +776,8 @@ export const createAppClient = ({
     return { ...snapshot, files };
   };
 
-  /** @param {{ appId?: string, path: string, sessionId?: string, reload?: boolean }} args */
-  const deleteFile = async ({ appId, path, sessionId, reload = true }) => {
+  /** @param {{ appId?: string, path: string, sessionId?: string, reload?: boolean, invalidateDweb?: boolean }} args */
+  const deleteFile = async ({ appId, path, sessionId, reload = true, invalidateDweb = true }) => {
     validateAppPath(path);
     const id = await resolveId({ sessionId, appId });
     await withMutation(id, async () => {
@@ -795,9 +795,9 @@ export const createAppClient = ({
       } catch (error) {
         return rollbackMutation(error, () => opfs.write(path, backup), id, rec);
       }
-    });
+    }, invalidateDweb);
     if (path === 'peerd.json') await onManifestMutation(id);
-    if (reload) tracker.reloadTab(id).catch(() => {});
+    if (reload) await tracker.reloadTab(id).catch(() => {});
   };
 
   /** @param {{ appId?: string, sessionId?: string, focus?: boolean }} [opts] */
@@ -840,8 +840,8 @@ export const createAppClient = ({
     // damage and prevents a caught nuke refusal from falling through to the
     // metadata delete.
     await beforeOpfsMutation();
-    await tracker.closeTab(appId);
     await withMutation(appId, async () => {
+      await tracker.closeTab(appId);
       await new Promise((r) => setTimeout(r, 100));
       // Every App now owns a separate peerd-git/app/<id> DAG and remote
       // configuration. Deletion is one fail-closed transaction: preserve the
@@ -860,7 +860,7 @@ export const createAppClient = ({
     const id = await resolveId({ appId, sessionId });
     const result = await withMutation(id, () => repositories.restoreApp(id, { to }));
     await onManifestMutation(id);
-    tracker.reloadTab(id).catch(() => {});
+    await tracker.reloadTab(id).catch(() => {});
     return result;
   };
 
@@ -870,7 +870,7 @@ export const createAppClient = ({
     const id = await resolveId({ appId, sessionId });
     const result = await withMutation(id, () => repositories.checkout({ kind: 'app', id }, { name }));
     await onManifestMutation(id);
-    tracker.reloadTab(id).catch(() => {});
+    await tracker.reloadTab(id).catch(() => {});
     return result;
   };
 

--- a/extension/background/app-quiescence.js
+++ b/extension/background/app-quiescence.js
@@ -1,22 +1,8 @@
 // @ts-check
-// Drain a live App editor before any repository snapshot or mutation. The
-// lifecycle lane is deliberately outside the editor flush: flushSave writes
-// through the repository coordinator itself, so taking that lock first would
-// deadlock on the pending save we are trying to preserve.
+// Drain the App editor before repository work.
+// why: Taking the repository lock before flushSave would deadlock.
 
-/**
- * @param {Object} deps
- * @param {{
- *   getTabId: (appId:string)=>number|null,
- *   quiesceTab?: (appId:string)=>Promise<boolean>,
- *   resumeTab?: (appId:string)=>Promise<boolean>,
- *   closeTab: (appId:string)=>Promise<boolean>,
- *   ensureTab: (appId:string, opts?:any)=>Promise<number>,
- *   reloadTab?: (appId:string)=>Promise<boolean>,
- * }} deps.tracker
- * @param {<T>(appId:string, operation:()=>Promise<T>)=>Promise<T>} deps.withLifecycle
- * @param {()=>Promise<void>} [deps.afterClose]
- */
+/** @param {{tracker:{getTabId:(id:string)=>number|null,quiesceTab?:(id:string)=>Promise<boolean>,resumeTab?:(id:string)=>Promise<boolean>,closeTab:(id:string)=>Promise<boolean>,ensureTab:(id:string,opts?:any)=>Promise<number>,reloadTab?:(id:string)=>Promise<boolean>,withDwebAuthority?:<T>(id:string,op:()=>Promise<T>,options?:{invalidate?:boolean,expectedGeneration?:number})=>Promise<T>},withLifecycle:<T>(id:string,op:()=>Promise<T>)=>Promise<T>,afterClose?:()=>Promise<void>}} deps */
 export const createAppQuiescence = ({
   tracker,
   withLifecycle,
@@ -29,34 +15,30 @@ export const createAppQuiescence = ({
     await tracker.reloadTab?.(appId).catch(() => {});
   };
 
-  /**
-   * Run while a live editor is frozen and its pending save has completed.
-   * Call this form only when the caller already owns the App lifecycle lane.
-   *
-   * @template T
-   * @param {string} appId
-   * @param {()=>Promise<T>} operation
-   * @param {{close?:boolean}} [options]
-   * @returns {Promise<T>}
-   */
-  const runUnlocked = async (appId, operation, { close = false } = {}) => {
-    const live = tracker.getTabId(appId) != null;
-    if (!live) return operation();
-    if (typeof tracker.quiesceTab !== 'function') {
-      throw new Error('App editor quiesce is unavailable');
+  /** Caller owns the lifecycle lane. @template T @param {string} appId @param {()=>Promise<T>} operation
+   * @param {{close?:boolean,invalidateDweb?:boolean,expectedDwebGeneration?:number}} [options] @returns {Promise<T>} */
+  const runUnlocked = async (appId, operation, { close = false, invalidateDweb = false, expectedDwebGeneration } = {}) => {
+    const trackedLive = tracker.getTabId(appId) != null;
+    let live = trackedLive;
+    if (typeof tracker.quiesceTab === 'function') {
+      live = await tracker.quiesceTab(appId);
+      if (trackedLive && !live) throw new Error('App editor disappeared before its pending save completed');
     }
-    if (await tracker.quiesceTab(appId) !== true) {
-      throw new Error('App editor disappeared before its pending save completed');
-    }
+    else if (live) throw new Error('App editor quiesce is unavailable');
 
     let closed = false;
     try {
-      if (close) {
-        closed = await tracker.closeTab(appId);
-        if (!closed) throw new Error('App tab could not close after its editor was flushed');
-        await afterClose();
-      }
-      return await operation();
+      const execute = async () => {
+        if (close && live) {
+          closed = await tracker.closeTab(appId);
+          if (!closed) throw new Error('App tab could not close after its editor was flushed');
+          await afterClose();
+        }
+        return operation();
+      };
+      return await (invalidateDweb && tracker.withDwebAuthority
+        ? tracker.withDwebAuthority(appId, execute, { invalidate: true, expectedGeneration: expectedDwebGeneration })
+        : execute());
     } finally {
       if (closed) {
         tracker.ensureTab(appId, { active: false, groupTitle: 'peerd' }).catch(() => {});
@@ -66,17 +48,8 @@ export const createAppQuiescence = ({
     }
   };
 
-  /**
-   * Serialize quiesce/freeze, the protected operation, and release/reopen as one
-   * App lifecycle transaction. Repository coordination belongs inside
-   * `operation`, after the editor flush.
-   *
-   * @template T
-   * @param {string} appId
-   * @param {()=>Promise<T>} operation
-   * @param {{close?:boolean}} [options]
-   * @returns {Promise<T>}
-   */
+  /** @template T @param {string} appId @param {()=>Promise<T>} operation
+   * @param {{close?:boolean,invalidateDweb?:boolean,expectedDwebGeneration?:number}} [options] @returns {Promise<T>} */
   const run = (appId, operation, options) => withLifecycle(
     appId,
     () => runUnlocked(appId, operation, options),

--- a/extension/background/app-tab-tracker.js
+++ b/extension/background/app-tab-tracker.js
@@ -1,31 +1,29 @@
 // @ts-check
-// app-tab-tracker — which appId lives in which tab. Thin config over the
-// shared createTabTracker.
-//
-// Mirror of vm-/js-tab-tracker for app-tab/index.html#<appId>. Apps are
-// user-facing artifacts (the agent wrote a small UI for the user), so
-// this kind also exposes reloadTab — the app body can be edited and the
-// iframe re-rendered (app-client.reloadTab). It has no isReady consumer.
-// Opening an app brings its tab to the foreground so the user sees it
-// (DECISIONS #20, 2026-06-14); ensureTab early-returns for a live tab,
-// so re-opening an existing app doesn't yank the user back.
+// Track the App instance and owner for each user-visible App tab.
+// Opening a live App reuses its tab. New user-opened Apps take focus.
 
 import { createTabTracker } from './tab-tracker.js';
 import { APP_TAB_PATH } from '/peerd-engine/background.js';
+import { APP_DWEB_GENERATION_PREFIX } from '/shared/dweb-interface.js';
 import browser from '/vendor/browser-polyfill.js';
 
 const READY_TIMEOUT_MS = 15_000;
 const QUIESCE_TIMEOUT_MS = 5_000;
+export class AppDwebAuthorityChangedError extends Error { constructor(/** @type {number} */ generation) { super('App dweb authority changed after approval'); this.name = 'AppDwebAuthorityChangedError'; this.generation = generation; } }
 
 /** @param {{ announce?: import('./tab-tracker.js').TabTrackerConfig['announce'],
  *   onAdopt?: import('./tab-tracker.js').TabTrackerConfig['onAdopt'],
  *   onDrop?: import('./tab-tracker.js').TabTrackerConfig['onDrop'],
  *   tabs?: typeof browser.tabs,
- *   sendTabMessage?: (tabId:number, message:any)=>Promise<any> }} [deps] */
+ *   sendTabMessage?: (tabId:number, message:any)=>Promise<any>,
+ *   purgeDwebOwners?: (appId:string,generation:number)=>Promise<void>,
+ *   storage?: typeof browser.storage.session }} [deps] */
 export const createAppTabTracker = ({
   announce, onAdopt, onDrop,
   tabs = browser.tabs,
   sendTabMessage = tabs.sendMessage.bind(tabs),
+  purgeDwebOwners = async () => {},
+  storage = browser.storage.session,
 } = {}) => {
   const tracker = createTabTracker({
     tabPath: APP_TAB_PATH,
@@ -33,7 +31,6 @@ export const createAppTabTracker = ({
     closedError: () => new Error('app tab closed before ready'),
     notReadyMessage: (id) => `app ${id} did not become ready`,
     announce,
-    onAdopt,
     onDrop,
     tabs,
     kindLabel: 'an App',
@@ -46,7 +43,17 @@ export const createAppTabTracker = ({
   const ownerRootByApp = new Map();
   /** @type {Map<number,string>} */
   const appByTab = new Map();
+  /** @type {Map<string,number>} */ const dwebGenerationByApp = new Map();
+  /** @type {Map<number,{epoch:number,pending?:Promise<any>,result?:any}>} */ const attachByTab = new Map();
+  /** @type {Map<string,Promise<unknown>>} */ const dwebAuthorityTails = new Map();
   const tabUrlPrefix = browser.runtime.getURL(APP_TAB_PATH);
+  const generationHydration = storage.get(null).then((generations) => {
+    for (const [storageKey, generation] of Object.entries(generations)) if (storageKey.startsWith(APP_DWEB_GENERATION_PREFIX)
+      && typeof generation === 'number' && Number.isSafeInteger(generation) && generation >= 0)
+      dwebGenerationByApp.set(storageKey.slice(APP_DWEB_GENERATION_PREFIX.length), generation);
+  });
+  generationHydration.catch(() => {});
+  const dwebGenerationsReady = () => generationHydration;
 
   /** @param {string|undefined} url */
   const parseOwnerFromUrl = (url) => {
@@ -63,14 +70,12 @@ export const createAppTabTracker = ({
     appByTab.set(tabId, appId);
     if (ownerClaim) ownerClaimByApp.set(appId, ownerClaim);
     if (ownerRoot) ownerRootByApp.set(appId, ownerRoot);
+    try { onAdopt?.(appId, tabId); } catch { /* liveness is best-effort */ }
   };
 
-  /**
-   * Existing App tabs are only candidates at worker boot. They are not runnable
-   * until the service worker revalidates URL/app/owner identity and reconciles
-   * the manifest actor. This deliberately differs from generic engine tabs.
-   */
+  /** why: A worker restart must revalidate each App tab before adoption. */
   const bootstrap = async () => {
+    await generationHydration;
     const liveTabs = await tabs.query({ url: `${tabUrlPrefix}*` });
     return liveTabs
       .filter((tab) => tab.id != null && tracker.parseIdFromUrl(tab.url ?? ''))
@@ -85,41 +90,71 @@ export const createAppTabTracker = ({
 
   /** @param {string} appId @param {number} tabId @param {string|null} [ownerClaim] @param {string|null} [ownerRoot] */
   const onTabPending = (appId, tabId, ownerClaim = null, ownerRoot = null) => {
+    const liveTabId = tracker.getTabId(appId);
+    if (liveTabId != null && liveTabId !== tabId) return false;
+    const priorAppId = appByTab.get(tabId);
+    if (priorAppId && priorAppId !== appId) {
+      tracker.onTabRemoved(tabId);
+      ownerClaimByApp.delete(priorAppId); ownerRootByApp.delete(priorAppId);
+    }
     tracker.onTabPending(appId, tabId);
     rememberOwner(appId, tabId, ownerClaim, ownerRoot);
+    return true;
   };
 
   /** @param {string} appId @param {number} tabId @param {string|null} [ownerClaim] @param {string|null} [ownerRoot] */
   const onTabReady = (appId, tabId, ownerClaim = null, ownerRoot = null) => {
+    if (tracker.getTabId(appId) !== tabId) return false;
     tracker.onTabReady(appId, tabId);
     rememberOwner(appId, tabId, ownerClaim, ownerRoot);
+    return true;
   };
 
-  /** @param {string} appId @param {Error} error */
-  const onTabFailed = (appId, error) => {
-    const tabId = tracker.onTabFailed(appId, error);
-    if (tabId != null) appByTab.delete(tabId);
-    ownerClaimByApp.delete(appId);
-    ownerRootByApp.delete(appId);
-    return tabId;
+  /** @param {string} appId @param {Error} error @param {number} [tabId] */
+  const onTabFailed = (appId, error, tabId) => {
+    if (tabId != null && tracker.getTabId(appId) !== tabId) return null;
+    const failedTabId = tracker.onTabFailed(appId, error);
+    if (failedTabId != null) {
+      appByTab.set(failedTabId, appId); try { onAdopt?.(appId, failedTabId); } catch { /* retain liveness until physical removal */ }
+    }
+    ownerClaimByApp.delete(appId); ownerRootByApp.delete(appId);
+    return failedTabId;
   };
 
   /** @param {number} tabId */
   const onTabRemoved = (tabId) => {
+    attachByTab.delete(tabId);
     const appId = appByTab.get(tabId) ?? null;
     const removed = tracker.onTabRemoved(tabId);
     appByTab.delete(tabId);
-    if (appId && removed === appId) {
-      ownerClaimByApp.delete(appId);
-      ownerRootByApp.delete(appId);
+    if (appId) {
+      ownerClaimByApp.delete(appId); ownerRootByApp.delete(appId);
+      if (!removed) try { onDrop?.(appId); } catch { /* liveness is best-effort */ }
     }
-    return removed;
+    return removed ?? appId;
   };
 
+  /** Share one actor attach per tab document. @param {number} tabId @param {(epoch:number)=>Promise<any>} operation */
+  const coordinateAttach = (tabId, operation) => {
+    const state = attachByTab.get(tabId) ?? { epoch: 0 };
+    attachByTab.set(tabId, state); if (state.pending) return state.pending;
+    if (state.result?.ok === true) return Promise.resolve(state.result);
+    const epoch = state.epoch;
+    const pending = Promise.resolve().then(() => operation(epoch)).then((result) => {
+      if (attachByTab.get(tabId) === state && result?.ok === true) state.result = result;
+      return result;
+    }).finally(() => { if (attachByTab.get(tabId) === state) delete state.pending; });
+    state.pending = pending; return pending;
+  };
+  const markAttachLoading = (/** @type {number} */ tabId) => {
+    const current = attachByTab.get(tabId);
+    if (!current) return null;
+    const epoch = current.epoch + 1; attachByTab.set(tabId, { epoch }); return epoch;
+  };
+  const isAttachCurrent = (/** @type {number} */ tabId, /** @type {number} */ epoch) => attachByTab.get(tabId)?.epoch === epoch;
   /** @param {string} appId @param {string} ownerRoot */
   const getOwnedTabId = (appId, ownerRoot) => ownerRootByApp.get(appId) === ownerRoot
-    ? tracker.getTabId(appId)
-    : null;
+    ? tracker.getTabId(appId) : null;
 
   /** Refuse ambient appId-only reuse across chat roots. */
   const ensureTab = async (/** @type {string} */ appId, /** @type {{active?:boolean,groupTitle?:string,hashSuffix?:string,ownerSessionId?:string}} */ opts = {}) => {
@@ -133,34 +168,98 @@ export const createAppTabTracker = ({
       try { actual ??= parseOwnerFromUrl((await tabs.get(existingTabId))?.url); } catch { /* generic tracker will replace stale tab */ }
       if (actual && actual !== desiredOwner) throw new Error('app-owned-by-another-chat');
     }
-    return tracker.ensureTab(appId, opts);
+    const tabId = await tracker.ensureTab(appId, opts);
+    if (desiredOwner) {
+      const actual = ownerClaimByApp.get(appId) ?? parseOwnerFromUrl((await tabs.get(tabId))?.url);
+      if (actual && actual !== desiredOwner) throw new Error('app-owned-by-another-chat');
+    }
+    return tabId;
   };
 
-  /** Flush and freeze a live App editor before its repository is locked. */
-  const quiesceTab = async (/** @type {string} */ appId) => {
-    const tabId = tracker.getTabId(appId);
-    if (tabId == null) return false;
-    /** @type {ReturnType<typeof setTimeout>|undefined} */ let timer;
-    try {
-      const response = /** @type {any} */ (await Promise.race([
-        sendTabMessage(tabId, { type: 'app/quiesce', action: 'acquire', appId }),
-        new Promise((_, reject) => {
-          timer = setTimeout(() => reject(new Error(`app ${appId} editor flush timed out`)), QUIESCE_TIMEOUT_MS);
-        }),
-      ]));
-      if (!response?.ok) throw new Error(response?.error ?? `app ${appId} editor flush failed`);
-      return true;
-    } finally { clearTimeout(timer); }
+  /** Find every exact App page, including tabs not adopted after a worker restart. @param {string} appId */
+  const exactTabIds = async (appId) => {
+    const tabIds = new Set((await tabs.query({ url: `${tabUrlPrefix}*` }))
+      .filter((tab) => tab.id != null && tracker.parseIdFromUrl(tab.url ?? '') === appId)
+      .map((tab) => /** @type {number} */ (tab.id)));
+    const tracked = tracker.getTabId(appId); if (tracked != null) tabIds.add(tracked);
+    return [...tabIds];
   };
+
+  /** Flush and freeze every exact live App editor before repository work. */
+  const quiesceTab = async (/** @type {string} */ appId) => {
+    const tabIds = await exactTabIds(appId);
+    await Promise.all(tabIds.map(async (tabId) => {
+      /** @type {ReturnType<typeof setTimeout>|undefined} */ let timer;
+      try {
+        const response = /** @type {any} */ (await Promise.race([
+          sendTabMessage(tabId, { type: 'app/quiesce', action: 'acquire', appId }),
+          new Promise((_, reject) => { timer = setTimeout(() => reject(new Error(`app ${appId} editor flush timed out`)), QUIESCE_TIMEOUT_MS); }),
+        ]));
+        if (!response?.ok) throw new Error(response?.error ?? `app ${appId} editor flush failed`);
+      } finally { clearTimeout(timer); }
+    }));
+    return tabIds.length > 0;
+  };
+
+  const getDwebGeneration = (/** @type {string} */ appId) => dwebGenerationByApp.get(appId) ?? 0;
+  const advanceDwebGeneration = async (/** @type {string} */ appId) => {
+    await generationHydration; const generation = getDwebGeneration(appId) + 1;
+    dwebGenerationByApp.set(appId, generation); await storage.set({ [`${APP_DWEB_GENERATION_PREFIX}${appId}`]: generation });
+    return generation;
+  };
+  const dwebGenerationSnapshot = async () => {
+    await generationHydration; return Object.fromEntries([...dwebGenerationByApp].map(([appId, generation]) =>
+      [`${APP_DWEB_GENERATION_PREFIX}${appId}`, generation]));
+  };
+  const disposeDwebTab = async (/** @type {string} */ appId, /** @type {number} */ tabId) => {
+    const response = /** @type {any} */ (await sendTabMessage(tabId, { type: 'app/quiesce', action: 'invalidate-dweb', appId }));
+    if (!response?.ok) throw new Error(response?.error ?? `app ${appId} dweb bridge did not stop`);
+    return true;
+  };
+  /** End the App's network authority before its bytes change. */
+  const invalidateDweb = async (/** @type {string} */ appId) => {
+    const tabIds = await exactTabIds(appId); const generation = await advanceDwebGeneration(appId);
+    const stopped = await Promise.allSettled(tabIds.map((tabId) => disposeDwebTab(appId, tabId)));
+    let failure = null;
+    for (const [index, result] of stopped.entries()) {
+      if (result.status === 'fulfilled') continue;
+      failure ??= result.reason; try { await tabs.remove(tabIds[index]); } catch { /* mutation still fails closed */ }
+    }
+    await purgeDwebOwners(appId, generation);
+    if (failure) throw failure;
+    return tabIds.length > 0;
+  };
+
+  /** Serialize identity reads with pre-lock authority rotation and mutation. @template T @param {string} appId @param {()=>Promise<T>} operation @param {{invalidate?:boolean,expectedGeneration?:number}} [options] */
+  const withDwebAuthority = async (appId, operation, { invalidate = false, expectedGeneration } = {}) => {
+    const prior = dwebAuthorityTails.get(appId) ?? Promise.resolve();
+    const current = prior.catch(() => {}).then(async () => {
+      if (expectedGeneration != null) {
+        await generationHydration; const generation = getDwebGeneration(appId);
+        if (generation !== expectedGeneration) throw new AppDwebAuthorityChangedError(generation);
+      }
+      if (invalidate) await invalidateDweb(appId);
+      return operation();
+    });
+    dwebAuthorityTails.set(appId, current); try { return await current; }
+    finally { if (dwebAuthorityTails.get(appId) === current) dwebAuthorityTails.delete(appId); }
+  };
+  const retireDwebTab = (/** @type {string} */ appId) => withDwebAuthority(appId, async () =>
+    purgeDwebOwners(appId, await advanceDwebGeneration(appId)));
 
   /** Re-enable a quiesced tab if closing it failed. */
   const resumeTab = async (/** @type {string} */ appId) => {
-    const tabId = tracker.getTabId(appId);
-    if (tabId == null) return false;
-    const response = /** @type {any} */ (await sendTabMessage(tabId, {
-      type: 'app/quiesce', action: 'release', appId,
-    }));
-    return response?.ok === true;
+    const tabIds = await exactTabIds(appId);
+    const replies = await Promise.all(tabIds.map((tabId) => sendTabMessage(tabId, { type: 'app/quiesce', action: 'release', appId })));
+    return replies.length > 0 && replies.every((response) => response?.ok === true);
+  };
+
+  const closeTab = async (/** @type {string} */ appId) => {
+    const tabIds = await exactTabIds(appId); const closed = await Promise.allSettled(tabIds.map((tabId) => tabs.remove(tabId)));
+    return closed.length > 0 && closed.every((result) => result.status === 'fulfilled');
+  };
+  const reloadTab = async (/** @type {string} */ appId) => {
+    tracker.markReloading(appId); return await tracker.reloadTab(appId) && !!await tracker.ensureTab(appId);
   };
 
   return {
@@ -172,12 +271,23 @@ export const createAppTabTracker = ({
     parseIdFromUrl: tracker.parseIdFromUrl,
     parseOwnerFromUrl,
     getTabId: tracker.getTabId,
+    getAppIdByTab: (/** @type {number} */ tabId) => appByTab.get(tabId) ?? null,
     getOwnedTabId,
     ensureTab,
-    closeTab: tracker.closeTab,
+    closeTab,
     quiesceTab,
+    invalidateDweb,
+    disposeDwebTab,
+    dwebGenerationsReady,
+    dwebGenerationSnapshot,
+    getDwebGeneration,
+    withDwebAuthority,
+    retireDwebTab,
+    coordinateAttach,
+    markAttachLoading,
+    isAttachCurrent,
     resumeTab,
-    reloadTab: tracker.reloadTab,
+    reloadTab,
     markReloading: tracker.markReloading,
     listLive: tracker.listLive,
   };

--- a/extension/background/routes/dweb.js
+++ b/extension/background/routes/dweb.js
@@ -1,18 +1,5 @@
 // @ts-check
-// background/routes/dweb.js — the dweb message routes (preview channel only).
-//
-// Every route is inert unless BOTH the build carries the module (DWEB_ENABLED)
-// AND the user turned the setting on (settingsStore.get().dwebEnabled) — the SW
-// stays the enforcement point; hidden UI is not a gate. Unblocked by the
-// settings store. The mesh itself lives in the offscreen doc; these routes
-// ensure it exists and relay to its dweb/base-host/* handler.
-//
-// BOUNDARY: this file names NO dweb-module path (it relays string message types
-// + uses appClient/vault), so it crosses no module boundary and ships inert in
-// the store package, same as when these routes were inline. (Do not write the
-// hyphenated module-dir name here — the store-artifact verifier greps for that
-// literal string in every shipped file.)
-// Every privileged collaborator is injected.
+// Gate dependency-injected dweb routes by build and user settings.
 
 /**
  * @param {Record<string, any>} deps
@@ -24,16 +11,18 @@ export const makeDwebRoutes = (deps) => {
     appRegistry, appClient, appTabTracker, appQuiescence, settingsStore, shareLocalApp,
     DWEB_ENABLED, APP_TAB_GROUP_TITLE,
     disableDweb, withDwebPublication, withAppLifecycle, ensureSettingsReady, repositories,
-    isOffscreenSender, createDwebRollbackGuard, getCurrentSessionId,
+    isOffscreenSender, createDwebRollbackGuard, appReleaseDescriptorMatches, getCurrentSessionId,
   } = deps;
   const rollbackGuard = createDwebRollbackGuard({ kv });
+  /** @param {string} appId */
+  const updateConflict = (appId) => ({
+    ok: false,
+    error: 'local-changes',
+    requiresAction: true,
+    conflictToken: appTabTracker.getDwebGeneration(appId),
+  });
 
-  /**
-   * Public discovery installs carry a complete stream tuple. Cold URI/private
-   * room installs carry neither dwapp_id nor seq and remain intentionally
-   * untracked. A partial tuple is never silently downgraded to untracked.
-   * @param {any} dweb
-   */
+  /** Refuse partial discovery lineage. @param {any} dweb */
   const trackedVersion = (dweb) => {
     const trackingClaimed = dweb?.dwapp_id != null || dweb?.seq != null;
     if (!trackingClaimed) return { ok: true, candidate: null };
@@ -64,8 +53,7 @@ export const makeDwebRoutes = (deps) => {
       : { ok: false, error: result.error ?? 'dweb-version-refused' };
   };
 
-  // Cold workers expose channel defaults until persisted settings hydrate.
-  // Effectful/read routes fail closed if that hydration is still unavailable.
+  // why: Cold workers fail closed until stored settings load.
   const dwebOn = () => DWEB_ENABLED && settingsStore.get().dwebEnabled;
   const dwebReady = async () => {
     if (!DWEB_ENABLED) return false;
@@ -83,9 +71,13 @@ export const makeDwebRoutes = (deps) => {
   };
 
   return {
-    // The offscreen discovery host calls this only after signature + shape +
-    // derived-id verification. Persist BEFORE its in-memory Library accepts the
-    // card, so tearing that host down cannot erase the anti-rollback decision.
+    'dweb/app-authority-generations': async (_msg, sender) => {
+      if (isOffscreenSender?.(sender) !== true) return { ok: false, error: 'offscreen-sender-required' };
+      try { return { ok: true, generations: await appTabTracker.dwebGenerationSnapshot() }; }
+      catch (error) { return { ok: false, error: /** @type {{ message?: string }} */ (error)?.message ?? String(error) }; }
+    },
+
+    // why: Persist verified lineage before an offscreen restart can erase it.
     'dweb/meta-admit': async ({ dwappId, publisher, seq, versionId }, sender) => {
       if (isOffscreenSender?.(sender) !== true) return { ok: false, accepted: false, error: 'offscreen-sender-required' };
       if (!(await dwebReady())) return { ok: false, accepted: false, error: 'dweb-disabled' };
@@ -100,9 +92,7 @@ export const makeDwebRoutes = (deps) => {
       if (!(await dwebReady())) return { ok: false, error: 'dweb-disabled' };
       if (typeof appId !== 'string') return { ok: false, error: 'appId-required' };
       try {
-        // Room publication already owns withAppLifecycle while the offscreen
-        // host calls back for these bytes. Freeze and flush before snapshotting;
-        // do not re-enter that lifecycle lane from the callback.
+        // why: The caller owns lifecycle, so only flush before the snapshot.
         return await appQuiescence.runUnlocked(appId, async () => ({
           ok: true,
           ...(await appClient.snapshotFilesBase64({ appId })),
@@ -112,8 +102,7 @@ export const makeDwebRoutes = (deps) => {
       }
     },
 
-    // Dweb pages append their security events to the ONE audit log
-    // (ARCHITECTURE §7: no new logging subsystem; new event types only).
+    // why: All security events use one audit log.
     'dweb/audit': async ({ type, details }) => {
       if (!DWEB_ENABLED) return { ok: false, error: 'dweb-disabled' };
       if (typeof type !== 'string' || !type.startsWith('dweb_')) {
@@ -123,10 +112,7 @@ export const makeDwebRoutes = (deps) => {
       return { ok: true };
     },
 
-    // Install a VERIFIED bundle as an engine App. The verification happened
-    // in the calling page (fetchBundle + installAppBundle); this route is
-    // the storage arm. Files cross runtime messaging as JSON-safe base64
-    // envelopes, then appClient applies the same byte limits as local imports.
+    // Store only bundles that the offscreen caller already verified.
     'dweb/app-install': async ({ appId, name, files, entryFile, fileKinds, dweb }, sender) => {
       if (isOffscreenSender?.(sender) !== true) return { ok: false, error: 'offscreen-sender-required' };
       if (!(await dwebReady())) return { ok: false, error: 'dweb-disabled' };
@@ -141,9 +127,12 @@ export const makeDwebRoutes = (deps) => {
         record = await appClient.create({ appId, name, files, entryFile, fileKinds, dweb, source: 'dweb' });
         createdAppId = record.id;
         const repository = await repositories.statusApp(record.id);
-        // Local history and signed publisher provenance are different lineages:
-        // git_oid is our safe-update baseline; source_git_oid came from the peer.
-        record = await appRegistry.update(record.id, { dweb: { git_oid: repository.oid } });
+        // why: Local Git history and signed publisher lineage differ.
+        record = await appRegistry.update(record.id, { dweb: {
+          git_oid: repository.oid,
+          release_entry_file: record.entryFile,
+          release_file_kinds: { ...(record.fileKinds ?? {}) },
+        } });
         if (!record) throw new Error('app disappeared while recording install lineage');
         const auditWarning = await auditCommittedChange({
           type: 'dweb_app_installed',
@@ -156,23 +145,20 @@ export const makeDwebRoutes = (deps) => {
       }
     },
 
-    // Overwrite an INSTALLED app's files in place with a newer verified version
-    // (the storage arm of dweb/base/update-app; verification happened offscreen).
-    // why replace-not-merge: a new version may DROP files, so we clear the app's
-    // OPFS dir first, then write the new set — otherwise stale files linger and can
-    // shadow the new entry. The dweb slot is MERGED so version_id/uri/seq advance
-    // while publisher/slug/dwapp_id stay put. The open tab reloads to show the update.
-    'dweb/app-update': async ({ appId, files, entryFile, fileKinds, dweb, strategy }, sender) => {
+    // Replace every release file so removed files cannot shadow the verified update.
+    'dweb/app-update': async ({ appId, files, entryFile, fileKinds, dweb, strategy, conflictToken }, sender) => {
       if (isOffscreenSender?.(sender) !== true) return { ok: false, error: 'offscreen-sender-required' };
       if (!(await dwebReady())) return { ok: false, error: 'dweb-disabled' };
       if (typeof appId !== 'string') return { ok: false, error: 'appId-required' };
+      const resolvesConflict = strategy === 'replace' || strategy === 'fork';
+      if (resolvesConflict && (!Number.isSafeInteger(conflictToken) || conflictToken < 0)) {
+        return { ok: false, error: 'update-conflict-token-required' };
+      }
       try {
-        // The App editor writes OPFS directly from its tab. Quiesce that host,
-        // then serialize every SW-side writer through the same per-App lock so
-        // the divergence check, optional fork, and replacement are one mutation.
-        // The initiating base/update route already owns withAppLifecycle, so this
-        // storage callback uses the non-reentrant form.
-        return await appQuiescence.runUnlocked(appId, () => appClient.withWriteLock(appId, async () => {
+        return await withDwebPublication((/** @type {() => boolean} */ isCurrent) => withAppLifecycle(appId, async () => {
+          if (!isCurrent() || !dwebOn()) return { ok: false, error: 'dweb-disabled' };
+          // why: Quiesce the editor before one locked check, fork, and replacement.
+          return appQuiescence.runUnlocked(appId, () => appClient.withWriteLock(appId, async () => {
           const rec = await appRegistry.get(appId);
           if (!rec) return { ok: false, error: 'app-not-found' };
           if (typeof entryFile !== 'string') return { ok: false, error: 'entryFile-required' };
@@ -188,20 +174,18 @@ export const makeDwebRoutes = (deps) => {
           }
           const admitted = await admitTrackedVersion(dweb);
           if (!admitted.ok) return { ok: false, error: admitted.error };
+          const cleanupHashes = [...new Set([
+            ...(Array.isArray(rec.dweb?.pending_seed_unserve_hashes) ? rec.dweb.pending_seed_unserve_hashes : []),
+            ...(typeof rec.dweb?.hash === 'string' ? [rec.dweb.hash] : []),
+          ].filter((hash) => typeof hash === 'string' && hash !== dweb?.hash))];
+          const nextDweb = { ...(dweb ?? {}) };
+          if (cleanupHashes.length) nextDweb.pending_seed_unserve_hashes = cleanupHashes;
+          else delete nextDweb.pending_seed_unserve_hashes;
 
-          const repository = await repositories.statusApp(appId);
           const diverged = !rec.dweb?.git_oid
-            || repository.oid !== rec.dweb.git_oid
-            || !await repositories.matches({ kind: 'app', id: appId }, { at: rec.dweb.git_oid });
-          if (diverged && strategy !== 'replace' && strategy !== 'fork') {
-            return {
-              ok: false,
-              error: 'local-changes',
-              requiresAction: true,
-              currentOid: repository.oid,
-              baseOid: rec.dweb?.git_oid ?? null,
-            };
-          }
+            || (typeof rec.dweb?.hash === 'string' && !appReleaseDescriptorMatches(rec))
+            || !await repositories.matches({ kind: 'app', id: appId }, { at: rec.dweb.git_oid, excludeAppData: true });
+          if (diverged && !resolvesConflict) return updateConflict(appId);
 
           let fork = null;
           if (diverged && strategy === 'fork') {
@@ -219,8 +203,7 @@ export const makeDwebRoutes = (deps) => {
                 fileKinds: rec.fileKinds ?? {},
                 entryFile: rec.entryFile,
                 tags: [...new Set([...(rec.tags || []), 'fork'])],
-                // Preserve the runtime capability, but detach the fork from the
-                // upstream publisher's update stream.
+                // why: A local fork must leave the publisher's update stream.
                 dweb: {
                   uri: null, publisher: null, hash: null, local: true,
                   forked_from: {
@@ -247,11 +230,13 @@ export const makeDwebRoutes = (deps) => {
             entryFile,
             fileKinds,
             message: `update from dweb ${dweb?.version_id?.slice?.(0, 10) ?? ''}`,
-            metadataForOid: (/** @type {string | null} */ oid, /** @type {any} */ oldRecord) => ({
+            metadataForOid: (/** @type {string | null} */ oid, /** @type {any} */ oldRecord, /** @type {Record<string, 'text'|'binary'>} */ releaseFileKinds = {}) => ({
               ...(dweb && typeof dweb === 'object' ? {
                 dweb: {
-                  ...dweb,
+                  ...nextDweb,
                   git_oid: oid,
+                  release_entry_file: entryFile,
+                  release_file_kinds: { ...releaseFileKinds },
                   published_hashes: [...new Set([
                     ...(oldRecord.dweb?.published_hashes ?? []),
                     ...(typeof dweb.hash === 'string' ? [dweb.hash] : []),
@@ -267,18 +252,25 @@ export const makeDwebRoutes = (deps) => {
           return {
             ok: true,
             app: committed.record,
+            cleanupHashes,
             ...(fork ? { fork: { id: fork.id, name: fork.name } } : {}),
             ...(auditWarning ? { warning: auditWarning } : {}),
           };
-        }), { close: true });
+        }), {
+          close: true,
+          invalidateDweb: true,
+          ...(resolvesConflict ? { expectedDwebGeneration: conflictToken } : {}),
+        });
+        }));
       } catch (e) {
+        if ((/** @type {{name?:string}} */ (e))?.name === 'AppDwebAuthorityChangedError') {
+          return updateConflict(appId);
+        }
         return { ok: false, error: /** @type {{ message?: string }} */ (e)?.message ?? String(e) };
       }
     },
 
-    // A dwapp can publish its current App into a room after explicit consent.
-    // Persist the latest room-published hash so replacement and deletion can
-    // revoke every version this node still serves.
+    // why: Persist served hashes so replacement and deletion can revoke them.
     'dweb/app-record-served': async ({ appId, uri, hash }, sender) => {
       if (isOffscreenSender?.(sender) !== true) return { ok: false, error: 'offscreen-sender-required' };
       if (!(await dwebReady())) return { ok: false, error: 'dweb-disabled' };
@@ -300,16 +292,11 @@ export const makeDwebRoutes = (deps) => {
       }
     },
 
-    // Install (first run) the commons seed app and open it — optionally
-    // straight into a room (`#<appId>?room=…`). `seed` comes FROM the page (the
-    // SW can't load the dweb module); the SW only checks the registry, stores
-    // via appClient, and opens the tab. `seed` is { name, files, entryFile, dweb }.
+    // Store the page-provided seed because the worker cannot load its module.
     'dweb/open-commons': async ({ seed, room, url } = {}) => {
       if (!(await dwebReady())) return { ok: false, error: 'dweb-disabled' };
       const seedKey = seed?.dweb?.seed;
-      // Bound the page-supplied key: it's used to dedupe + persisted in app
-      // metadata, so a short plain string only (the real cap on file size
-      // lives in appClient.create). 64 is generous for 'commons'-class keys.
+      // why: Bound the persisted deduplication key.
       if (typeof seedKey !== 'string' || !seedKey || seedKey.length > 64) {
         return { ok: false, error: 'seed-required' };
       }
@@ -336,10 +323,7 @@ export const makeDwebRoutes = (deps) => {
       }
     },
 
-    // Ensure a seed app (e.g. commons) is present in the Library WITHOUT opening
-    // it — the Home/Library page calls this once. why a once-ever flag, not just
-    // dedupe-by-seed: a user who DELETES the app must not have it silently
-    // re-seeded on the next Library open.
+    // why: A durable flag prevents a deleted seed from returning.
     'dweb/ensure-seed-app': async ({ seed } = {}) => {
       if (!(await dwebReady())) return { ok: false, error: 'dweb-disabled' };
       const seedKey = seed?.dweb?.seed;
@@ -347,11 +331,7 @@ export const makeDwebRoutes = (deps) => {
         return { ok: false, error: 'seed-required' };
       }
       try {
-        // One-time rename migration: a seed install created under the legacy
-        // display name (name === key, e.g. 'commons') is renamed to the current
-        // seed name. Gated on name === seedKey so a user's OWN rename is never
-        // clobbered; runs before the once-ever flag so already-seeded installs
-        // still pick up the new name; idempotent (won't re-fire once renamed).
+        // why: Rename only the legacy default, never a user name.
         if (typeof seed?.name === 'string' && seed.name && seed.name !== seedKey) {
           const legacy = (await appRegistry.list()).find((/** @type {any} */ a) => a.dweb?.seed === seedKey && a.name === seedKey);
           if (legacy) {
@@ -375,10 +355,7 @@ export const makeDwebRoutes = (deps) => {
       }
     },
 
-    // The always-on BASE NETWORK (S1b) lives in the OFFSCREEN document. These
-    // routes ensure the offscreen doc exists, then forward to its
-    // dweb/base-host/* handler. Distinct type so the SW's own dispatcher doesn't
-    // re-catch the forward.
+    // A distinct host type prevents the worker from catching its own relay.
     'dweb/base/start': async () => {
       if (!(await dwebReady())) return { ok: false, error: 'dweb-disabled' };
       return withDwebPublication(async (/** @type {() => boolean} */ isCurrent) => {
@@ -387,12 +364,7 @@ export const makeDwebRoutes = (deps) => {
         return browser.runtime.sendMessage({ type: 'dweb/base-host/start' });
       });
     },
-    // The master OFF — the user-facing kill switch, symmetric to start
-    // (docs/specs/FEATURE-FIRST-CLASS-MESSAGING.md §2). Persist the preference
-    // FIRST so it won't auto-restart on the next unlock (maybeStartBaseNetwork
-    // gates on dwebEnabled), then tear down a live host. NOT gated on dwebOn():
-    // we must be able to stop precisely as we flip the setting off. Gated only on
-    // DWEB_ENABLED — the store package prunes this module entirely.
+    // why: The kill switch must work after the preference becomes false.
     'dweb/base/stop': async () => {
       if (!DWEB_ENABLED) return { ok: false, error: 'dweb-disabled' };
       return disableDweb();
@@ -413,24 +385,17 @@ export const makeDwebRoutes = (deps) => {
       return browser.runtime.sendMessage({ type: 'dweb/base-host/find', dwappId, publisherDid });
     },
 
-    // --- THE DWEB APP STORE ---
-    // Share a local app: read its files (the same OPFS read as export), then have
-    // the offscreen base host publish the signed bundle + announce it. A RESHARE
-    // reuses the stored slug — the namespace is locked once chosen so the
-    // dwapp_id stays stable. On success we persist the version identity.
+    // why: Reshares reuse the stored namespace identity.
     'dweb/base/share-app': async ({ appId, slug } = {}) => {
       if (!(await dwebReady())) return { ok: false, error: 'dweb-disabled' };
       return shareLocalApp(appId, slug);
     },
-    // Discover: what peers have announced (gossip cache + DHT hits).
     'dweb/base/heard': async () => {
       if (!(await dwebReady())) return { ok: false, error: 'dweb-disabled' };
       await ensureOffscreen();
       return browser.runtime.sendMessage({ type: 'dweb/base-host/heard' });
     },
-    // Install a discovered app: the offscreen fetches its signed bundle over the
-    // base mesh, verifies it, and persists it. The card's version identity rides
-    // along so the installed record can be matched against future announces.
+    // The offscreen host verifies peer bytes before this storage route runs.
     'dweb/base/install': async ({ uri, name, dwappId, slug, seq } = {}) => {
       if (!(await dwebReady())) return { ok: false, error: 'dweb-disabled' };
       return withDwebPublication(async (/** @type {() => boolean} */ isCurrent) => {
@@ -439,9 +404,7 @@ export const makeDwebRoutes = (deps) => {
         return browser.runtime.sendMessage({ type: 'dweb/base-host/install-app', uri, name, dwappId, slug, seq });
       });
     },
-    // Which installed dweb apps have a NEWER version announced? Cross-reference the
-    // local catalog against the offscreen discovery Library (the heard cards).
-    // Returns a map keyed by local appId. Best-effort + read-only.
+    // Match installed lineage to newer verified announcements.
     'dweb/base/updates': async () => {
       if (!(await dwebReady())) return { ok: false, error: 'dweb-disabled' };
       if (vault.isLocked()) return { ok: false, error: 'vault-locked' };
@@ -465,14 +428,16 @@ export const makeDwebRoutes = (deps) => {
         return { ok: false, error: /** @type {{ message?: string }} */ (e)?.message ?? String(e) };
       }
     },
-    // Update an installed app in place to a newer announced version: the offscreen
-    // refetches + verifies the new bundle and the SW overwrites the existing app's
-    // files. The user keeps ONE copy that just updates.
-    'dweb/base/update-app': async ({ appId, uri, name, strategy } = {}) => {
+    // The offscreen host verifies the update before replacement.
+    'dweb/base/update-app': async ({ appId, uri, name, strategy, conflictToken } = {}) => {
       if (!(await dwebReady())) return { ok: false, error: 'dweb-disabled' };
       if (vault.isLocked()) return { ok: false, error: 'vault-locked' };
       if (typeof appId !== 'string' || typeof uri !== 'string') return { ok: false, error: 'appId-and-uri-required' };
-      return withDwebPublication((/** @type {() => boolean} */ isCurrent) => withAppLifecycle(appId, async () => {
+      const resolvesConflict = strategy === 'replace' || strategy === 'fork';
+      if (resolvesConflict && (!Number.isSafeInteger(conflictToken) || conflictToken < 0)) {
+        return { ok: false, error: 'update-conflict-token-required' };
+      }
+      const launch = await withDwebPublication(async (/** @type {() => boolean} */ isCurrent) => {
         if (!isCurrent() || !dwebOn()) return { ok: false, error: 'dweb-disabled' };
         const record = await appRegistry.get(appId);
         if (!record) return { ok: false, error: 'app-not-found' };
@@ -483,67 +448,109 @@ export const makeDwebRoutes = (deps) => {
           return { ok: false, error: 'app-update-identity-missing' };
         }
         await ensureOffscreen();
-        const reply = await browser.runtime.sendMessage({
+        if (!isCurrent() || !dwebOn()) return { ok: false, error: 'dweb-disabled' };
+        return { ok: true, reply: browser.runtime.sendMessage({
           type: 'dweb/base-host/update-app', appId, uri, name,
           expectedDwappId,
           expectedPublisher,
-          previousHash: record.dweb?.hash ?? null,
-          pendingHashes: Array.isArray(record.dweb?.pending_seed_unserve_hashes)
-            ? record.dweb.pending_seed_unserve_hashes
-            : [],
-          ...(strategy === 'replace' || strategy === 'fork' ? { strategy } : {}),
-        });
-        if (!reply?.ok || !Array.isArray(reply.pendingUnserveHashes)) return reply;
+          ...(resolvesConflict ? { strategy, conflictToken } : {}),
+        }) };
+      });
+      if (!launch.ok) return launch;
+      const reply = await launch.reply;
+      if (!reply?.ok || !Array.isArray(reply.cleanupHashes)
+          || !Array.isArray(reply.pendingUnserveHashes)) return reply;
 
-        const warnings = new Set(Array.isArray(reply.warnings) ? reply.warnings : []);
-        if (reply.warning) warnings.add(reply.warning);
-        const current = await appRegistry.get(appId);
-        if (!current) return { ...reply, ok: false, error: 'app-not-found' };
-        const nextDweb = { ...(current.dweb ?? {}) };
-        if (reply.pendingUnserveHashes.length) {
-          nextDweb.pending_seed_unserve_hashes = [...new Set(reply.pendingUnserveHashes)];
-        } else {
-          delete nextDweb.pending_seed_unserve_hashes;
-        }
-        try {
-          const updated = await appRegistry.update(appId, { dwebExact: nextDweb });
-          if (!updated) throw new Error('app-not-found');
-          reply.app = updated;
-        } catch {
-          // The atomic version commit already retained the full cleanup list.
-          // A stale handle is safe and lets the next update or delete retry.
-          warnings.add('previous-version-cleanup-pending');
-          reply.cleanupPending = true;
-        }
-        reply.warnings = [...warnings];
-        if (reply.warnings.length) reply.warning = reply.warnings[0];
-        else {
-          delete reply.warning;
-          delete reply.warnings;
-        }
-        return reply;
-      }));
+      const warnings = new Set(Array.isArray(reply.warnings) ? reply.warnings : []);
+      if (reply.warning) warnings.add(reply.warning);
+      try {
+        const updated = await withDwebPublication(() => withAppLifecycle(appId, async () => {
+          const current = await appRegistry.get(appId);
+          if (!current) return null;
+          const failed = new Set(reply.pendingUnserveHashes.filter((/** @type {unknown} */ hash) => typeof hash === 'string'));
+          const cleaned = new Set(reply.cleanupHashes.filter((/** @type {unknown} */ hash) => typeof hash === 'string' && !failed.has(hash)));
+          const pending = [...new Set((Array.isArray(current.dweb?.pending_seed_unserve_hashes)
+            ? current.dweb.pending_seed_unserve_hashes
+            : []).filter((/** @type {unknown} */ hash) => typeof hash === 'string' && !cleaned.has(hash)))];
+          const nextDweb = { ...(current.dweb ?? {}) };
+          if (pending.length) nextDweb.pending_seed_unserve_hashes = pending;
+          else delete nextDweb.pending_seed_unserve_hashes;
+          return appRegistry.update(appId, { dwebExact: nextDweb });
+        }));
+        if (!updated) return { ...reply, ok: false, error: 'app-not-found' };
+        reply.app = updated;
+      } catch {
+        // why: Keep stale handles so later cleanup can retry.
+        warnings.add('previous-version-cleanup-pending');
+        reply.cleanupPending = true;
+      }
+      reply.warnings = [...warnings];
+      if (reply.warnings.length) reply.warning = reply.warnings[0];
+      else {
+        delete reply.warning;
+        delete reply.warnings;
+      }
+      return reply;
     },
-    // A dwapp room op (join/leave/publish/subscribe/dm/presence/history/…) — one
-    // thin relay to the offscreen base host. Events flow back to the app-tab
-    // directly as `dweb/base-room/event` runtime messages, so the SW only
-    // carries the request/response.
-    'dweb/base/room': async (msg = {}) => {
+    // why: A hash-bound join stays in the same mutation lane as verification.
+    'dweb/base/room': async (msg = {}, sender) => {
       if (!(await dwebReady())) return { ok: false, error: 'dweb-disabled' };
-      const { type: _t, ...args } = msg;
+      const { type: _t, bridgeAppId, bridgeAppHash, bridgeAppForked, bridgeAppGeneration, ...args } = msg;
+      const senderAppId = appTabTracker.parseIdFromUrl?.(sender?.tab?.url);
+      const senderTabId = sender?.tab?.id;
+      if (!senderAppId || senderTabId == null || bridgeAppId !== senderAppId) return { ok: false, error: 'app-identity-changed' };
+      if (args.op !== 'leave') {
+        try { await appTabTracker.dwebGenerationsReady(); }
+        catch { return { ok: false, error: 'app-authority-unavailable' }; }
+      }
+      const ownsTab = () => senderTabId === appTabTracker.getTabId(senderAppId);
+      const current = () => ownsTab() && Number.isSafeInteger(bridgeAppGeneration)
+        && bridgeAppGeneration === (appTabTracker.getDwebGeneration?.(senderAppId) ?? 0);
+      if (!Number.isSafeInteger(bridgeAppGeneration) || bridgeAppGeneration < 0) return { ok: false, error: 'app-identity-changed' };
+      const relay = (extra = {}) => browser.runtime.sendMessage({
+        type: 'dweb/base-host/room', ...args,
+        roomOwnerId: `app:${senderAppId}:${senderTabId}:${bridgeAppGeneration}`,
+        roomOwnerAppId: senderAppId,
+        roomOwnerGeneration: bridgeAppGeneration,
+        ...extra,
+      });
+      if (args.op === 'leave') {
+        await ensureOffscreen();
+        return relay();
+      }
       return withDwebPublication(async (/** @type {() => boolean} */ isCurrent) => {
         if (!isCurrent() || !dwebOn()) return { ok: false, error: 'dweb-disabled' };
         await ensureOffscreen();
-        const relay = () => browser.runtime.sendMessage({ type: 'dweb/base-host/room', ...args });
-        if (args.op === 'publish-app' && typeof args.appId === 'string') {
-          return withAppLifecycle(args.appId, relay);
+        if (!ownsTab()) return { ok: false, error: 'app-identity-changed' };
+        const authorized = () => isCurrent() && dwebOn() && current();
+        if (!authorized()) return { ok: false, error: 'app-identity-changed' };
+        if (args.op === 'publish-app') {
+          if (args.appId !== senderAppId) return { ok: false, error: 'app-identity-changed' };
+          return withAppLifecycle(senderAppId, () => appQuiescence.runUnlocked(senderAppId, async () => {
+            const roomSnapshot = { ok: true, ...(await appClient.snapshotFilesBase64({ appId: senderAppId })) };
+            return appClient.withWriteLock(senderAppId,
+              () => authorized() ? relay({ roomSnapshot }) : { ok: false, error: 'app-identity-changed' });
+          }));
         }
-        return relay();
+        return appClient.withWriteLock(senderAppId, async () => {
+          if (!authorized()) return { ok: false, error: 'app-identity-changed' };
+          if (args.op === 'join') {
+            const record = await appRegistry.get(senderAppId);
+            const hash = record?.dweb?.hash;
+            const exact = typeof hash === 'string' && typeof record.dweb.git_oid === 'string'
+              && appReleaseDescriptorMatches(record)
+              && await repositories.matches({ kind: 'app', id: senderAppId }, { at: record.dweb.git_oid, excludeAppData: true }).catch(() => false);
+            if (!record || !authorized()
+                || (hash != null && (typeof hash !== 'string' || bridgeAppHash !== hash
+                  || typeof bridgeAppForked !== 'boolean' || exact === bridgeAppForked))) {
+              return { ok: false, error: 'app-identity-changed' };
+            }
+          }
+          return relay();
+        });
       });
     },
-    // The READ surface behind peerd.distributed.{whoami,status,peers,presence} in
-    // a Notebook. Side-effect-free: it reports the base host's CURRENT state with
-    // rosters; it never STARTS the lobby (maybeStartBaseNetwork does, on unlock).
+    // Read state without starting the base host.
     'dweb/distributed/info': async () => {
       if (!(await dwebReady())) return { ok: false, error: 'dweb-disabled' };
       await ensureOffscreen();

--- a/extension/background/routes/engine.js
+++ b/extension/background/routes/engine.js
@@ -1,20 +1,8 @@
 // @ts-check
-// background/routes/engine.js — engine-instance metadata, the Library (apps)
-// surface, .peerd artifact export/import, and VM-originated HTTP egress.
-//
-// apps/delete stays inline in the SW (it reads the reassigned settings to
-// decide whether to un-share over the dweb). Everything here closes over only
-// stable collaborators. Bodies verbatim, deps injected, imports none.
+// Keep engine routes import-free and inject stable collaborators.
 
-/**
- * Await work through the same cancellation boundary as the operation it gates.
- * The underlying one-time hydration may still finish for other callers, but a
- * stopped or expired run no longer waits for it or proceeds to egress.
- * @template T
- * @param {() => Promise<T>} start
- * @param {AbortSignal | null} signal
- * @returns {Promise<T>}
- */
+/** why: A stopped run must not wait for shared hydration or reach egress.
+ * @template T @param {()=>Promise<T>} start @param {AbortSignal|null} signal @returns {Promise<T>} */
 const awaitWithinSignal = (start, signal) => {
   if (!signal) return Promise.resolve().then(start);
   if (signal.aborted) return Promise.reject(new DOMException('Aborted', 'AbortError'));
@@ -49,7 +37,8 @@ export const makeEngineRoutes = (deps) => {
     ArtifactTooLargeError, EnvelopeFormatError, EnvelopeIntegrityError,
     settingsStore, DWEB_ENABLED, applyWebExtract, withDwebPublication, withAppLifecycle,
     listOffscreenContexts, scriptRuns, isOffscreenSender, awaitDenylistPolicy, assertOpfsWritable,
-    repositories, parseAppManifest, podGitRemoteOperation, getCurrentSessionId, onAppDeleted,
+    repositories, parseAppManifest, podGitRemoteOperation, appReleaseDescriptorMatches,
+    getCurrentSessionId, onAppDeleted,
   } = deps;
   if (typeof awaitDenylistPolicy !== 'function') {
     throw new TypeError('makeEngineRoutes: awaitDenylistPolicy is required');
@@ -67,15 +56,15 @@ export const makeEngineRoutes = (deps) => {
   /** @param {string} appId @param {() => Promise<any>} operation */
   const coordinateApp = (appId, operation) => repositories.coordinate({ kind: 'app', id: appId }, operation);
   /** @param {string} appId @param {() => Promise<any>} operation */
-  const quiesceApp = (appId, operation) => appQuiescence.run(
+  const quiesceApp = (appId, operation, options = {}) => appQuiescence.run(
     appId,
     () => coordinateApp(appId, operation),
-    { close: true },
+    { close: true, ...options },
   );
-  /** @param {unknown} appId @param {unknown} path @param {any} sender */
-  const ownsAppDataMutation = (appId, path, sender) => typeof appId === 'string'
-    && typeof path === 'string'
-    && /^data\/[a-z0-9][a-z0-9._-]{0,63}\.json$/i.test(path)
+  /** @param {string} appId @param {() => Promise<any>} operation */
+  const mutateApp = (appId, operation) => quiesceApp(appId, operation, { invalidateDweb: true });
+  /** @param {unknown} appId @param {any} sender */
+  const ownsAppTab = (appId, sender) => typeof appId === 'string'
     && sender?.tab?.id != null
     && appTabTracker.getTabId(appId) === sender.tab.id
     && appTabTracker.parseIdFromUrl?.(sender.tab.url) === appId;
@@ -124,13 +113,8 @@ export const makeEngineRoutes = (deps) => {
     catch { return null; }
   };
 
-  /**
-   * Pod Git stays behind an exact instance/tab pin. Agent jobs receive one
-   * structured, target-bound grant; direct terminal jobs carry the explicit
-   * `true` grant minted by their visible first-party host.
-   * @param {any} msg
-   * @param {any} sender
-   */
+  /** why: Remote Pod Git requires an exact tab and target grant.
+   * @param {any} msg @param {any} sender */
   const runPodGit = async ({ podId, jobId, argv = [], remoteGrant = null }, sender) => {
     if (typeof podId !== 'string' || !Array.isArray(argv)) {
       return { ok: false, error: 'podId-and-argv-required' };
@@ -138,9 +122,7 @@ export const makeEngineRoutes = (deps) => {
     const senderError = await podSenderError(podId, sender);
     if (senderError) return { ok: false, error: senderError };
     const ref = { kind: 'pod', id: podId };
-    // Grant validation and the resulting Git operation are one repository
-    // transaction. Otherwise a concurrent remote set-url can land after the
-    // user approves target A but before push reads origin, sending to target B.
+    // why: One transaction prevents a remote change after target approval.
     return repositories.coordinate(ref, async () => {
     const [command = '', ...args] = argv.map(String);
     const remoteOp = podGitRemoteOperation(argv);
@@ -324,9 +306,7 @@ export const makeEngineRoutes = (deps) => {
         record: { id: record.id, name: record.name, persistent: record.persistent !== false },
       };
     },
-    // Notebook tabs and the offscreen job host own the actual OPFS handles.
-    // They ask here immediately before mutation so the service worker's live
-    // schema posture remains authoritative in Chrome and Firefox alike.
+    // why: The worker stays authoritative for OPFS write posture.
     'lifecycle/assert-opfs-writable': async (_msg, sender = undefined) => {
       const notebookHost = browser.runtime.getURL('engine-tabs/notebook-tab/index.html');
       const senderUrl = sender?.url ?? sender?.tab?.url;
@@ -345,16 +325,7 @@ export const makeEngineRoutes = (deps) => {
       }
     },
 
-    // VM-originated HTTP egress. The VM tab's HTTP-marker dispatcher
-    // calls this when it sees a wrapper script's request marker. webFetch
-    // applies the denylist + audit; response body is base64-encoded back
-    // so runtime.sendMessage's JSON serialization preserves the bytes.
-    // Max ~50MB body (matches vm_import's cap) so we don't allow a
-    // runaway curl to OOM the SW.
-    // why vmHttpFetch (not webFetch directly): #53 moved the VM egress glue into
-    // an IO-injected factory (vm-net/vm-http-fetch.js) so it's bun-testable — it
-    // layers the revalidating IDB GET cache + host-bound git-auth + body cap +
-    // chunked base64 on top of webFetch's denylist/SSRF/audit chokepoint.
+    // why: vmHttpFetch adds cache, credentials, size, and byte transport to the egress gate.
     'sw/web-fetch': async ({ url, method, headers, body, gitAuth, noCache, extract, runId, ownerSessionId, deadlineAt, abortToken, notebookId }, sender = undefined) => {
       if (typeof url !== 'string' || url.length === 0) {
         return { ok: false, error: 'url-required' };
@@ -399,17 +370,8 @@ export const makeEngineRoutes = (deps) => {
           else deadlineTimer = setTimeout(() => runController?.abort(), remaining);
         }
       }
-      // GET callers (the VM HTTP marker fast path) pass only { url } and behave
-      // exactly as before; the rich VM path + the Notebook code-mode bridge pass
-      // method/headers/body. webFetch applies denylist + SSRF + audit on EVERY
-      // method (parity with fetch_url), so a POST here is not a new egress surface.
-      // vmHttpFetch layers the IDB GET cache + optional git-auth on top; noCache
-      // (module-source fetches) bypasses that cache so every run is re-audited.
       try {
-        // why: hydration is part of the egress operation, not a preflight outside
-        // it. Admit the run and arm Stop/deadline first, then await policy through
-        // that signal. A stopped or expired run cannot reach vmHttpFetch even if
-        // the shared hydration later succeeds.
+        // why: Stop and deadline also cancel policy hydration before egress.
         await awaitWithinSignal(
           awaitDenylistPolicy,
           runController?.signal ?? null,
@@ -419,9 +381,6 @@ export const makeEngineRoutes = (deps) => {
           url, method, headers, body, gitAuth, noCache: noCache === true,
           ...(runController ? { signal: runController.signal } : {}),
         });
-        // Design 2a extract post-step (Notebook tab relay) — why + security
-        // posture: shared/fetch-extract.js. Absent `extract` (every VM caller)
-        // it is a passthrough, byte-for-byte as before.
         return await applyWebExtract(resp, extract, url);
       } catch (e) {
         const ev = /** @type {{ name?: string, message?: string }} */ (e);
@@ -446,55 +405,53 @@ export const makeEngineRoutes = (deps) => {
       return { ok: true, aborted: controller != null };
     },
 
-    // --- App metadata fetch -----------------------------------------------
-    // app-tab/index.html requests its name + entry filename here at load
-    // time. The parent then reads files from OPFS directly + composes the
-    // body before posting to the sandboxed runner.
-    'app/get-meta': async ({ appId }) => {
+    'app/get-meta': async ({ appId }, sender) => {
       if (typeof appId !== 'string') return { ok: false, error: 'appId-required' };
       try {
-        let meta = await appRegistry.get(appId);
-        if (!meta) return { ok: false, error: 'app-not-found' };
-        let runtimeDweb = meta.dweb ?? null;
-        let runtimeAgent = { kind: 'bound-app', profile: 'developer', surface: 'code' };
-        try {
-          const contract = parseAppManifest(await appClient.readFile({ appId, path: 'peerd.json' }));
-          const paths = new Set((await appClient.listFiles({ appId })).map((/** @type {{path:string}} */ file) => file.path.replace(/^\/+/, '')));
-          if (!paths.has(contract.entry)) return { ok: false, error: `peerd.json entry is missing: ${contract.entry}` };
-          runtimeDweb = contract.capabilities.includes('dweb') && DWEB_ENABLED
-            ? (meta.dweb ?? { uri: null, publisher: null, hash: null, local: true })
-            : null;
-          runtimeAgent = contract.agent;
-          if (contract.entry !== meta.entryFile) meta = await appRegistry.update(appId, { entryFile: contract.entry });
-        } catch (error) {
-          if ((/** @type {{name?:string}} */ (error)).name !== 'NotFoundError') {
-            return { ok: false, error: /** @type {{message?:string}} */ (error)?.message ?? String(error) };
+        await appTabTracker.dwebGenerationsReady();
+        return await appTabTracker.withDwebAuthority(appId, () => coordinateApp(appId, async () => {
+          let meta = await appRegistry.get(appId);
+          if (!meta) return { ok: false, error: 'app-not-found' };
+          if (meta.dweb?.hash && !ownsAppTab(appId, sender)) return { ok: false, error: 'app-sender-not-instance-pinned' };
+          let runtimeDweb = meta.dweb ?? null;
+          let runtimeAgent = { kind: 'bound-app', profile: 'developer', surface: 'code' };
+          try {
+            const contract = parseAppManifest(await appClient.readFile({ appId, path: 'peerd.json' }));
+            const paths = new Set((await appClient.listFiles({ appId })).map((/** @type {{path:string}} */ file) => file.path.replace(/^\/+/, '')));
+            if (!paths.has(contract.entry)) return { ok: false, error: `peerd.json entry is missing: ${contract.entry}` };
+            runtimeDweb = contract.capabilities.includes('dweb') && DWEB_ENABLED
+              ? (meta.dweb ?? { uri: null, publisher: null, hash: null, local: true })
+              : null;
+            runtimeAgent = contract.agent;
+            if (contract.entry !== meta.entryFile) meta = await appRegistry.update(appId, { entryFile: contract.entry });
+          } catch (error) {
+            if ((/** @type {{name?:string}} */ (error)).name !== 'NotFoundError') {
+              return { ok: false, error: /** @type {{message?:string}} */ (error)?.message ?? String(error) };
+            }
           }
-        }
-        // dweb meta unlocks the app-tab bridge for dwapps (preview builds);
-        // harmless null elsewhere.
-        return {
-          ok: true,
-          name: meta.name,
-          entryFile: meta.entryFile,
-          fileKinds: meta.fileKinds ?? {},
-          dweb: runtimeDweb,
-          agent: runtimeAgent,
-        };
+          // A hash grant applies only to the installed App bytes, not a mutable fork.
+          const installedBytesMatch = !runtimeDweb?.hash || (appReleaseDescriptorMatches(meta)
+            && typeof runtimeDweb.git_oid === 'string'
+            && await repositories.matches({ kind: 'app', id: appId }, { at: runtimeDweb.git_oid, excludeAppData: true }).catch(() => false));
+          if (!installedBytesMatch) runtimeDweb = { ...runtimeDweb, forked: true };
+          if (runtimeDweb) runtimeDweb = { ...runtimeDweb, generation: appTabTracker.getDwebGeneration?.(appId) ?? 0 };
+          return {
+            ok: true, name: meta.name, entryFile: meta.entryFile,
+            fileKinds: meta.fileKinds ?? {}, dweb: runtimeDweb, agent: runtimeAgent,
+          };
+        }));
       } catch (e) {
         return { ok: false, error: /** @type {{ message?: string }} */ (e)?.message ?? String(e) };
       }
     },
 
-    // The App editor reads OPFS directly but sends every mutation through the
-    // SW client so byte caps, kind metadata, and rollback stay one contract.
     'app/editor-write': async ({ appId, path, content, runtimeData = false }, sender) => {
       if (typeof appId !== 'string') return { ok: false, error: 'appId-required' };
       if (typeof path !== 'string') return { ok: false, error: 'path-required' };
       if (typeof content !== 'string') return { ok: false, error: 'content-required' };
-      if (runtimeData && !ownsAppDataMutation(appId, path, sender)) return { ok: false, error: 'app-data-unauthorized' };
+      if (!ownsAppTab(appId, sender) || (runtimeData && !/^data\/[a-z0-9][a-z0-9._-]{0,63}\.json$/i.test(path))) return { ok: false, error: 'app-data-unauthorized' };
       try {
-        const result = await appClient.writeFile({ appId, path, content, reload: false });
+        const result = await appClient.writeFile({ appId, path, content, reload: false, invalidateDweb: !runtimeData });
         return { ok: true, ...result };
       } catch (e) {
         return { ok: false, error: /** @type {{ message?: string }} */ (e)?.message ?? String(e) };
@@ -504,9 +461,9 @@ export const makeEngineRoutes = (deps) => {
     'app/editor-delete': async ({ appId, path, runtimeData = false }, sender) => {
       if (typeof appId !== 'string') return { ok: false, error: 'appId-required' };
       if (typeof path !== 'string') return { ok: false, error: 'path-required' };
-      if (runtimeData && !ownsAppDataMutation(appId, path, sender)) return { ok: false, error: 'app-data-unauthorized' };
+      if (!ownsAppTab(appId, sender) || (runtimeData && !/^data\/[a-z0-9][a-z0-9._-]{0,63}\.json$/i.test(path))) return { ok: false, error: 'app-data-unauthorized' };
       try {
-        await appClient.deleteFile({ appId, path, reload: false });
+        await appClient.deleteFile({ appId, path, reload: false, invalidateDweb: !runtimeData });
         return { ok: true };
       } catch (e) {
         if (runtimeData && (/** @type {{name?:string}} */ (e))?.name === 'NotFoundError') return { ok: true };
@@ -514,34 +471,20 @@ export const makeEngineRoutes = (deps) => {
       }
     },
 
-    // vm-tab/index.html fetches its full record here at boot. why a route
-    // (not a direct chrome.storage.local read like before): the VM catalog
-    // moved to IndexedDB (idbKV('vms')), which the tab page reaches through
-    // the registry the SW owns — mirroring app/get-meta.
+    // why: The worker owns the IndexedDB VM registry.
     'vm/get-meta': async ({ vmId }) => {
       if (typeof vmId !== 'string') return { ok: false, error: 'vmId-required' };
       try {
         const record = await vmRegistry.get(vmId);
         if (!record) return { ok: false, error: 'vm-not-found' };
-        // why devMode rides along: vm-tab has no settings of its own; it reads
-        // it here (once, at boot) to honour the "verbose VM diagnostics" toggle
-        // (Settings → Behavior) — surfaces the install/verify output in the
-        // terminal at boot (the persistent shell is never traced with `set -x`).
+        // why: The VM tab has no settings store.
         return { ok: true, record, devMode: !!settingsStore.get().devMode };
       } catch (e) {
         return { ok: false, error: /** @type {{ message?: string }} */ (e)?.message ?? String(e) };
       }
     },
 
-    // --- Library (the full-tab apps surface in the options page) ----------
-    // Metadata only — the catalog records, never OPFS file bodies (the grid
-    // stays light under default persistence). Open goes through the appClient
-    // so tab lifecycle + OPFS teardown match the agent's tools.
-    // why vault-gated: matches the memory/* + session/* convention — the
-    // lock is a privacy curtain over plaintext-IDB user content (the app
-    // catalog reveals what the user has been building), and export is
-    // exfiltrating. The options page already hides the Library when locked;
-    // this is the message-level backstop.
+    // why: The vault lock hides plaintext App metadata at the message boundary.
     'apps/list': async () => {
       if (vault.isLocked()) return { ok: false, error: 'vault-locked' };
       try {
@@ -602,8 +545,7 @@ export const makeEngineRoutes = (deps) => {
         return { ok: false, error: /** @type {{ message?: string }} */ (e)?.message ?? String(e) };
       }
     },
-    // App-tab editor IO goes through the same mutation coordinator as Git.
-    // This keeps a multi-surface browser App from writing around restore/share.
+    // why: Editor and Git writes use one mutation coordinator.
     'app/editor/read': async ({ appId, path }) => {
       if (typeof appId !== 'string' || typeof path !== 'string') return { ok: false, error: 'appId-and-path-required' };
       try { return { ok: true, content: await appClient.readFile({ appId, path }) }; }
@@ -656,7 +598,7 @@ export const makeEngineRoutes = (deps) => {
     'apps/repository/restore': async ({ appId, to }) => {
       if (typeof appId !== 'string' || typeof to !== 'string') return { ok: false, error: 'appId-and-to-required' };
       try {
-        const result = await quiesceApp(appId, () => repositories.restoreApp(appId, { to }));
+        const result = await mutateApp(appId, () => repositories.restoreApp(appId, { to }));
         appTabTracker.reloadTab(appId).catch(() => {});
         await auditLog.append({ type: 'git_version_restored', details: { kind: 'app', appId, to, oid: result.oid } });
         return { ok: true, result };
@@ -664,13 +606,13 @@ export const makeEngineRoutes = (deps) => {
     },
     'apps/repository/branch': async ({ appId, name, checkout = true }) => {
       if (typeof appId !== 'string' || typeof name !== 'string') return { ok: false, error: 'appId-and-name-required' };
-      try { return { ok: true, result: await (checkout === false ? coordinateApp : quiesceApp)(appId, () => repositories.branch({ kind: 'app', id: appId }, { name, checkout: checkout !== false })) }; }
+      try { return { ok: true, result: await (checkout === false ? coordinateApp : mutateApp)(appId, () => repositories.branch({ kind: 'app', id: appId }, { name, checkout: checkout !== false })) }; }
       catch (e) { return { ok: false, error: /** @type {{message?:string}} */ (e)?.message ?? String(e) }; }
     },
     'apps/repository/checkout': async ({ appId, name }) => {
       if (typeof appId !== 'string' || typeof name !== 'string') return { ok: false, error: 'appId-and-name-required' };
       try {
-        const result = await quiesceApp(appId, () => repositories.checkout({ kind: 'app', id: appId }, { name }));
+        const result = await mutateApp(appId, () => repositories.checkout({ kind: 'app', id: appId }, { name }));
         appTabTracker.reloadTab(appId).catch(() => {});
         return { ok: true, result };
       } catch (e) { return { ok: false, error: /** @type {{message?:string}} */ (e)?.message ?? String(e) }; }
@@ -707,15 +649,12 @@ export const makeEngineRoutes = (deps) => {
       if (typeof appId !== 'string') return { ok: false, error: 'appId-required' };
       try {
         const result = await withDwebPublication(() => withAppLifecycle(appId, async () => {
-          // Revoke the live network copy before removing the only durable record
-          // that names it. A transient host failure leaves the local App intact so
-          // the user can retry without losing the hashes needed for revocation.
+          // why: Keep the record until all live network copies are revoked.
           const record = await appRegistry.get(appId);
           if (!record) return { ok: false, error: 'app-not-found' };
           if (DWEB_ENABLED && (record.dweb || record.shared)) {
             try {
-              // Never create a host just to revoke. No offscreen context means
-              // no in-memory content store can still be serving these bytes.
+              // why: An absent host cannot still serve in-memory bytes.
               const contexts = await listOffscreenContexts(browser);
               if (contexts.length) {
                 const reply = await browser.runtime.sendMessage({
@@ -754,14 +693,7 @@ export const makeEngineRoutes = (deps) => {
       }
     },
 
-    // --- artifacts: .peerd export/import (DESIGN-10) ---
-    //
-    // One bundle format under manual shares, web publishing, and (later)
-    // dwapps. The engine module owns the format (build/verify/unpack);
-    // these routes inject the IO: registry records, OPFS trees, the
-    // stored TOFU image pin. Same inspect-then-apply shape as the
-    // settings transfer — and like every import here, apply mints
-    // a FRESH id, never overwriting an existing artifact.
+    // why: Imports mint fresh IDs and never replace existing artifacts.
     'export/artifact': async ({ kind, id }) => {
       if (typeof id !== 'string' || !id) return { ok: false, error: 'id-required' };
       /** @param {string[]} rootPath @param {'text' | 'bytes'} mode */
@@ -780,8 +712,7 @@ export const makeEngineRoutes = (deps) => {
         if (kind === 'app') {
           const snapshot = await appClient.snapshotFiles({ appId: id });
           record = snapshot.record;
-          // why every App file is read as bytes: artifact transfer is lossless;
-          // the persisted kind map decides which bytes are editable text.
+          // why: App artifact transfer must preserve every byte.
           envelope = await buildAppExport({ record, files: snapshot.files });
         } else if (kind === 'notebook') {
           record = await jsRegistry.get(id);
@@ -790,10 +721,7 @@ export const makeEngineRoutes = (deps) => {
         } else if (kind === 'vm') {
           record = await vmRegistry.get(id);
           if (!record) return { ok: false, error: 'vm-not-found' };
-          // The recipe's whole point is carrying the base-image pin
-          // (receiver pins BEFORE first boot). v1 streams ONE stock
-          // image, so the sole pin entry is the image; without it
-          // (never booted) there is nothing trustworthy to export.
+          // why: A VM recipe needs a trusted base-image pin.
           const stored = await browser.storage.local.get(IMAGE_PIN_STORAGE_KEY);
           const pins = stored?.[IMAGE_PIN_STORAGE_KEY] ?? {};
           const [imageUrl, pin] = Object.entries(pins)[0] ?? [];
@@ -807,16 +735,13 @@ export const makeEngineRoutes = (deps) => {
         auditLog.append({ type: 'artifact_exported', details: { kind, id, name: record.name } }).catch(() => {});
         return { ok: true, filename: exportFilename(record.name, kind), envelope };
       } catch (e) {
-        // why cast: the error class arrives via the `any` deps bag, so
-        // instanceof can't narrow `e` for tsc — read .message off a view.
+        // why: The any-typed dependency does not narrow the caught value.
         if (e instanceof ArtifactTooLargeError) return { ok: false, error: /** @type {{ message?: string }} */ (e).message };
         throw e;
       }
     },
 
-    // Pre-flight: parse + verify hashes + summarize BEFORE any write
-    // (the envelope is self-verifying; nothing is trusted until the
-    // chunk hashes match the manifest).
+    // why: Verify the envelope before any write.
     'import/inspect': async ({ envelope }) => inspectEnvelope(envelope),
 
     'import/apply': async ({ envelope }) => {
@@ -827,15 +752,13 @@ export const makeEngineRoutes = (deps) => {
         if (e instanceof EnvelopeFormatError
             || e instanceof EnvelopeIntegrityError
             || e instanceof ArtifactTooLargeError) {
-          // why cast: the error classes arrive via the `any` deps bag, so
-          // instanceof can't narrow `e` for tsc — read .message off a view.
+          // why: The any-typed dependency does not narrow the caught value.
           return { ok: false, error: /** @type {{ message?: string }} */ (e).message };
         }
         throw e;
       }
       const { kind, name, entry, files, fileKinds, meta } = opened;
-      // Notebook source files use the existing text contract. Apps receive the
-      // raw file map so import preserves every byte, including unknown suffixes.
+      // why: Apps keep raw bytes, but Notebooks use text files.
       const textFiles = () => {
         /** @type {Record<string, string>} */
         const out = {};
@@ -845,8 +768,6 @@ export const makeEngineRoutes = (deps) => {
       };
       let result;
       if (kind === 'app') {
-        // appClient.create is the same path the agent's sandbox_create app arm takes:
-        // fresh id, registry record, OPFS writes.
         let record;
         try {
           record = await appClient.create({
@@ -861,9 +782,7 @@ export const makeEngineRoutes = (deps) => {
         }
         result = { ok: true, kind, id: record.id };
       } else if (kind === 'notebook') {
-        // Refuse before minting metadata. The guarded OPFS helper checks again
-        // at each file write, but a preflight avoids an empty registry record
-        // when the workspace schema is read-only.
+        // why: Refuse before a read-only workspace gets an empty record.
         try { await assertOpfsWritable(); }
         catch (error) {
           return {
@@ -879,10 +798,7 @@ export const makeEngineRoutes = (deps) => {
         result = { ok: true, kind, id: record.id };
       } else {
         const record = await vmRegistry.create({ name });
-        // Seed the TOFU pin BEFORE first boot — the recipe's payoff. A
-        // pin we already hold for the same URL is NEVER overwritten:
-        // TOFU means local evidence wins, and the boot path fails
-        // closed on any mismatch either way.
+        // why: Existing local TOFU evidence wins over imported evidence.
         const image = meta.image;
         if (typeof image?.url === 'string' && typeof image?.pin?.headSha256 === 'string') {
           const stored = await browser.storage.local.get(IMAGE_PIN_STORAGE_KEY);

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -1,31 +1,5 @@
 // @ts-check
-// Service worker — wiring + dependency-injection assembly (architecture.md §6).
-//
-// The SW imports each peerd-* module's public surface, creates concrete
-// instances (vault, audit log, session store), assembles the per-call
-// dependency context (buildToolContext, buildStateSnapshot), drives the agent
-// turn, and routes messages. It owns no business logic of its own — that lives
-// in the peerd-* modules and in the route handlers under background/routes/.
-//
-// Message routes: the dispatcher handlers live in background/routes/*.js —
-// import-free, deps-injected factories (makeVaultRoutes, makeProviderRoutes, …)
-// spread into makeDispatcher with a shared `routeDeps` object. They are
-// Bun-unit-tested in tests/background/ and statically wiring-checked in
-// tests/meta/sw-routes-wiring.test.ts. A route stays INLINE here only when it
-// closes over reassigned module state (settings, activeSession, denylist*,
-// defaultProfile, localModel*) that a captured reference couldn't track — those
-// are the handful left in the dispatcher below. Keep that rule: a new route
-// that needs only stable collaborators belongs in a routes/ module, not here.
-// New non-route logic that grows past a few lines of glue belongs in a module
-// (a peerd-* barrel, or a background/*.js helper like settings-patch.js), not
-// inlined into a handler.
-//
-// SW lifetime: this module is re-executed on every cold start. Module
-// scope is the "per-SW-lifetime singleton" surface. The offscreen doc
-// holds a keepalive port so the SW survives the 30s idle timer during
-// active sessions. State that must survive SW termination lives in
-// chrome.storage.session (`peerd-egress` sessionCache namespace) or
-// chrome.storage.local (`egress.kv`).
+// Assemble module surfaces. Keep logic in modules and durable state in browser storage.
 
 import browser from '/vendor/browser-polyfill.js';
 import { makeDispatcher, isTrustedSender } from '/shared/messaging.js';
@@ -405,7 +379,7 @@ import { makeOffscreenPdfClient } from './offscreen-pdf-client.js';
 import { makeOffscreenDocClient } from './offscreen-doc-client.js';
 import { makeOffscreenWebClient } from './offscreen-web-client.js';
 import { makeUiPorts } from './ui-ports.js';
-import { createAppClient, APP_TAB_GROUP_TITLE } from './app-client.js';
+import { createAppClient, APP_TAB_GROUP_TITLE, appReleaseDescriptorMatches } from './app-client.js';
 import { createPageActivityReporter } from './page-activity.js';
 import { createAppTabTracker } from './app-tab-tracker.js';
 import { createAppQuiescence } from './app-quiescence.js';
@@ -3140,10 +3114,19 @@ const podTabTracker = createPodTabTracker({
 // App registry + tracker + client. Apps' files live in OPFS at
 // peerd-apps/<appId>/; the registry tracks metadata only.
 const appRegistry = createAppRegistry({ storage: idbKV('apps'), onActorArchive: archiveOrphanedActor });
+const purgeAppRoomOwners = async (/** @type {string} */ appId, /** @type {number} */ generation) => {
+  if (!DWEB_ENABLED) return;
+  await ensureOffscreen();
+  const reply = /** @type {any} */ (await browser.runtime.sendMessage({
+    type: 'dweb/base-host/room', op: 'leave-app-owners', appId, generation,
+  }));
+  if (!reply?.ok) throw new Error(reply?.error ?? 'App dweb owners did not stop');
+};
 const appTabTracker = createAppTabTracker({
   announce: trackerNote(appRegistry, 'App'),
   onAdopt: (/** @type {string} */ id, /** @type {number} */ tabId) => engineLiveness.adopt('app', id, tabId),
   onDrop: (/** @type {string} */ id) => engineLiveness.drop('app', id),
+  purgeDwebOwners: purgeAppRoomOwners,
 });
 const repositories = createRepositoryService({
   loadGit: async () => browserGit,
@@ -4595,21 +4578,11 @@ const pushState = makeCoalescedStatePush({
   onError: (error) => console.warn('[state] push failed', error),
 });
 
-// Keepalive ports we hold references to so they're not GC'd. Recent
-// Chrome versions retain SW ports via their internal table, but holding
-// our own reference is belt-and-suspenders against version-to-version
-// drift.
+// why: Hold keepalive ports across browser-version changes.
 /** @type {Set<chrome.runtime.Port>} */
 const keepalivePorts = new Set();
 
-// Side-panel forwarder. The offscreen doc broadcasts voice/* (chunk,
-// auto-stop, error, permission-result) and the VM tabs broadcast
-// vm/stdout-chunk + vm/stderr-chunk via runtime.sendMessage; the SW
-// forwards them all to the active side-panel port so the side panel
-// only has to subscribe to one surface. (Voice chunks stream the live
-// transcript; VM chunks render per-tool-use stdout/stderr inline next
-// to the vm_boot card.) Returns false so the unified makeDispatcher
-// continues to other listeners that might care.
+// Forward host streams through the side panel's single message surface.
 const FORWARD_TYPES = new Set([
   'voice/chunk', 'voice/auto-stop', 'voice/error', 'voice/permission-result',
   'vm/stdout-chunk', 'vm/stderr-chunk',
@@ -4624,17 +4597,61 @@ browser.runtime.onMessage.addListener((/** @type {any} */ msg, /** @type {any} *
   return false;
 });
 
-// Tab tracker wiring. Each kind's tab broadcasts <kind>/tab-ready
-// on load; we resolve the pending readyPromise so any in-flight
-// ensureTab call returns. Closed tabs drop from the map via
-// chrome.tabs.onRemoved.
+// Resolve host readiness messages and drop closed tabs.
+/** @type {Map<number,Promise<void>>} */
+const appRetirements = new Map();
+const retireAppDweb = (/** @type {string} */ appId) =>
+  appTabTracker.retireDwebTab(appId).catch((error) => {
+    console.warn('[app] authority retirement failed', appId, error);
+    throw error;
+  });
+const trackAppRetirement = (/** @type {number} */ tabId, /** @type {()=>Promise<void>} */ operation) => {
+  const retirement = operation();
+  appRetirements.set(tabId, retirement);
+  retirement.then(() => appRetirements.get(tabId) === retirement && appRetirements.delete(tabId), () => {});
+  return retirement;
+};
+const failAppTab = async (/** @type {string} */ appId, /** @type {Error} */ error, /** @type {number} */ tabId) => {
+  const failedTabId = appTabTracker.onTabFailed(appId, error, tabId);
+  if (failedTabId != null) await trackAppRetirement(tabId, () => retireAppDweb(appId)).catch(() => {});
+  return failedTabId;
+};
+/** @param {number} tabId @param {string|undefined} url @param {string|null} trackedAppId */
+const retireAppDocument = async (tabId, url, trackedAppId) => {
+  const entry = trackedAppId ? null : await engineLiveness.findByTab('app', tabId);
+  const appId = trackedAppId ?? entry?.id;
+  if (!appId) return;
+  if (typeof url === 'string' && appTabTracker.parseIdFromUrl(url) !== appId) {
+    if (trackedAppId) appTabTracker.onTabRemoved(tabId);
+    else engineLiveness.drop('app', appId);
+  }
+  await retireAppDweb(appId);
+};
+const refuseAppTab = async (/** @type {string} */ appId, /** @type {number} */ tabId, /** @type {string} */ error) => {
+  await appTabTracker.disposeDwebTab(appId, tabId).catch(() => {});
+  setTimeout(() => browser.tabs.remove(tabId).catch(() => {}), 250);
+  return { ok: false, error };
+};
 /** @param {any} msg @param {any} sender */
-const attachAppTabActor = async (msg, sender) => {
+const attachAppTabActorUnlocked = async (/** @type {any} */ msg, /** @type {any} */ sender, /** @type {number|null} */ attachEpoch = null) => {
+  try {
+    if (sender?.tab?.id != null) await appRetirements.get(sender.tab.id);
+    await appTabTracker.dwebGenerationsReady();
+  }
+  catch {
+    const appId = appTabTracker.parseIdFromUrl(sender?.tab?.url);
+    if (attachEpoch != null && sender?.tab?.id != null && !appTabTracker.isAttachCurrent(sender.tab.id, attachEpoch)) {
+      return { ok: false, error: 'stale-app-attach' };
+    }
+    return appId && sender?.tab?.id != null
+      ? refuseAppTab(appId, sender.tab.id, 'App authority state is unavailable.')
+      : { ok: false, error: 'App authority state is unavailable.' };
+  }
   const claim = validateAppTabClaim({
     claimedAppId: msg?.appId,
     urlAppId: appTabTracker.parseIdFromUrl(sender?.tab?.url),
     senderTabId: sender?.tab?.id,
-    liveTabId: typeof msg?.appId === 'string' ? appTabTracker.getTabId(msg.appId) : null,
+    liveTabId: null,
   });
   if (!claim.ok) return claim;
   const { appId, tabId } = claim;
@@ -4649,19 +4666,24 @@ const attachAppTabActor = async (msg, sender) => {
   });
   if (!ownerClaim.ok) return ownerClaim;
   const ownerSessionId = ownerClaim.ownerSessionId;
+  const attachCurrent = () => attachEpoch == null || appTabTracker.isAttachCurrent(tabId, attachEpoch);
 
+  if (!attachCurrent()) return { ok: false, error: 'stale-app-attach' };
+  if (!appTabTracker.onTabPending(appId, tabId, ownerSessionId)) {
+    return refuseAppTab(appId, tabId, 'app-already-open');
+  }
   if (msg.type === 'app/actor-retry') appTabTracker.markReloading(appId);
-  appTabTracker.onTabPending(appId, tabId, ownerSessionId);
   if (typeof browser.runtime.getBrowserInfo === 'function') {
-    appTabTracker.onTabFailed(appId, new Error('Apps are not available in Firefox yet.'));
+    await failAppTab(appId, new Error('Apps are not available in Firefox yet.'), tabId);
     setTimeout(() => browser.tabs.remove(tabId).catch(() => {}), 250);
     return { ok: false, error: 'Apps are not available in Firefox yet. Use Chrome for isolated Apps.' };
   }
 
   await denylistNetGuard.sync();
   const net = denylistNetGuard.state();
+  if (!attachCurrent()) return { ok: false, error: 'stale-app-attach' };
   if (!net.supported || net.lastError) {
-    appTabTracker.onTabFailed(appId, new Error('App network isolation is unavailable.'));
+    await failAppTab(appId, new Error('App network isolation is unavailable.'), tabId);
     setTimeout(() => browser.tabs.remove(tabId).catch(() => {}), 250);
     return {
       ok: false,
@@ -4674,13 +4696,17 @@ const attachAppTabActor = async (msg, sender) => {
     if (!actorSessionId) throw new Error('manifest-defined App actor could not be attached');
     const actor = await sessions.get(actorSessionId);
     if (!actor?.parentSessionId) throw new Error('manifest-defined App actor has no owner root');
-    appTabTracker.onTabReady(appId, tabId, ownerSessionId, actor.parentSessionId);
+    if (!attachCurrent()) return { ok: false, error: 'stale-app-attach' };
+    if (!appTabTracker.onTabReady(appId, tabId, ownerSessionId, actor.parentSessionId)) {
+      return refuseAppTab(appId, tabId, 'app-already-open');
+    }
     poisonedAppRuntimeTabs.delete(tabId);
     return { ok: true, actorSessionId };
   } catch (error) {
-    // The actor is required, not optional degradation. Keep the trusted shell
-    // open so it can show Retry, but drop this failed host from runnable state.
-    appTabTracker.onTabFailed(appId, error instanceof Error ? error : new Error(String(error)));
+    // why: Keep the shell for Retry, but drop its failed runnable state.
+    if (!attachCurrent()) return { ok: false, error: 'stale-app-attach' };
+    if (appTabTracker.getTabId(appId) !== tabId) return refuseAppTab(appId, tabId, 'app-already-open');
+    await failAppTab(appId, error instanceof Error ? error : new Error(String(error)), tabId);
     denylistNetGuard.sync();
     console.warn('[app] required manifest actor attach failed', error);
     return {
@@ -4691,11 +4717,16 @@ const attachAppTabActor = async (msg, sender) => {
     };
   }
 };
+/** @param {any} msg @param {any} sender */
+const attachAppTabActor = (msg, sender) => {
+  const tabId = sender?.tab?.id;
+  if (tabId == null) return attachAppTabActorUnlocked(msg, sender);
+  return appTabTracker.coordinateAttach(tabId, (epoch) => attachAppTabActorUnlocked(msg, sender, epoch));
+};
 
 browser.runtime.onMessage.addListener((/** @type {any} */ msg, /** @type {any} */ sender) => {
   if (!isTrustedSender(sender)) return false;
-  // Each tab-ready is a new tabId entering the driven set, so each one resyncs
-  // the denylist network backstop (idempotent; a no-op when nothing moved).
+  // why: Add each ready tab to the denylist network backstop.
   if (msg?.type === 'vm/tab-ready') {
     if (typeof msg.vmId !== 'string' || sender?.tab?.id == null) return false;
     vmTabTracker.onTabReady(msg.vmId, sender.tab.id);
@@ -4734,6 +4765,7 @@ browser.runtime.onMessage.addListener((/** @type {any} */ msg, /** @type {any} *
 });
 
 browser.tabs.onRemoved.addListener((tabId) => {
+  appRetirements.delete(tabId);
   poisonedAppRuntimeTabs.delete(tabId);
   // why the vmClient hop: a VM tab closing mid-command would otherwise
   // leave its pending RPCs stalling out the 90s message timeout. The
@@ -4758,19 +4790,16 @@ browser.tabs.onRemoved.addListener((tabId) => {
     }).catch((error) => console.warn('[sw] ephemeral Pod cleanup failed', closedPodId, error))
       .finally(() => podsClosing.delete(closedPodId));
   }
-  appTabTracker.onTabRemoved(tabId);
-  // DESIGN-17 note: only the VM client owns a per-instance COMMAND QUEUE to
-  // interrupt on tab-close (above). The Notebook/App clients have no such lane —
-  // their ops are request/response with a per-call timeout — so there is nothing
-  // to "generalize" for js/app at P0 beyond the tracker mapping drop already
-  // done here. An actor bound to a tabless instance simply re-spawns the tab on
-  // its next op (the clients ensureTab internally); the binding persists.
-  // Drop any DOM-nav refs for the closed tab.
+  const closedAppId = appTabTracker.onTabRemoved(tabId);
+  if (closedAppId) void retireAppDweb(closedAppId).catch(() => {});
+  else void engineLiveness.findByTab('app', tabId).then((entry) => {
+    if (!entry) return;
+    engineLiveness.drop('app', entry.id);
+    return retireAppDweb(entry.id);
+  }).catch((error) => console.warn('[app] cold tab authority retirement failed', error));
   domRefs.clear(tabId);
   browserOriginCustody.close(tabId).catch(() => {});
   browserNetworkCustody.close(tabId).catch(() => {});
-  // ...and drop it out of the network backstop's tab scope. Tab ids remain
-  // unique within one browser session, but closed tabs no longer need rules.
   denylistNetGuard.sync();
   // A downloaded preview update may have been waiting only for this engine
   // host to close. The update module re-checks every other surface and active
@@ -4778,12 +4807,17 @@ browser.tabs.onRemoved.addListener((tabId) => {
   updateCheck.onQuiet();
 });
 
-// Invalidate a tab's DOM-nav refs when it starts navigating. The backend DOM
-// node ids belong to the old document. tabs.onUpdated covers full navigations;
-// an SPA route change that slips through still fails safe when DOM.resolveNode
-// cannot find the node and the model has to take a new snapshot.
+// why: DOM node IDs and App attach authority belong to one document.
 browser.tabs.onUpdated.addListener((tabId, changeInfo) => {
-  if (changeInfo.status === 'loading') domRefs.clear(tabId);
+  const appDocumentChanged = changeInfo.status === 'loading'
+    || changeInfo.discarded === true || typeof changeInfo.url === 'string';
+  if (appDocumentChanged) {
+    domRefs.clear(tabId);
+    appTabTracker.markAttachLoading(tabId);
+    const trackedAppId = appTabTracker.getAppIdByTab(tabId);
+    void trackAppRetirement(tabId,
+      () => retireAppDocument(tabId, changeInfo.url, trackedAppId));
+  }
   if (typeof changeInfo.url === 'string' && drivenTabIds().includes(tabId)) {
     browserOriginCustody.retain(tabId, changeInfo.url, { keepOnPersistFailure: true })
       .then((originReceipt) => {
@@ -6280,12 +6314,14 @@ const dwebAgentOn = () => DWEB_ENABLED
 // — so without this guard repeated unlocks leak refs + presence beacons. The
 // flag resets when the base host tears down (a fresh SW re-joins cleanly).
 let dwebAgentRoomJoined = false;
+const DWEB_AGENT_ROOM_OWNER = 'agent:dweb';
 const joinDwebAgentInbox = async () => {
   if (!dwebAgentOn() || dwebAgentRoomJoined) return;
   const r = /** @type {any} */ (await withDwebPublication(async (isCurrent) => {
     if (!isCurrent() || !dwebAgentOn() || dwebAgentRoomJoined) return null;
     return browser.runtime.sendMessage({
-      type: 'dweb/base-host/room', roomId: DWEB_AGENT_ROOM, op: 'join', name: 'peerd agent',
+      type: 'dweb/base-host/room', roomId: DWEB_AGENT_ROOM, roomOwnerId: DWEB_AGENT_ROOM_OWNER,
+      op: 'join', name: 'peerd agent',
     });
   }).catch(() => null));
   if (r?.ok) { dwebAgentRoomJoined = true; console.log('[sw] dweb agent inbox joined'); }
@@ -6293,7 +6329,9 @@ const joinDwebAgentInbox = async () => {
 const leaveDwebAgentInbox = async () => {
   if (!dwebAgentRoomJoined) return;
   dwebAgentRoomJoined = false;
-  await browser.runtime.sendMessage({ type: 'dweb/base-host/room', roomId: DWEB_AGENT_ROOM, op: 'leave' }).catch(() => {});
+  await browser.runtime.sendMessage({
+    type: 'dweb/base-host/room', roomId: DWEB_AGENT_ROOM, roomOwnerId: DWEB_AGENT_ROOM_OWNER, op: 'leave',
+  }).catch(() => {});
   console.log('[sw] dweb agent inbox left');
 };
 // The base host tore down (master OFF) → every room closed, incl. the inbox, so
@@ -8156,7 +8194,7 @@ browser.runtime.onMessage.addListener(/** @type {any} */ (makeDispatcher({
     ArtifactTooLargeError, EnvelopeFormatError, EnvelopeIntegrityError,
     settingsStore, DWEB_ENABLED, applyWebExtract, withDwebPublication, withAppLifecycle,
     listOffscreenContexts, scriptRuns, isOffscreenSender, awaitDenylistPolicy, assertOpfsWritable,
-    repositories, parseAppManifest, podGitRemoteOperation,
+    repositories, parseAppManifest, podGitRemoteOperation, appReleaseDescriptorMatches,
     getCurrentSessionId,
     onAppDeleted,
   }),
@@ -8238,7 +8276,7 @@ browser.runtime.onMessage.addListener(/** @type {any} */ (makeDispatcher({
     appRegistry, appClient, appTabTracker, appQuiescence, settingsStore, shareLocalApp,
     DWEB_ENABLED, APP_TAB_GROUP_TITLE,
     disableDweb, withDwebPublication, withAppLifecycle, ensureSettingsReady,
-    repositories, isOffscreenSender, createDwebRollbackGuard,
+    repositories, isOffscreenSender, createDwebRollbackGuard, appReleaseDescriptorMatches,
     getCurrentSessionId,
   }),
 

--- a/extension/background/tab-tracker.js
+++ b/extension/background/tab-tracker.js
@@ -1,65 +1,21 @@
 // @ts-check
-// tab-tracker — SW-side bookkeeping of which engine-instance id lives in
-// which browser tab. The shared core behind vm-/notebook-/pod-/app-tab-tracker.
-//
-// Each TAB-HOSTED peerd execution kind (WebVM, Notebook, Pod, App) is a discrete
-// browser tab at chrome-extension://<id>/<kind>-tab/index.html#<id> (the
-// headless script worker has no tab, so it isn't tracked here). The
-// tab announces itself on load (`<kind>/tab-ready` message) and we learn
-// its tabId from the sender. We also pre-populate the map at SW startup
-// by querying for matching URLs (the SW can restart while instance tabs
-// keep running). chrome.tabs.onRemoved drops stale entries.
-//
-// The kinds share the same bookkeeping; the only real
-// differences are the tab path, the ready timeout, the injectable tabs
-// API (the in-browser vm test stubs it), and the error thrown when a tab
-// closes before it's ready. Those are the config below. Each kind's
-// module is now a thin wrapper that picks a name + the subset of methods
-// it exposes (e.g. app adds reloadTab and omits isReady).
-//
-// What this module is NOT responsible for:
-//   - Spawning the instance (that happens here too, as a convenience,
-//     but the caller decides when).
-//   - Tracking which session is attached to which instance (registry).
-//   - Persisting anything (the persisted catalog lives in the registry).
+// Track each tab-hosted engine instance across service-worker restarts.
 
 import browser from '/vendor/browser-polyfill.js';
 
-/**
- * @typedef {Object} TabTrackerConfig
+/** @typedef {Object} TabTrackerConfig
  * @property {string} tabPath
- *   Extension-relative path to the instance tab page (e.g. VM_TAB_PATH).
  * @property {number} readyTimeoutMs
- *   How long ensureTab waits for the tab's `ready` broadcast before
- *   rejecting. VMs stream a disk image (slow); Notebooks/apps boot fast.
- * @property {(id: string) => Error} closedError
- *   Builds the rejection for a tab that closes before ready. vm injects
- *   VMTabClosedError (carries `.vmId`); notebook/app use a plain Error.
- * @property {(id: string) => string} notReadyMessage
- *   Message for the ensureTab readiness-timeout Error.
+ * @property {(id:string)=>Error} closedError
+ * @property {(id:string)=>string} notReadyMessage
  * @property {import('webextension-polyfill').TabGroups.Color} [groupColor]
- *   tabGroups color for the collapsible peerd group. Defaults to orange.
  * @property {typeof browser.tabs} [tabs]
- *   Injected tabs API (query/get/create/update/remove). Defaults to the
- *   real browser.tabs; the in-browser tests inject a stub so tracker
- *   behavior is exercised without spawning real tabs.
- * @property {((tabId: number, kindLabel: string, id?: string) => void) | null} [announce]
- *   Drops a "go there" card in the chat for an agent-opened background tab.
- *   Injected by the SW (announceAgentTab); null when no announcer is wired.
+ * @property {((tabId:number,kindLabel:string,id?:string)=>void)|null} [announce]
  * @property {string} [kindLabel]
- *   Human noun for the announce card ('a Linux VM', 'a Notebook', 'an App').
  * @property {boolean} [announceOnReady]
- *   Delay the card until mandatory host initialization succeeds.
- * @property {((id: string, tabId: number) => void) | null} [onAdopt]
- *   Lifecycle liveness hook: fired on every id↔tab association (spawn,
- *   tab-ready, bootstrap re-adoption). Best-effort — see the §9 ledger.
- * @property {((id: string) => void) | null} [onDrop]
- *   Lifecycle liveness hook: fired on a clean tab removal.
- */
-
-/**
- * @param {TabTrackerConfig} config
- */
+ * @property {((id:string,tabId:number)=>void)|null} [onAdopt]
+ * @property {((id:string)=>void)|null} [onDrop] */
+/** @param {TabTrackerConfig} config */
 export const createTabTracker = ({
   tabPath,
   readyTimeoutMs,
@@ -67,17 +23,11 @@ export const createTabTracker = ({
   notReadyMessage,
   groupColor = 'orange',
   tabs = browser.tabs,
-  // why: agent-opened tabs open in the BACKGROUND (active:false) and never steal
-  // focus; `announce(tabId, kindLabel)` drops a "go there" card in the chat
-  // instead (DESIGN-12). Injected by the SW (announceAgentTab). kindLabel is the
-  // human noun for the card ('a Linux VM', 'a Notebook', 'an App').
+  // why: Announce agent-opened background tabs without taking focus.
   announce = null,
   kindLabel = 'a tab',
   announceOnReady = false,
-  // Lifecycle liveness hooks (§9): fired on every id↔tab association and
-  // clean drop, so the durable ledger knows which instances were HOSTED if
-  // an eviction hits. Optional + best-effort — tracker bookkeeping never
-  // depends on them.
+  // why: Best-effort hooks keep the durable liveness ledger current.
   onAdopt = /** @type {((id: string, tabId: number) => void) | null} */ (null),
   onDrop = /** @type {((id: string) => void) | null} */ (null),
 }) => {
@@ -87,6 +37,8 @@ export const createTabTracker = ({
   const byId = new Map();
   /** @type {Map<number, string>} */
   const tabIdToId = new Map();
+  /** @type {Map<string,Promise<number>>} */
+  const ensureById = new Map();
 
   /** @param {string | undefined} url @returns {string | null} */
   const parseIdFromUrl = (url) => {
@@ -102,8 +54,7 @@ export const createTabTracker = ({
   const recordEntry = (id, tabId, ready = false) => {
     let entry = byId.get(id);
     if (!entry) {
-      // why the executor runs synchronously, so both are assigned before the
-      // constructor returns; the casts express that to tsc (it can't prove it).
+      // why: The Promise executor assigns both callbacks synchronously.
       /** @type {(tabId: number) => void} */
       let resolveReady = () => {};
       /** @type {(err: Error) => void} */
@@ -113,15 +64,12 @@ export const createTabTracker = ({
         resolveReady = resolve;
         rejectReady = reject;
       });
-      // why the no-op catch: if the tab closes while NOBODY is awaiting
-      // readiness (no ensureTab in flight), the rejectReady below would
-      // otherwise surface as an unhandled rejection in the SW console.
-      // Attaching one handler marks it handled; ensureTab's racers still
-      // observe the rejection normally.
+      // why: Handle a rejection when no caller waits for readiness.
       readyPromise.catch(() => {});
       entry = { tabId, ready, readyPromise, resolveReady, rejectReady };
       byId.set(id, entry);
     } else {
+      tabIdToId.delete(entry.tabId);
       entry.tabId = tabId;
     }
     tabIdToId.set(tabId, id);
@@ -137,15 +85,7 @@ export const createTabTracker = ({
     entry.resolveReady?.(entry.tabId);
   };
 
-  /**
-   * Reset an id's entry to "reloading": not-ready, with a FRESH readyPromise the
-   * reloaded tab resolves when it re-announces <kind>/tab-ready. why: a wedged
-   * tab is recovered with tabs.reload — same tabId, but the old readyPromise is
-   * already settled, so without this an ensureTab after the reload would early-
-   * return on the stale `ready` flag and race the re-boot. The tab is NOT removed,
-   * so no onTabRemoved / command-queue interrupt fires. No-op if the entry is gone.
-   * @param {string} id
-   */
+  /** why: A reload needs a new readiness promise for the same tab. @param {string} id */
   const markReloading = (id) => {
     const entry = byId.get(id);
     if (!entry) return;
@@ -162,11 +102,7 @@ export const createTabTracker = ({
     entry.rejectReady = rejectReady;
   };
 
-  /**
-   * Walk existing tabs at SW boot. Any instance tab still alive in the
-   * browser gets re-registered. They've already booted, so they're
-   * considered ready immediately.
-   */
+  /** Adopt existing instance tabs after a service-worker restart. */
   const bootstrap = async () => {
     try {
       const liveTabs = await tabs.query({ url: `${tabUrlPrefix}*` });
@@ -182,11 +118,7 @@ export const createTabTracker = ({
     }
   };
 
-  /**
-   * Called from the SW's runtime.onMessage when a tab broadcasts
-   * <kind>/tab-ready. Marks the tracker entry ready and pins the tabId.
-   * @param {string} id @param {number} tabId
-   */
+  /** @param {string} id @param {number} tabId */
   const onTabReady = (id, tabId) => {
     recordEntry(id, tabId, true);
     markReady(id);
@@ -195,14 +127,11 @@ export const createTabTracker = ({
     }
   };
 
-  // Record a host tab before it is runnable. Apps use this while installing
-  // their mandatory tab-scoped network rule; only onTabReady resolves callers.
+  // why: Apps must install tab-scoped network rules before they become ready.
   /** @param {string} id @param {number} tabId */
   const onTabPending = (id, tabId) => { recordEntry(id, tabId, false); };
 
-  /** Reject readiness immediately when a host cannot establish its mandatory
-   * runtime floor. why: callers need the real failure, not a later timeout.
-   * @param {string} id @param {Error} error */
+  /** why: Return the host failure instead of a later timeout. @param {string} id @param {Error} error */
   const onTabFailed = (id, error) => {
     const entry = byId.get(id);
     if (!entry) return null;
@@ -213,16 +142,7 @@ export const createTabTracker = ({
     return entry.tabId;
   };
 
-  /**
-   * Called from chrome.tabs.onRemoved. Drops the entry and rejects any
-   * pending ready waiters with the configured closedError. Returns the
-   * id that lived in the closed tab (or null) so the SW wiring can
-   * interrupt that instance's pending RPCs in its client — the tracker
-   * only knows tabId↔id; the client owns the command queue.
-   *
-   * @param {number} tabId
-   * @returns {string | null}
-   */
+  /** @param {number} tabId @returns {string|null} */
   const onTabRemoved = (tabId) => {
     const id = tabIdToId.get(tabId);
     if (!id) return null;
@@ -236,40 +156,22 @@ export const createTabTracker = ({
     return id;
   };
 
-  /**
-   * Return the tabId for id without creating it. Used for "is the
-   * instance live?" checks (e.g. for the side panel chip).
-   * @param {string} id
-   */
+  /** @param {string} id */
   const getTabId = (id) => byId.get(id)?.tabId ?? null;
 
   /** @param {string} id */
   const isReady = (id) => !!byId.get(id)?.ready;
 
-  /**
-   * Ensure a tab exists for id. If one is already live, return its id
-   * immediately. Otherwise spawn a tab and wait for its <kind>/tab-ready
-   * broadcast.
-   *
-   * `active` applies ONLY to the create path: a newly spawned tab can
-   * take focus so the user sees it appear (DECISIONS #20, 2026-06-14),
-   * while a call that finds the tab already live returns early and never
-   * re-focuses it — so acting on an existing instance leaves the user put.
-   *
-   * @param {string} id
-   * @param {{ active?: boolean, groupTitle?: string, hashSuffix?: string }} [opts]
-   * @returns {Promise<number>} tabId
-   */
-  const ensureTab = async (id, opts = {}) => {
+  /** why: Only a newly created active tab can take focus.
+   * @param {string} id @param {{active?:boolean,groupTitle?:string,hashSuffix?:string}} [opts] @returns {Promise<number>} */
+  const ensureTabUnlocked = async (id, opts = {}) => {
     const existing = byId.get(id);
     if (existing) {
       // If the tab is still alive, we're done; otherwise spawn.
       try {
         const tab = await tabs.get(existing.tabId);
         if (tab) {
-          // Interacting with an EXISTING agent tab (e.g. vm_boot on a live VM)
-          // — update the "current agent tab" card so it tracks where the loop is
-          // working, not just where it last created a tab. Background only.
+          // why: Keep the current agent-tab card on the live background tab.
           if (opts.active !== true && announce) {
             try { announce(existing.tabId, kindLabel, id); } catch { /* best-effort */ }
           }
@@ -280,15 +182,12 @@ export const createTabTracker = ({
           ]);
         }
       } catch {
-        // Tab no longer exists; fall through to create a new one.
         tabIdToId.delete(existing.tabId);
         byId.delete(id);
       }
     }
 
-    // Launch context belongs in the fragment so it never leaves the extension
-    // origin. Refuse a second fragment or an unbounded value; callers supply an
-    // encoded query beginning with `?` (for example the App actor owner).
+    // why: Keep bounded launch context inside the extension origin fragment.
     const hashSuffix = typeof opts.hashSuffix === 'string'
       && opts.hashSuffix.startsWith('?')
       && !opts.hashSuffix.includes('#')
@@ -305,14 +204,11 @@ export const createTabTracker = ({
     const entry = recordEntry(id, tab.id, false);
     entry.announceWhenReady = opts.active !== true;
 
-    // Agent-opened (background) tab → announce a "go there" card. Fired on CREATE
-    // (not after ready) so even a slow-booting background tab surfaces a card the
-    // moment it exists. A user-focused open (active:true) doesn't announce.
+    // why: Surface a slow background tab as soon as it exists.
     if (opts.active !== true && announce && !announceOnReady) {
       try { announce(tab.id, kindLabel, id); } catch { /* best-effort card */ }
     }
 
-    // Best-effort: park in a tab group so the user can collapse them.
     if (opts.groupTitle) {
       addToGroup(tab.id, opts.groupTitle, groupColor).catch((e) => {
         console.debug(`[tab-tracker ${tabPath}] addToGroup failed`, e);
@@ -324,11 +220,17 @@ export const createTabTracker = ({
       timeout(readyTimeoutMs, notReadyMessage(id)),
     ]);
   };
+  const ensureTab = (/** @type {string} */ id, /** @type {{active?:boolean,groupTitle?:string,hashSuffix?:string}} */ opts = {}) => {
+    const active = ensureById.get(id);
+    if (active) return active;
+    const pending = ensureTabUnlocked(id, opts).finally(() => {
+      if (ensureById.get(id) === pending) ensureById.delete(id);
+    });
+    ensureById.set(id, pending);
+    return pending;
+  };
 
-  /**
-   * Close an id's tab (if alive). Returns true if a close was issued.
-   * @param {string} id
-   */
+  /** @param {string} id */
   const closeTab = async (id) => {
     const tabId = getTabId(id);
     if (tabId == null) return false;
@@ -340,8 +242,7 @@ export const createTabTracker = ({
     }
   };
 
-  /** Re-trigger a reload (used after app body updates so the iframe re-renders).
-   * @param {string} id */
+  /** @param {string} id */
   const reloadTab = async (id) => {
     const tabId = getTabId(id);
     if (tabId == null) return false;

--- a/extension/engine-tabs/app-tab/app-tab.js
+++ b/extension/engine-tabs/app-tab/app-tab.js
@@ -1,13 +1,6 @@
 // @ts-check
-// app-tab/app-tab.js — trusted parent shell logic.
-//
-// Two modes:
-//   - render (default): read OPFS files, compose into a single HTML
-//                       body, postMessage to the sandboxed runner.
-//   - edit: mount the shared peerd-engine/editor module into a panel
-//           that overlays the iframe. Same UX as the Notebook.
-// The toggle is a small floating button (top-right) that swaps modes
-// without leaving the tab.
+// Host a rendered App or its editor in one trusted parent tab.
+// why: App code stays in the opaque runner while the parent owns storage and controls.
 
 import browser from '/vendor/browser-polyfill.js';
 import {
@@ -22,6 +15,7 @@ import { loadDweb } from '/shared/dweb-loader.js';
 import { mountPullInPeerd } from '/shared/pull-in-peerd.js';
 import { isServiceWorkerSender } from '/shared/messaging.js';
 import { createAppDataClient } from './app-data-client.js';
+import { createDwebBridgeLifecycle } from './dweb-bridge-lifecycle.js';
 
 const appId = location.hash.slice(1).split(/[?&]/)[0];
 const hashParams = new URLSearchParams(location.hash.slice(1).split('?')[1] ?? '');
@@ -207,6 +201,13 @@ browser.runtime.onMessage.addListener(/** @type {any} */ ((
   if (!isServiceWorkerSender(sender)
       || message?.type !== 'app/quiesce'
       || message.appId !== appId) return false;
+  if (message.action === 'invalidate-dweb') {
+    dwebBridgeLifecycle.invalidate().then(
+      () => sendResponse({ ok: true }),
+      (/** @type {{message?:string}} */ error) => sendResponse({ ok: false, error: error?.message ?? String(error) }),
+    );
+    return true;
+  }
   if (message.action === 'release') {
     document.body.inert = false;
     sendResponse({ ok: true });
@@ -265,6 +266,7 @@ const copyFileKinds = (value) => Object.assign(
   Object.create(null),
   value && typeof value === 'object' ? value : {},
 );
+const APP_DATA_PATH_RE = /^data\/[a-z0-9][a-z0-9._-]{0,63}\.json$/i;
 
 // ---------------------------------------------------------------------------
 // Render mode — compose multi-file from OPFS, post to the runner iframe
@@ -280,6 +282,12 @@ const readForRender = async () => {
   for (const e of entries) {
     const path = e.path.replace(/^\/+/, '');
     const bytes = await opfs.readBytes(path);
+    if (APP_DATA_PATH_RE.test(path)) {
+      const text = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+      JSON.parse(text);
+      textFiles[path] = text;
+      continue;
+    }
     if (isBinaryAppFile(path, bytes, appMeta?.fileKinds?.[path])) {
       binaryFilePaths.add(path);
       binaryAssets[path] = bytes.buffer;
@@ -451,7 +459,7 @@ const startRunner = () => {
 };
 
 /** Stop the current App document before the editor becomes interactive. */
-const suspendRunnerForEdit = () => {
+const suspendRunnerForEdit = async () => {
   rejectAgentCalls('app_runtime_suspended_for_editing');
   if (runnerWatchdog) { clearTimeout(runnerWatchdog); runnerWatchdog = null; }
   runnerPort?.close();
@@ -462,7 +470,7 @@ const suspendRunnerForEdit = () => {
   runnerStarted = false;
   expectingRunnerLoad = false;
   expectingBodyLoad = false;
-  if (dwebBridge) { dwebBridge.dispose(); dwebBridge = null; }
+  await dwebBridgeLifecycle.dispose();
   // Replacing the document is the only way to stop a late async handler from
   // the prior generation; hiding the iframe would leave it running.
   frame.src = 'about:blank';
@@ -527,6 +535,7 @@ const renderMode = async () => {
     agent: meta.agent ?? { kind: 'bound-app' },
   };
   actorChatName.textContent = appMeta.agent?.name || `${appMeta.name || 'App'} actor`;
+  dwebBridgeLifecycle.allow();
   attachDwebBridge(); // no-op unless this app is a dwapp on a dweb build
 
   let textFiles, binaryAssets;
@@ -685,10 +694,11 @@ frame.addEventListener('load', () => {
   }
   if (expectingBodyLoad) { expectingBodyLoad = false; return; }  // the runner's document.write delivery — not a navigation
   runnerPhase = 'idle';
-  if (dwebBridge) { dwebBridge.dispose(); dwebBridge = null; }
   console.warn('[app-tab] app frame navigated unexpectedly; restarting the trusted runner');
-  startRunner();
-  renderMode().catch((e) => fail(/** @type {{ message?: string }} */ (e)?.message ?? String(e)));
+  dwebBridgeLifecycle.dispose().then(() => {
+    startRunner();
+    return renderMode();
+  }).catch((/** @type {{message?:string}} */ error) => fail(error?.message ?? String(error)));
 });
 
 // ---------------------------------------------------------------------------
@@ -698,10 +708,7 @@ frame.addEventListener('load', () => {
 // confirm bar (consent UI) + OPFS/SW accessors it needs injected.
 // ---------------------------------------------------------------------------
 
-// why any: the dweb bridge is created by the live (preview-only) dweb module,
-// whose shape exceeds the stub interface — typed any at this hosting boundary.
-/** @type {any} */
-let dwebBridge = null;
+const dwebBridgeLifecycle = createDwebBridgeLifecycle();
 
 // A minimal monochrome consent bar follows the project color rule.
 let confirmationTail = Promise.resolve();
@@ -753,34 +760,32 @@ const confirmAction = (args) => {
   return result;
 };
 
-const attachDwebBridge = async () => {
-  if (dwebBridge || !appMeta?.dweb) return;
-  try {
-    const client = /** @type {any} */ (await loadDweb());
-    if (!client.available || !client.createAppBridge) return;
-    dwebBridge = client.createAppBridge({
-      appId,
-      appName: appMeta.name,
-      appDweb: appMeta.dweb,
-      entryFile: appMeta.entryFile,
-      frame,
-      client,
-      swCall: (/** @type {string} */ type, /** @type {object} */ payload = {}) => browser.runtime.sendMessage({ type, ...payload }),
-      storage: browser.storage.local,
-      confirmAction,
-      // The offscreen base host pushes room events (feed/dm/presence) as
-      // `dweb/base-room/event` runtime messages — every extension context gets
-      // them, so the bridge listens here and filters to the room it joined.
-      onHostEvent: (/** @type {(msg: any) => void} */ handler) => {
-        const fn = (/** @type {any} */ msg) => { if (msg?.type === 'dweb/base-room/event') handler(msg); };
-        browser.runtime.onMessage.addListener(fn);
-        return () => browser.runtime.onMessage.removeListener(fn);
-      },
-      launch: launchParams,
-    });
-  } catch (e) {
-    console.warn('[app-tab] dweb bridge unavailable:', e);
-  }
+const attachDwebBridge = () => {
+  const meta = appMeta;
+  if (!meta?.dweb) return;
+  const dweb = meta.dweb;
+  void dwebBridgeLifecycle.attach(async () => {
+    try {
+      const client = /** @type {any} */ (await loadDweb());
+      if (appMeta?.dweb !== dweb || !client.available || !client.createAppBridge) return null;
+      return client.createAppBridge({
+        appId, appName: meta.name, appDweb: dweb, entryFile: meta.entryFile,
+        frame, client,
+        swCall: (/** @type {string} */ type, /** @type {object} */ payload = {}) => browser.runtime.sendMessage({ type, ...payload }),
+        storage: browser.storage.local,
+        confirmAction,
+        onHostEvent: (/** @type {(msg: any) => void} */ handler) => {
+          const fn = (/** @type {any} */ msg) => { if (msg?.type === 'dweb/base-room/event') handler(msg); };
+          browser.runtime.onMessage.addListener(fn);
+          return () => browser.runtime.onMessage.removeListener(fn);
+        },
+        launch: launchParams,
+      });
+    } catch (e) {
+      console.warn('[app-tab] dweb bridge unavailable:', e);
+      return null;
+    }
+  });
 };
 
 // ---------------------------------------------------------------------------
@@ -789,7 +794,7 @@ const attachDwebBridge = async () => {
 
 const editMode = async () => {
   mode = 'edit';
-  suspendRunnerForEdit();
+  await suspendRunnerForEdit();
   document.body.classList.remove('mode-render');
   document.body.classList.add('mode-edit');
   toggleBtn.textContent = 'View ▶';
@@ -806,7 +811,6 @@ const editMode = async () => {
       agent: meta.agent ?? { kind: 'bound-app' },
     };
     actorChatName.textContent = appMeta.agent?.name || `${appMeta.name || 'App'} actor`;
-    attachDwebBridge();
   }
 
   if (!editorApi) {
@@ -902,7 +906,7 @@ window.addEventListener('pagehide', () => {
   flushEditorBeforeSuspension();
   rejectAgentCalls('app_runtime_closed');
   runnerPort?.close();
-  dwebBridge?.dispose();
+  void dwebBridgeLifecycle.invalidate().catch(() => {});
 });
 
 // ---------------------------------------------------------------------------

--- a/extension/engine-tabs/app-tab/dweb-bridge-lifecycle.js
+++ b/extension/engine-tabs/app-tab/dweb-bridge-lifecycle.js
@@ -1,0 +1,32 @@
+// @ts-check
+/** @typedef {{ dispose: () => void | Promise<void>, invalidate?: () => void | Promise<void> }} DisposableBridge */
+export const createDwebBridgeLifecycle = () => {
+  /** @type {DisposableBridge | null} */ let active = null;
+  /** @type {Record<'attach'|'dispose'|'invalidate',Promise<void>|null>} */ const pending = { attach: null, dispose: null, invalidate: null };
+  let blocked = true, invalidated = false;
+  const settle = async (/** @type {boolean} */ invalidate) => {
+    await pending.attach; const bridge = active;
+    if (invalidate && bridge?.invalidate) await bridge.invalidate(); else await bridge?.dispose();
+    if (active === bridge) active = null;
+  };
+  const dispose = () => {
+    blocked = true; if (pending.invalidate) return pending.invalidate;
+    return pending.dispose ??= settle(false).finally(() => { pending.dispose = null; });
+  };
+  return {
+    allow() { if (!invalidated) blocked = false; },
+    /** @param {() => Promise<DisposableBridge | null>} create */
+    attach(create) {
+      if (blocked || active) return Promise.resolve();
+      return pending.attach ??= (async () => { await pending.dispose;
+        if (blocked || active) return;
+        const candidate = await create();
+        if (candidate && active) await candidate.dispose(); else if (candidate) active = candidate;
+      })().finally(() => { pending.attach = null; });
+    },
+    dispose,
+    invalidate() {
+      invalidated = blocked = true; return pending.invalidate ??= settle(true).finally(() => { pending.invalidate = null; });
+    },
+  };
+};

--- a/extension/home/library-section.js
+++ b/extension/home/library-section.js
@@ -253,7 +253,17 @@ export const LibrarySection = {
   refreshUpdates(vnode) {
     if (!vnode.attrs.dweb) return;
     vnode.attrs.send({ type: 'dweb/base/updates' }).then((/** @type {any} */ r) => {
-      if (r?.ok) { vnode.state.updates = r.updates ?? {}; m.redraw(); }
+      if (r?.ok) {
+        const updates = r.updates ?? {};
+        const id = vnode.state.updateConflictId;
+        const current = vnode.state.updates[id];
+        const fresh = updates[id];
+        if (current && fresh && current.version_id === fresh.version_id && Number.isSafeInteger(current.conflictToken)) {
+          fresh.conflictToken = current.conflictToken;
+        }
+        vnode.state.updates = updates;
+        m.redraw();
+      }
     }).catch(() => { /* best-effort — no badge on failure */ });
   },
 
@@ -647,7 +657,7 @@ export const LibrarySection = {
     vnode.state.busyId = app.id;
     let succeeded = false;
     try {
-      const r = await vnode.attrs.send({ type: 'dweb/base/update-app', appId: app.id, uri: up.uri, name: up.name, dwappId: up.dwapp_id, slug: up.slug, seq: up.seq, publisher: up.publisher, ...(strategy ? { strategy } : {}) });
+      const r = await vnode.attrs.send({ type: 'dweb/base/update-app', appId: app.id, uri: up.uri, name: up.name, dwappId: up.dwapp_id, slug: up.slug, seq: up.seq, publisher: up.publisher, ...(strategy ? { strategy, conflictToken: up.conflictToken } : {}) });
       if (r?.ok) {
         succeeded = true;
         delete vnode.state.updates[app.id];      // cleared: we're now on the new version
@@ -669,7 +679,8 @@ export const LibrarySection = {
           notices.push('Older shared bytes will be cleaned up on the next update or delete.');
         }
         vnode.state.warning = notices.join(' ') || null;
-      } else if (r?.error === 'local-changes') {
+      } else if (r?.error === 'local-changes' && Number.isSafeInteger(r.conflictToken)) {
+        up.conflictToken = r.conflictToken;
         vnode.state.updateConflictId = app.id;
       } else {
         vnode.state.error = r?.error ?? 'update failed';

--- a/extension/offscreen/app-room-authority.js
+++ b/extension/offscreen/app-room-authority.js
@@ -1,0 +1,27 @@
+// @ts-check
+import { APP_DWEB_GENERATION_PREFIX } from '/shared/dweb-interface.js';
+export class AppRoomAuthorityChangedError extends Error { constructor() { super('App room authority changed'); this.name = 'AppRoomAuthorityChangedError'; } }
+/** @param {{get:(key:null)=>Promise<Record<string,unknown>>}} storage */
+export const createAppRoomAuthority = (storage) => {
+  const floors = new Map(), tails = new Map();
+  const ready = storage.get(null).then((values) => {
+    for (const [key, value] of Object.entries(values)) if (key.startsWith(APP_DWEB_GENERATION_PREFIX)
+      && Number.isSafeInteger(value) && Number(value) >= 0) floors.set(key.slice(APP_DWEB_GENERATION_PREFIX.length), Number(value));
+  }); ready.catch(() => {});
+  const isCurrent = (/** @type {string} */ appId, /** @type {number} */ generation) => Number.isSafeInteger(generation) && generation >= 0 && generation >= (floors.get(appId) ?? 0);
+  /** @template T @param {string} appId @param {()=>Promise<T>|T} operation */
+  const queue = (appId, operation) => {
+    const current = (tails.get(appId) ?? Promise.resolve()).catch(() => {}).then(operation); tails.set(appId, current);
+    return current.finally(() => { if (tails.get(appId) === current) tails.delete(appId); });
+  };
+  /** @template T @param {string} appId @param {number} generation @param {(current:()=>boolean,advanced:boolean)=>Promise<T>|T} operation */
+  const run = (appId, generation, operation) => ready.then(() => queue(appId, () => {
+    const floor = floors.get(appId) ?? 0; if (!isCurrent(appId, generation)) throw new AppRoomAuthorityChangedError();
+    floors.set(appId, generation); return operation(() => isCurrent(appId, generation), generation > floor);
+  }));
+  /** @template T @param {string} appId @param {number} generation @param {()=>Promise<T>|T} operation */
+  const rotate = (appId, generation, operation) => ready.then(() => {
+    if (!isCurrent(appId, generation)) throw new AppRoomAuthorityChangedError(); floors.set(appId, generation); return queue(appId, operation);
+  });
+  return { run, rotate };
+};

--- a/extension/offscreen/dweb-base.js
+++ b/extension/offscreen/dweb-base.js
@@ -1,21 +1,7 @@
 // @ts-check
-// offscreen/dweb-base.js — the always-on base network, hosted offscreen (S1b).
-//
-// The lobby connection (mesh, gossip, DHT, presence) lives HERE, in the
-// offscreen document, not in a tab — so the network outlives any single tab,
-// which is the whole point of S1 (GLOBAL-NETWORK.md). The SW forwards
-// `dweb/base-host/*` messages here (after ensureOffscreen); we answer.
-//
-// VERBOSE by design: every step logs with an [offscreen/dweb] tag so a
-// real-network bug is visible in the offscreen DevTools immediately. This path
-// can't run under bun (WebRTC + the offscreen lifecycle), so logging IS the
-// verification surface — per the owner's "be verbose with errors".
-//
-// Store-build safety: gated on DWEB_ENABLED (false there) and reaches the dweb
-// module only via loadDweb() (the stub there) — this file names no dweb module
-// path, so the boundary check + store artifact verifier stay clean (the verifier
-// greps the SHIPPED bytes for that path; even a mention in a comment trips it).
-// Inert on store.
+// Host the preview base network outside tabs.
+// why: The network must survive tab closure. The store build stays inert.
+// Keep detailed logs because WebRTC and offscreen lifecycles require live diagnosis.
 
 import browser from '/vendor/browser-polyfill.js';
 import { DWEB_ENABLED } from '/shared/channel-config.js';
@@ -25,6 +11,7 @@ import { makeStartStopBarrier } from '/offscreen/start-stop-barrier.js';
 import { createContentOwnership } from '/offscreen/content-ownership.js';
 import { rollbackSharePublication } from '/offscreen/share-publication.js';
 import { createShareRollbackStore } from '/offscreen/share-rollback-store.js';
+import { AppRoomAuthorityChangedError, createAppRoomAuthority } from '/offscreen/app-room-authority.js';
 import {
   discoveredAppFromRow,
   discoveredIdentityError,
@@ -39,11 +26,7 @@ const log = (...a) => console.log('[offscreen/dweb]', ...a);
 /** @param {...any} a */
 const warn = (...a) => console.warn('[offscreen/dweb]', ...a);
 
-// why any: the LIVE (preview-channel) dweb module exposes a much richer surface
-// than the stub DwebClient interface in shared/dweb-interface.js (joinBaseNetwork,
-// BASE_TOPIC, base.snapshot/mesh/discovery, …). Core code never sees these — only
-// this offscreen host does — so the handle/client are typed any at this boundary
-// rather than widening the shared stub (the dweb boundary stays intact).
+// why: Keep the larger live surface local instead of widening the shared stub.
 /** @type {any} */
 let handle = null;    // { base, room, close } once the lobby is joined
 const contentOwnership = createContentOwnership();
@@ -91,10 +74,10 @@ const servedHashesForApp = (appId) => [...new Set(
 )];
 
 /** @param {any} h @param {{ appId: string, name: string, entry: string,
- *   created?: number, expectedHash?: string, release?: any, releaseSnapshot?: any }} msg @param {string} ownerSlot */
+ *   created?: number, expectedHash?: string, release?: any, releaseSnapshot?: any, roomSnapshot?: any }} msg @param {string} ownerSlot */
 const publishLocalApp = async (h, msg, ownerSlot) => {
-  const supplied = msg.releaseSnapshot;
-  if (supplied && (
+  const supplied = msg.releaseSnapshot ?? msg.roomSnapshot;
+  if (msg.releaseSnapshot && (
     !msg.release
     || supplied.oid !== msg.release.gitCommitOid
     || !/^[a-f0-9]{40}$/.test(supplied.oid)
@@ -132,17 +115,20 @@ const publishLocalApp = async (h, msg, ownerSlot) => {
   const ownershipAdded = trackServedHash(appContentOwner(msg.appId, ownerSlot), published.hash);
   return { ...published, size: published.packedBytes, storedBytes: snapshot.totalBytes, ownershipAdded };
 };
-// dwapp ROOMS hosted here — each is base.openRoom(id) ONCE, ref-counted across
-// the app-tabs that join it. The room's connectivity IS the base mesh (no second
-// rendezvous): a dwapp is a sub-protocol, not tied to a signaler.
-/** @type {Map<string, { room: any, refs: number, name: string, topicSubs: Map<string, () => void>, offs: (() => void)[] }>} */
-const rooms = new Map();        // roomId -> { room, refs, name, topicSubs:Map, offs:[] }
+// One base room can serve several exact App-generation owners.
+/** @type {Map<string, { room: any, owners: Set<string>, name: string, topicSubs: Map<string, () => void>, offs: (() => void)[] }>} */
+const rooms = new Map();
+/** @type {Map<string,string>} */
+const roomByOwner = new Map();
 /** @param {string} type @param {object} [payload] @returns {Promise<any>} */
 const swCall = (type, payload = {}) => browser.runtime.sendMessage({ type, ...payload });
+const appRoomAuthority = createAppRoomAuthority({ get: async () => {
+  const response = await swCall('dweb/app-authority-generations');
+  if (!response?.ok) throw new Error(response?.error ?? 'App room authority unavailable');
+  return response.generations ?? {};
+} });
 
-// The permanent identity seed and backup passphrase never ride swCall. This
-// dedicated channel is accepted only after the service worker verifies the
-// browser-owned offscreen sender metadata.
+// why: Permanent identity secrets use a worker-verified custody channel.
 const CUSTODY_PORT_NAME = 'dweb-custody';
 const CUSTODY_RECONNECT_MS = 500;
 const CUSTODY_TIMEOUT_MS = 60_000;
@@ -343,6 +329,7 @@ const baseLifecycle = makeStartStopBarrier({
       for (const off of entry.topicSubs.values()) { try { off(); } catch { /* already closed */ } }
     }
     rooms.clear();
+    roomByOwner.clear();
     contentOwnership.clear();
     shareRollbacks.clear();
     if (resubTimer) { clearInterval(resubTimer); resubTimer = null; }
@@ -461,67 +448,80 @@ const info = () => {
   return { running: true, did: handle.base.did, rendezvous: handle.room?.rendezvous?.() ?? 'none', bootstrapUrl: handle.url ?? null, ...snap };
 };
 
-// --- dwapp room hosting (sub-protocols on the shared base mesh) ---------------
-// Events (feed message / direct / presence / status) are PUSHED to the dwapp's
-// app-tab as a `dweb/base-room/event` runtime message it filters by roomId. Every
-// extension context receives a runtime.sendMessage, so the app-tab gets it
-// directly — no SW forwarding bus. (The SW + offscreen ignore it: wrong prefix.)
+// Push room events directly to the App tab. It filters them by roomId.
 /** @param {string} roomId @param {string} event @param {any} data */
 const pushRoomEvent = (roomId, event, data) =>
   browser.runtime.sendMessage({ type: 'dweb/base-room/event', roomId, event, data }).catch(() => {});
 
-/** @param {string} roomId @param {string} [name] */
-const ensureRoom = async (roomId, name) => {
+/** @param {string} roomId @param {string} ownerId @param {string} [name] @param {()=>boolean} [current] */
+const ensureRoom = async (roomId, ownerId, name, current = () => true) => {
   const h = await start();
+  if (!current()) throw new AppRoomAuthorityChangedError();
+  const priorRoomId = roomByOwner.get(ownerId);
+  if (priorRoomId && priorRoomId !== roomId) {
+    const prior = rooms.get(priorRoomId);
+    if (prior) closeRoom(prior, priorRoomId, ownerId);
+    else roomByOwner.delete(ownerId);
+  }
   let entry = rooms.get(roomId);
   if (!entry) {
-    /** @type {{ room: any, refs: number, name: string, topicSubs: Map<string, () => void>, offs: (() => void)[] }} */
-    const e = { room: null, refs: 0, name: name ?? '', topicSubs: new Map(), offs: [] };
+    /** @type {{ room: any, owners: Set<string>, name: string, topicSubs: Map<string, () => void>, offs: (() => void)[] }} */
+    const e = { room: null, owners: new Set(), name: name ?? '', topicSubs: new Map(), offs: [] };
     entry = e;
     const room = h.base.openRoom(roomId, { meta: () => ({ name: e.name }) }); // meta reads the latest name
     entry.room = room;
     rooms.set(roomId, entry);
-    // presence-join/leave carry did + names and are the room's only liveness;
-    // direct delivers 1:1 messages. (No separate peer/status pushes — they all
-    // derived from this same presence event.)
+    // why: Presence events are the room liveness source.
     entry.offs.push(room.presence.onJoin((/** @type {any} */ j) => pushRoomEvent(roomId, 'presence-join', j)));
     entry.offs.push(room.presence.onLeave((/** @type {any} */ l) => pushRoomEvent(roomId, 'presence-leave', l)));
     entry.offs.push(room.direct.onMessage((/** @type {any} */ { from, data, ts, id }) => pushRoomEvent(roomId, 'direct', { from, data, ts, id })));
     log(`room "${roomId}" opened on the base mesh`);
   }
   if (name) entry.name = name;     // latest joiner's name wins (one identity per browser)
-  entry.refs += 1;
+  entry.owners.add(ownerId);
+  roomByOwner.set(ownerId, roomId);
   return entry;
 };
 
-/** @param {{ refs: number, room: any, offs: (() => void)[], topicSubs: Map<string, () => void> }} entry @param {string} roomId */
-const closeRoom = (entry, roomId) => {
-  entry.refs -= 1;
-  if (entry.refs > 0) return;
+/** @param {{owners:Set<string>,room:any,offs:(()=>void)[],topicSubs:Map<string,()=>void>}} entry @param {string} roomId @param {string} ownerId */
+const closeRoom = (entry, roomId, ownerId) => {
+  if (roomByOwner.get(ownerId) !== roomId || !entry.owners.delete(ownerId)) return false;
+  roomByOwner.delete(ownerId);
+  if (entry.owners.size > 0) return true;
   for (const off of entry.offs) off();
   for (const off of entry.topicSubs.values()) off();
   entry.room.leave();
   rooms.delete(roomId);
   log(`room "${roomId}" closed (no app-tabs left)`);
+  return true;
 };
 
-// One relayed op from the dwapp bridge (app-tab -> SW -> here). Returns the reply.
-/** @param {any} msg */
-const handleRoomOp = async (msg) => {
+/** @param {string} appId */
+const purgeAppRoomOwners = (appId) => {
+  const prefix = `app:${appId}:`;
+  let left = 0;
+  for (const [ownerId, ownedRoomId] of [...roomByOwner]) {
+    if (!ownerId.startsWith(prefix)) continue;
+    const entry = rooms.get(ownedRoomId);
+    if (entry && closeRoom(entry, ownedRoomId, ownerId)) left += 1;
+  }
+  return { ok: true, left };
+};
+
+/** Run one room operation after its host authority gate. @param {any} msg @param {()=>boolean} [current] */
+const handleRoomOpUnlocked = async (msg, current = () => true) => {
   const { op, roomId } = msg;
   if (op === 'join') {
-    const entry = await ensureRoom(roomId, msg.name);
+    if (typeof msg.roomOwnerId !== 'string' || !msg.roomOwnerId || msg.roomOwnerId.length > 256) return { ok: false, error: 'room-owner-required' };
+    const entry = await ensureRoom(roomId, msg.roomOwnerId, msg.name, current);
     return { ok: true, did: entry.room.did, joined: roomId, ...entry.room.status() };
   }
-  // Content install doesn't need a joined room; the bridge prompts from the
-  // URI's bounded publisher identity before this full fetch can begin.
+  // why: The bridge confirms the bounded publisher identity before this fetch.
   if (op === 'install-app') {
     const h = await start();
     const { manifest, payload } = await h.base.fetchApp(msg.uri);
     const client = /** @type {any} */ (await loadDweb());
-    // why: seed before the App becomes visible. After create resolves, delete
-    // can discover the record; its durable version hash can then revoke these
-    // bytes even before the in-memory ownership index is updated.
+    // why: Seed first so deletion can revoke bytes as soon as the App is visible.
     const appId = mintAppId();
     const ownerId = appContentOwner(appId, 'seed');
     const { announced: installed } = await runPublishTransaction({
@@ -548,11 +548,15 @@ const handleRoomOp = async (msg) => {
       ...(installed.warning ? { warning: installed.warning } : {}),
     };
   }
+  if (op === 'leave') {
+    if (typeof msg.roomOwnerId !== 'string' || !msg.roomOwnerId || msg.roomOwnerId.length > 256) return { ok: false, error: 'room-owner-required' };
+    const entry = rooms.get(roomId);
+    return { ok: true, left: entry ? closeRoom(entry, roomId, msg.roomOwnerId) : false };
+  }
   const entry = rooms.get(roomId);
   if (!entry) return { ok: false, error: 'not-in-room' };
   const { room } = entry;
   switch (op) {
-    case 'leave': closeRoom(entry, roomId); return { ok: true, left: true };
     case 'status': return { ok: true, ...room.status() };
     case 'presence': return { ok: true, present: room.presence.list() };
     case 'announce': { if (typeof msg.name === 'string') entry.name = msg.name.slice(0, 40); await room.presence.announce(); return { ok: true }; }
@@ -570,13 +574,9 @@ const handleRoomOp = async (msg) => {
       items: room.sync.history(msg.topic).map((/** @type {any} */ env) => ({ topic: msg.topic, from: env.from, data: env.body.data, ts: env.ts, id: env.id })),
     };
     case 'dm': { const { id, ts } = await room.direct.send(msg.to, msg.data); return { ok: true, id, ts }; }
-    // A2A Agent Card advertise/fetch over a retained '~card' topic: card-set
-    // publishes MY signed card (retained so late joiners backfill), card-get
-    // reads a peer's latest card from the retained history by its did.
+    // Agent cards use the retained '~card' topic for late joiners.
     case 'card-set': {
-      // Validate + clamp MY card before it hits the mesh: strips arbitrary extra
-      // fields and REJECTS an oversized one (the agent-card caps — MAX_CARD_BYTES
-      // etc.), so a retained '~card' envelope we emit can't amplify to late-joiners.
+      // why: Validate before retention can amplify a card to late joiners.
       const client = /** @type {any} */ (await loadDweb());
       let clean;
       try { clean = client.validateCard(msg.card).card; }
@@ -588,15 +588,10 @@ const handleRoomOp = async (msg) => {
     }
     case 'card-get': {
       room.sync.retain('~card');
-      // why max-by-ts, not last-inserted: the retained store is a Map keyed by
-      // sig, so history() yields SIG-INSERTION order — a late-join backfill can
-      // append an OLDER card version after the newer one was seen live. Pick the
-      // newest by envelope ts so a re-advertised card always supersedes.
+      // why: A late backfill can append an older card, so select by timestamp.
       const mine = room.sync.history('~card').filter((/** @type {any} */ e) => e.from === msg.did);
       const latest = mine.reduce((/** @type {any} */ best, /** @type {any} */ e) => (!best || (e.ts ?? 0) >= (best.ts ?? 0) ? e : best), null);
-      // Clamp the UNTRUSTED peer card (parsePeerCard: coerce + cap, null if it
-      // blows the ceiling) before it reaches the actor's a2a_run worker — the caps
-      // exist precisely to bound a malicious multi-MB / unbounded-fields card.
+      // why: Parse and cap an untrusted card before it reaches the actor.
       const client = /** @type {any} */ (await loadDweb());
       return { ok: true, card: latest ? client.parsePeerCard(latest.body.data) : null };
     }
@@ -615,6 +610,46 @@ const handleRoomOp = async (msg) => {
       return { ok: true, uri, hash };
     }
     default: return { ok: false, error: `unknown room op: ${op}` };
+  }
+};
+
+// Leave bypasses the lane so invalidation can clean an in-flight client.
+/** @param {any} msg */
+const handleRoomOp = async (msg) => {
+  if (msg?.op === 'leave-app-owners') {
+    if (typeof msg.appId !== 'string' || !msg.appId || msg.appId.length > 128
+        || !Number.isSafeInteger(msg.generation) || msg.generation < 0) {
+      return { ok: false, error: 'app-authority-required' };
+    }
+    try { return await appRoomAuthority.rotate(msg.appId, msg.generation, () => purgeAppRoomOwners(msg.appId)); }
+    catch (error) {
+      if (error instanceof AppRoomAuthorityChangedError) return { ok: false, error: 'app-authority-changed' };
+      throw error;
+    }
+  }
+  if (msg?.op === 'leave') return handleRoomOpUnlocked(msg);
+  if (msg?.roomOwnerAppId == null) {
+    return typeof msg?.roomOwnerId === 'string' && msg.roomOwnerId.startsWith('app:')
+      ? { ok: false, error: 'app-authority-required' }
+      : handleRoomOpUnlocked(msg);
+  }
+  const appId = msg.roomOwnerAppId;
+  const generation = msg.roomOwnerGeneration;
+  if (typeof appId !== 'string' || !appId || appId.length > 128
+      || !Number.isSafeInteger(generation) || generation < 0
+      || typeof msg.roomOwnerId !== 'string' || !msg.roomOwnerId.startsWith(`app:${appId}:`)
+      || !msg.roomOwnerId.endsWith(`:${generation}`)) {
+    return { ok: false, error: 'app-authority-required' };
+  }
+  try {
+    return await appRoomAuthority.run(appId, generation, (current, advanced) => {
+      if (advanced) purgeAppRoomOwners(appId);
+      return handleRoomOpUnlocked(msg, current);
+    });
+  }
+  catch (error) {
+    if (error instanceof AppRoomAuthorityChangedError) return { ok: false, error: 'app-authority-changed' };
+    throw error;
   }
 };
 
@@ -681,10 +716,7 @@ const onBaseHostMessage = (msg, sender, sendResponse) => {
         // then announce it (gossip + DHT). dwapp_id = content hash.
         case 'dweb/base-host/share-app': {
           const h = await start();
-          // The UI passes an edited namespace on FIRST share (and the stored slug on
-          // reshare); fall back to the name. A RESHARE reuses the same slug → same
-          // dwapp_id → publishMeta amends the existing card (higher seq) instead of
-          // forking a new app — that's the whole versioning story.
+          // why: Reuse the slug so a reshare advances one App stream.
           const slug = slugify(msg.slug || msg.name);
           const previousHash = typeof msg.previousHash === 'string' ? msg.previousHash : null;
           const previousCard = h.base.heardDwapps().find((/** @type {any} */ row) => (
@@ -703,9 +735,7 @@ const onBaseHostMessage = (msg, sender, sendResponse) => {
                 ...(msg.release?.changelog
                   ? { changelog: msg.release.changelog } : {}),
               },
-              // A normal share omits seq. A re-seed reuses both the stored manifest
-              // timestamp and sequence, and publishApp refuses changed bytes before
-              // this card can be announced.
+              // why: A reseed reuses its signed version identity.
               ...(Number.isInteger(msg.seq) ? { seq: msg.seq } : {}),
             }),
             rollback: ({ hash, ownershipAdded }) => {
@@ -740,11 +770,7 @@ const onBaseHostMessage = (msg, sender, sendResponse) => {
           });
           return;
         }
-        // Un-share: the user deleted an app — stop announcing + serving it. The host
-        // resolves the dwapp_id from its own identity + the app's slug (a self-
-        // published app) or unannounces an explicit hash (an installed app we were
-        // seeding). Idempotent: if the base network never started, there's nothing
-        // to unshare — answer ok so delete still succeeds.
+        // Unshare is idempotent so deletion succeeds when the network is off.
         case 'dweb/base-host/unshare-app': {
           if (!handle) { sendResponse({ ok: true, unserved: false, removed: false }); return; }
           /** @type {string[]} */
@@ -823,16 +849,12 @@ const onBaseHostMessage = (msg, sender, sendResponse) => {
           });
           return;
         }
-        // A dwapp room op (join/leave/publish/subscribe/dm/presence/…) — the
-        // bridge's room surface, served over the shared base mesh.
+        // Relay the narrow App room surface.
         case 'dweb/base-host/room': { sendResponse(await handleRoomOp(msg)); return; }
-        // Install: fetch the signed bundle over the base mesh, verify, install +
-        // persist as an engine App (via the SW). Returns the new app record.
+        // Install a verified mesh bundle through the worker.
         case 'dweb/base-host/install-app': {
           const h = await start();
-          // The model and UI identify a discovery row by URI. Rebind all update
-          // identity fields to the exact card held by this host so copied or
-          // mixed arguments cannot attach an App to another update stream.
+          // why: Rebind identity to the host card before install.
           const identity = identityForDiscoveredUri(h.base.heardDwapps(), msg.uri);
           if (!identity) {
             sendResponse({
@@ -881,11 +903,7 @@ const onBaseHostMessage = (msg, sender, sendResponse) => {
           });
           return;
         }
-        // Update an INSTALLED app in place to a newer announced version. Same fetch+
-        // verify path as install, but the install callback overwrites the existing
-        // app (dweb/app-update) instead of creating a new one — the user keeps one
-        // copy that just updates (the old version's bytes stay announced on whoever
-        // still seeds them, the substrate for a future revert/changelog).
+        // Update one installed App through the same verified fetch path as install.
         case 'dweb/base-host/update-app': {
           const h = await start();
           const identity = identityForDiscoveredUri(h.base.heardDwapps(), msg.uri);
@@ -906,7 +924,6 @@ const onBaseHostMessage = (msg, sender, sendResponse) => {
             return;
           }
           const client = /** @type {any} */ (await loadDweb());
-          const previousHash = typeof msg.previousHash === 'string' ? msg.previousHash : null;
           const ownerId = appContentOwner(msg.appId, 'seed');
           /** @type {string[]} */
           let cleanupHashes = [];
@@ -923,21 +940,21 @@ const onBaseHostMessage = (msg, sender, sendResponse) => {
               slug: identity?.slug ?? null,
               seq: identity?.seq ?? null,
               install: async (/** @type {any} */ a) => {
-                cleanupHashes = [...new Set([
-                  ...(Array.isArray(msg.pendingHashes) ? msg.pendingHashes : []),
-                  ...(previousHash ? [previousHash] : []),
-                ].filter((hash) => typeof hash === 'string' && hash !== a.dweb?.hash))];
                 const r = await swCall('dweb/app-update', {
                   appId: msg.appId,
-                  ...(msg.strategy === 'replace' || msg.strategy === 'fork' ? { strategy: msg.strategy } : {}),
+                  ...(msg.strategy === 'replace' || msg.strategy === 'fork'
+                    ? { strategy: msg.strategy, conflictToken: msg.conflictToken }
+                    : {}),
                   ...a,
-                  dweb: {
-                    ...a.dweb,
-                    ...(cleanupHashes.length ? { pending_seed_unserve_hashes: cleanupHashes } : {}),
-                  },
                   files: jsonSafeFiles(a.files),
                 });
-                if (!r?.ok) throw new Error(r?.error ?? 'update failed');
+                if (!r?.ok) throw Object.assign(new Error(r?.error ?? 'update failed'), {
+                  conflictToken: r?.conflictToken,
+                  requiresAction: r?.requiresAction,
+                });
+                cleanupHashes = Array.isArray(r.cleanupHashes)
+                  ? [...new Set(r.cleanupHashes.filter((/** @type {unknown} */ hash) => typeof hash === 'string'))]
+                  : [];
                 return { app: r.app, warning: r.warning, fork: r.fork };
               },
             }),
@@ -960,6 +977,7 @@ const onBaseHostMessage = (msg, sender, sendResponse) => {
             ok: true,
             app: updated.app,
             ...(updated.fork ? { fork: updated.fork } : {}),
+            cleanupHashes,
             pendingUnserveHashes: remainingCleanupHashes,
             ...(remainingCleanupHashes.length ? { cleanupPending: true } : {}),
             ...(warnings.length ? { warning: warnings[0], warnings } : {}),
@@ -975,8 +993,16 @@ const onBaseHostMessage = (msg, sender, sendResponse) => {
         default: sendResponse({ ok: false, error: `unknown:${msg.type}` }); return;
       }
     } catch (e) {
-      warn('handler threw', msg.type, '—', /** @type {{ message?: string }} */ (e)?.message ?? e);
-      sendResponse({ ok: false, error: /** @type {{ message?: string }} */ (e)?.message ?? String(e) });
+      const failure = /** @type {{message?:string,conflictToken?:unknown,requiresAction?:unknown}} */ (e);
+      warn('handler threw', msg.type, '-', failure?.message ?? e);
+      sendResponse({
+        ok: false,
+        error: failure?.message ?? String(e),
+        ...(Number.isSafeInteger(failure?.conflictToken) ? {
+          conflictToken: failure.conflictToken,
+          requiresAction: failure.requiresAction === true,
+        } : {}),
+      });
     }
   })();
   return true; // async sendResponse

--- a/extension/peerd-distributed/apps/bridge.js
+++ b/extension/peerd-distributed/apps/bridge.js
@@ -1,65 +1,10 @@
 // @ts-check
-// peerd-distributed/apps/bridge.js — the dwapp API (bridge v0).
-//
-// THE new privilege boundary (NORTH-STAR §4, MIGRATION §3): a sandboxed,
-// opaque-origin dwapp talks to the dweb ONLY through this postMessage RPC,
-// hosted by the trusted app-tab parent page. The surface is deliberately
-// small and FROZEN for Phase 1 — growing it is a security event, not a
-// convenience.
-//
-// CONNECTIVITY = THE ALWAYS-ON BASE NETWORK. A dwapp is a SUB-PROTOCOL, not a
-// thing tied to a signaler: "join a room" opens a NAMESPACED overlay on the one
-// shared base mesh in the offscreen document (base-network.js openRoom), so the
-// app rides connections that already exist — no per-app rendezvous, no per-app
-// mesh, no rendezvous prompt. The bridge relays each op to that offscreen host
-// over the SW (swCall 'dweb/base/room'); the host pushes feed/dm/presence events
-// back as 'dweb/base-room/event' runtime messages (onHostEvent), filtered to the
-// room we joined. The identity is the user's vault did, held by the offscreen
-// base node — the bridge never mints or sees key material.
-//
-// v0 surface (one room per app):
-//   hello                          → { available, app, launch, did, joined }
-//   join { roomId, name? }         → CONSENT-GATED (confirm + remembered
-//                                    per-app grant; every outcome audited)
-//   leave · status · presence · history { topic } · retain { topic }
-//   publish { topic, data, retain? } · subscribe { topic } · mute { did }
-//   dm-send { to, data }           → a DIRECT 1:1 message (ch=3, PROTOCOL
-//                                    §6.1): point-to-point over one mesh
-//                                    link, never flooded or relayed. This is
-//                                    a NARROWER send than publish (one peer,
-//                                    not the whole room), so it adds no reach
-//                                    a flooding app didn't already have.
-//   announce { meta }
-//   install-app { uri, name? }     → CONSENT-GATED EVERY TIME (never
-//                                    remembered): fetch from base peers,
-//                                    verify, install as an engine App
-// Events pushed to the app: message · direct · presence-join · presence-leave ·
-//   peer · peer-gone · status
-//
-// What v0 deliberately does NOT expose:
-//   - raw sign(): nothing in the demo needs it — post/doc attribution is
-//     the platform envelope's `from`. When an app-visible sign() lands it
-//     MUST be domain-separated per D-8; until then the capability simply
-//     doesn't exist, which is safer than scoping it.
-//   - content put/get: attachments are a Phase 2 surface.
-//   - cross-room/multi-room: one room per app keeps consent legible.
-//   - a custom signaler: the base network IS the connectivity (above).
-//
-// Trust notes:
-//   - Replies go ONLY to the app frame (e.source identity check in the
-//     transport), and the identity key never crosses the boundary — the app
-//     sees its did string, never material.
-//   - Inbound host events are filtered to OUR room id before reaching the
-//     app, so a second dwapp's traffic can't leak across the shared push.
-//   - Payloads stay opaque end-to-end (D-7): `data` passes through
-//     structured-clone untouched.
+// Expose one consent-bound room to one opaque App frame.
+// why: The App can use its did, but it never receives identity key material.
 
 const GRANTS_KEY = 'dweb.grants.v1';
 
-// The default transport for the app-tab host: post events into the dwapp's
-// iframe and receive its ops (identity-checked by e.source). createDwebBridge
-// is otherwise transport-agnostic — the SAME bridge logic runs in the app-tab
-// page today and, with an SW-relay transport, in the offscreen document.
+// The parent accepts iframe requests only from the exact App frame.
 /** @param {HTMLIFrameElement} frame */
 export const iframeTransport = (frame) => ({
   /** @param {any} msg */
@@ -99,12 +44,14 @@ export const createDwebBridge = ({
   onHostEvent,
   launch = {},
 }) => {
-  // Grants key on the app's content identity when it has one (stable
-  // across reinstalls of the same bundle), else the seed key / local id.
-  const appKey = appDweb?.hash || (appDweb?.seed ? `seed:${appDweb.seed}` : appId);
+  // Grants key on verified content. Mutable forks also bind to their base version.
+  let appKey = appDweb?.forked ? `fork:${appId}:${appDweb.hash}`
+    : appDweb?.hash || (appDweb?.seed ? `seed:${appDweb.seed}` : appId);
 
   /** @type {string | null} */
   let roomId = null;        // the room we're in (one per app, v0)
+  /** @type {string | null} */
+  let hostRoomId = null;
   /** @type {string | null} */
   let did = null;           // our base-network did (the offscreen's vault identity)
   let displayName = '';
@@ -112,16 +59,13 @@ export const createDwebBridge = ({
   let roomClientId = null;
   /** @type {string | null} */
   let activeClientId = null;
-  // Once an iframe epoch has been replaced or disposed it can never become
-  // active again. Otherwise a late ordinary RPC from A can replace B, reclaim
-  // roomClientId, and make A's later dispose tear down B's adopted room.
-  // Refuse new epochs after a generous per-tab ceiling instead of evicting
-  // tombstones and making very old epochs replayable again.
+  // why: Keep bounded tombstones so retired iframe epochs cannot regain authority.
   const MAX_CLIENT_EPOCHS = 128;
   /** @type {Set<string>} */
   const retiredClientIds = new Set();
   let admittedClientEpochs = 0;
   let disposed = false;
+  let hostJoinInFlight = false;
   let transitionTail = Promise.resolve();
   /** @type {Map<string,{clientId:string,id:string,cancelled:boolean}>} */
   const pending = new Map();
@@ -143,7 +87,16 @@ export const createDwebBridge = ({
   // One room op, relayed to the offscreen base host (which serves the room as a
   // namespaced sub-protocol on the shared mesh). roomId rides every op.
   /** @param {string} op @param {Record<string, any>} [args] @param {string|null} [exactRoomId] */
-  const room = (op, args = {}, exactRoomId = roomId) => swCall('dweb/base/room', { op, roomId: exactRoomId, ...args });
+  const room = (op, args = {}, exactRoomId = roomId) => swCall('dweb/base/room', {
+    op, roomId: exactRoomId, ...args,
+    bridgeAppId: appId, bridgeAppHash: appDweb?.hash, bridgeAppForked: appKey.startsWith('fork:'),
+    bridgeAppGeneration: appDweb?.generation ?? 0,
+  });
+  /** @param {string} exactRoomId */
+  const leaveRoom = async (exactRoomId) => {
+    const result = await room('leave', {}, exactRoomId);
+    if (!result?.ok) throw new Error(result?.error ?? 'leave failed');
+  };
 
   /** @template T @param {()=>Promise<T>} operation */
   const serializeTransition = (operation) => {
@@ -169,9 +122,7 @@ export const createDwebBridge = ({
     if (activeClientId === clientId) activeClientId = null;
   };
 
-  // Grants are keyed by ROOM id, not just per-app: the consent dialog names a
-  // specific room, so a remembered grant must authorize only THAT room — else
-  // one approval would let the app silently join any room name it likes later.
+  // why: A grant authorizes one room for the current verified App identity.
   const grantStore = {
     /** @param {string} rid */
     async has(rid) {
@@ -191,9 +142,7 @@ export const createDwebBridge = ({
     },
   };
 
-  // Events pushed from the offscreen base host. Filter to OUR room (the shared
-  // runtime push reaches every app-tab) and, for feed messages, to topics this
-  // app actually subscribed — so another dwapp in the same room can't bleed in.
+  // Filter shared host events to this room and its subscribed topics.
   const offHostEvent = onHostEvent?.((/** @type {any} */ m) => {
     if (!roomId || m?.roomId !== roomId) return;
     if (m.event === 'message' && !subbedTopics.has(m.data?.topic)) return;
@@ -201,11 +150,14 @@ export const createDwebBridge = ({
   }) ?? (() => {});
   disposers.push(offHostEvent);
 
-  // The consent gate every join runs. A remembered grant skips the dialog,
-  // never the audit. No rendezvous in the copy: connectivity is the base network.
   /** @param {string} rid @param {{clientId:string,cancelled:boolean}} request */
   const consent = async (rid, request) => {
     if (isCancelled(request)) throw new Error('cancelled');
+    if (appDweb?.hash) {
+      const current = await swCall('app/get-meta', { appId });
+      if (!current?.ok || current.dweb?.hash !== appDweb.hash || (appKey.startsWith('fork:') && !current.dweb?.forked)) throw new Error('App identity changed. Reload the App.');
+      appKey = current.dweb.forked ? `fork:${appId}:${current.dweb.hash}` : current.dweb.hash;
+    }
     if (await grantStore.has(rid)) return true;
     if (isCancelled(request)) throw new Error('cancelled');
     const okd = await confirmAction({
@@ -231,6 +183,11 @@ export const createDwebBridge = ({
         if (roomId === rid) return { did, joined: roomId };
         throw new Error('already in a room — leave first (one room per app)');
       }
+      if (hostRoomId) {
+        await leaveRoom(hostRoomId);
+        hostRoomId = null;
+        roomClientId = null;
+      }
       if (typeof rid !== 'string' || !rid.trim()) throw new Error('roomId required');
       const id = rid.trim();
       if (id.length > 64) throw new Error('room name too long (max 64 chars)');
@@ -239,28 +196,41 @@ export const createDwebBridge = ({
       if (isCancelled(request)) throw new Error('cancelled');
       const nextDisplayName = String(name ?? '').slice(0, 40);
       // Do not publish shared state until the host proves the exact room joined.
-      const r = await room('join', { name: nextDisplayName }, id);
-      if (!r?.ok) throw new Error(r?.error ?? 'join failed');
-      if (isCancelled(request)) {
-        // The host may have incremented an offscreen room ref after the client
-        // disappeared. Exact-room rollback is mandatory; ambient roomId is
-        // still null and must never select another client's room.
-        await room('leave', {}, id).catch(() => {});
-        throw new Error('cancelled');
-      }
-      displayName = nextDisplayName;
-      roomId = id;
+      hostJoinInFlight = true;
+      hostRoomId = id;
       roomClientId = request.clientId;
-      did = r.did;
-      audit('room_joined', { roomId, did });
-      return { did, joined: roomId, present: r.present };
+      try {
+        const r = await room('join', { name: nextDisplayName }, id);
+        if (!r?.ok) throw new Error(r?.error ?? 'join failed');
+        if (isCancelled(request)) {
+          await leaveRoom(id);
+          hostRoomId = null;
+          roomClientId = null;
+          throw new Error('cancelled');
+        }
+        displayName = nextDisplayName;
+        roomId = id;
+        roomClientId = request.clientId;
+        did = r.did;
+        audit('room_joined', { roomId, did });
+        return { did, joined: roomId, present: r.present };
+      } catch (error) {
+        if (hostRoomId === id) {
+          try { await leaveRoom(id); hostRoomId = null; roomClientId = null; }
+          catch { /* dispose retries the exact owner */ }
+        }
+        throw error;
+      } finally {
+        hostJoinInFlight = false;
+      }
     },
 
     leave: async () => {
-      if (!roomId) return { left: false };
-      const was = roomId;
-      await room('leave', {}, was);
+      const was = roomId ?? hostRoomId;
+      if (!was) return { left: false };
+      await leaveRoom(was);
       roomId = null;
+      hostRoomId = null;
       roomClientId = null;
       subbedTopics.clear();
       audit('room_left', { roomId: was });
@@ -388,17 +358,18 @@ export const createDwebBridge = ({
       // also prevents hostile dispose spam from growing the retired set.
       if (activeClientId !== m.clientId) return;
       retireClient(m.clientId);
-      if (roomId && roomClientId === m.clientId) {
+      if (hostRoomId && roomClientId === m.clientId) {
         void serializeTransition(async () => {
-          if (!roomId || roomClientId !== m.clientId) return;
-          const was = roomId;
-          await room('leave', {}, was).catch(() => {});
+          if (!hostRoomId || roomClientId !== m.clientId) return;
+          const was = hostRoomId;
+          await leaveRoom(was);
           roomId = null;
+          hostRoomId = null;
           roomClientId = null;
           did = null;
           subbedTopics.clear();
           audit('room_left', { roomId: was, reason: 'client-disposed' });
-        });
+        }).catch(() => {});
       }
       return;
     }
@@ -425,13 +396,12 @@ export const createDwebBridge = ({
     if (activeClientId && activeClientId !== m.clientId) {
       const priorClientId = activeClientId;
       retireClient(priorClientId);
-      // A completed membership belongs to the bridge/App tab, not a dead
-      // iframe epoch. The replacement adopts it; late dispose from the old
-      // epoch can no longer tear down the replacement's room.
-      if (roomId && roomClientId === priorClientId) roomClientId = m.clientId;
+      // why: A replacement iframe adopts the bridge's completed membership.
+      if (hostRoomId && roomClientId === priorClientId) roomClientId = m.clientId;
     }
     if (activeClientId !== m.clientId) {
       activeClientId = m.clientId;
+      if (roomClientId && retiredClientIds.has(roomClientId)) roomClientId = m.clientId;
       admittedClientEpochs += 1;
     }
     const op = /** @type {Record<string, (args?: any) => Promise<any>>} */ (/** @type {unknown} */ (ops))[m.op];
@@ -464,9 +434,7 @@ export const createDwebBridge = ({
       if (!isCancelled(request)) reply(true, value);
       else if (activeClientId === request.clientId) reply(false, 'cancelled');
     } catch (err) {
-      // A stale epoch receives no late result into a replacement client. Same-
-      // epoch cancellation gets a terminal rejection so its pending promise can
-      // settle if the frame is still alive.
+      // why: Never send a late result to a replacement iframe.
       if (activeClientId === request.clientId) reply(false, err);
     } finally {
       pending.delete(pendingKey);
@@ -475,22 +443,30 @@ export const createDwebBridge = ({
   };
 
   const offTransport = transport.onMessage(handleOp);
+  const clearRoom = () => { roomId = null; hostRoomId = null; roomClientId = null; did = null; subbedTopics.clear(); };
 
+  const dispose = async (waitForJoin = true) => {
+    disposed = true;
+    if (activeClientId) cancelClient(activeClientId);
+    offTransport();
+    for (const off of disposers.splice(0)) off();
+    if (!waitForJoin) {
+      const was = hostRoomId;
+      if (was) void leaveRoom(was).catch(() => {});
+      clearRoom();
+      return;
+    }
+    if (hostJoinInFlight) await transitionTail;
+    if (!hostRoomId) return;
+    await serializeTransition(async () => {
+      const was = hostRoomId;
+      if (!was) return;
+      await leaveRoom(was);
+      clearRoom();
+    });
+  };
   return {
-    dispose() {
-      disposed = true;
-      if (activeClientId) cancelClient(activeClientId);
-      offTransport();
-      for (const off of disposers.splice(0)) off();
-      void serializeTransition(async () => {
-        if (!roomId) return;
-        const was = roomId;
-        await room('leave', {}, was).catch(() => {});
-        roomId = null;
-        roomClientId = null;
-        did = null;
-        subbedTopics.clear();
-      });
-    },
+    dispose: () => dispose(),
+    invalidate: () => dispose(false),
   };
 };

--- a/extension/peerd-distributed/apps/loader.js
+++ b/extension/peerd-distributed/apps/loader.js
@@ -1,28 +1,12 @@
 // @ts-check
-// peerd-distributed/apps/loader.js — verified bundle → engine App.
-//
-// Phase 0 built fetch + verify; this is the missing last mile: turn a
-// verified `app`-type bundle into an installed App the existing engine
-// runtime opens in its sandbox (NORTH-STAR beat 1 — install-from-peer).
-// The single biggest reuse in the module: we do not build an app runtime,
-// we feed the existing one (ARCHITECTURE §4.4).
-//
-// Trust posture: fetchBundle already verified the manifest hash, the
-// manifest signature, and every chunk hash. This file RE-verifies the
-// manifest commitment anyway (cheap, and fail-closed against a future
-// caller that skips fetchBundle), then validates the SHAPE: an `app`
-// bundle with a present entry file, bounded file count and size. The
-// install itself is INJECTED — the SW route or page supplies it — so the
-// loader stays pure logic over bytes.
+// Validate a verified peer App bundle before the injected installer runs.
 
 import { assertBundleWithinLimits, manifestHash, verifyManifest } from '../content/manifest.js';
 import { unpackTransportBundle } from '../content/bundle.js';
 import { chunkBytes, sha256hex } from '../content/chunk.js';
 import { parsePeerdUri } from '../content/uri.js';
 
-// The peer-install rails are enforced both before bundle decoding and again on
-// the decoded file tree. Keep the live values beside the checks rather than in
-// prose that drifts from the storage and publishing layers.
+// why: Enforce limits before and after bundle decoding.
 const MAX_TOTAL_BYTES = 50_000_000;
 const MAX_FILES = 256;
 
@@ -49,7 +33,8 @@ export class BundleRejectedError extends Error {
  *     dweb: { uri: string, publisher: string | null, hash: string,
  *             version_id: string, dwapp_id?: string, slug?: string, seq?: number,
  *             published_hashes?: string[], previous_version_id?: string,
- *             source_git_oid?: string, changelog?: string },
+ *             source_git_oid?: string, changelog?: string, release_entry_file: string,
+ *             release_file_kinds: Record<string, 'text' | 'binary'> },
  *   }) => Promise<any>,
  *   name?: string,
  *   dwappId?: string | null,
@@ -150,6 +135,8 @@ export const installAppBundle = async ({ uri, manifest, payload, install, name, 
     dweb: {
       uri, publisher: manifest.publisher ?? null, hash, version_id: hash,
       published_hashes: [hash],
+      release_entry_file: entry,
+      release_file_kinds: { ...fileKinds },
       ...(dwappId ? { dwapp_id: dwappId } : {}),
       ...(slug ? { slug } : {}),
       ...(Number.isInteger(seq) ? { seq: /** @type {number} */ (seq) } : {}),

--- a/extension/peerd-engine/app-compose.js
+++ b/extension/peerd-engine/app-compose.js
@@ -1,41 +1,22 @@
 // @ts-check
-// peerd-engine/app-compose.js — turn a per-app file map into a single
-// HTML document the sandboxed runner can document.write.
-//
-// Apps are multi-file (index.html + style.css + script.js + data.json
-// + …) but the runner only takes a single HTML body. We inline the
-// tag-relative referenced files at compose time:
-//
-//   <link rel="stylesheet" href="style.css">     →  <style>…</style>
-//   <script src="script.js">…</script>           →  <script>…</script>
-//   new Worker('worker.js')                      →  blob: worker (shim, see below)
-//   <img src="./logo.png">                       →  runner resolves bundled binary asset
-//   <a href="./other.html">                      →  (left as-is — nav)
-//
-// "tag-relative" is liberal on purpose: a bundle file resolves whether the
-// agent writes it bare ('style.css'), dot-relative ('./style.css'),
-// parent-relative ('../style.css'), or root-relative ('/style.css') — same
-// latitude the Worker resolver already gives `new Worker('worker.js')`.
-// Absolute URLs (scheme:), protocol-relative (//host), data: URIs, and
-// pure #fragment / ?query refs pass through unchanged. The App sandbox refuses
-// remote loads; data:/blob: resources are the only non-bundle asset paths.
-//
-// Pure function, browser-free. Tested in Bun against a file map.
+// Compose an App file map into one sandbox document.
+// Relative references use bundle files. Absolute references stay unchanged.
+// why: The opaque runner can load only bundled, data, and blob resources.
 
 import { escapeAttr } from '/shared/util.js';
 
-/**
- * Inline tag-relative <link rel="stylesheet"> and <script src> references
- * by reading from `files` and substituting the file's content.
- *
- * @param {Record<string, string>} files - path → content
- * @param {string} [entry='index.html']
- * @returns {string} composed HTML
- */
+const APP_DATA_PATH_RE = /^data\/[a-z0-9][a-z0-9._-]{0,63}\.json$/i;
+/** why: Mutable App data must never become executable without consent rotation. @param {string} path */
+const assertStaticSource = (path) => {
+  if (APP_DATA_PATH_RE.test(path)) throw new Error(`app runtime data cannot be a composed source: ${path}`);
+};
+
+/** @param {Record<string,string>} files @param {string} [entry] @returns {string} */
 export const composeApp = (files, entry = 'index.html') => {
   if (!(entry in files)) {
     throw new Error(`app entry not found: ${entry}`);
   }
+  assertStaticSource(entry);
   const visited = new Set();
 
   // Inline <link rel="stylesheet" href="./...">  → <style>…</style>
@@ -47,6 +28,7 @@ export const composeApp = (files, entry = 'index.html') => {
     const href = hrefMatch[2];
     if (!isRelativeAndKnown(href, files, entry)) return full;
     const path = resolveRel(entry, href);
+    assertStaticSource(path);
     visited.add(path);
     return `<style data-from="${escapeAttr(path)}">${files[path]}</style>`;
   });
@@ -57,6 +39,7 @@ export const composeApp = (files, entry = 'index.html') => {
   composed = composed.replace(SCRIPT_RE, (full, beforeSrc, _q, src, afterSrc, inner) => {
     if (!isRelativeAndKnown(src, files, entry)) return full;
     const path = resolveRel(entry, src);
+    assertStaticSource(path);
     visited.add(path);
     // Preserve type="module" etc. if present.
     const attrs = (`${beforeSrc} ${afterSrc}`).replace(/\bsrc\s*=\s*['"][^'"]*['"]/i, '').trim();
@@ -64,42 +47,18 @@ export const composeApp = (files, entry = 'index.html') => {
     return `<script${attrStr} data-from="${escapeAttr(path)}">${files[path]}</script>`;
   });
 
-  // Make `new Worker('worker.js')` Just Work. A Worker URL inside the opaque-
-  // origin sandbox can't load by path (a chrome-extension:// or null-origin
-  // worker script is blocked — "cannot be accessed from origin 'null'"); the
-  // ONLY thing that loads is a same-origin blob: URL (the manifest sandbox CSP
-  // allows worker-src blob:). So embed the referenced worker file's source and
-  // shim Worker to build a blob URL from it at runtime (blob URLs only exist at
-  // runtime). Precise: only files actually named in a `new Worker('literal')`
-  // are embedded, so data/libs aren't bloated in. why a shim over telling the
-  // agent to hand-roll a blob — it reaches for `new Worker('worker.js')`.
+  // why: The opaque runner needs an inlined blob for each literal worker path.
   composed = inlineWorkerFiles(composed, files, entry);
 
   return composed;
 };
 
-// ---------------------------------------------------------------------------
-
-// A href/src is inlinable when it's a same-bundle relative reference AND it
-// resolves to a file we actually hold. why two gates: `isBundleRelative`
-// rejects things that are categorically NOT bundle files (CDN URLs, data:
-// URIs, #fragments) so we don't misread them; the "resolves to a known file"
-// guard is what makes accepting BARE paths ('style.css') safe — a CDN URL
-// can't collide with a bundle key, so there's no need to demand a './' prefix.
-// Resolution is anchored at the real `entry` (not a hardcoded 'index.html'),
-// so a nested entry (pages/about.html) resolves its siblings correctly and the
-// check agrees with the resolveRel() the caller uses to read the file.
-/**
- * @param {string} ref
- * @param {Record<string, string>} files
- * @param {string} [entry]
- */
+// why: Accept only known bundle paths and resolve them from the actual entry.
+/** @param {string} ref @param {Record<string,string>} files @param {string} [entry] */
 const isRelativeAndKnown = (ref, files, entry = 'index.html') =>
   isBundleRelative(ref) && resolveRel(entry, ref) in files;
 
-// True unless `ref` is something that can't name a bundled file: an absolute
-// URL with a scheme (https:, data:, mailto:, blob:…), a protocol-relative
-// //host reference, or a pure in-document #fragment / ?query.
+// Reject absolute and in-document references.
 /** @param {string} ref */
 const isBundleRelative = (ref) =>
   !/^[a-z][a-z0-9+.-]*:/i.test(ref)
@@ -164,7 +123,10 @@ const inlineWorkerFiles = (composed, files, entry) => {
     const spec = m[2];
     if (srcBySpec[spec] != null) continue;
     const path = workerFilePath(spec, entry, files);
-    if (path) srcBySpec[spec] = files[path];
+    if (path) {
+      assertStaticSource(path);
+      srcBySpec[spec] = files[path];
+    }
   }
   if (Object.keys(srcBySpec).length === 0) return composed;
 

--- a/extension/peerd-engine/repository/repository-service.js
+++ b/extension/peerd-engine/repository/repository-service.js
@@ -14,10 +14,7 @@ const MAX_LIGHTWEIGHT_BYTES = 128_000_000;
 /** @typedef {{ git:any, fs:any, dir:string, gitdir:string }} RepositoryContext */
 /** @typedef {[string, number, number, number]} StatusRow */
 
-// Extension pages may load the heavy vendor on first repository use. Chrome's
-// MV3 service worker injects a static loader instead because its global rejects
-// runtime import(); keeping that host choice out of this core also keeps engine
-// consumers that only need a small helper from loading Git.
+// why: Extension pages load Git lazily. The service worker injects a static loader.
 const loadVendoredGit = async () => (await import('/vendor/isomorphic-git/index.js')).default;
 
 /** @param {unknown} message @param {string} [fallback] */
@@ -211,10 +208,11 @@ const quotaFsFor = (ctx) => {
   };
 };
 
-/** @param {Record<string,Uint8Array>} left @param {Record<string,Uint8Array>} right */
-const snapshotsEqual = (left, right) => {
-  const leftPaths = Object.keys(left).sort();
-  const rightPaths = Object.keys(right).sort();
+/** @param {Record<string,Uint8Array>} left @param {Record<string,Uint8Array>} right @param {boolean} [excludeAppData] */
+const snapshotsEqual = (left, right, excludeAppData = false) => {
+  const included = (/** @type {string} */ path) => !excludeAppData || !/^data\/[a-z0-9][a-z0-9._-]{0,63}\.json$/i.test(path);
+  const leftPaths = Object.keys(left).filter(included).sort();
+  const rightPaths = Object.keys(right).filter(included).sort();
   if (leftPaths.length !== rightPaths.length || leftPaths.some((path, index) => path !== rightPaths[index])) return false;
   return leftPaths.every((path) => {
     const a = left[path];
@@ -267,18 +265,20 @@ export const createRepositoryService = ({
     return matrix;
   };
 
-  /** @param {RepositoryContext} ctx @param {string} [initialMessage] */
-  const ensureUnlocked = async (ctx, initialMessage = 'initial snapshot') => {
+  /** @param {RepositoryContext} ctx @param {string} [initialMessage] @param {boolean} [includeIgnored] */
+  const ensureUnlocked = async (ctx, initialMessage = 'initial snapshot', includeIgnored = false) => {
     const head = await resolveHead(ctx);
     if (head) return head;
     await ctx.git.init({ fs: ctx.fs, dir: ctx.dir, gitdir: ctx.gitdir, defaultBranch: DEFAULT_BRANCH });
-    const matrix = await stageAll(ctx);
+    const matrix = await stageAll(ctx, { includeIgnored });
     if (!matrix.length) return null;
     return ctx.git.commit({ fs: ctx.fs, dir: ctx.dir, gitdir: ctx.gitdir, message: commitMessage(initialMessage), author: AUTHOR });
   };
 
-  /** @param {{kind:string,id:string}} ref @param {{message?:string}} [opts] */
-  const init = (ref, { message = 'initial snapshot' } = {}) => run(ref, (ctx) => ensureUnlocked(ctx, message));
+  /** @param {{kind:string,id:string}} ref @param {{message?:string,includeIgnored?:boolean}} [opts] */
+  const init = (ref, { message = 'initial snapshot', includeIgnored = false } = {}) => run(
+    ref, (ctx) => ensureUnlocked(ctx, message, includeIgnored),
+  );
 
   /** Stage selected paths, or the complete visible worktree for `.` / no paths. */
   /** @param {{kind:string,id:string}} ref @param {{paths?:string[]}} [opts] */
@@ -514,12 +514,12 @@ export const createRepositoryService = ({
   });
 
   /** Compare every live byte (including ignored files) with one commit tree. */
-  /** @param {{kind:string,id:string}} ref @param {{at?:string}} [opts] */
-  const matches = (ref, { at = 'HEAD' } = {}) => run(ref, async (ctx) => {
+  /** @param {{kind:string,id:string}} ref @param {{at?:string,excludeAppData?:boolean}} [opts] */
+  const matches = (ref, { at = 'HEAD', excludeAppData = false } = {}) => run(ref, async (ctx) => {
     await ensureUnlocked(ctx);
     return snapshotsEqual(
       await snapshotAtUnlocked(ctx, at),
-      await readWorkingTree(ctx.fs, ctx.dir),
+      await readWorkingTree(ctx.fs, ctx.dir), excludeAppData && ref.kind === 'app',
     );
   });
 
@@ -537,20 +537,39 @@ export const createRepositoryService = ({
     return statusUnlocked(targetCtx);
   });
 
-  /** @param {{kind:string,id:string}} ref @param {{files:Record<string,string|Uint8Array>,message?:string}} opts */
-  const replaceWorkingTree = (ref, { files, message = 'replace working tree' }) => run(ref, async (ctx) => {
+  /** @param {{kind:string,id:string}} ref @param {{files:Record<string,string|Uint8Array>,message?:string,includeIgnored?:boolean}} opts */
+  const replaceWorkingTree = (ref, { files, message = 'replace working tree', includeIgnored = false }) => run(ref, async (ctx) => {
     await ensureUnlocked(ctx);
     /** @type {Record<string,Uint8Array>} */ const bytes = Object.create(null);
     for (const [path, value] of Object.entries(files)) {
       bytes[path] = typeof value === 'string' ? new TextEncoder().encode(value) : value;
     }
     await replaceWorkingTreeUnlocked(ctx, bytes);
-    const matrix = await stageAll(ctx);
+    const matrix = await stageAll(ctx, { includeIgnored });
     if (!matrix.some((/** @type {StatusRow} */ row) => row[1] !== row[2])) {
       return { oid: await resolveHead(ctx), changed: [], created: false };
     }
     const oid = await ctx.git.commit({ fs: ctx.fs, dir: ctx.dir, gitdir: ctx.gitdir, message: commitMessage(message), author: AUTHOR });
     return { oid, changed: matrix.map((/** @type {StatusRow} */ row) => row[0]), created: true };
+  });
+
+  /** Reset a failed replacement before restoring its exact prior worktree.
+   * @param {{kind:string,id:string}} ref @param {{to:string,files:Record<string,string|Uint8Array>}} opts */
+  const rollbackWorkingTree = (ref, { to, files }) => run(ref, async (ctx) => {
+    const oid = await ctx.git.resolveRef({ fs: ctx.fs, gitdir: ctx.gitdir, ref: to });
+    /** @type {Record<string,Uint8Array>} */ const bytes = Object.create(null);
+    for (const [path, value] of Object.entries(files)) {
+      validRelativePath(path);
+      bytes[path] = typeof value === 'string' ? new TextEncoder().encode(value) : value;
+    }
+    const branchName = await ctx.git.currentBranch({ fs: ctx.fs, dir: ctx.dir, gitdir: ctx.gitdir, fullname: false });
+    await ctx.git.writeRef({
+      fs: ctx.fs, dir: ctx.dir, gitdir: ctx.gitdir,
+      ref: branchName ? `refs/heads/${branchName}` : 'HEAD', value: oid, force: true,
+    });
+    await ctx.git.checkout({ fs: ctx.fs, dir: ctx.dir, gitdir: ctx.gitdir, ref: branchName ?? oid, force: true });
+    await replaceWorkingTreeUnlocked(ctx, bytes);
+    return { oid };
   });
 
   /** @param {RepositoryContext} ctx */
@@ -578,8 +597,8 @@ export const createRepositoryService = ({
     coordinate,
     init, stage, commit, status, branches, history, diff, restore, branch, checkout,
     setRemote, getRemote, fetch: fetchRemote, push, clone, snapshot, matches, fork: forkRepository,
-    replaceWorkingTree, destroy,
-    initApp: (/** @type {string} */ appId, /** @type {{message?:string}} */ opts) => init(appRepositoryRef(appId), opts),
+    replaceWorkingTree, rollbackWorkingTree, destroy,
+    initApp: (/** @type {string} */ appId, /** @type {{message?:string,includeIgnored?:boolean}} */ opts) => init(appRepositoryRef(appId), opts),
     commitApp: (/** @type {string} */ appId, /** @type {{message?:string}} */ opts) => commit(appRepositoryRef(appId), opts),
     statusApp: (/** @type {string} */ appId) => status(appRepositoryRef(appId)),
     historyApp: (/** @type {string} */ appId, /** @type {{depth?:number,includeSafety?:boolean}} */ opts) => history(appRepositoryRef(appId), opts),

--- a/extension/peerd-runtime/lifecycle/engine-liveness.js
+++ b/extension/peerd-runtime/lifecycle/engine-liveness.js
@@ -71,6 +71,10 @@ export const makeEngineLiveness = ({ storage, now = Date.now }) => {
     await storage.set(ENGINE_LIVENESS_KEY, map).catch(() => {});
   }).catch(() => {});
 
+  /** @param {string} kind @param {number} tabId @returns {Promise<LivenessEntry|null>} */
+  const findByTab = (kind, tabId) => enqueue(async () =>
+    Object.values(await load()).find((entry) => entry?.kind === kind && entry.tabId === tabId) ?? null);
+
   /**
    * The boot sweep: entries whose instance is NOT in the survivor set lost
    * their process to the interruption. The ledger is rewritten to exactly
@@ -95,5 +99,5 @@ export const makeEngineLiveness = ({ storage, now = Date.now }) => {
     return lost;
   });
 
-  return { adopt, drop, sweep };
+  return { adopt, drop, findByTab, sweep };
 };

--- a/extension/peerd-runtime/tools/defs/app-version.js
+++ b/extension/peerd-runtime/tools/defs/app-version.js
@@ -69,7 +69,10 @@ export const repositoryVersionTool = {
         throw new Error('unknown_repo_version_op');
       });
       const result = kind === 'app'
-        ? await appQuiescence?.run?.(id, operation, { close: true })
+        ? await appQuiescence?.run?.(id, operation, {
+          close: true,
+          invalidateDweb: args.op === 'branch' || args.op === 'checkout' || args.op === 'restore',
+        })
         : podLive
           ? await podClient?.withWorkspaceLock?.(id, operation)
           : await operation();

--- a/extension/shared/dweb-interface.js
+++ b/extension/shared/dweb-interface.js
@@ -15,6 +15,8 @@
 // directory: this file ships in the store artifact, and the verifier
 // greps it like everything else.)
 
+export const APP_DWEB_GENERATION_PREFIX = 'app.dweb-generation.';
+
 /**
  * @typedef {Object} DwebStatus
  * @property {boolean} available  false in the store package / stub

--- a/extension/tests/unit/background/app-tab-tracker.test.js
+++ b/extension/tests/unit/background/app-tab-tracker.test.js
@@ -2,31 +2,325 @@
 
 import { describe, expect, it } from '../../framework.js';
 import { createAppTabTracker } from '/background/app-tab-tracker.js';
+import { AppRoomAuthorityChangedError, createAppRoomAuthority } from '/offscreen/app-room-authority.js';
+import { makeEngineLiveness } from '/peerd-runtime/background.js';
+
+const deferred = () => {
+  /** @type {(value:any)=>void} */ let resolve = () => {};
+  /** @type {(error:Error)=>void} */ let reject = () => {};
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+};
 
 describe('App tab tracker quiescence', () => {
   it('sends an instance-pinned editor flush before repository callers proceed', async () => {
     /** @type {any[]} */ const messages = [];
+    /** @type {Record<string,any>} */ const stored = {};
+    const invalidationStarted = deferred();
+    /** @type {(value:any)=>void} */ let releaseInvalidation = () => {};
+    const invalidationReply = new Promise((resolve) => { releaseInvalidation = resolve; });
+    const storage = /** @type {any} */ ({
+      get: async () => ({ ...stored }),
+      set: async (/** @type {any} */ values) => { Object.assign(stored, values); },
+    });
     const tracker = createAppTabTracker({
+      tabs: /** @type {any} */ ({ query: async () => [], remove: async () => {} }),
       sendTabMessage: async (tabId, message) => {
         messages.push({ tabId, message });
-        return { ok: true };
+        if (message.action !== 'invalidate-dweb') return { ok: true };
+        invalidationStarted.resolve(undefined);
+        return invalidationReply;
       },
+      storage,
     });
     tracker.onTabPending('app-1', 41);
+    expect(tracker.getDwebGeneration('app-1')).toBe(0);
     expect(await tracker.quiesceTab('app-1')).toBe(true);
-    expect(messages).toEqual([{
-      tabId: 41,
-      message: { type: 'app/quiesce', action: 'acquire', appId: 'app-1' },
-    }]);
+    const invalidating = tracker.invalidateDweb('app-1');
+    await invalidationStarted.promise;
+    expect(tracker.getDwebGeneration('app-1')).toBe(1);
+    releaseInvalidation({ ok: true });
+    expect(await invalidating).toBe(true);
+    expect(messages).toEqual([
+      { tabId: 41, message: { type: 'app/quiesce', action: 'acquire', appId: 'app-1' } },
+      { tabId: 41, message: { type: 'app/quiesce', action: 'invalidate-dweb', appId: 'app-1' } },
+    ]);
+    const restarted = createAppTabTracker({
+      tabs: /** @type {any} */ ({ query: async () => [] }),
+      sendTabMessage: async () => ({ ok: true }), storage,
+    });
+    await restarted.bootstrap();
+    expect(restarted.getDwebGeneration('app-1')).toBe(1);
   });
 
   it('fails closed when the App editor refuses to flush', async () => {
     const tracker = createAppTabTracker({
+      tabs: /** @type {any} */ ({ query: async () => [], remove: async () => {} }),
       sendTabMessage: async () => ({ ok: false, error: 'save failed' }),
+      storage: /** @type {any} */ ({ get: async () => ({}), set: async () => {} }),
     });
     tracker.onTabPending('app-1', 41);
     await expect(() => tracker.quiesceTab('app-1'))
       .toThrow((error) => error?.message === 'save failed');
+    await expect(() => tracker.invalidateDweb('app-1'))
+      .toThrow((error) => error?.message === 'save failed');
+    expect(tracker.getDwebGeneration('app-1')).toBe(1);
+  });
+
+  it('retires room authority when a tab closes without a page leave', async () => {
+    /** @type {Record<string,any>} */ const stored = { 'app.dweb-generation.app-1': 3 };
+    const owners = new Set(['app:app-1:41:3']);
+    const authority = createAppRoomAuthority({ get: async () => ({ ...stored }) });
+    const tracker = createAppTabTracker({
+      tabs: /** @type {any} */ ({ query: async () => [] }),
+      sendTabMessage: async () => ({ ok: true }),
+      purgeDwebOwners: (appId, generation) => authority.rotate(appId, generation, () => { owners.clear(); }),
+      storage: /** @type {any} */ ({
+        get: async () => ({ ...stored }),
+        set: async (/** @type {any} */ values) => { Object.assign(stored, values); },
+      }),
+    });
+    tracker.onTabPending('app-1', 41);
+    tracker.onTabReady('app-1', 41);
+    const appId = tracker.onTabRemoved(41);
+    expect(appId).toBe('app-1');
+    expect(await tracker.retireDwebTab(/** @type {string} */ (appId))).toBe(undefined);
+    expect(stored['app.dweb-generation.app-1']).toBe(4);
+    expect(owners.size).toBe(0);
+    let staleError = null;
+    try { await authority.run('app-1', 3, () => { owners.add('late'); }); }
+    catch (error) { staleError = error; }
+    expect(staleError instanceof AppRoomAuthorityChangedError).toBe(true);
+    expect(owners.size).toBe(0);
+  });
+
+  it('retires a cold App tab from its durable liveness entry', async () => {
+    /** @type {any} */ let ledger = null;
+    const livenessStorage = {
+      get: async () => structuredClone(ledger),
+      set: async (/** @type {string} */ _key, /** @type {any} */ value) => { ledger = structuredClone(value); },
+    };
+    await makeEngineLiveness({ storage: livenessStorage, now: () => 1 }).adopt('app', 'app-1', 41);
+    const stored = { 'app.dweb-generation.app-1': 3 };
+    const authority = createAppRoomAuthority({ get: async () => ({ ...stored }) });
+    const tracker = createAppTabTracker({
+      tabs: /** @type {any} */ ({ query: async () => [] }),
+      sendTabMessage: async () => ({ ok: true }),
+      purgeDwebOwners: (appId, generation) => authority.rotate(appId, generation, () => {}),
+      storage: /** @type {any} */ ({
+        get: async () => ({ ...stored }), set: async (/** @type {any} */ values) => { Object.assign(stored, values); },
+      }),
+    });
+    expect(tracker.onTabRemoved(41)).toBe(null);
+    const entry = await makeEngineLiveness({ storage: livenessStorage }).findByTab('app', 41);
+    expect(entry?.id).toBe('app-1');
+    await tracker.retireDwebTab(/** @type {string} */ (entry?.id));
+    expect(stored['app.dweb-generation.app-1']).toBe(4);
+    let accepted = false;
+    try { await authority.run('app-1', 3, () => { accepted = true; }); } catch { /* stale */ }
+    expect(accepted).toBe(false);
+  });
+
+  it('keeps failed tab identity durable until physical removal', async () => {
+    /** @type {string[]} */ const liveness = [];
+    const tracker = createAppTabTracker({
+      tabs: /** @type {any} */ ({ query: async () => [] }),
+      sendTabMessage: async () => ({ ok: true }),
+      onAdopt: (appId, tabId) => { liveness.push(`adopt:${appId}:${tabId}`); },
+      onDrop: (appId) => { liveness.push(`drop:${appId}`); },
+      storage: /** @type {any} */ ({ get: async () => ({}), set: async () => {} }),
+    });
+    tracker.onTabPending('app-1', 41);
+    expect(tracker.onTabFailed('app-1', new Error('attach failed'), 41)).toBe(41);
+    expect(tracker.getAppIdByTab(41)).toBe('app-1');
+    expect(tracker.onTabRemoved(41)).toBe('app-1');
+    expect(liveness).toEqual([
+      'adopt:app-1:41', 'drop:app-1', 'adopt:app-1:41', 'drop:app-1',
+    ]);
+  });
+
+  it('does not persist a new App tab before its first document claims it', async () => {
+    /** @type {string[]} */ const adopted = [];
+    const tracker = createAppTabTracker({
+      tabs: /** @type {any} */ ({
+        create: async () => ({ id: 41 }), query: async () => [],
+      }),
+      sendTabMessage: async () => ({ ok: true }),
+      onAdopt: (appId, tabId) => { adopted.push(`${appId}:${tabId}`); },
+      storage: /** @type {any} */ ({ get: async () => ({}), set: async () => {} }),
+    });
+    const opening = tracker.ensureTab('app-1');
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(adopted).toEqual([]);
+    tracker.onTabPending('app-1', 41);
+    tracker.onTabReady('app-1', 41);
+    expect(await opening).toBe(41);
+    expect(adopted).toEqual(['app-1:41', 'app-1:41']);
+  });
+
+  it('invalidates an exact cold-start App tab and persists its generation', async () => {
+    const reply = deferred();
+    const reached = deferred();
+    /** @type {Record<string,any>} */ const stored = {
+      'app.dweb-generation.app-1': 4,
+    };
+    const tabs = /** @type {any} */ ({
+      query: async (/** @type {{url:string}} */ query) => [{
+        id: 51,
+        url: `${query.url.slice(0, -1)}#app-1`,
+      }],
+      remove: async () => {},
+    });
+    const storage = /** @type {any} */ ({
+      get: async () => ({ ...stored }),
+      set: async (/** @type {Record<string,any>} */ values) => { Object.assign(stored, values); },
+    });
+    const tracker = createAppTabTracker({
+      tabs,
+      sendTabMessage: async (tabId, message) => {
+        reached.resolve({ tabId, message });
+        return reply.promise;
+      },
+      storage,
+    });
+    expect(tracker.getTabId('app-1')).toBe(null);
+    const invalidating = tracker.invalidateDweb('app-1');
+    let settled = false;
+    invalidating.then(() => { settled = true; }, () => { settled = true; });
+    expect(await reached.promise).toEqual({
+      tabId: 51,
+      message: { type: 'app/quiesce', action: 'invalidate-dweb', appId: 'app-1' },
+    });
+    expect(settled).toBe(false);
+    expect(stored['app.dweb-generation.app-1']).toBe(5);
+    reply.resolve({ ok: true });
+    expect(await invalidating).toBe(true);
+
+    const restarted = createAppTabTracker({
+      tabs: /** @type {any} */ ({ query: async () => [] }),
+      sendTabMessage: async () => ({ ok: true }),
+      storage,
+    });
+    await restarted.dwebGenerationsReady();
+    expect(restarted.getDwebGeneration('app-1')).toBe(5);
+  });
+
+  it('drains a delayed room join before failed cold invalidation and retry mutation', async () => {
+    const invalidationReply = deferred();
+    const invalidationStarted = deferred();
+    const joinStarted = deferred();
+    const releaseJoin = deferred();
+    /** @type {number[]} */ const removed = [];
+    const owners = new Set();
+    let live = true;
+    let mutated = false;
+    let invalidationCalls = 0;
+    let purgeCalls = 0;
+    /** @type {number[]} */ const purgedGenerations = [];
+    const tracker = createAppTabTracker({
+      tabs: /** @type {any} */ ({
+        query: async (/** @type {{url:string}} */ query) => live ? [{
+          id: 51,
+          url: `${query.url.slice(0, -1)}#app-1`,
+        }] : [],
+        remove: async (/** @type {number} */ tabId) => { removed.push(tabId); live = false; },
+      }),
+      sendTabMessage: async () => {
+        invalidationCalls += 1;
+        invalidationStarted.resolve(undefined);
+        return invalidationReply.promise;
+      },
+      purgeDwebOwners: async (_appId, generation) => {
+        purgeCalls += 1;
+        purgedGenerations.push(generation);
+        owners.clear();
+      },
+      storage: /** @type {any} */ ({ get: async () => ({}), set: async () => {} }),
+    });
+    expect(tracker.getTabId('app-1')).toBe(null);
+    const joining = tracker.withDwebAuthority('app-1', async () => {
+      joinStarted.resolve(undefined);
+      await releaseJoin.promise;
+      owners.add('app:app-1:51:0');
+    });
+    await joinStarted.promise;
+    const firstMutation = tracker.withDwebAuthority('app-1', async () => { mutated = true; }, { invalidate: true });
+    await Promise.resolve();
+    expect(invalidationCalls).toBe(0);
+    expect(purgeCalls).toBe(0);
+    releaseJoin.resolve(undefined);
+    await joining;
+    await invalidationStarted.promise;
+    expect(owners.size).toBe(1);
+    invalidationReply.reject(new Error('cold App tab did not respond'));
+    await expect(() => firstMutation)
+      .toThrow((error) => error?.message === 'cold App tab did not respond');
+    expect(removed).toEqual([51]);
+    expect(owners.size).toBe(0);
+    expect(purgeCalls).toBe(1);
+    expect(purgedGenerations).toEqual([1]);
+    expect(mutated).toBe(false);
+    await tracker.withDwebAuthority('app-1', async () => {
+      expect(owners.size).toBe(0);
+      mutated = true;
+    }, { invalidate: true });
+    expect(mutated).toBe(true);
+    expect(purgeCalls).toBe(2);
+    expect(purgedGenerations).toEqual([1, 2]);
+  });
+
+  it('waits for generation hydration before it invalidates a bridge', async () => {
+    const hydration = deferred();
+    /** @type {any[]} */ const messages = [];
+    const tracker = createAppTabTracker({
+      tabs: /** @type {any} */ ({ query: async () => [], remove: async () => {} }),
+      sendTabMessage: async (_tabId, message) => {
+        messages.push(message);
+        return { ok: true };
+      },
+      storage: /** @type {any} */ ({
+        get: async () => hydration.promise,
+        set: async () => {},
+      }),
+    });
+    tracker.onTabPending('app-1', 41);
+    const invalidating = tracker.invalidateDweb('app-1');
+    await Promise.resolve();
+    expect(messages).toEqual([]);
+    expect(tracker.getDwebGeneration('app-1')).toBe(0);
+    hydration.resolve({ 'app.dweb-generation.app-1': 3 });
+    expect(await invalidating).toBe(true);
+    expect(tracker.getDwebGeneration('app-1')).toBe(4);
+    expect(messages).toEqual([{
+      type: 'app/quiesce', action: 'invalidate-dweb', appId: 'app-1',
+    }]);
+  });
+
+  it('fails closed when generation hydration fails', async () => {
+    const hydration = deferred();
+    /** @type {any[]} */ const messages = [];
+    const tracker = createAppTabTracker({
+      tabs: /** @type {any} */ ({ query: async () => [], remove: async () => {} }),
+      sendTabMessage: async (_tabId, message) => {
+        messages.push(message);
+        return { ok: true };
+      },
+      storage: /** @type {any} */ ({
+        get: async () => hydration.promise,
+        set: async () => {},
+      }),
+    });
+    tracker.onTabPending('app-1', 41);
+    const invalidating = tracker.invalidateDweb('app-1');
+    hydration.reject(new Error('generation storage unavailable'));
+    await expect(() => invalidating)
+      .toThrow((error) => error?.message === 'generation storage unavailable');
+    expect(messages).toEqual([]);
+    expect(tracker.getDwebGeneration('app-1')).toBe(0);
   });
 
   it('pins an adopted App host to one owner root and refuses cross-chat reuse', async () => {
@@ -36,12 +330,191 @@ describe('App tab tracker quiescence', () => {
       query: async () => [], create: async () => ({ id: 42 }),
       reload: async () => {}, remove: async () => {},
     });
-    const tracker = createAppTabTracker({ tabs });
+    const tracker = createAppTabTracker({
+      tabs,
+      storage: /** @type {any} */ ({ get: async () => ({}), set: async () => {} }),
+    });
     tracker.onTabPending('app-1', 41, 'chat-a', 'root-a');
     tracker.onTabReady('app-1', 41, 'chat-a', 'root-a');
     expect(tracker.getOwnedTabId('app-1', 'root-a')).toBe(41);
     expect(tracker.getOwnedTabId('app-1', 'root-b')).toBe(null);
     await expect(() => tracker.ensureTab('app-1', { ownerSessionId: 'chat-b' }))
       .toThrow((error) => error?.message === 'app-owned-by-another-chat');
+  });
+});
+
+describe('App tab tracker races', () => {
+  it('waits for actor readiness after it reloads an App tab', async () => {
+    const reloadStarted = deferred();
+    const tracker = createAppTabTracker({
+      tabs: /** @type {any} */ ({
+        get: async (/** @type {number} */ tabId) => ({ id: tabId }), query: async () => [],
+        reload: async () => { reloadStarted.resolve(undefined); },
+      }),
+      sendTabMessage: async () => ({ ok: true }),
+      storage: /** @type {any} */ ({ get: async () => ({}), set: async () => {} }),
+    });
+    tracker.onTabPending('app-1', 41);
+    tracker.onTabReady('app-1', 41);
+    const reloading = tracker.reloadTab('app-1');
+    await reloadStarted.promise;
+    let settled = false;
+    reloading.finally(() => { settled = true; });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    tracker.onTabPending('app-1', 41);
+    tracker.onTabReady('app-1', 41);
+    expect(await reloading).toBe(true);
+  });
+
+  it('uses a new attach epoch after reload and removes it with the tab', async () => {
+    const firstAttach = deferred();
+    const nextAttach = deferred();
+    let operationCalls = 0;
+    /** @type {number[]} */ const epochs = [];
+    const tracker = createAppTabTracker({
+      tabs: /** @type {any} */ ({ query: async () => [] }),
+      sendTabMessage: async () => ({ ok: true }),
+      storage: /** @type {any} */ ({ get: async () => ({}), set: async () => {} }),
+    });
+    tracker.onTabPending('app-1', 41);
+    const operation = async (/** @type {number} */ epoch) => {
+      operationCalls += 1;
+      epochs.push(epoch);
+      return firstAttach.promise;
+    };
+    const first = tracker.coordinateAttach(41, operation);
+    const duplicate = tracker.coordinateAttach(41, operation);
+    expect(duplicate).toBe(first);
+    await Promise.resolve();
+    expect(operationCalls).toBe(1);
+    expect(tracker.markAttachLoading(41)).toBe(1);
+    expect(tracker.isAttachCurrent(41, 0)).toBe(false);
+    const reloaded = tracker.coordinateAttach(41, async (epoch) => {
+      operationCalls += 1;
+      epochs.push(epoch);
+      return nextAttach.promise;
+    });
+    expect(reloaded === first).toBe(false);
+    await Promise.resolve();
+    expect(epochs).toEqual([0, 1]);
+    firstAttach.resolve({ ok: false, error: 'stale-app-attach' });
+    expect(await first).toEqual({ ok: false, error: 'stale-app-attach' });
+    expect(await duplicate).toEqual({ ok: false, error: 'stale-app-attach' });
+    const attached = { ok: true, actorId: 'actor-2' };
+    nextAttach.resolve(attached);
+    expect(await reloaded).toBe(attached);
+    expect(await tracker.coordinateAttach(41, async () => { throw new Error('must not run'); })).toBe(attached);
+    expect(operationCalls).toBe(2);
+
+    expect(tracker.onTabRemoved(41)).toBe('app-1');
+    const removedResult = { ok: true, actorId: 'actor-3' };
+    expect(await tracker.coordinateAttach(41, async () => {
+      operationCalls += 1;
+      return removedResult;
+    })).toBe(removedResult);
+    expect(operationCalls).toBe(3);
+  });
+
+  it('creates one tab for concurrent requests', async () => {
+    const created = deferred();
+    let createCalls = 0;
+    const tabs = /** @type {any} */ ({
+      create: () => {
+        createCalls += 1;
+        return created.promise;
+      },
+      get: async (/** @type {number} */ tabId) => ({ id: tabId }),
+      query: async () => [], remove: async () => {},
+      reload: async () => {}, sendMessage: async () => ({ ok: true }),
+    });
+    const tracker = createAppTabTracker({
+      tabs,
+      storage: /** @type {any} */ ({ get: async () => ({}), set: async () => {} }),
+    });
+    const first = tracker.ensureTab('app-1');
+    const second = tracker.ensureTab('app-1');
+    expect(createCalls).toBe(1);
+    created.resolve({ id: 42 });
+    await Promise.resolve();
+    tracker.onTabReady('app-1', 42);
+    expect(await Promise.all([first, second])).toEqual([42, 42]);
+    expect(createCalls).toBe(1);
+  });
+
+  it('does not give one owner the tab that another owner opened', async () => {
+    const created = deferred();
+    let createCalls = 0;
+    const tabs = /** @type {any} */ ({
+      create: () => {
+        createCalls += 1;
+        return created.promise;
+      },
+      get: async (/** @type {number} */ tabId) => ({ id: tabId }),
+      query: async () => [], remove: async () => {},
+      reload: async () => {}, sendMessage: async () => ({ ok: true }),
+    });
+    const tracker = createAppTabTracker({
+      tabs,
+      storage: /** @type {any} */ ({ get: async () => ({}), set: async () => {} }),
+    });
+    const first = tracker.ensureTab('app-1', { ownerSessionId: 'chat-a' });
+    const second = tracker.ensureTab('app-1', { ownerSessionId: 'chat-b' });
+    const secondResult = second.then(
+      () => null,
+      (error) => error,
+    );
+    created.resolve({ id: 42 });
+    await Promise.resolve();
+    tracker.onTabReady('app-1', 42, 'chat-a', 'root-a');
+    expect(await first).toBe(42);
+    expect((await secondResult)?.message).toBe('app-owned-by-another-chat');
+    expect(createCalls).toBe(1);
+  });
+
+  it('refuses a second pending tab for the same App', () => {
+    const tracker = createAppTabTracker({
+      tabs: /** @type {any} */ ({ query: async () => [] }),
+      sendTabMessage: async () => ({ ok: true }),
+      storage: /** @type {any} */ ({ get: async () => ({}), set: async () => {} }),
+    });
+    expect(tracker.onTabPending('app-1', 41, 'chat-a', 'root-a')).toBe(true);
+    expect(tracker.onTabPending('app-1', 42, 'chat-b', 'root-b')).toBe(false);
+    expect(tracker.getTabId('app-1')).toBe(41);
+    expect(tracker.getOwnedTabId('app-1', 'root-a')).toBe(41);
+    expect(tracker.getOwnedTabId('app-1', 'root-b')).toBe(null);
+  });
+
+  it('ignores stale ready, failure, removal, and same-tab navigation events', async () => {
+    const tracker = createAppTabTracker({
+      tabs: /** @type {any} */ ({ query: async () => [] }),
+      sendTabMessage: async () => ({ ok: true }),
+      storage: /** @type {any} */ ({ get: async () => ({}), set: async () => {} }),
+    });
+    tracker.onTabPending('app-1', 41, 'chat-a', 'root-a');
+    expect(tracker.onTabRemoved(41)).toBe('app-1');
+    tracker.onTabPending('app-1', 42, 'chat-b', 'root-b');
+    tracker.onTabReady('app-1', 42, 'chat-b', 'root-b');
+    expect(tracker.onTabReady('app-1', 41, 'chat-a', 'root-a')).toBe(false);
+    expect(tracker.onTabFailed('app-1', new Error('late failure'), 41)).toBe(null);
+    expect(tracker.onTabRemoved(41)).toBe(null);
+    expect(tracker.getTabId('app-1')).toBe(42);
+    expect(tracker.getOwnedTabId('app-1', 'root-b')).toBe(42);
+    expect(tracker.getOwnedTabId('app-1', 'root-a')).toBe(null);
+
+    /** @type {any[]} */ const messages = [];
+    const rebound = createAppTabTracker({
+      tabs: /** @type {any} */ ({ query: async () => [] }),
+      sendTabMessage: async (tabId, message) => { messages.push({ tabId, message }); return { ok: true }; },
+      storage: /** @type {any} */ ({ get: async () => ({}), set: async () => {} }),
+    });
+    rebound.onTabPending('app-a', 61);
+    rebound.onTabPending('app-b', 61);
+    expect(rebound.getTabId('app-a')).toBe(null);
+    expect(rebound.getTabId('app-b')).toBe(61);
+    expect(await rebound.invalidateDweb('app-a')).toBe(false);
+    expect(messages).toEqual([]);
+    expect(rebound.onTabRemoved(61)).toBe('app-b');
+    expect(rebound.getTabId('app-b')).toBe(null);
   });
 });

--- a/extension/tests/unit/engine-tabs/app-tab/app-binary-assets.test.js
+++ b/extension/tests/unit/engine-tabs/app-tab/app-binary-assets.test.js
@@ -5,10 +5,11 @@
 import { describe, expect, it } from '../../../framework.js';
 import {
   createEditor,
+  createRepositoryService,
   isBinaryAssetPath,
   opfsHelpers,
 } from '/peerd-engine/index.js';
-import { createAppClient } from '/background/app-client.js';
+import { AppFileContentError, AppFileLimitError, createAppClient, MAX_APP_FILES } from '/background/app-client.js';
 import { createAppDataClient, MAX_APP_DATA_BYTES } from '../../../../engine-tabs/app-tab/app-data-client.js';
 
 const VALID_EMPTY_WASM = [0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
@@ -96,9 +97,11 @@ describe('App storage binary contract', () => {
 
   it('stores base64 as raw bytes and refuses text reads of binary assets', async () => {
     const registry = memoryRegistry();
+    /** @type {any[]} */ const initializations = [];
     const client = createAppClient({
       registry: /** @type {any} */ (registry),
       tracker: /** @type {any} */ ({ reloadTab: async () => {} }),
+      repositories: /** @type {any} */ ({ initApp: async (/** @type {string} */ _id, /** @type {any} */ opts) => { initializations.push(opts); } }),
     });
     const record = await client.create({
       name: 'Binary storage',
@@ -114,7 +117,110 @@ describe('App storage binary contract', () => {
     try { await client.readFile({ appId: record.id, path: 'asset.bin' }); }
     catch (error) { code = /** @type {{ code?: string }} */ (error).code ?? ''; }
     expect(code).toBe('binary_asset_not_text');
+    await expect(() => client.writeFile({
+      appId: record.id, path: 'data/state.json', content: { base64: 'AP/AgH8=' },
+    })).toThrow((error) => error instanceof AppFileContentError);
+    await expect(() => client.writeFile({
+      appId: record.id, path: 'data/state.json', content: 'not JSON',
+    })).toThrow((error) => error instanceof AppFileContentError);
+    await client.writeFile({ appId: record.id, path: 'data/state.json', content: '{"ok":true}' });
+    expect(await client.readFile({ appId: record.id, path: 'data/state.json' })).toBe('{"ok":true}');
+    expect(initializations[0].includeIgnored).toBe(false);
+    const installed = await client.create({
+      name: 'Installed storage', files: { 'index.html': '<h1>peer</h1>' },
+      source: 'dweb', dweb: { uri: 'peerd://signed-hash', publisher: 'did:key:zPeer', hash: 'signed-hash' },
+    });
+    expect(initializations[1].includeIgnored).toBe(true);
     await client.opfsForApp(record.id).nuke();
+    await client.opfsForApp(installed.id).nuke();
+  });
+
+  it('preserves runtime data, checks the merged cap, and rolls back a failed verified update', async () => {
+    const registry = memoryRegistry();
+    /** @type {any[]} */ const replacements = [];
+    const repositories = {
+      initApp: async () => 'base',
+      statusApp: async () => ({ oid: 'base' }),
+      replaceWorkingTree: async (/** @type {any} */ _ref, /** @type {any} */ options) => {
+        replacements.push(options);
+        return { oid: 'next', created: true };
+      },
+      rollbackWorkingTree: async () => ({ oid: 'base' }),
+    };
+    const client = createAppClient({
+      registry: /** @type {any} */ (registry),
+      tracker: /** @type {any} */ ({ reloadTab: async () => {} }),
+      repositories: /** @type {any} */ (repositories),
+    });
+    const record = await client.create({
+      name: 'Stateful App', files: { 'index.html': 'old', 'data/state.json': '{"count":1}' },
+    });
+    await client.replaceVersionedFilesUnlocked({
+      appId: record.id,
+      files: { 'index.html': 'new', 'peerd.json': '{}' },
+      entryFile: 'index.html',
+    });
+    expect(new TextDecoder().decode(replacements[0].files['data/state.json'])).toBe('{"count":1}');
+    expect(replacements[0].includeIgnored).toBe(true);
+    await client.opfsForApp(record.id).nuke();
+
+    const dataFiles = Object.fromEntries(Array.from(
+      { length: MAX_APP_FILES - 2 },
+      (_, index) => [`data/state-${index}.json`, '{}'],
+    ));
+    const capped = await client.create({ name: 'Capped App', files: { 'index.html': 'old', ...dataFiles } });
+    let error = null;
+    try {
+      await client.replaceVersionedFilesUnlocked({
+        appId: capped.id,
+        files: { 'index.html': 'new', 'peerd.json': '{}', 'new.js': 'x' },
+        entryFile: 'index.html',
+      });
+    } catch (cause) { error = cause; }
+    expect(error instanceof AppFileLimitError).toBe(true);
+    expect(replacements.length).toBe(1);
+    await client.opfsForApp(capped.id).nuke();
+
+    const rollbackRegistry = memoryRegistry();
+    const realRepositories = createRepositoryService();
+    const rollbackClient = createAppClient({
+      registry: /** @type {any} */ (rollbackRegistry),
+      tracker: /** @type {any} */ ({ reloadTab: async () => {} }),
+      repositories: realRepositories,
+    });
+    const rollbackRecord = await rollbackClient.create({
+      name: 'Rollback App',
+      files: { 'index.html': 'old', '.gitignore': '.env\n' },
+    });
+    const ref = { kind: 'app', id: rollbackRecord.id };
+    await rollbackClient.writeFile({ appId: rollbackRecord.id, path: '.env', content: 'TOKEN=local-secret\n' });
+    const baseOid = (await realRepositories.status(ref)).oid;
+    const updateRecord = rollbackRegistry.update;
+    let failMetadata = true;
+    rollbackRegistry.update = async (id, patch) => {
+      if (failMetadata) { failMetadata = false; throw new Error('catalog unavailable'); }
+      return updateRecord(id, patch);
+    };
+    let updateFailed = false;
+    try {
+      await rollbackClient.replaceVersionedFilesUnlocked({
+        appId: rollbackRecord.id,
+        files: { 'index.html': 'release', '.gitignore': '.env\n', '.env': 'TOKEN=publisher-value\n' },
+        entryFile: 'index.html',
+      });
+    } catch { updateFailed = true; }
+    expect(updateFailed).toBe(true);
+    expect(await rollbackClient.readFile({ appId: rollbackRecord.id, path: '.env' })).toBe('TOKEN=local-secret\n');
+    expect((await realRepositories.status(ref)).oid).toBe(baseOid);
+    expect((await realRepositories.commit(ref, { message: 'must stay clean' })).created).toBe(false);
+    const history = await realRepositories.history(ref);
+    expect(history.length).toBe(1);
+    for (const row of history) {
+      const snapshot = await realRepositories.snapshot(ref, { at: row.oid });
+      expect(Object.hasOwn(snapshot, '.env')).toBe(false);
+      expect(Object.values(snapshot).some((bytes) => new TextDecoder().decode(bytes).includes('local-secret'))).toBe(false);
+    }
+    await realRepositories.destroy(ref, { worktree: true });
   });
 
   it('removes the catalog record and partial OPFS tree when create fails', async () => {
@@ -171,9 +277,12 @@ describe('App storage binary contract', () => {
 
   it('changes durable kind when a deleted unknown binary is recreated as text', async () => {
     const registry = memoryRegistry();
+    let invalidations = 0;
     const client = createAppClient({
       registry: /** @type {any} */ (registry),
-      tracker: /** @type {any} */ ({ reloadTab: async () => {} }),
+      tracker: /** @type {any} */ ({
+        invalidateDweb: async () => { invalidations += 1; }, reloadTab: async () => {},
+      }),
     });
     const record = await client.create({
       name: 'Kinds',
@@ -183,6 +292,7 @@ describe('App storage binary contract', () => {
     expect(registry.records.get(record.id).fileKinds['model.custom']).toBe('binary');
     await client.deleteFile({ appId: record.id, path: 'model.custom' });
     await client.writeFile({ appId: record.id, path: 'model.custom', content: 'text now' });
+    expect(invalidations).toBe(2);
     expect(registry.records.get(record.id).fileKinds['model.custom']).toBe('text');
     expect(await client.readFile({ appId: record.id, path: 'model.custom' })).toBe('text now');
     await client.opfsForApp(record.id).nuke();

--- a/extension/tests/unit/home/library-section.test.js
+++ b/extension/tests/unit/home/library-section.test.js
@@ -385,7 +385,7 @@ describe('home.library', () => {
       'dweb/base/updates': () => ({ ok: true, updates: { 'app-7': { uri: 'peerd://x/v2', version_id: 'v2', seq: 2, name: 'Notes', slug: 'notes', dwapp_id: 'D', changelog: 'Improve sync' } } }),
       'dweb/base/update-app': (msg) => msg.strategy === 'fork'
         ? { ok: true, app: { dweb: { version_id: 'v2' } }, fork: { id: 'fork-1', name: 'Notes: local fork' } }
-        : { ok: false, error: 'local-changes' },
+        : { ok: false, error: 'local-changes', conflictToken: 7 },
     });
     const { root, unmount } = await mountView(send, { dweb: true });
     try {
@@ -394,10 +394,13 @@ describe('home.library', () => {
       clickText(root, 'button', 'Update');
       await flush();
       expect(root.textContent).toContain('will not overwrite');
+      window.dispatchEvent(new Event('focus'));
+      await flush();
       clickText(root, 'button', 'Keep a fork & update');
       await flush();
       const calls = send.calls.filter((c) => c.type === 'dweb/base/update-app');
       expect(calls.at(-1)?.strategy).toBe('fork');
+      expect(calls.at(-1)?.conflictToken).toBe(7);
       expect(root.textContent).toContain('Kept your local work');
     } finally { unmount(); }
   });

--- a/extension/tests/unit/peerd-engine/repository.test.js
+++ b/extension/tests/unit/peerd-engine/repository.test.js
@@ -38,25 +38,54 @@ describe('peerd-engine repository: real OPFS + vendored Git', () => {
     const repositories = createRepositoryService();
     try {
       await files.write('index.html', '<h1>one</h1>\n');
-      await files.write('.gitignore', '.env\n');
+      await files.write('.gitignore', '.env\nignored/\n');
+      await files.write('ignored/signed.js', 'export const signed = true;\n');
       await files.write('__proto__', 'prototype-shaped file\n');
       await files.write('constructor', 'constructor-shaped file\n');
       await files.write('toString', 'string-shaped file\n');
-      const firstOid = await repositories.init(ref, { message: 'initial app' });
+      const firstOid = await repositories.initApp(id, { message: 'initial app', includeIgnored: true });
       expect(typeof firstOid).toBe('string');
       expect((await repositories.status(ref)).dirty).toBe(false);
+      expect(await repositories.matches(ref, { at: firstOid })).toBe(true);
       const initialSnapshot = await repositories.snapshot(ref, { at: firstOid });
       expect(Object.hasOwn(initialSnapshot, '__proto__')).toBe(true);
       expect(Object.hasOwn(initialSnapshot, 'constructor')).toBe(true);
       expect(Object.hasOwn(initialSnapshot, 'toString')).toBe(true);
+      expect(Object.hasOwn(initialSnapshot, 'ignored/signed.js')).toBe(true);
 
       await files.write('index.html', '<h1>two</h1>\n');
       await files.write('src/main.js', 'export const n = 2;\n');
+      await files.write('ignored/local-only.txt', 'local\n');
+      expect(await repositories.matches(ref, { at: firstOid })).toBe(false);
       const liveDiff = await repositories.diff(ref);
       expect(liveDiff.files.map((/** @type {{path:string}} */ f) => f.path)).toEqual(['index.html', 'src/main.js']);
       const second = await repositories.commit(ref, { message: 'second app' });
       expect(second.created).toBe(true);
+      const secondSnapshot = await repositories.snapshot(ref, { at: second.oid });
+      expect(Object.hasOwn(secondSnapshot, 'ignored/signed.js')).toBe(true);
+      expect(Object.hasOwn(secondSnapshot, 'ignored/local-only.txt')).toBe(false);
+      await files.remove('ignored/local-only.txt');
+      expect(await repositories.matches(ref, { at: second.oid })).toBe(true);
       expect((await repositories.history(ref, { depth: 5 })).length).toBe(2);
+
+      await files.write('data/state.json', '{}\n');
+      expect(await repositories.matches(ref, { at: second.oid, excludeAppData: true })).toBe(true);
+      await files.remove('data/state.json');
+      await files.write('.env', 'TOKEN=local-only\n');
+      expect(await repositories.matches(ref, { at: second.oid })).toBe(false);
+      const preReleaseFiles = await repositories.snapshot(ref, { at: second.oid });
+      preReleaseFiles['.env'] = new TextEncoder().encode('TOKEN=local-only\n');
+
+      const replaced = await repositories.replaceWorkingTree(ref, {
+        files: { 'index.html': '<h1>release</h1>\n', '.gitignore': '.env\nignored/\n', 'ignored/release.js': 'export const release = true;\n', '.env': 'TOKEN=publisher\n' },
+        message: 'verified release', includeIgnored: true,
+      });
+      expect(Object.hasOwn(await repositories.snapshot(ref, { at: replaced.oid }), 'ignored/release.js')).toBe(true);
+      await repositories.rollbackWorkingTree(ref, { to: second.oid, files: preReleaseFiles });
+      expect((await repositories.status(ref)).oid).toBe(second.oid);
+      expect((await repositories.commit(ref, { message: 'must stay clean' })).created).toBe(false);
+      expect(Object.hasOwn(await repositories.snapshot(ref, { at: second.oid }), '.env')).toBe(false);
+      expect(await files.read('.env')).toBe('TOKEN=local-only\n');
 
       // A restore is allowed to be destructive only after the exact live tree
       // (including ignored local bytes) is preserved on a private safety ref.

--- a/packaging/security-baseline.json
+++ b/packaging/security-baseline.json
@@ -479,7 +479,7 @@
     "peerd-runtime/tools/hooks/compile.js": 1
   },
   "messageHostSites": {
-    "background/service-worker.js": 3,
+    "background/service-worker.js": 4,
     "engine-tabs/app-tab/app-tab.js": 3,
     "engine-tabs/notebook-tab/notebook-tab.js": 1,
     "engine-tabs/pod-tab/pod-tab.js": 1,

--- a/scripts/cdp/e2e-harness.mjs
+++ b/scripts/cdp/e2e-harness.mjs
@@ -261,8 +261,13 @@ export const WIDE_METRICS = Object.freeze({ width: 1280, height: 900, deviceScal
  * @param {{ bringToFront?: boolean }} [options]
  * @returns {Promise<Buffer>}
  */
+const foregroundedPages = new WeakSet();
 export async function capturePage(page, { bringToFront = true } = {}) {
-  if (bringToFront) await page.send('Page.bringToFront').catch(() => {});
+  // why: Repeating bringToFront can stall the next headless screenshot.
+  if (bringToFront && !foregroundedPages.has(page)) {
+    await page.send('Page.bringToFront').catch(() => {});
+    foregroundedPages.add(page);
+  }
   let pumping = true;
   let toggle = false;
   const pump = (async () => {
@@ -293,6 +298,11 @@ export async function openWidePage(ctx, path, { metrics = WIDE_METRICS, ready } 
   const url = `chrome-extension://${ctx.sw.id}/${String(path).replace(/^\//, '')}`;
   const created = await (await fetch(`http://127.0.0.1:${ctx.port}/json/new?about:blank`, { method: 'PUT' })).json();
   const page = await attach(created.webSocketDebuggerUrl);
+  const disconnect = page.close;
+  page.close = () => {
+    disconnect();
+    return fetch(`http://127.0.0.1:${ctx.port}/json/close/${created.id}`).catch(() => {});
+  };
   await page.send('Runtime.enable');
   await page.send('Page.enable');
   await page.send('Emulation.setDeviceMetricsOverride', metrics);
@@ -750,6 +760,11 @@ export async function openExtPage(ctx, path) {
   // before navigation captures the FULL load. (Same pattern as run-inbrowser-tests.)
   const created = await (await fetch(`http://127.0.0.1:${ctx.port}/json/new?about:blank`, { method: 'PUT' })).json();
   const page = await attach(created.webSocketDebuggerUrl);
+  const disconnect = page.close;
+  page.close = () => {
+    disconnect();
+    return fetch(`http://127.0.0.1:${ctx.port}/json/close/${created.id}`).catch(() => {});
+  };
   await page.send('Runtime.enable');
   await page.send('Page.enable');
   // The packaged-page boot check needs failed subresource loads (a pruned CSS/font/

--- a/tests/background/app-tab-host-security.test.ts
+++ b/tests/background/app-tab-host-security.test.ts
@@ -1,6 +1,95 @@
 import { describe, expect, test } from 'bun:test';
+import { createDwebBridgeLifecycle } from '../../extension/engine-tabs/app-tab/dweb-bridge-lifecycle.js';
 
 describe('App tab required-actor and runtime lifecycle contracts', () => {
+  test('concurrent bridge attach and detach share one lifecycle', async () => {
+    let releaseCreate!: () => void;
+    let releaseLeave!: () => void;
+    const creating = new Promise<void>((resolve) => { releaseCreate = resolve; });
+    const leaving = new Promise<void>((resolve) => { releaseLeave = resolve; });
+    let creates = 0;
+    let disposes = 0;
+    const lifecycle = createDwebBridgeLifecycle();
+    lifecycle.allow();
+    const create = async () => {
+      await creating;
+      creates += 1;
+      return { dispose: async () => { disposes += 1; await leaving; } };
+    };
+    const firstAttach = lifecycle.attach(create);
+    const secondAttach = lifecycle.attach(create);
+    expect(secondAttach).toBe(firstAttach);
+    releaseCreate();
+    await firstAttach;
+    expect(creates).toBe(1);
+
+    const firstDispose = lifecycle.dispose();
+    const secondDispose = lifecycle.dispose();
+    expect(secondDispose).toBe(firstDispose);
+    await Promise.resolve();
+    expect(disposes).toBe(1);
+    releaseLeave();
+    await firstDispose;
+
+    let retries = 0;
+    const retained = createDwebBridgeLifecycle();
+    retained.allow();
+    await retained.attach(async () => ({
+      dispose: async () => { if (++retries === 1) throw new Error('leave-failed'); },
+    }));
+    await expect(retained.invalidate()).rejects.toThrow('leave-failed');
+    retained.allow();
+    let recreated = false;
+    await retained.attach(async () => { recreated = true; return null; });
+    expect(recreated).toBe(false);
+    await retained.invalidate();
+    expect(retries).toBe(2);
+  });
+
+  test('authority invalidation bypasses a generic dispose that waits for a join', async () => {
+    let disposeStarted!: () => void;
+    let releaseDispose!: () => void;
+    const started = new Promise<void>((resolve) => { disposeStarted = resolve; });
+    const blocked = new Promise<void>((resolve) => { releaseDispose = resolve; });
+    let invalidated = 0;
+    const lifecycle = createDwebBridgeLifecycle();
+    lifecycle.allow();
+    await lifecycle.attach(async () => ({
+      dispose: async () => { disposeStarted(); await blocked; },
+      invalidate: async () => { invalidated += 1; },
+    }));
+    const disposing = lifecycle.dispose();
+    await started;
+    await lifecycle.invalidate();
+    expect(invalidated).toBe(1);
+    releaseDispose();
+    await disposing;
+
+    let fallbackDispose = 0;
+    const synchronous = createDwebBridgeLifecycle();
+    synchronous.allow();
+    await synchronous.attach(async () => ({
+      dispose: () => { fallbackDispose += 1; },
+      invalidate: () => { invalidated += 1; },
+    }));
+    await synchronous.invalidate();
+    expect(fallbackDispose).toBe(0);
+  });
+
+  test('document loss retires authority after a lost page leave and a cold worker', async () => {
+    const tracker = await Bun.file('./extension/background/app-tab-tracker.js').text();
+    const worker = await Bun.file('./extension/background/service-worker.js').text();
+    expect(tracker).toContain('purgeDwebOwners(appId, await advanceDwebGeneration(appId))');
+    expect(worker).toContain('retireAppDweb(closedAppId)');
+    expect(worker).toContain("engineLiveness.findByTab('app', tabId)");
+    expect(worker).toContain('retireAppDweb(entry.id)');
+    expect(worker).toContain("changeInfo.discarded === true || typeof changeInfo.url === 'string'");
+    expect(worker).toContain('await appRetirements.get(sender.tab.id)');
+    expect(worker).toContain('retireAppDocument(tabId, changeInfo.url, trackedAppId)');
+    expect(worker).toContain('await retireAppDweb(appId)');
+    expect(worker).toContain('await trackAppRetirement(tabId, () => retireAppDweb(appId))');
+  });
+
   test('the host binds owner from its URL, exposes retry, and never delivers owner to App launch data', async () => {
     const source = await Bun.file('./extension/engine-tabs/app-tab/app-tab.js').text();
     const html = await Bun.file('./extension/engine-tabs/app-tab/index.html').text();

--- a/tests/background/routes-dweb.test.ts
+++ b/tests/background/routes-dweb.test.ts
@@ -2,8 +2,32 @@ import { describe, test, expect } from 'bun:test';
 import { makeDwebRoutes } from '../../extension/background/routes/dweb.js';
 import { createDwebRollbackGuard } from '../../extension/background/dweb-rollback-guard.js';
 import { createAppQuiescence } from '../../extension/background/app-quiescence.js';
+import { appReleaseDescriptorMatches } from '../../extension/background/app-client.js';
+import { createDwebBridge } from '../../extension/peerd-distributed/apps/bridge.js';
 
 const offscreenSender = { url: 'moz-extension://peerd/offscreen/offscreen.html' };
+
+const makeLane = () => {
+  let tail = Promise.resolve();
+  return async <T>(operation: () => Promise<T>) => {
+    const prior = tail;
+    let release!: () => void;
+    tail = new Promise<void>((resolve) => { release = resolve; });
+    await prior;
+    await Promise.resolve();
+    try { return await operation(); } finally { release(); }
+  };
+};
+
+const within = async <T>(promise: Promise<T>) => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => { timer = setTimeout(() => reject(new Error('lock order timed out')), 250); }),
+    ]);
+  } finally { clearTimeout(timer); }
+};
 
 const baseDeps = (over: any = {}) => {
   const sent: any[] = [];
@@ -28,6 +52,10 @@ const baseDeps = (over: any = {}) => {
     },
     appTabTracker: {
       getTabId: () => null,
+      getDwebGeneration: () => 0,
+      dwebGenerationSnapshot: async () => ({}),
+      dwebGenerationsReady: async () => {},
+      withDwebAuthority: async (_appId: string, operation: () => Promise<any>) => operation(),
       quiesceTab: async () => true,
       resumeTab: async () => true,
       closeTab: async () => true,
@@ -46,6 +74,7 @@ const baseDeps = (over: any = {}) => {
     ensureSettingsReady: async () => {},
     isOffscreenSender: (sender: any) => sender?.url === offscreenSender.url,
     createDwebRollbackGuard,
+    appReleaseDescriptorMatches,
     repositories: {
       statusApp: async () => ({ oid: 'base', branch: 'main', dirty: false }),
       matches: async () => true,
@@ -127,6 +156,23 @@ describe('dweb audit', () => {
 });
 
 describe('dweb app store', () => {
+  test('only the offscreen host can read App authority generations', async () => {
+    const { deps } = baseDeps({
+      appTabTracker: {
+        dwebGenerationSnapshot: async () => ({ 'app.dweb-generation.a1': 3 }),
+      },
+    });
+    const route = makeDwebRoutes(deps)['dweb/app-authority-generations'];
+    expect(await route({}, { url: 'https://example.test/' })).toEqual({
+      ok: false,
+      error: 'offscreen-sender-required',
+    });
+    expect(await route({}, offscreenSender)).toEqual({
+      ok: true,
+      generations: { 'app.dweb-generation.a1': 3 },
+    });
+  });
+
   test('commons launch pins the required App actor owner without exposing it outside the hash', async () => {
     let createArgs: any = null;
     let tabArgs: any = null;
@@ -185,6 +231,7 @@ describe('dweb app store', () => {
     const res = await makeDwebRoutes(deps)['dweb/app-install']({ appId: 'app-new12345', name: 'X', files: {}, entryFile: 'i.html', dweb: { uri: 'u', publisher: 'p' } }, offscreenSender);
     expect(res.ok).toBe(true);
     expect(created).toMatchObject({ appId: 'app-new12345', source: 'dweb' });
+    expect(res.app.dweb).toMatchObject({ release_entry_file: 'i.html', release_file_kinds: {} });
     expect(audits.at(-1)).toMatchObject({ type: 'dweb_app_installed', details: { uri: 'u', publisher: 'p' } });
   });
   test('durable discovery history rejects a lower-sequence fresh install after restart', async () => {
@@ -307,8 +354,11 @@ describe('dweb app store', () => {
       entryFile: 'index.html',
       files: { 'index.html': { base64: 'PGgxPng8L2gxPg==' } },
     });
-    expect(replacement.metadataForOid('new-base', { dweb: { git_oid: 'base' } })).toEqual({
-      dweb: { version_id: 'v2', git_oid: 'new-base', published_hashes: [] },
+    expect(replacement.metadataForOid('new-base', { dweb: { git_oid: 'base' } }, { 'index.html': 'text' })).toEqual({
+      dweb: {
+        version_id: 'v2', git_oid: 'new-base', release_entry_file: 'index.html',
+        release_file_kinds: { 'index.html': 'text' }, published_hashes: [],
+      },
     });
     expect(directMetadataWrites).toBe(0);
   });
@@ -413,7 +463,7 @@ describe('dweb app store', () => {
       dweb: { seed: 'commons', room_hash: 'new', room_uri: 'peerd://new' },
     });
   });
-  test('update-app tells the host which served version it replaces', async () => {
+  test('update-app sends durable identity without a stale cleanup snapshot', async () => {
     const { deps, sent } = baseDeps({
       appRegistry: {
         get: async () => ({
@@ -426,18 +476,20 @@ describe('dweb app store', () => {
         list: async () => [],
         update: async (_id: string, patch: any) => ({ id: 'a1', dweb: patch.dwebExact }),
       },
-      _reply: { ok: true, app: { id: 'a1' }, pendingUnserveHashes: [] },
+      _reply: { ok: true, app: { id: 'a1' }, cleanupHashes: ['v0', 'v1'], pendingUnserveHashes: [] },
     });
     const result = await makeDwebRoutes(deps)['dweb/base/update-app']({
-      appId: 'a1', uri: 'peerd://v2', name: 'A', dwappId: 'd', slug: 'a', seq: 2, strategy: 'fork',
+      appId: 'a1', uri: 'peerd://v2', name: 'A', dwappId: 'd', slug: 'a', seq: 2,
+      strategy: 'fork', conflictToken: 0,
     });
     expect(sent.at(-1)).toMatchObject({
       type: 'dweb/base-host/update-app', appId: 'a1',
       expectedDwappId: 'durable-d', expectedPublisher: 'did:key:zDurable',
-      previousHash: 'v1', pendingHashes: ['v0'],
-      strategy: 'fork',
+      strategy: 'fork', conflictToken: 0,
     });
     expect(sent.at(-1).dwappId).toBeUndefined();
+    expect(sent.at(-1).previousHash).toBeUndefined();
+    expect(sent.at(-1).pendingHashes).toBeUndefined();
     expect(result.app.dweb.pending_seed_unserve_hashes).toBeUndefined();
   });
   test('update cleanup persistence failure remains committed with a retry warning', async () => {
@@ -450,7 +502,7 @@ describe('dweb app store', () => {
         list: async () => [],
         update: async () => { throw new Error('disk'); },
       },
-      _reply: { ok: true, app: { id: 'a1' }, pendingUnserveHashes: [] },
+      _reply: { ok: true, app: { id: 'a1' }, cleanupHashes: ['v1'], pendingUnserveHashes: [] },
     });
     expect(await makeDwebRoutes(deps)['dweb/base/update-app']({
       appId: 'a1', uri: 'peerd://v2', name: 'A', dwappId: 'd', slug: 'a', seq: 2,
@@ -459,6 +511,28 @@ describe('dweb app store', () => {
       warning: 'previous-version-cleanup-pending',
       cleanupPending: true,
     });
+  });
+  test('update cleanup removes only confirmed hashes from later pending work', async () => {
+    let reads = 0;
+    let saved: any = null;
+    const { deps } = baseDeps({
+      appRegistry: {
+        get: async () => ++reads === 1
+          ? { id: 'a1', dweb: { hash: 'v1', dwapp_id: 'd', publisher: 'did:key:zPeer' } }
+          : { id: 'a1', dweb: { hash: 'v3', pending_seed_unserve_hashes: ['v0', 'v1', 'v2'] } },
+        list: async () => [],
+        update: async (_id: string, patch: any) => {
+          saved = patch.dwebExact;
+          return { id: 'a1', dweb: saved };
+        },
+      },
+      _reply: {
+        ok: true, app: { id: 'a1' }, cleanupHashes: ['v0', 'v1'], pendingUnserveHashes: ['v1'],
+      },
+    });
+    const result = await makeDwebRoutes(deps)['dweb/base/update-app']({ appId: 'a1', uri: 'peerd://v2' });
+    expect(result.ok).toBe(true);
+    expect(saved.pending_seed_unserve_hashes).toEqual(['v1', 'v2']);
   });
   test('update refuses an App without a durable discovery stream', async () => {
     const { deps, sent } = baseDeps({
@@ -498,6 +572,80 @@ describe('dweb app store', () => {
     expect(result).toMatchObject({ ok: false, error: 'local-changes', requiresAction: true });
     expect(replaced).toBe(false);
   });
+  test('replace approval expires when local bytes change before apply', async () => {
+    let generation = 3;
+    let replaced = false;
+    const { deps } = baseDeps({
+      appRegistry: { get: async () => ({ id: 'a1', name: 'A', entryFile: 'i.html', dweb: { git_oid: 'base' } }) },
+      appTabTracker: {
+        getDwebGeneration: () => generation,
+        withDwebAuthority: async (_appId: string, operation: () => Promise<any>, options: any = {}) => {
+          if (options.expectedGeneration != null && options.expectedGeneration !== generation) {
+            const error = new Error('changed');
+            error.name = 'AppDwebAuthorityChangedError';
+            throw error;
+          }
+          if (options.invalidate) generation += 1;
+          return operation();
+        },
+      },
+      repositories: {
+        statusApp: async () => ({ oid: 'local', branch: 'main', dirty: true }),
+        matches: async () => false,
+      },
+      appClient: {
+        replaceVersionedFilesUnlocked: async () => {
+          replaced = true;
+          return { record: { id: 'a1' }, oid: 'new' };
+        },
+      },
+    });
+    const route = makeDwebRoutes(deps)['dweb/app-update'];
+    const args = { appId: 'a1', files: { 'i.html': 'new' }, entryFile: 'i.html', dweb: { version_id: 'v2' } };
+    const conflict = await route(args, offscreenSender);
+    expect(conflict).toMatchObject({ error: 'local-changes', conflictToken: 4 });
+
+    generation += 1; // A local edit lands while the approved peer update is fetched.
+    const result = await route({ ...args, strategy: 'replace', conflictToken: conflict.conflictToken }, offscreenSender);
+    expect(result).toMatchObject({ error: 'local-changes', conflictToken: 5 });
+    expect(replaced).toBe(false);
+  });
+  test('runtime data create and delete do not block a verified App update', async () => {
+    const compared: any[] = [];
+    let replaced = 0;
+    let record: any = {
+      id: 'a1', name: 'A', entryFile: 'i.html', fileKinds: { 'data/state.json': 'text' },
+      dweb: { hash: 'v1', git_oid: 'base', release_entry_file: 'i.html', release_file_kinds: {} },
+    };
+    const { deps } = baseDeps({
+      appRegistry: { get: async () => record },
+      repositories: {
+        statusApp: async () => ({ oid: 'data-only', branch: 'main', dirty: false }),
+        matches: async (ref: any, options: any) => { compared.push({ ref, options }); return true; },
+      },
+      appClient: {
+        replaceVersionedFilesUnlocked: async (args: any) => {
+          replaced += 1;
+          return { record: { id: 'a1', ...args.metadataForOid('new', { dweb: { git_oid: 'base' } }) }, oid: 'new' };
+        },
+      },
+    });
+    const route = makeDwebRoutes(deps)['dweb/app-update'];
+    expect((await route({
+      appId: 'a1', files: { 'i.html': 'new' }, entryFile: 'i.html', dweb: { version_id: 'v2' },
+    }, offscreenSender)).ok).toBe(true);
+    record = {
+      ...record, fileKinds: {},
+      dweb: { ...record.dweb, release_file_kinds: { 'data/state.json': 'text' } },
+    };
+    expect((await route({
+      appId: 'a1', files: { 'i.html': 'new' }, entryFile: 'i.html', dweb: { version_id: 'v2' },
+    }, offscreenSender)).ok).toBe(true);
+    expect(replaced).toBe(2);
+    expect(compared).toEqual(Array(2).fill({
+      ref: { kind: 'app', id: 'a1' }, options: { at: 'base', excludeAppData: true },
+    }));
+  });
   test('fork strategy preserves local files before applying the verified update', async () => {
     let forked: any = null;
     let replacement: any = null;
@@ -524,10 +672,11 @@ describe('dweb app store', () => {
       },
       repositories: {
         statusApp: async () => ({ oid: 'local', branch: 'main', dirty: true }),
+        matches: async () => false,
         fork: async () => { order.push('fork-copy'); return { oid: 'local' }; },
       },
     });
-    const result = await makeDwebRoutes(deps)['dweb/app-update']({ appId: 'a1', strategy: 'fork', files: { 'i.html': 'upstream' }, entryFile: 'i.html', dweb: { version_id: 'v2' } }, offscreenSender);
+    const result = await makeDwebRoutes(deps)['dweb/app-update']({ appId: 'a1', strategy: 'fork', conflictToken: 0, files: { 'i.html': 'upstream' }, entryFile: 'i.html', dweb: { version_id: 'v2' } }, offscreenSender);
     expect(result).toMatchObject({ ok: true, fork: { id: 'fork-1' } });
     expect(new TextDecoder().decode(forked.files['i.html'])).toBe('local');
     expect(replacement.files).toEqual({ 'i.html': 'upstream' });
@@ -556,9 +705,461 @@ describe('dweb app store', () => {
     });
     expect((await makeDwebRoutes(deps)['dweb/base/updates']()).updates).toEqual({});
   });
-  test('room relay strips the type and forwards args', async () => {
-    const { deps, sent } = baseDeps();
-    await makeDwebRoutes(deps)['dweb/base/room']({ type: 'dweb/base/room', op: 'join', roomId: 'r1' });
-    expect(sent[0]).toEqual({ type: 'dweb/base-host/room', op: 'join', roomId: 'r1' });
+  test('room relay admits a pinned local App without a bundle hash', async () => {
+    let liveTabId = 41;
+    const { deps, sent } = baseDeps({
+      appRegistry: { get: async () => ({ id: 'a1', dweb: { hash: null } }) },
+      appTabTracker: { getTabId: () => liveTabId, parseIdFromUrl: () => 'a1' },
+    });
+    const route = makeDwebRoutes(deps)['dweb/base/room'];
+    const firstSender = { tab: { id: 41, url: 'moz-extension://peerd/engine-tabs/app-tab/index.html#a1' } } as any;
+    await route({
+      type: 'dweb/base/room', op: 'join', roomId: 'r1', bridgeAppId: 'a1', bridgeAppForked: false, bridgeAppGeneration: 0,
+    }, firstSender);
+    expect(sent[0]).toEqual({
+      type: 'dweb/base-host/room', op: 'join', roomId: 'r1', roomOwnerId: 'app:a1:41:0',
+      roomOwnerAppId: 'a1', roomOwnerGeneration: 0,
+    });
+    await route({ op: 'join', roomId: 'r1', bridgeAppId: 'a1', bridgeAppForked: false, bridgeAppGeneration: 0 }, firstSender);
+    liveTabId = 42;
+    await route({
+      op: 'join', roomId: 'r1', bridgeAppId: 'a1', bridgeAppForked: false, bridgeAppGeneration: 0,
+    }, { tab: { id: 42, url: firstSender.tab.url } } as any);
+    await route({ op: 'leave', roomId: 'r1', bridgeAppId: 'a1', bridgeAppGeneration: 0 }, firstSender);
+    expect(sent.map((message) => message.roomOwnerId)).toEqual([
+      'app:a1:41:0', 'app:a1:41:0', 'app:a1:42:0', 'app:a1:41:0',
+    ]);
+  });
+  test('room join holds a matching App identity through the host relay', async () => {
+    let relayed: any[] = [];
+    let record: any = {
+      id: 'a1', entryFile: 'index.html', fileKinds: { 'payload.custom': 'binary' },
+      dweb: {
+        hash: 'bundle-v1', git_oid: 'base-v1', release_entry_file: 'index.html',
+        release_file_kinds: { 'payload.custom': 'binary' },
+      },
+    };
+    const { deps, sent } = baseDeps({
+      appRegistry: { get: async () => record },
+      appTabTracker: {
+        getTabId: () => 41,
+        parseIdFromUrl: (url: string) => url.endsWith('#a1') ? 'a1' : null,
+      },
+      appClient: {
+        withWriteLock: async (_appId: string, operation: () => Promise<any>) => {
+          const before = relayed.length;
+          const result = await operation();
+          expect(relayed).toHaveLength(before + (result?.ok === true ? 1 : 0));
+          return result;
+        },
+      },
+      repositories: { matches: async () => true },
+    });
+    relayed = sent;
+    const result = await makeDwebRoutes(deps)['dweb/base/room']({
+      type: 'dweb/base/room', op: 'join', roomId: 'r1',
+      bridgeAppId: 'a1', bridgeAppHash: 'bundle-v1', bridgeAppForked: false, bridgeAppGeneration: 0,
+    }, { tab: { id: 41, url: 'moz-extension://peerd/engine-tabs/app-tab/index.html#a1' } } as any);
+    expect(result).toEqual({ ok: true });
+    expect(sent[0]).toEqual({
+      type: 'dweb/base-host/room', op: 'join', roomId: 'r1', roomOwnerId: 'app:a1:41:0',
+      roomOwnerAppId: 'a1', roomOwnerGeneration: 0,
+    });
+    record = { ...record, entryFile: 'other.html' };
+    expect(await makeDwebRoutes(deps)['dweb/base/room']({
+      op: 'join', roomId: 'r1', bridgeAppId: 'a1', bridgeAppHash: 'bundle-v1', bridgeAppForked: false, bridgeAppGeneration: 0,
+    }, { tab: { id: 41, url: 'moz-extension://peerd/engine-tabs/app-tab/index.html#a1' } } as any))
+      .toEqual({ ok: false, error: 'app-identity-changed' });
+    record = { ...record, entryFile: 'index.html', fileKinds: { 'payload.custom': 'text' } };
+    expect(await makeDwebRoutes(deps)['dweb/base/room']({
+      op: 'join', roomId: 'r1', bridgeAppId: 'a1', bridgeAppHash: 'bundle-v1', bridgeAppForked: false, bridgeAppGeneration: 0,
+    }, { tab: { id: 41, url: 'moz-extension://peerd/engine-tabs/app-tab/index.html#a1' } } as any))
+      .toEqual({ ok: false, error: 'app-identity-changed' });
+  });
+  test('room join refuses bytes that changed after consent', async () => {
+    const { deps, sent } = baseDeps({
+      appRegistry: { get: async () => ({ id: 'a1', entryFile: 'index.html', fileKinds: {}, dweb: { hash: 'bundle-v1', git_oid: 'base-v1', release_entry_file: 'index.html', release_file_kinds: {} } }) },
+      appTabTracker: {
+        getTabId: () => 41,
+        parseIdFromUrl: () => 'a1',
+      },
+      repositories: { matches: async () => false },
+    });
+    const result = await makeDwebRoutes(deps)['dweb/base/room']({
+      op: 'join', roomId: 'r1', bridgeAppId: 'a1', bridgeAppHash: 'bundle-v1', bridgeAppForked: false, bridgeAppGeneration: 0,
+    }, { tab: { id: 41, url: 'moz-extension://peerd/engine-tabs/app-tab/index.html#a1' } } as any);
+    expect(result).toEqual({ ok: false, error: 'app-identity-changed' });
+    expect(sent).toEqual([]);
+  });
+  test('room relay rejects missing identity and a displaced App tab', async () => {
+    let tabId = 41;
+    const { deps, sent } = baseDeps({
+      appRegistry: { get: async () => ({ id: 'a1', entryFile: 'index.html', fileKinds: {}, dweb: { hash: 'bundle-v1', git_oid: 'base-v1', release_entry_file: 'index.html', release_file_kinds: {} } }) },
+      appTabTracker: { getTabId: () => tabId, parseIdFromUrl: () => 'a1' },
+      repositories: { matches: async () => { tabId = 42; return true; } },
+    });
+    const route = makeDwebRoutes(deps)['dweb/base/room'];
+    const sender = { tab: { id: 41, url: 'moz-extension://peerd/engine-tabs/app-tab/index.html#a1' } } as any;
+    expect(await route({ op: 'join', roomId: 'r1' }, sender))
+      .toEqual({ ok: false, error: 'app-identity-changed' });
+    expect(await route({
+      op: 'join', roomId: 'r1', bridgeAppId: 'a1', bridgeAppHash: 'bundle-v1', bridgeAppForked: false, bridgeAppGeneration: 0,
+    }, sender)).toEqual({ ok: false, error: 'app-identity-changed' });
+    expect(await route({ op: 'publish', roomId: 'r1', bridgeAppId: 'a1', bridgeAppGeneration: 0 }, sender))
+      .toEqual({ ok: false, error: 'app-identity-changed' });
+    expect(sent).toEqual([]);
+  });
+  test('room relay rejects authority that changes while its host starts', async () => {
+    let generation = 0;
+    let release!: () => void;
+    const hostReady = new Promise<void>((resolve) => { release = resolve; });
+    const { deps, sent } = baseDeps({
+      ensureOffscreen: async () => hostReady,
+      appTabTracker: {
+        getTabId: () => 41, getDwebGeneration: () => generation,
+        parseIdFromUrl: () => 'a1',
+      },
+    });
+    const pending = makeDwebRoutes(deps)['dweb/base/room']({
+      op: 'publish', roomId: 'r1', bridgeAppId: 'a1', bridgeAppGeneration: 0,
+    }, { tab: { id: 41, url: 'moz-extension://peerd/engine-tabs/app-tab/index.html#a1' } } as any);
+    await Promise.resolve();
+    generation = 1;
+    release();
+    expect(await pending).toEqual({ ok: false, error: 'app-identity-changed' });
+    expect(sent).toEqual([]);
+  });
+  test('room relay holds ordinary effects in the App write lane and lets stale leave clean up', async () => {
+    let locked = false;
+    let fenceCalls = 0;
+    let authorityCalls = 0;
+    let release!: () => void;
+    let hostStarted!: () => void;
+    const hostDone = new Promise<void>((resolve) => { release = resolve; });
+    const started = new Promise<void>((resolve) => { hostStarted = resolve; });
+    const { deps, sent } = baseDeps({
+      browser: { runtime: { sendMessage: async (message: any) => {
+        sent.push(message); hostStarted(); await hostDone; return { ok: true };
+      } } },
+      appTabTracker: {
+        getTabId: () => 41, getDwebGeneration: () => 2, parseIdFromUrl: () => 'a1',
+        withDwebAuthority: async (_appId: string, operation: () => Promise<any>) => {
+          authorityCalls += 1;
+          return operation();
+        },
+      },
+      appClient: {
+        withWriteLock: async (_appId: string, operation: () => Promise<any>) => {
+          locked = true;
+          try { return await operation(); } finally { locked = false; }
+        },
+      },
+      withDwebPublication: async (operation: (isCurrent: () => boolean) => Promise<any>) => {
+        fenceCalls += 1;
+        return operation(() => true);
+      },
+    });
+    const route = makeDwebRoutes(deps)['dweb/base/room'];
+    const sender = { tab: { id: 41, url: 'moz-extension://peerd/engine-tabs/app-tab/index.html#a1' } } as any;
+    for (const bridgeAppGeneration of [undefined, 1, 2.5]) {
+      expect(await route({ op: 'publish', roomId: 'r1', bridgeAppId: 'a1', bridgeAppGeneration }, sender))
+        .toEqual({ ok: false, error: 'app-identity-changed' });
+    }
+    const publishing = route({ op: 'publish', roomId: 'r1', bridgeAppId: 'a1', bridgeAppGeneration: 2 }, sender);
+    await started;
+    expect(locked).toBe(true);
+    release();
+    expect(await publishing).toEqual({ ok: true });
+    expect(locked).toBe(false);
+    expect(await route({ op: 'leave', roomId: 'r1', bridgeAppId: 'a1', bridgeAppGeneration: 1 }, sender)).toEqual({ ok: true });
+    expect(sent.at(-1)).toEqual({
+      type: 'dweb/base-host/room', op: 'leave', roomId: 'r1', roomOwnerId: 'app:a1:41:1',
+      roomOwnerAppId: 'a1', roomOwnerGeneration: 1,
+    });
+    expect(fenceCalls).toBe(2);
+    expect(authorityCalls).toBe(0);
+  });
+  test('room publication flushes a re-entrant App mutation before it takes authority', async () => {
+    const authority = makeLane();
+    const order: string[] = [];
+    let flushing = false;
+    const withDwebAuthority = (_appId: string, operation: () => Promise<any>) => authority(async () => {
+      order.push(flushing ? 'flush-authority' : 'publish-authority');
+      return operation();
+    });
+    const { deps } = baseDeps({
+      appTabTracker: {
+        getTabId: () => 41, getDwebGeneration: () => 0, parseIdFromUrl: () => 'a1',
+        withDwebAuthority,
+        quiesceTab: async () => {
+          flushing = true;
+          try { await withDwebAuthority('a1', async () => {}); }
+          finally { flushing = false; }
+          return true;
+        },
+      },
+      appClient: {
+        snapshotFilesBase64: async () => ({ record: { id: 'a1' }, files: {}, totalBytes: 0 }),
+      },
+    });
+    const result = await within(makeDwebRoutes(deps)['dweb/base/room']({
+      op: 'publish-app', roomId: 'r1', appId: 'a1', bridgeAppId: 'a1', bridgeAppGeneration: 0,
+    }, { tab: { id: 41, url: 'moz-extension://peerd/engine-tabs/app-tab/index.html#a1' } } as any));
+    expect(result).toEqual({ ok: true });
+    expect(order).toEqual(['flush-authority']);
+  });
+  test('join settles while invalidation owns App authority and waits for bridge disposal', async () => {
+    const authority = makeLane();
+    let joining!: Promise<any>;
+    let releaseMutation!: () => void;
+    const mutationReady = new Promise<void>((resolve) => { releaseMutation = resolve; });
+    let continueMutation!: () => void;
+    const mutationGate = new Promise<void>((resolve) => { continueMutation = resolve; });
+    const { deps } = baseDeps({
+      appRegistry: { get: async () => ({ id: 'a1', dweb: { hash: null } }) },
+      appTabTracker: {
+        getTabId: () => 41, getDwebGeneration: () => 0, parseIdFromUrl: () => 'a1',
+        withDwebAuthority: (_appId: string, operation: () => Promise<any>) => authority(operation),
+      },
+    });
+    const mutation = authority(async () => {
+      releaseMutation();
+      await mutationGate;
+      await joining;
+    });
+    await mutationReady;
+    joining = makeDwebRoutes(deps)['dweb/base/room']({
+      op: 'join', roomId: 'r1', bridgeAppId: 'a1', bridgeAppForked: false, bridgeAppGeneration: 0,
+    }, { tab: { id: 41, url: 'moz-extension://peerd/engine-tabs/app-tab/index.html#a1' } } as any);
+    continueMutation();
+    const [joined] = await within(Promise.all([joining, mutation]));
+    expect(joined).toEqual({ ok: true });
+  });
+  test('room effects and updates settle in both publication queue orders', async () => {
+    for (const roomFirst of [false, true]) {
+      const publication = makeLane();
+      const lifecycle = makeLane();
+      const authority = makeLane();
+      const repository = makeLane();
+      const { deps } = baseDeps({
+        withDwebPublication: (operation: (current: () => boolean) => Promise<any>) => publication(() => operation(() => true)),
+        withAppLifecycle: (_appId: string, operation: () => Promise<any>) => lifecycle(operation),
+        appTabTracker: {
+          getTabId: () => 41, getDwebGeneration: () => 0, parseIdFromUrl: () => 'a1',
+          withDwebAuthority: (_appId: string, operation: () => Promise<any>) => authority(operation),
+        },
+        appClient: {
+          withWriteLock: (_appId: string, operation: () => Promise<any>) => repository(operation),
+        },
+      });
+      const routes = makeDwebRoutes(deps);
+      const room = () => routes['dweb/base/room']({
+        op: 'publish', roomId: 'r1', bridgeAppId: 'a1', bridgeAppGeneration: 0,
+      }, { tab: { id: 41, url: 'moz-extension://peerd/engine-tabs/app-tab/index.html#a1' } } as any);
+      const update = () => routes['dweb/app-update']({
+        appId: 'a1', files: { 'i.html': 'new' }, entryFile: 'i.html', dweb: { version_id: 'v2' },
+      }, offscreenSender);
+      const operations = roomFirst ? [room(), update()] : [update(), room()];
+      const results = await within(Promise.all(operations));
+      expect(results.every((result) => result.ok === true)).toBe(true);
+    }
+  });
+  test('outer update re-entry settles around a joining bridge in both queue orders', async () => {
+    const run = async (callbackFirst: boolean) => {
+    const publication = makeLane();
+    const lifecycle = makeLane();
+    const authority = makeLane();
+    let releaseUpdateHost!: () => void;
+    let updateHostStarted!: () => void;
+    const updateHostGate = new Promise<void>((resolve) => { releaseUpdateHost = resolve; });
+    const updateHostReady = new Promise<void>((resolve) => { updateHostStarted = resolve; });
+    let releaseJoinHost!: () => void;
+    let joinRequested!: () => void;
+    const joinHostGate = new Promise<void>((resolve) => { releaseJoinHost = resolve; });
+    const joinReady = new Promise<void>((resolve) => { joinRequested = resolve; });
+    let updateReentered!: () => void;
+    const updateReentryReady = new Promise<void>((resolve) => { updateReentered = resolve; });
+    let storagePublicationStarted!: () => void;
+    const storagePublicationReady = new Promise<void>((resolve) => { storagePublicationStarted = resolve; });
+    let releaseStorageQuiesce!: () => void;
+    let storageQuiesceStarted!: () => void;
+    const storageQuiesceGate = new Promise<void>((resolve) => { releaseStorageQuiesce = resolve; });
+    const storageQuiesceReady = new Promise<void>((resolve) => { storageQuiesceStarted = resolve; });
+    let storageCallbackActive = false;
+    let leaveCalls = 0;
+    const lostLeaveReply = new Promise<never>(() => {});
+    let routes!: ReturnType<typeof makeDwebRoutes>;
+    let bridge!: ReturnType<typeof createDwebBridge>;
+    const dwappId = 'd'.repeat(64);
+    const publisher = 'did:key:zPublisher';
+    const record = {
+      id: 'a1', name: 'A', entryFile: 'index.html', fileKinds: {},
+      dweb: {
+        hash: 'bundle-v1', git_oid: 'base-v1', dwapp_id: dwappId, publisher,
+        seq: 1, version_id: 'a'.repeat(64), release_entry_file: 'index.html', release_file_kinds: {},
+      },
+    };
+    const sender = { tab: { id: 41, url: 'moz-extension://peerd/engine-tabs/app-tab/index.html#a1' } } as any;
+    const tracker = {
+      getTabId: () => 41,
+      getDwebGeneration: () => 0,
+      dwebGenerationsReady: async () => {},
+      parseIdFromUrl: () => 'a1',
+      withDwebAuthority: (_appId: string, operation: () => Promise<any>) => authority(operation),
+    };
+    const { deps } = baseDeps({
+      appRegistry: {
+        get: async () => record,
+        update: async () => record,
+      },
+      appTabTracker: tracker,
+      appQuiescence: {
+        runUnlocked: async (_appId: string, operation: () => Promise<any>, options: any = {}) => {
+          if (!options.invalidateDweb) return operation();
+          if (callbackFirst) {
+            storageQuiesceStarted();
+            await storageQuiesceGate;
+          }
+          return tracker.withDwebAuthority('a1', operation);
+        },
+      },
+      appClient: {
+        withWriteLock: async (_appId: string, operation: () => Promise<any>) => operation(),
+        replaceVersionedFilesUnlocked: async () => ({ record, oid: 'base-v2', created: true }),
+      },
+      createDwebRollbackGuard: () => ({ admit: async () => ({ accepted: true }) }),
+      withDwebPublication: (operation: (current: () => boolean) => Promise<any>) => publication(() => {
+        if (storageCallbackActive) storagePublicationStarted();
+        return operation(() => true);
+      }),
+      withAppLifecycle: (_appId: string, operation: () => Promise<any>) => lifecycle(operation),
+      browser: { runtime: { sendMessage: async (message: any): Promise<any> => {
+        if (message.type === 'dweb/base-host/update-app') {
+          updateHostStarted();
+          await updateHostGate;
+          updateReentered();
+          storageCallbackActive = true;
+          let applied;
+          try {
+            applied = await routes['dweb/app-update']({
+              appId: 'a1', files: { 'index.html': 'new' }, entryFile: 'index.html', fileKinds: {},
+              dweb: {
+                hash: 'bundle-v2', dwapp_id: dwappId, publisher,
+                seq: 2, version_id: 'b'.repeat(64),
+              },
+            }, offscreenSender);
+          } finally { storageCallbackActive = false; }
+          return {
+            ...applied,
+            cleanupHashes: applied.cleanupHashes ?? ['bundle-v1'],
+            pendingUnserveHashes: [],
+          };
+        }
+        if (message.type === 'dweb/base-host/room' && message.op === 'join') {
+          await joinHostGate;
+          return { ok: true, did: 'did:key:self', present: 1 };
+        }
+        if (message.type === 'dweb/base-host/room' && message.op === 'leave') {
+          leaveCalls += 1;
+          if (callbackFirst && leaveCalls === 1) return lostLeaveReply;
+          return { ok: true, left: true };
+        }
+        return { ok: true };
+      } } },
+    });
+    routes = makeDwebRoutes(deps);
+
+    let bridgeMessage!: (message: any) => Promise<void>;
+    bridge = createDwebBridge({
+      appId: 'a1', appName: 'A', appDweb: { hash: 'bundle-v1', generation: 0 }, entryFile: 'index.html',
+      transport: {
+        send: () => {},
+        onMessage: (handler) => {
+          bridgeMessage = async (message) => { await handler(message); };
+          return () => {};
+        },
+      },
+      swCall: async (type, payload = {}) => {
+        if (type === 'app/get-meta') return { ok: true, dweb: { hash: 'bundle-v1', forked: false } };
+        if (type === 'dweb/base/room') {
+          if (payload.op === 'join') joinRequested();
+          return routes[type]({ type, ...payload }, sender);
+        }
+        return { ok: true };
+      },
+      storage: {
+        get: async () => ({ 'dweb.grants.v1': { 'bundle-v1': { rooms: { r1: true } } } }),
+        set: async () => {},
+      },
+      confirmAction: async () => true,
+    });
+
+    const updating = routes['dweb/base/update-app']({ appId: 'a1', uri: 'peerd://did:key:publisher/dw1' });
+    await updateHostReady;
+    if (callbackFirst) {
+      releaseUpdateHost();
+      await updateReentryReady;
+      await storagePublicationReady;
+      await storageQuiesceReady;
+    }
+    const joining = bridgeMessage({
+      peerd: 'dweb', op: 'join', clientId: 'client-0001', id: 'request-0001', args: { roomId: 'r1' },
+    });
+    await joinReady;
+    let editorStarted!: () => void;
+    const editorReady = new Promise<void>((resolve) => { editorStarted = resolve; });
+    const editing = authority(async () => {
+      editorStarted();
+      await bridge.invalidate();
+    });
+    await editorReady;
+    if (callbackFirst) releaseStorageQuiesce();
+    else {
+      releaseUpdateHost();
+      await updateReentryReady;
+    }
+    releaseJoinHost();
+    const [updated] = await within(Promise.all([updating, joining, editing]));
+    expect(updated).toMatchObject({ ok: true });
+    if (callbackFirst) expect(leaveCalls).toBe(2);
+    };
+    for (const callbackFirst of [false, true]) await run(callbackFirst);
+  });
+  test('room publication relays one immutable snapshot only for the current generation', async () => {
+    let generation = 0;
+    const snapshot = { record: { id: 'a1', entryFile: 'index.html' }, files: { 'index.html': { base64: 'eA==' } }, totalBytes: 1 };
+    const sender = { tab: { id: 41, url: 'moz-extension://peerd/engine-tabs/app-tab/index.html#a1' } } as any;
+    const make = (changeAfterSnapshot: boolean) => baseDeps({
+      appTabTracker: {
+        getTabId: () => 41, getDwebGeneration: () => generation, parseIdFromUrl: () => 'a1',
+      },
+      appQuiescence: { runUnlocked: async (_appId: string, operation: () => Promise<any>) => operation() },
+      appClient: {
+        snapshotFilesBase64: async () => {
+          if (changeAfterSnapshot) generation += 1;
+          return snapshot;
+        },
+      },
+      _reply: { ok: true, uri: 'peerd://bundle', hash: 'hash' },
+    });
+    let context = make(true);
+    let route = makeDwebRoutes(context.deps)['dweb/base/room'];
+    expect(await route({ op: 'publish-app', roomId: 'r1', appId: 'a2', bridgeAppId: 'a1', bridgeAppGeneration: 0 }, sender))
+      .toEqual({ ok: false, error: 'app-identity-changed' });
+    expect(await route({ op: 'publish-app', roomId: 'r1', appId: 'a1', bridgeAppId: 'a1', bridgeAppGeneration: 0 }, sender))
+      .toEqual({ ok: false, error: 'app-identity-changed' });
+    expect(context.sent).toEqual([]);
+
+    generation = 0;
+    context = make(false);
+    route = makeDwebRoutes(context.deps)['dweb/base/room'];
+    expect(await route({ op: 'publish-app', roomId: 'r1', appId: 'a1', bridgeAppId: 'a1', bridgeAppGeneration: 0 }, sender))
+      .toEqual({ ok: true, uri: 'peerd://bundle', hash: 'hash' });
+    expect(context.sent).toEqual([{
+      type: 'dweb/base-host/room', op: 'publish-app', roomId: 'r1', appId: 'a1',
+      roomOwnerId: 'app:a1:41:0',
+      roomOwnerAppId: 'a1', roomOwnerGeneration: 0,
+      roomSnapshot: { ok: true, ...snapshot },
+    }]);
   });
 });

--- a/tests/background/routes-engine.test.ts
+++ b/tests/background/routes-engine.test.ts
@@ -5,6 +5,7 @@ import { listOffscreenContexts } from '../../extension/background/offscreen-cont
 import { requireDenylistPolicy } from '../../extension/background/denylist-store.js';
 import { parseAppManifest } from '../../extension/peerd-engine/app-manifest.js';
 import { podGitRemoteOperation } from '../../extension/peerd-engine/pod-shell.js';
+import { appReleaseDescriptorMatches } from '../../extension/background/app-client.js';
 
 class ArtifactTooLargeError extends Error {}
 class EnvelopeFormatError extends Error {}
@@ -51,6 +52,8 @@ const baseDeps = (over: any = {}) => ({
   appTabTracker: {
     reloadTab: async () => {}, getTabId: () => null,
     parseIdFromUrl: () => null,
+    dwebGenerationsReady: async () => {}, getDwebGeneration: () => 0,
+    withDwebAuthority: async (_appId: string, operation: () => Promise<any>) => operation(),
     quiesceTab: async () => true, resumeTab: async () => true,
     closeTab: async () => {}, ensureTab: async () => {},
   },
@@ -78,6 +81,7 @@ const baseDeps = (over: any = {}) => ({
   awaitDenylistPolicy: async () => {},
   parseAppManifest,
   podGitRemoteOperation,
+  appReleaseDescriptorMatches,
   repositories: {
     init: async () => 'abc123456789',
     status: async () => ({ oid: 'abc', branch: 'main', dirty: false, changed: [] }),
@@ -98,6 +102,7 @@ const baseDeps = (over: any = {}) => ({
     diffApp: async () => ({ files: [], patch: '', truncated: false }),
     commitApp: async () => ({ oid: 'abc', changed: [], created: false }),
     restoreApp: async (_id: string, opts: any) => ({ oid: opts.to, restored: true }),
+    matches: async () => true,
     coordinate: async (_ref: any, operation: any) => operation(),
     destroy: async () => {},
   },
@@ -242,6 +247,10 @@ describe('App repository quiescence', () => {
         closeTab: async () => { order.push('close'); return true; },
         ensureTab: async () => { order.push('reopen'); return 41; },
         reloadTab: async () => true,
+        withDwebAuthority: async (_appId: string, operation: () => Promise<any>, options?: any) => {
+          if (options?.invalidate) order.push('rotate');
+          return operation();
+        },
       };
       const deps = baseDeps({
         appTabTracker: tracker,
@@ -274,6 +283,8 @@ describe('App repository quiescence', () => {
       expect(result.ok).toBe(true);
       const operationOrder = repositoryMethod === 'push'
         ? ['lifecycle', 'flush', 'close', 'lock', 'checkpoint', 'operation', 'unlock', 'reopen', 'lifecycle-release']
+        : repositoryMethod === 'restoreApp' || repositoryMethod === 'checkout'
+          ? ['lifecycle', 'flush', 'rotate', 'close', 'lock', 'operation', 'unlock', 'reopen', 'lifecycle-release']
         : ['lifecycle', 'flush', 'close', 'lock', 'operation', 'unlock', 'reopen', 'lifecycle-release'];
       expect(order).toEqual(operationOrder);
     });
@@ -303,6 +314,38 @@ describe('App repository quiescence', () => {
     expect(result).toEqual({ ok: false, error: 'save failed' });
     expect(closed).toBe(false);
     expect(mutated).toBe(false);
+  });
+
+  test('a cold App restore finds its tab and rotates authority before the repository lock', async () => {
+    const order: string[] = [];
+    const tracker = {
+      getTabId: () => null,
+      quiesceTab: async () => { order.push('cold-flush'); return true; },
+      withDwebAuthority: async (_appId: string, operation: () => Promise<any>, options?: any) => {
+        expect(options).toEqual({ invalidate: true });
+        order.push('rotate');
+        return operation();
+      },
+      closeTab: async () => { order.push('close'); return true; },
+      ensureTab: async () => { order.push('reopen'); return 41; },
+      resumeTab: async () => true,
+      reloadTab: async () => true,
+    };
+    const deps = baseDeps({
+      appTabTracker: tracker,
+      appQuiescence: createAppQuiescence({
+        tracker,
+        withLifecycle: async (_appId, operation) => operation(),
+        afterClose: async () => {},
+      }),
+    });
+    deps.repositories.coordinate = async (_ref: any, operation: () => Promise<any>) => {
+      order.push('lock');
+      try { return await operation(); } finally { order.push('unlock'); }
+    };
+    deps.repositories.restoreApp = async () => { order.push('restore'); return { oid: 'old' }; };
+    expect((await makeEngineRoutes(deps)['apps/repository/restore']({ appId: 'a1', to: 'old' })).ok).toBe(true);
+    expect(order).toEqual(['cold-flush', 'rotate', 'close', 'lock', 'restore', 'unlock', 'reopen']);
   });
 });
 
@@ -599,6 +642,16 @@ describe('sw/web-fetch', () => {
 });
 
 describe('app/vm meta + apps Library', () => {
+  const dwebSender = { tab: { id: 41, url: 'moz-extension://peerd/engine-tabs/app-tab/index.html#a1' } };
+  const dwebMetaDeps = (over: any) => baseDeps({
+    appTabTracker: {
+      getTabId: (id: string) => id === 'a1' ? 41 : null,
+      parseIdFromUrl: (url: string) => url.endsWith('#a1') ? 'a1' : null,
+      dwebGenerationsReady: async () => {}, getDwebGeneration: () => 0,
+      withDwebAuthority: async (_appId: string, operation: () => Promise<any>) => operation(),
+    },
+    ...over,
+  });
   test('app/get-meta unknown → app-not-found', async () => {
     const r = makeEngineRoutes(baseDeps());
     expect(await r['app/get-meta']({ appId: 'zzz' })).toEqual({ ok: false, error: 'app-not-found' });
@@ -662,6 +715,127 @@ describe('app/vm meta + apps Library', () => {
       },
     }));
     expect((await r['app/get-meta']({ appId: 'a1' })).dweb).toMatchObject({ local: true });
+  });
+  test('app/get-meta keeps the installed identity across runtime data create and delete', async () => {
+    const dweb = {
+      hash: 'bundle-v1', git_oid: 'commit-v1', version_id: 'bundle-v1',
+      release_entry_file: 'index.html', release_file_kinds: {},
+    };
+    let record: any = {
+      id: 'a1', name: 'App', entryFile: 'index.html', fileKinds: { 'data/state.json': 'text' }, dweb,
+    };
+    const deps = dwebMetaDeps({
+      DWEB_ENABLED: true,
+      appRegistry: {
+        get: async () => record,
+        update: async () => null,
+      },
+      appClient: {
+        readFile: async () => JSON.stringify({ schema: 1, kind: 'app', entry: 'index.html', agent: { kind: 'bound-app' }, capabilities: ['dweb'] }),
+        listFiles: async () => [{ path: '/index.html' }, { path: '/peerd.json' }],
+      },
+    });
+    deps.repositories.matches = async () => true;
+    const route = makeEngineRoutes(deps)['app/get-meta'];
+    expect(await route({ appId: 'a1' }, { tab: { id: 42, url: dwebSender.tab.url } }))
+      .toEqual({ ok: false, error: 'app-sender-not-instance-pinned' });
+    expect((await route({ appId: 'a1' }, dwebSender)).dweb).toEqual({ ...dweb, generation: 0 });
+    record = {
+      ...record, fileKinds: {},
+      dweb: { ...dweb, release_file_kinds: { 'data/state.json': 'text' } },
+    };
+    expect((await route({ appId: 'a1' }, dwebSender)).dweb)
+      .toEqual({ ...record.dweb, generation: 0 });
+  });
+  test('app/get-meta rotates the runtime identity after local byte changes', async () => {
+    const dweb = {
+      hash: 'bundle-v1', git_oid: 'commit-v1', version_id: 'bundle-v1',
+      release_entry_file: 'index.html', release_file_kinds: {},
+    };
+    const deps = dwebMetaDeps({
+      DWEB_ENABLED: true,
+      appRegistry: {
+        get: async () => ({ id: 'a1', name: 'App', entryFile: 'index.html', dweb }),
+        update: async () => null,
+      },
+      appClient: {
+        readFile: async () => JSON.stringify({ schema: 1, kind: 'app', entry: 'index.html', agent: { kind: 'bound-app' }, capabilities: ['dweb'] }),
+        listFiles: async () => [{ path: '/index.html' }, { path: '/peerd.json' }],
+      },
+    });
+    let comparison: any = null;
+    deps.repositories.matches = async (ref: any, options: any) => { comparison = { ref, options }; return false; };
+    expect((await makeEngineRoutes(deps)['app/get-meta']({ appId: 'a1' }, dwebSender)).dweb).toMatchObject({
+      hash: 'bundle-v1',
+      forked: true,
+    });
+    expect(comparison).toEqual({ ref: { kind: 'app', id: 'a1' }, options: { at: 'commit-v1', excludeAppData: true } });
+  });
+  test('app/get-meta waits for a second fork mutation before it reads generation', async () => {
+    let release!: () => void;
+    let entered!: () => void;
+    const mutation = new Promise<void>((resolve) => { release = resolve; });
+    const coordinated = new Promise<void>((resolve) => { entered = resolve; });
+    let generation = 1;
+    let reads = 0;
+    const deps = dwebMetaDeps({
+      DWEB_ENABLED: true,
+      appRegistry: {
+        get: async () => { reads += 1; return { id: 'a1', name: 'App', entryFile: 'index.html', fileKinds: {}, dweb: { hash: 'bundle-v1', git_oid: 'commit-v1', release_entry_file: 'index.html', release_file_kinds: {} } }; },
+        update: async () => null,
+      },
+      appClient: { readFile: async () => { throw Object.assign(new Error('missing'), { name: 'NotFoundError' }); } },
+    });
+    deps.appTabTracker.getDwebGeneration = () => generation;
+    deps.repositories.matches = async () => false;
+    deps.repositories.coordinate = async (_ref: any, operation: () => Promise<any>) => {
+      entered();
+      await mutation;
+      return operation();
+    };
+    const pending = makeEngineRoutes(deps)['app/get-meta']({ appId: 'a1' }, dwebSender);
+    await coordinated;
+    expect(reads).toBe(0);
+    generation = 2;
+    release();
+    expect((await pending).dweb).toMatchObject({ forked: true, generation: 2 });
+  });
+  test('app/get-meta checks changed bytes when peerd.json is missing', async () => {
+    const deps = dwebMetaDeps({
+      DWEB_ENABLED: true,
+      appRegistry: {
+        get: async () => ({ id: 'a1', name: 'App', entryFile: 'index.html', fileKinds: {}, dweb: { hash: 'bundle-v1', git_oid: 'commit-v1', release_entry_file: 'index.html', release_file_kinds: {} } }),
+        update: async () => null,
+      },
+      appClient: {
+        readFile: async () => { throw Object.assign(new Error('missing'), { name: 'NotFoundError' }); },
+      },
+    });
+    deps.repositories.matches = async () => false;
+    expect((await makeEngineRoutes(deps)['app/get-meta']({ appId: 'a1' }, dwebSender)).dweb).toMatchObject({ forked: true });
+  });
+  test('app/get-meta rotates the runtime identity when the baseline is missing or unavailable', async () => {
+    for (const [dweb, expectedChecks] of [
+      [{ hash: 'bundle-v1' }, 0],
+      [{ hash: 'bundle-v1', git_oid: 'commit-v1' }, 0],
+      [{ hash: 'bundle-v1', git_oid: 'commit-v1', release_entry_file: 'index.html', release_file_kinds: {} }, 1],
+    ] as const) {
+      const deps = dwebMetaDeps({
+        DWEB_ENABLED: true,
+        appRegistry: {
+          get: async () => ({ id: 'a1', name: 'App', entryFile: 'index.html', dweb }),
+          update: async () => null,
+        },
+        appClient: {
+          readFile: async () => JSON.stringify({ schema: 1, kind: 'app', entry: 'index.html', agent: { kind: 'bound-app' }, capabilities: ['dweb'] }),
+          listFiles: async () => [{ path: '/index.html' }, { path: '/peerd.json' }],
+        },
+      });
+      let checks = 0;
+      deps.repositories.matches = async () => { checks += 1; throw new Error('repository unavailable'); };
+      expect((await makeEngineRoutes(deps)['app/get-meta']({ appId: 'a1' }, dwebSender)).dweb).toMatchObject({ forked: true });
+      expect(checks).toBe(expectedChecks);
+    }
   });
   test('vm/get-meta requires a string id', async () => {
     const r = makeEngineRoutes(baseDeps());
@@ -729,12 +903,14 @@ describe('app/vm meta + apps Library', () => {
         parseIdFromUrl: (url: string) => url.endsWith('#app-1') ? 'app-1' : null,
       },
       appClient: {
-        writeFile: async ({ path, content, reload }: any) => {
+        writeFile: async ({ path, content, reload, invalidateDweb }: any) => {
           expect(reload).toBe(false);
+          expect(invalidateDweb).toBe(false);
           writes.push({ path, content });
         },
-        deleteFile: async ({ path, reload }: any) => {
+        deleteFile: async ({ path, reload, invalidateDweb }: any) => {
           expect(reload).toBe(false);
+          expect(invalidateDweb).toBe(false);
           writes.push({ path, delete: true });
         },
       },
@@ -757,6 +933,10 @@ describe('app/vm meta + apps Library', () => {
       .toEqual({ ok: false, error: 'app-data-unauthorized' });
     expect(await r['app/editor-write'](
       { appId: 'app-1', path: 'data/document.json', content: '{}', runtimeData: true },
+      { tab: { id: 45, url: sender.tab.url } },
+    )).toEqual({ ok: false, error: 'app-data-unauthorized' });
+    expect(await r['app/editor-write'](
+      { appId: 'app-1', path: 'script.js', content: 'changed' },
       { tab: { id: 45, url: sender.tab.url } },
     )).toEqual({ ok: false, error: 'app-data-unauthorized' });
   });

--- a/tests/meta/sw-barrel-imports.test.ts
+++ b/tests/meta/sw-barrel-imports.test.ts
@@ -182,7 +182,7 @@ describe('service-worker ↔ peerd-runtime barrel link integrity', () => {
     // one small repository bootstrap verb, not a worker-side UI controller.
     expect(graph.size).toBeLessThanOrEqual(458);
     expect(bytes).toBeLessThanOrEqual(4_705_000);
-    expect(statSync(entry).size).toBeLessThanOrEqual(460_000);
+    expect(statSync(entry).size).toBeLessThanOrEqual(461_000);
   });
 
   test('the offscreen host uses its exact runtime and engine surfaces', async () => {

--- a/tests/offscreen/app-room-authority.test.ts
+++ b/tests/offscreen/app-room-authority.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  AppRoomAuthorityChangedError,
+  createAppRoomAuthority,
+} from '../../extension/offscreen/app-room-authority.js';
+
+const deferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
+};
+
+const storage = (values: Record<string, unknown> = {}) => ({ get: async () => values });
+
+describe('offscreen App room authority', () => {
+  test('rotation cancels a delayed stale join before its synchronous commit', async () => {
+    const authority = createAppRoomAuthority(storage());
+    const started = deferred();
+    const release = deferred();
+    let committed = false;
+    let purged = false;
+    const joining = authority.run('a1', 0, async (current) => {
+      started.resolve();
+      await release.promise;
+      if (!current()) throw new AppRoomAuthorityChangedError();
+      committed = true;
+    });
+    await started.promise;
+    const rotating = authority.rotate('a1', 1, () => { purged = true; });
+    expect(purged).toBe(false);
+    release.resolve();
+    await expect(joining).rejects.toBeInstanceOf(AppRoomAuthorityChangedError);
+    await rotating;
+    expect(committed).toBe(false);
+    expect(purged).toBe(true);
+  });
+
+  test('rotation drains an admitted effect before its purge can finish', async () => {
+    const authority = createAppRoomAuthority(storage());
+    const started = deferred();
+    const release = deferred();
+    const order: string[] = [];
+    const effect = authority.run('a1', 0, async () => {
+      started.resolve();
+      await release.promise;
+      order.push('effect');
+    });
+    await started.promise;
+    const rotating = authority.rotate('a1', 1, () => { order.push('purge'); });
+    await Promise.resolve();
+    expect(order).toEqual([]);
+    release.resolve();
+    await Promise.all([effect, rotating]);
+    expect(order).toEqual(['effect', 'purge']);
+  });
+
+  test('durable and newer floors reject stale work and an older rotation', async () => {
+    const authority = createAppRoomAuthority(storage({ 'app.dweb-generation.a1': 2 }));
+    let called = false;
+    await expect(authority.run('a1', 1, () => { called = true; }))
+      .rejects.toBeInstanceOf(AppRoomAuthorityChangedError);
+    let advanced = false;
+    await authority.run('a1', 3, (_current, didAdvance) => { advanced = didAdvance; });
+    expect(advanced).toBe(true);
+    await expect(authority.rotate('a1', 2, () => { called = true; }))
+      .rejects.toBeInstanceOf(AppRoomAuthorityChangedError);
+    expect(called).toBe(false);
+  });
+});

--- a/tests/peerd-distributed/app-store.test.ts
+++ b/tests/peerd-distributed/app-store.test.ts
@@ -97,6 +97,8 @@ describe('the dweb app store (base-network content + discovery)', () => {
       previous_version_id: release.previousVersionId,
       source_git_oid: release.gitCommitOid,
       changelog: release.changelog,
+      release_entry_file: 'index.html',
+      release_file_kinds: {},
     });
     a.close(); b.close();
   });

--- a/tests/peerd-distributed/bridge.test.ts
+++ b/tests/peerd-distributed/bridge.test.ts
@@ -30,15 +30,20 @@ const mockTransport = () => {
 // The bridge now talks to the offscreen base host over swCall('dweb/base/room')
 // and receives pushed room events via onHostEvent — no in-page room host, no
 // identity minting, no signaler. The fakes below stand in for that host.
-const makeBridge = ({ confirm = true, joinHost }: {
+const makeBridge = ({ confirm = true, joinHost, leaveHost, appDweb = { seed: 'commons' }, currentDweb = appDweb, storage = { get: async () => ({}), set: async () => {} } }: {
   confirm?: boolean | ((request: any) => boolean | Promise<boolean>),
   joinHost?: (payload: any) => Promise<any>,
+  leaveHost?: (payload: any) => Promise<any>,
+  appDweb?: any,
+  currentDweb?: any,
+  storage?: { get: (key: any) => Promise<any>, set: (value: any) => Promise<void> },
 } = {}) => {
   const mt = mockTransport();
   const calls: any[] = [];
   const confirmations: any[] = [];
   let pushEvent: ((m: any) => void) | null = null;
   const swCall = async (type: string, payload: any = {}) => {
+    if (type === 'app/get-meta') return { ok: true, dweb: currentDweb };
     if (type !== 'dweb/base/room') return { ok: true };
     calls.push(payload);
     switch (payload.op) {
@@ -49,16 +54,16 @@ const makeBridge = ({ confirm = true, joinHost }: {
       case 'dm': return { ok: true, id: 'd1', ts: 2 };
       case 'presence': return { ok: true, present: [{ did: 'did:key:zBOB', meta: { name: 'bob' } }] };
       case 'history': return { ok: true, items: [] };
-      case 'leave': return { ok: true, left: true };
+      case 'leave': return leaveHost ? leaveHost(payload) : { ok: true, left: true };
       case 'publish-app': return { ok: true, uri: 'peerd://bundle', hash: 'hash' };
       default: return { ok: true };
     }
   };
   const bridge = createDwebBridge({
-    appId: 'commons', appName: 'commons', appDweb: { seed: 'commons' }, entryFile: 'index.html',
+    appId: 'commons', appName: 'commons', appDweb, entryFile: 'index.html',
     transport: mt.transport,
     swCall,
-    storage: { get: async () => ({}), set: async () => {} },
+    storage,
     confirmAction: async (request: any) => {
       confirmations.push(request);
       return typeof confirm === 'function' ? confirm(request) : confirm;
@@ -80,7 +85,7 @@ describe('dwapp bridge (base-network rooms, transport-agnostic)', () => {
   });
 
   test('join → publish relays room ops over swCall', async () => {
-    const { mt, calls } = makeBridge();
+    const { mt, bridge, calls } = makeBridge({ appDweb: { seed: 'commons', generation: 7 } });
     mt.drive(rpc('request-0001', 'join', { roomId: 'peerd-global', name: 'ada' }));
     await tick();
     expect(mt.results().find((r) => r.id === 'request-0001')).toMatchObject({ ok: true, value: { joined: 'peerd-global', did: 'did:key:zME' } });
@@ -88,6 +93,13 @@ describe('dwapp bridge (base-network rooms, transport-agnostic)', () => {
     mt.drive(rpc('request-0002', 'publish', { topic: 'feed', data: { text: 'hi' } }));
     await tick();
     expect(calls.find((c) => c.op === 'publish')).toMatchObject({ roomId: 'peerd-global', topic: 'feed', data: { text: 'hi' } });
+    await bridge.dispose();
+    await tick();
+    mt.drive(rpc('request-0003', 'publish', { topic: 'feed', data: { text: 'late' } }));
+    await tick();
+    expect(calls.filter((call) => call.op === 'publish')).toHaveLength(1);
+    expect(calls.filter((call) => call.op === 'leave')).toHaveLength(1);
+    expect(calls.every((call) => call.bridgeAppGeneration === 7)).toBe(true);
     expect(mt.results().find((r) => r.id === 'request-0002')).toMatchObject({ ok: true, value: { id: 'e1' } });
   });
 
@@ -142,6 +154,69 @@ describe('dwapp bridge (base-network rooms, transport-agnostic)', () => {
     mt.drive(rpc('request-0001', 'join', { roomId: 'peerd-global', name: 'ada' }));
     await tick();
     expect(mt.results().find((r) => r.id === 'request-0001')).toMatchObject({ ok: false });
+  });
+
+  test('a local fork cannot reuse consent granted to the installed bundle', async () => {
+    const stored: Record<string, any> = {
+      'dweb.grants.v1': { 'bundle-v1': { rooms: { 'peerd-global': true } } },
+    };
+    const storage = {
+      get: async () => stored,
+      set: async (value: any) => { Object.assign(stored, value); },
+    };
+    const first = makeBridge({
+      appDweb: { hash: 'bundle-v1' },
+      currentDweb: { hash: 'bundle-v1', forked: true },
+      storage,
+    });
+    first.mt.drive(rpc('request-0001', 'join', { roomId: 'peerd-global' }));
+    await tick();
+    expect(first.confirmations).toHaveLength(1);
+    expect(stored['dweb.grants.v1']['fork:commons:bundle-v1'].rooms['peerd-global']).toBe(true);
+    await first.bridge.dispose();
+
+    const second = makeBridge({ confirm: false, appDweb: { hash: 'bundle-v1', forked: true }, storage });
+    second.mt.drive(rpc('request-0002', 'join', { roomId: 'peerd-global' }));
+    await tick();
+    expect(second.confirmations).toHaveLength(0);
+    expect(second.calls.some((call) => call.op === 'join')).toBe(true);
+
+    const nextVersion = makeBridge({
+      confirm: false,
+      appDweb: { hash: 'bundle-v2', forked: true },
+      storage,
+    });
+    nextVersion.mt.drive(rpc('request-0003', 'join', { roomId: 'peerd-global' }));
+    await tick();
+    expect(nextVersion.confirmations).toHaveLength(1);
+    expect(nextVersion.calls.some((call) => call.op === 'join')).toBe(false);
+
+    const staleVersion = makeBridge({
+      appDweb: { hash: 'bundle-v1' },
+      currentDweb: { hash: 'bundle-v2' },
+      storage,
+    });
+    staleVersion.mt.drive(rpc('request-0004', 'join', { roomId: 'peerd-global' }));
+    await tick();
+    expect(staleVersion.confirmations).toHaveLength(0);
+    expect(staleVersion.calls.some((call) => call.op === 'join')).toBe(false);
+    expect(staleVersion.mt.results().find((result) => result.id === 'request-0004')?.error).toContain('Reload');
+  });
+
+  test('a clean App cannot join after it changes during consent', async () => {
+    const current = { hash: 'bundle-v1', forked: false };
+    const bridge = makeBridge({
+      appDweb: { hash: 'bundle-v1' },
+      currentDweb: current,
+      confirm: () => { current.forked = true; return true; },
+      joinHost: async (request) => request.bridgeAppForked === current.forked
+        ? { ok: true, did: 'did:key:zME', joined: request.roomId, present: [] }
+        : { ok: false, error: 'app-identity-changed' },
+    });
+    bridge.mt.drive(rpc('request-0005', 'join', { roomId: 'peerd-global' }));
+    await tick();
+    expect(bridge.calls.at(-1)).toMatchObject({ bridgeAppId: 'commons', bridgeAppHash: 'bundle-v1', bridgeAppForked: false, bridgeAppGeneration: 0 });
+    expect(bridge.mt.results().at(-1)).toMatchObject({ ok: false, error: 'app-identity-changed' });
   });
 
   test('prototype-shaped room names cannot inherit a remembered grant', async () => {
@@ -248,6 +323,23 @@ describe('dwapp bridge (base-network rooms, transport-agnostic)', () => {
     await tick();
     expect(calls.filter((call) => call.op === 'leave')).toHaveLength(1);
     expect(calls.find((call) => call.op === 'leave').roomId).toBe('stable-room');
+
+    let leaveAttempts = 0;
+    const retry = makeBridge({
+      leaveHost: async () => ++leaveAttempts === 1
+        ? { ok: false, error: 'leave-failed' }
+        : { ok: true, left: true },
+    });
+    retry.mt.drive(rpc('request-owner-join-retry', 'join', { roomId: 'retry-room' }, CLIENT));
+    await tick();
+    retry.mt.drive({ peerd: 'dweb:dispose', clientId: CLIENT });
+    await tick();
+    retry.mt.drive(rpc('request-new-hello-retry', 'hello', {}, replacement));
+    await tick();
+    retry.mt.drive({ peerd: 'dweb:dispose', clientId: replacement });
+    await tick();
+    expect(retry.calls.filter((call) => call.op === 'leave').map((call) => call.roomId))
+      .toEqual(['retry-room', 'retry-room']);
   });
 
   test('a retired epoch cannot recapture the bridge with a late RPC or dispose the replacement room', async () => {
@@ -274,13 +366,113 @@ describe('dwapp bridge (base-network rooms, transport-agnostic)', () => {
     });
   });
 
+  test('dispose waits for a joined room to leave', async () => {
+    const leaving = deferred<any>();
+    const { mt, bridge, calls } = makeBridge({ leaveHost: async () => leaving.promise });
+    mt.drive(rpc('request-join-dispose', 'join', { roomId: 'stable-room' }));
+    await tick();
+    let settled = false;
+    const disposing = bridge.dispose().then(() => { settled = true; });
+    await tick();
+    expect(calls.filter((call) => call.op === 'leave')).toHaveLength(1);
+    expect(settled).toBe(false);
+    leaving.resolve({ ok: true, left: true });
+    await disposing;
+    expect(settled).toBe(true);
+
+    const failed = makeBridge({ leaveHost: async () => ({ ok: false, error: 'leave-failed' }) });
+    failed.mt.drive(rpc('request-failed-leave', 'join', { roomId: 'failed-room' }));
+    await tick();
+    await expect(failed.bridge.dispose()).rejects.toThrow('leave-failed');
+
+    const explicitLeave = deferred<any>();
+    const concurrent = makeBridge({ leaveHost: async () => explicitLeave.promise });
+    concurrent.mt.drive(rpc('request-concurrent-join', 'join', { roomId: 'concurrent-room' }));
+    await tick();
+    concurrent.mt.drive(rpc('request-concurrent-leave', 'leave'));
+    await tick();
+    const concurrentDispose = concurrent.bridge.dispose();
+    explicitLeave.resolve({ ok: true, left: true });
+    await concurrentDispose;
+    expect(concurrent.calls.filter((call) => call.op === 'leave')).toHaveLength(1);
+  });
+
+  test('dispose waits for a started host join and its exact-room rollback', async () => {
+    const joining = deferred<any>();
+    const leaving = deferred<any>();
+    const { mt, bridge, calls } = makeBridge({
+      joinHost: async () => joining.promise,
+      leaveHost: async () => leaving.promise,
+    });
+    mt.drive(rpc('request-pending-dispose', 'join', { roomId: 'pending-room' }));
+    await tick();
+    let settled = false;
+    const disposing = bridge.dispose().then(() => { settled = true; });
+    await tick();
+    expect(settled).toBe(false);
+    joining.resolve({ ok: true, did: 'did:key:zME', joined: 'pending-room', present: [] });
+    await tick();
+    expect(calls.map((call) => call.op)).toEqual(['join', 'leave']);
+    expect(settled).toBe(false);
+    leaving.resolve({ ok: true, left: true });
+    await disposing;
+    expect(settled).toBe(true);
+  });
+
+  test('authority invalidation does not wait for a join or leave reply', async () => {
+    const joining = deferred<any>();
+    const leaving = deferred<any>();
+    const { mt, bridge, calls } = makeBridge({
+      joinHost: async () => joining.promise,
+      leaveHost: async () => leaving.promise,
+    });
+    mt.drive(rpc('request-pending-invalidate', 'join', { roomId: 'pending-room' }));
+    await tick();
+    let settled = false;
+    await bridge.invalidate().then(() => { settled = true; });
+    expect(settled).toBe(true);
+    expect(calls.map((call) => call.op)).toEqual(['join', 'leave']);
+    joining.resolve({ ok: true, did: 'did:key:zME', joined: 'pending-room', present: [] });
+    leaving.resolve({ ok: true, left: true });
+    await tick();
+  });
+
+  test('dispose removes an exact owner after the host loses its join reply', async () => {
+    const owners = new Set<string>();
+    let leaves = 0;
+    const ownerOf = (payload: any) => `${payload.bridgeAppId}:${payload.bridgeAppGeneration}`;
+    const { mt, bridge, calls } = makeBridge({
+      appDweb: { seed: 'commons', generation: 9 },
+      joinHost: async (payload) => {
+        owners.add(ownerOf(payload));
+        throw new Error('join reply lost');
+      },
+      leaveHost: async (payload) => {
+        leaves += 1;
+        if (leaves === 1) throw new Error('cleanup unavailable');
+        owners.delete(ownerOf(payload));
+        return { ok: true, left: true };
+      },
+    });
+    mt.drive(rpc('request-lost-join', 'join', { roomId: 'lost-room' }));
+    await tick(20);
+    expect(owners).toEqual(new Set(['commons:9']));
+    await bridge.dispose();
+    expect(owners.size).toBe(0);
+    expect(calls.map((call) => [call.op, call.roomId, ownerOf(call)])).toEqual([
+      ['join', 'lost-room', 'commons:9'],
+      ['leave', 'lost-room', 'commons:9'],
+      ['leave', 'lost-room', 'commons:9'],
+    ]);
+  });
+
   test('unknown op is rejected; dispose unsubscribes transport + host events', async () => {
     const { mt, bridge } = makeBridge();
     mt.drive(rpc('request-0007', 'nonsense'));
     await tick();
     expect(mt.results().find((r) => r.id === 'request-0007')).toMatchObject({ ok: false });
     expect(mt.hasHandler()).toBe(true);
-    bridge.dispose();
+    await bridge.dispose();
     expect(mt.hasHandler()).toBe(false);
   });
 });

--- a/tests/peerd-engine/app-compose.test.ts
+++ b/tests/peerd-engine/app-compose.test.ts
@@ -185,6 +185,20 @@ describe('composeApp', () => {
     expect(out).toContain('\\u003c/script>');
   });
 
+  test('runtime data cannot become an entry, script, style, or worker source', () => {
+    const payload = '"</script><script>globalThis.pwned=1</script>"';
+    for (const html of [
+      '<script src="data/state.json"></script>',
+      '<link rel="stylesheet" href="data/state.json">',
+      '<script>new Worker("data/state.json")</script>',
+    ]) {
+      expect(() => composeApp({ 'index.html': html, 'data/state.json': payload }))
+        .toThrow('app runtime data cannot be a composed source');
+    }
+    expect(() => composeApp({ 'data/state.json': payload }, 'data/state.json'))
+      .toThrow('app runtime data cannot be a composed source');
+  });
+
   // Execute the injected shim against mocked Worker/Blob/URL to prove the
   // runtime rewrite — a known spec becomes a blob: worker, anything else passes
   // straight through. Guards against a regression in the shim source string.

--- a/tests/peerd-runtime/lifecycle/engine-liveness.test.ts
+++ b/tests/peerd-runtime/lifecycle/engine-liveness.test.ts
@@ -46,6 +46,17 @@ describe('adopt / drop / sweep', () => {
     expect(typeof storage.map.get(ENGINE_LIVENESS_KEY)).toBe('object');
   });
 
+  test('a cold worker resolves an App from its durable tab id', async () => {
+    const storage = makeStorage();
+    await makeEngineLiveness({ storage, now: () => 1 }).adopt('app', 'app-1', 41);
+    const restarted = makeEngineLiveness({ storage, now: () => 2 });
+    expect(await restarted.findByTab('app', 41)).toEqual({
+      kind: 'app', id: 'app-1', tabId: 41, at: 1,
+    });
+    await restarted.drop('app', 'app-1');
+    expect(await restarted.findByTab('app', 41)).toBe(null);
+  });
+
   test('a failing storage layer never throws into the tracker hooks', async () => {
     const liveness = makeEngineLiveness({
       storage: {


### PR DESCRIPTION
## Summary

- Rotate App dweb authority after code changes, updates, reloads, navigation, failure, or tab closure.
- Bind room joins and grants to the App identity, verified content hash, tab, and document generation.
- Preserve runtime data only after verified updates. Block stale or conflicting updates.

## Verification

- `bun test ./tests --timeout 30000`: 6,445 passed.
- Chrome in-browser suite: 963 passed.
- Firefox Store smoke and Gecko suite: 957 passed.
- Functional E2E: 42 states passed.
- Visual E2E: 34 states passed and every PNG was reviewed.
- `bun run preflight -- --matrix`: passed.

Refs #316